### PR TITLE
Engine java opts annotations and ambassador timeout annotation

### DIFF
--- a/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/Constants.java
+++ b/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/Constants.java
@@ -20,4 +20,8 @@ public class Constants {
     public static final String STATE_CREATING = "Creating";
     public static final String STATE_FAILED = "Failed";
     public static final String STATE_AVAILABLE = "Available";
+    
+    public static final String ENGINE_JAVA_OPTS_ANNOTATION = "seldon.io/engine-java-opts";
+    public static final String REST_READ_TIMEOUT_ANNOTATION = "seldon.io/rest-read-timeout";
+    public static final String GRPC_READ_TIMEOUT_ANNOTATION = "seldon.io/grpc-read-timeout";
 }

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -23,6 +23,12 @@ You can configure aspects of Seldon Core via annotations in the SeldonDeployment
    * Locations : SeldonDeployment.spec.annotations
    * [Example](../notebooks/resources/model_long_timeouts.json)
 
+### Service Orchestrator
+
+  * ```seldon.io/engine-java-opts``` : Java Opts for Service Orchestrator
+    * Locations : SeldonDeployment.spec.predictors.annotations
+    * [Example](../notebooks/resources/model_engine_java_opts.json)
+    
 ## API OAuth Gateway Annotations
 The API OAuth Gateway, if used, can also have the following annotations:
 

--- a/notebooks/resources/model_engine_java_opts.json
+++ b/notebooks/resources/model_engine_java_opts.json
@@ -5,16 +5,9 @@
         "labels": {
             "app": "seldon"
         },
-        "name": "seldon-deployment-example"
+        "name": "seldon-model"
     },
     "spec": {
-        "annotations": {
-            "project_name": "FX Market Prediction",
-            "deployment_version": "v1",
-	    "seldon.io/rest-read-timeout":"10000",
-	    "seldon.io/rest-connection-timeout":"10000",	    
-	    "seldon.io/grpc-read-timeout":"10000"
-        },
         "name": "test-deployment",
         "oauth_key": "oauth-key",
         "oauth_secret": "oauth-secret",
@@ -34,7 +27,7 @@
                                 }
                             }
                         ],
-                        "terminationGracePeriodSeconds": 20
+                        "terminationGracePeriodSeconds": 1
                     }
                 }],
                 "graph": {
@@ -45,11 +38,12 @@
 		    },
                     "type": "MODEL"
                 },
-                "name": "fx-market-predictor",
+                "name": "example",
                 "replicas": 1,
-		"annotations": {
-		    "predictor_version" : "v1"
-		}
+		"labels": {
+		    "version" : "v1"
+		},
+		"annotations" : { "seldon.io/engine-java-opts" : "-Xmx1G" }
             }
         ]
     }


### PR DESCRIPTION

 * Allow engine java_opts via annotation ```seldon.io/engine-java-opts```
 * Ensure timeout annotations are added to Ambassador svc configuration