### PR TITLE
Allow disable redis

### DIFF
--- a/helm-charts/seldon-core/templates/redis-deployment.yaml
+++ b/helm-charts/seldon-core/templates/redis-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -45,5 +46,4 @@ spec:
   type: ClusterIP
 status:
   loadBalancer: {}
-
-
+{{- end }}

--- a/helm-charts/seldon-core/values.yaml
+++ b/helm-charts/seldon-core/values.yaml
@@ -45,5 +45,6 @@ rbac:
     create: true
     name: seldon
 redis:
+  enabled: true
   image:
     name: redis:4.0.1


### PR DESCRIPTION
This PR is to fix issue #304 

`Redis` shipped in `seldon-core` helm chart is used for two purposes:

1. Store oauth keys for `seldon-apiserver`.
2. Persist `Predictive Unit` if its `.s2i/environment` `PERSISTENCE` flag is set to 1.

Since we can use `ambassador` to replace `seldon-apiserver` (which means we can disable `seldon-apiserver` in that case), and we can use a different `Redis` server for `PERSISTENCE` flag (if the admin already has a `Redis` server running), there is a need to disable the `Redis` shipped in `seldon-core` helm chart.