### PR TITLE
Allow JAEGER_AGENT_PORT env on default Jaeger configuration

### DIFF
--- a/docs/distributed-tracing.md
+++ b/docs/distributed-tracing.md
@@ -22,7 +22,7 @@ You will need to annotate your Seldon Deployment resource with environment varia
 
 Add an environment variable: TRACING with value 1 to activate tracing.
 
-You can utilize the default configuration by simply providing the name of the Jaeger agent service by providing  JAEGER_AGENT_HOST environment variable.
+You can utilize the default configuration by simply providing the name of the Jaeger agent service by providing JAEGER_AGENT_HOST environment variable. Override default Jaeger agent port `5775` by setting JAEGER_AGENT_PORT environment variable.
 
 To provide a custom configuration following the Jarger Python configuration yaml defined [here](https://github.com/jaegertracing/jaeger-client-python) you can provide a configmap and the path to the YAML file in JAEGER_CONFIG_PATH environment variable.
 

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -322,6 +322,7 @@ def main():
         from jaeger_client import Config
 
         jaeger_serv = os.environ.get("JAEGER_AGENT_HOST","0.0.0.0")
+        jaeger_port = os.environ.get("JAEGER_AGENT_PORT", 5775)
         jaeger_config = os.environ.get("JAEGER_CONFIG_PATH",None)
         if jaeger_config is None:
             logger.info("Using default tracing config")
@@ -333,7 +334,7 @@ def main():
                     },
                     'local_agent': {
                         'reporting_host': jaeger_serv,
-                        'reporting_port': 5775,
+                        'reporting_port': jaeger_port,
                     },
                     'logging': True,
                 },


### PR DESCRIPTION
For: https://github.com/SeldonIO/seldon-core/issues/396
Allows `JAEGER_AGENT_PORT` to be set on deployment manifest to expose specific Jaeger agent port. 