### PR TITLE
Update kubectl_demo_minikube_rbac.ipynb

### DIFF
--- a/notebooks/kubectl_demo_minikube_rbac.ipynb
+++ b/notebooks/kubectl_demo_minikube_rbac.ipynb
@@ -34,7 +34,7 @@
     "Your start command would then look like:\n",
     "```\n",
     "minikube start --vm-driver kvm2 --memory 4096 --feature-gates=CustomResourceValidation=true --extra-config=apiserver.Authorization.Mode=RBAC\n",
-    "```"
+    "```\n",
     "**2018-09-24** : Alternatively, you can try this command with a new formatting of --extra-config parameter otherwise your start command will hang forever (see https://github.com/kubernetes/minikube/issues/2798#issuecomment-420402313 )\n",
     "\n",
     "Your start command would then look like:\n",


### PR DESCRIPTION
- Fixed a typo introduced by editing directly the source of ipynb on github editor. I have tested it locally this time before the PR. (sorry for that :/)

