### PR TITLE
Add missing curl to engine Dockerfile

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8u171-jre-alpine3.7
 
 ARG APP_VERSION=UNKOWN_VERSION
 
-#RUN apt-get update && apt-get install -y curl libblas-dev
+RUN apk add curl
 
 COPY /target/seldon-engine-${APP_VERSION}.jar app.jar
 COPY /target/generated-resources /licenses/


### PR DESCRIPTION
 Used in preStop to get Tomcat server to pause and no longer be "ready"

Fixes #283 