### PR TITLE
ignore pickle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ examples/models/sk_mnist/MNIST_data/
 examples/models/sk_mnist/sk.pkl
 examples/models/sklearn_iris_fbs/IrisClassifier.sav
 
+# Pickle files
+*.pickle
+
 # api tester created proto folder
 util/api_tester/proto/
 


### PR DESCRIPTION
Noticed these are generated when running some notebooks. Some other projects are ignoring e.g.

https://github.com/enigmampc/catalyst/blob/master/.gitignore#L75

In our case sometimes we have files committed:

https://github.com/SeldonIO/seldon-core/tree/ignore-pickle-files/components/outlier-detection/seq2seq-lstm/models

But for the [isolation forest notebook](https://github.com/SeldonIO/seldon-core/tree/ignore-pickle-files/components/outlier-detection/isolation-forest). I end up with a models/if.pickle file being generated locally. 

I suspect we want to remove the existing pickle files and add to gitignore but not totally sure - raising this get feedback.