### PR TITLE
fix crd.libsonnet error

### DIFF
--- a/seldon-core/seldon-core/crd.libsonnet
+++ b/seldon-core/seldon-core/crd.libsonnet
@@ -255,4 +255,4 @@ local podTemplateValidation = import 'json/pod-template-spec-validation.json';
     },
 },
 
-},
+}


### PR DESCRIPTION
Error when apply crd.libonnet of seldon-core through ksonnet

```
ks registry add seldon-core github.com/SeldonIO/seldon-core/tree/master/seldon-core && \
ks pkg install seldon-core/seldon-core@master && \
ks generate seldon-core seldon-core --withApife=false --namespace=seldon --withRbac=true
ks apply default
```

> ERROR find objects:
vendor/seldon-core/seldon-core/crd.libsonnet:258:2-3 Did not expect: (",", ",")
},

