### PR TITLE
Update ngraph s2i image and remove torch from demo

### DIFF
--- a/examples/models/onnx_resnet50/ONNXResNet.py
+++ b/examples/models/onnx_resnet50/ONNXResNet.py
@@ -1,6 +1,3 @@
-from torch.autograd import Variable
-import torch.onnx
-import torchvision
 from keras.applications.imagenet_utils import decode_predictions
 from keras.applications.resnet50 import preprocess_input
 from keras.preprocessing import image
@@ -13,7 +10,7 @@ class ONNXResNet(object):
     def __init__(self):
         print("Loading model")
         # Import the ONNX file
-        models = import_onnx_file('resnet.onnx')
+        models = import_onnx_file('resnet50/model.onnx')
         # Create an nGraph runtime environment
         runtime = ng.runtime(backend_name='CPU')
         # Select the first model and compile it to a callable function
@@ -29,11 +26,11 @@ class ONNXResNet(object):
         x = preprocess_input(x,mode='torch')
         x = x.transpose(0,3,1,2)
         preds = self.resnet(x)
-        print(decode_predictions(preds, top=5))
+        print(decode_predictions(preds[0], top=5))
         
     def predict(self,X,features_names):
         print(X.shape)
         X = preprocess_input(X,mode='torch')
         preds = self.resnet(X)
-        print(decode_predictions(preds, top=5))
+        print(decode_predictions(preds[0], top=5))
         return preds

--- a/examples/models/onnx_resnet50/requirements.txt
+++ b/examples/models/onnx_resnet50/requirements.txt
@@ -1,4 +1,3 @@
-torch==0.4.0
-torchvision==0.2.1
-keras==2.2.2
-tensorflow==1.10.1
+keras
+Keras-Preprocessing
+pillow

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ Follow the [install guide](docs/install.md) for details on ways to install seldo
 | [Seldon Python 3 (3.6) Wrapper for S2I](docs/wrappers/python.md) | [seldonio/seldon-core-s2i-python3](https://hub.docker.com/r/seldonio/seldon-core-s2i-python3/tags/) | 0.4 | 0.5-SNAPSHOT |
 | [Seldon Python 3.6 Wrapper for S2I](docs/wrappers/python.md) | [seldonio/seldon-core-s2i-python36](https://hub.docker.com/r/seldonio/seldon-core-s2i-python36/tags/) | 0.4 | 0.5-SNAPSHOT |
 | [Seldon Python 2 Wrapper for S2I](docs/wrappers/python.md) | [seldonio/seldon-core-s2i-python2](https://hub.docker.com/r/seldonio/seldon-core-s2i-python2/tags/) | 0.4 | 0.5-SNAPSHOT |
-| [Seldon Python ONNX Wrapper for S2I](docs/wrappers/python.md) | [seldonio/seldon-core-s2i-python3-ngraph-onnx](https://hub.docker.com/r/seldonio/seldon-core-s2i-python3-ngraph-onnx/tags/) | 0.2  |   |
+| [Seldon Python ONNX Wrapper for S2I](docs/wrappers/python.md) | [seldonio/seldon-core-s2i-python3-ngraph-onnx](https://hub.docker.com/r/seldonio/seldon-core-s2i-python3-ngraph-onnx/tags/) | 0.3  |   |
 | [Seldon Java Build Wrapper for S2I](docs/wrappers/java.md) | [seldonio/seldon-core-s2i-java-build](https://hub.docker.com/r/seldonio/seldon-core-s2i-java-build/tags/) | 0.1 | |
 | [Seldon Java Runtime Wrapper for S2I](docs/wrappers/java.md) | [seldonio/seldon-core-s2i-java-runtime](https://hub.docker.com/r/seldonio/seldon-core-s2i-java-runtime/tags/) | 0.1 | |
 | [Seldon R Wrapper for S2I](docs/wrappers/r.md) | [seldonio/seldon-core-s2i-r](https://hub.docker.com/r/seldonio/seldon-core-s2i-r/tags/) | 0.2 | |

--- a/wrappers/s2i/python-ngraph-onnx/Dockerfile
+++ b/wrappers/s2i/python-ngraph-onnx/Dockerfile
@@ -1,4 +1,4 @@
-FROM seldonio/seldon-core-s2i-python3:0.3
+FROM seldonio/seldon-core-s2i-python3:0.4
 
 RUN apt-get update && apt-get install -y \
 	build-essential cmake clang-3.9 clang-format-3.9 \
@@ -9,30 +9,36 @@ RUN apt-get update && apt-get install -y \
 
 RUN apt-get clean autoclean && \
     apt-get autoremove -y
-#RUN pip install --upgrade pip
+
+RUN pip install --upgrade pip
 
 WORKDIR /home
 
+# This follows the build instructions at https://github.com/NervanaSystems/ngraph-onnx/blob/master/BUILDING.md
+#
 # Change to particular branch when stable
 #RUN git clone --branch v0.7.0 https://github.com/NervanaSystems/ngraph.git && \
-
-RUN git clone https://github.com/NervanaSystems/ngraph.git && \
+# Missing addition in cmake line below in offical docs see https://github.com/NervanaSystems/ngraph/issues/1584
+#
+#RUN git clone https://github.com/NervanaSystems/ngraph.git && \
+#
+RUN git clone --single-branch --branch python_docker_fix https://github.com/cliveseldon/ngraph.git && \
     cd ngraph && \
     mkdir build && cd build && \
     cmake ../ -DNGRAPH_USE_PREBUILT_LLVM=TRUE -DCMAKE_INSTALL_PREFIX=/home/ngraph_dist -DNGRAPH_ONNX_IMPORT_ENABLE=TRUE && \
     make -j 6 && \
-    make install && \
-    cd .. && rm -rf build
+    make install 
+#    cd .. && rm -rf build
 
 RUN cd ngraph/python && \
     git clone --recursive -b allow-nonconstructible-holders https://github.com/jagerman/pybind11.git && \
     export PYBIND_HEADERS_PATH=$PWD/pybind11 && \
     export NGRAPH_CPP_BUILD_PATH=/home/ngraph_dist && \
     python3 setup.py bdist_wheel && \
-    pip install -U dist/ngraph-0.9.0-cp36-cp36m-linux_x86_64.whl && \
+    pip install -U dist/ngraph_core*.whl && \
     rm -rf build && rm -rf dist
 
 RUN pip install git+https://github.com/NervanaSystems/ngraph-onnx/
 
-WORKDIR /microservice
+#WORKDIR /microservice
 

--- a/wrappers/s2i/python-ngraph-onnx/Makefile
+++ b/wrappers/s2i/python-ngraph-onnx/Makefile
@@ -1,11 +1,11 @@
-IMAGE_VERSION=0.2
+IMAGE_VERSION=0.3
 IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python3-ngraph-onnx
 
 SELDON_CORE_DIR=../../..
 
 .PHONY: build
 build: 
-	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
+	docker build  -t $(IMAGE_NAME):$(IMAGE_VERSION) .
 
 push_to_dockerhub:
 	docker push $(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION

 * Update to new version of ngraph s2i image
 * Update notebook demo so does not use Torch as the latest ResNet model from torch when converted to ONNX includes the Gather operation which is not supported by Intel ngraph

See #379 