### PR TITLE
Update java base images

### DIFF
--- a/api-frontend/Dockerfile
+++ b/api-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u171-jre-alpine3.7
+FROM openjdk:8u181-jre-alpine3.8
 
 ARG APP_VERSION=UNKOWN_VERSION
 

--- a/cluster-manager/Dockerfile
+++ b/cluster-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u171-jre-alpine3.7
+FROM openjdk:8u181-jre-alpine3.8
 
 ARG APP_VERSION=UNKOWN_VERSION
 

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u171-jre-alpine3.7
+FROM openjdk:8u181-jre-alpine3.8
 
 ARG APP_VERSION=UNKOWN_VERSION
 


### PR DESCRIPTION

 * Update to 8u181-jre-alpine3.8

As a by product fixes some default [security vulnerabilities in X11](https://nvd.nist.gov/vuln/detail/CVE-2018-14599) which don't effect us as we don't use Java X11 services but cause failing in default image vulnerability checkers.