### PR TITLE
5 fix average combiner

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,8 +1,6 @@
-FROM openjdk:8u131-jre-alpine
+FROM deeplearning4j/dl4j-devkit
 
 ARG APP_VERSION=UNKOWN_VERSION
-
-RUN apk update && apk add curl
 
 ADD /target/seldon-engine-${APP_VERSION}.jar app.jar
 

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,6 +1,8 @@
-FROM deeplearning4j/dl4j-devkit
+FROM openjdk:8u151-jre-slim-stretch
 
 ARG APP_VERSION=UNKOWN_VERSION
+
+RUN apt-get update && apt-get install -y curl libblas-dev
 
 ADD /target/seldon-engine-${APP_VERSION}.jar app.jar
 


### PR DESCRIPTION
The engine base docker image goes from openjdk (alpine) to deeplearning4j/dl4j-devkit (centOS)

**RUN apk update && apk add curl** has been removed
  