### PR TITLE
Engine merge meta puid

### DIFF
--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
@@ -351,7 +351,7 @@ public class PredictiveUnitBean extends PredictiveUnitImpl {
 		Meta.Builder metaBuilder = Meta.newBuilder(message.getMeta());
 		for (SeldonMessage originalMessage : messages){
 			metaBuilder.putAllTags(originalMessage.getMeta().getTagsMap());
-			metaBuilder.setPuid(meta.getPuid());
+			metaBuilder.setPuid(originalMessage.getMeta().getPuid());
 		}
 		metaBuilder.clearMetrics();
 		return SeldonMessage.newBuilder(message).setMeta(metaBuilder).build();

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
@@ -351,7 +351,7 @@ public class PredictiveUnitBean extends PredictiveUnitImpl {
 		Meta.Builder metaBuilder = Meta.newBuilder(message.getMeta());
 		for (SeldonMessage originalMessage : messages){
 			metaBuilder.putAllTags(originalMessage.getMeta().getTagsMap());
-      metaBuilder.setPuid(meta.getPuid());
+			metaBuilder.setPuid(meta.getPuid());
 		}
 		metaBuilder.clearMetrics();
 		return SeldonMessage.newBuilder(message).setMeta(metaBuilder).build();
@@ -359,7 +359,7 @@ public class PredictiveUnitBean extends PredictiveUnitImpl {
 	
 	private SeldonMessage mergeMeta(SeldonMessage message, Meta meta) {
 		Meta.Builder metaBuilder = Meta.newBuilder(message.getMeta());
-    metaBuilder.setPuid(meta.getPuid());
+		metaBuilder.setPuid(meta.getPuid());
 		metaBuilder.putAllTags(meta.getTagsMap());
 		metaBuilder.clearMetrics();
 		return SeldonMessage.newBuilder(message).setMeta(metaBuilder).build();

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
@@ -351,6 +351,7 @@ public class PredictiveUnitBean extends PredictiveUnitImpl {
 		Meta.Builder metaBuilder = Meta.newBuilder(message.getMeta());
 		for (SeldonMessage originalMessage : messages){
 			metaBuilder.putAllTags(originalMessage.getMeta().getTagsMap());
+      metaBuilder.setPuid(meta.getPuid());
 		}
 		metaBuilder.clearMetrics();
 		return SeldonMessage.newBuilder(message).setMeta(metaBuilder).build();
@@ -358,6 +359,7 @@ public class PredictiveUnitBean extends PredictiveUnitImpl {
 	
 	private SeldonMessage mergeMeta(SeldonMessage message, Meta meta) {
 		Meta.Builder metaBuilder = Meta.newBuilder(message.getMeta());
+    metaBuilder.setPuid(meta.getPuid());
 		metaBuilder.putAllTags(meta.getTagsMap());
 		metaBuilder.clearMetrics();
 		return SeldonMessage.newBuilder(message).setMeta(metaBuilder).build();


### PR DESCRIPTION
This fixes a bug where the puid is assigned by the engine when the request is first received but is dropped as it goes through the components and only added back at the very end. Some  stateful components need access to the puid. 