### PR TITLE
484 metrics port

### DIFF
--- a/api-frontend/src/main/resources/application.properties
+++ b/api-frontend/src/main/resources/application.properties
@@ -3,8 +3,8 @@ seldon.kafka.enable=false
 logging.level.org.springframework.web=INFO
 log4j.logger.org.springframework.security=DEBUG 
 
-io.seldon.apife.engine-container-port=8000
-io.seldon.apife.engine-grpc-container-port=5001
+io.seldon.apife.engine-container-port=${ENGINE_SERVER_PORT:8000}
+io.seldon.apife.engine-grpc-container-port=${ENGINE_SERVER_GRPC_PORT:5001}
 io.seldon.apife.namespace=${SELDON_CLUSTER_MANAGER_POD_NAMESPACE}
 io.seldon.apife.single-namespace=${SELDON_SINGLE_NAMESPACE}
 

--- a/cluster-manager/src/main/java/io/seldon/clustermanager/ClusterManagerProperites.java
+++ b/cluster-manager/src/main/java/io/seldon/clustermanager/ClusterManagerProperites.java
@@ -29,6 +29,7 @@ public class ClusterManagerProperites {
     private String namespace;
     private boolean singleNamespace = true;
     private int engineUser = 8889;
+    private String enginePrometheusPath = "prometheus";
 
     public int getEngineContainerPort() {
         return engineContainerPort;
@@ -102,7 +103,15 @@ public class ClusterManagerProperites {
 		this.engineUser = engineUser;
 	}
 
-	@Override
+    public String getEnginePrometheusPath() {
+        return enginePrometheusPath;
+    }
+
+    public void setEnginePrometheusPath(String enginePrometheusPath) {
+        this.enginePrometheusPath = enginePrometheusPath;
+    }
+
+    @Override
     public String toString() {
         return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }

--- a/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/SeldonDeploymentOperatorImpl.java
+++ b/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/SeldonDeploymentOperatorImpl.java
@@ -664,7 +664,7 @@ public class SeldonDeploymentOperatorImpl implements SeldonDeploymentOperator {
 			podSpecBuilder.getMetadataBuilder()
 				.putAllAnnotations(mlDep.getSpec().getAnnotationsMap()) // Add all spec annotations first
 				.putAllAnnotations(p.getAnnotationsMap()) // ...then add those for predictor overwriting any from spec above
-		    	.putAnnotations("prometheus.io/path", "/prometheus")
+		    	.putAnnotations("prometheus.io/path", "/"+clusterManagerProperites.getEnginePrometheusPath())
 		    	.putAnnotations("prometheus.io/port",""+clusterManagerProperites.getEngineContainerPort())
 		    	.putAnnotations("prometheus.io/scrape", "true");
 
@@ -779,7 +779,7 @@ public class SeldonDeploymentOperatorImpl implements SeldonDeploymentOperator {
 			    	.addContainers(createEngineContainer(mlDep,p))
 			    	.setServiceAccountName(clusterManagerProperites.getEngineContainerServiceAccountName());
 					podSpecBuilder.getMetadataBuilder()
-				    	.putAnnotations("prometheus.io/path", "/prometheus")
+				    	.putAnnotations("prometheus.io/path", "/"+clusterManagerProperites.getEnginePrometheusPath())
 				    	.putAnnotations("prometheus.io/port",""+clusterManagerProperites.getEngineContainerPort())
 				    	.putAnnotations("prometheus.io/scrape", "true");
 					// LABELS - START

--- a/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/SeldonDeploymentOperatorImpl.java
+++ b/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/SeldonDeploymentOperatorImpl.java
@@ -124,6 +124,7 @@ public class SeldonDeploymentOperatorImpl implements SeldonDeploymentOperator {
 			.addEnv(EnvVar.newBuilder().setName("ENGINE_SERVER_GRPC_PORT").setValue(""+clusterManagerProperites.getEngineGrpcContainerPort()))		
 			.addEnv(EnvVar.newBuilder().setName("JAVA_OPTS").setValue(predictorDef.getAnnotationsOrDefault(Constants.ENGINE_JAVA_OPTS_ANNOTATION, DEFAULT_ENGINE_JAVA_OPTS)))
 			.addPorts(V1.ContainerPort.newBuilder().setContainerPort(clusterManagerProperites.getEngineContainerPort()))
+			.addPorts(V1.ContainerPort.newBuilder().setContainerPort(clusterManagerProperites.getEngineGrpcContainerPort()).setName("grpc"))
 			.addPorts(V1.ContainerPort.newBuilder().setContainerPort(8082).setName("admin"))
 			.addPorts(V1.ContainerPort.newBuilder().setContainerPort(9090).setName("jmx"))
 			.setSecurityContext(SecurityContext.newBuilder().setRunAsUser(clusterManagerProperites.getEngineUser()).build())

--- a/cluster-manager/src/main/resources/application.properties
+++ b/cluster-manager/src/main/resources/application.properties
@@ -12,6 +12,7 @@ io.seldon.clustermanager.engine-user=${ENGINE_CONTAINER_USER:8888}
 io.seldon.clustermanager.pu-container-port-base=${PREDICTIVE_UNIT_SERVICE_PORT:9000}
 io.seldon.clustermanager.namespace=${SELDON_CLUSTER_MANAGER_POD_NAMESPACE}
 io.seldon.clustermanager.single-namespace=${SELDON_CLUSTER_MANAGER_SINGLE_NAMESPACE}
+io.seldon.clustermanager.engine-prometheus-path=${ENGINE_PROMETHEUS_PATH:prometheus}
 
 #logging.file=myapp.log
 logging.file=

--- a/cluster-manager/src/main/resources/application.properties
+++ b/cluster-manager/src/main/resources/application.properties
@@ -3,13 +3,13 @@ build.version=@project.version@
 server.port = 8080
 
 # ClusterManagerProperites
-io.seldon.clustermanager.engine-container-port=8000
-io.seldon.clustermanager.engine-grpc-container-port=5001
+io.seldon.clustermanager.engine-container-port=${ENGINE_SERVER_PORT:8000}
+io.seldon.clustermanager.engine-grpc-container-port=${ENGINE_SERVER_GRPC_PORT:5001}
 io.seldon.clustermanager.engine-container-image-and-version=${ENGINE_CONTAINER_IMAGE_AND_VERSION}
 io.seldon.clustermanager.engine-container-image-pull-policy=${ENGINE_CONTAINER_IMAGE_PULL_POLICY}
 io.seldon.clustermanager.engine-container-service-account-name=${ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME}
 io.seldon.clustermanager.engine-user=${ENGINE_CONTAINER_USER:8888}
-io.seldon.clustermanager.pu-container-port-base=9000
+io.seldon.clustermanager.pu-container-port-base=${PREDICTIVE_UNIT_SERVICE_PORT:9000}
 io.seldon.clustermanager.namespace=${SELDON_CLUSTER_MANAGER_POD_NAMESPACE}
 io.seldon.clustermanager.single-namespace=${SELDON_CLUSTER_MANAGER_SINGLE_NAMESPACE}
 

--- a/cluster-manager/src/test/java/io/seldon/clustermanager/AppTest.java
+++ b/cluster-manager/src/test/java/io/seldon/clustermanager/AppTest.java
@@ -32,9 +32,10 @@ public class AppTest
 	protected ClusterManagerProperites getClusterManagerprops()
 	{
 		ClusterManagerProperites c = new ClusterManagerProperites();
-		c.setEngineContainerPort(9000);
+		c.setEngineContainerPort(8000);
+		c.setEngineGrpcContainerPort(5001);
 		c.setEngineContainerImageAndVersion("seldonio/engine:0.1.6");
-		c.setPuContainerPortBase(8000);
+		c.setPuContainerPortBase(9000);
 		return c;
 	}	
 }

--- a/cluster-manager/src/test/java/io/seldon/clustermanager/k8s/End2EndBase.java
+++ b/cluster-manager/src/test/java/io/seldon/clustermanager/k8s/End2EndBase.java
@@ -121,6 +121,9 @@ public class End2EndBase extends AppTest {
 		props.setEngineContainerImageAndVersion("engine:0.1");
 		props.setEngineContainerImagePullPolicy("IfNotPresent");
 		props.setEngineContainerServiceAccountName("default");
+		props.setEngineContainerPort(8000);
+		props.setPuContainerPortBase(9000);
+		props.setEngineGrpcContainerPort(5001);
 		crdHandler = new KubeCRDHandlerImpl(mockK8sApiProvider,mockK8sClientProvider,props);
 		mlCache = new SeldonDeploymentCacheImpl(props, crdHandler);
 		operator = new SeldonDeploymentOperatorImpl(props);

--- a/cluster-manager/src/test/java/io/seldon/clustermanager/k8s/End2EndSeparateEngineTest.java
+++ b/cluster-manager/src/test/java/io/seldon/clustermanager/k8s/End2EndSeparateEngineTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.verify;
 
+import io.kubernetes.client.proto.V1;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -14,6 +15,8 @@ import com.google.protobuf.Message;
 import io.kubernetes.client.ProgressRequestBody.ProgressRequestListener;
 import io.kubernetes.client.ProgressResponseBody.ProgressListener;
 import io.kubernetes.client.proto.V1beta1Extensions.Deployment;
+
+import java.util.List;
 
 public class End2EndSeparateEngineTest extends End2EndBase {
 
@@ -86,10 +89,35 @@ public class End2EndSeparateEngineTest extends End2EndBase {
 		Assert.assertEquals("test-deployment-abtest-abtest-svc-orch", d.getMetadata().getName());
 		Assert.assertEquals(1, d.getSpec().getReplicas());
 		Assert.assertEquals(1, d.getSpec().getTemplate().getSpec().getContainersCount());
+
+
+		List<V1.Container> containerList = d.getSpec().getTemplate().getSpec().getContainersList();
+		for(V1.Container container:containerList){
+			if(container.getName().contains("engine")){
+				for(V1.EnvVar envVar:container.getEnvList()){
+					if(envVar.getName().equals("ENGINE_SERVER_PORT")){
+						Assert.assertEquals(getClusterManagerprops().getEngineContainerPort()+"",envVar.getValue());
+					}
+					if(envVar.getName().equals("ENGINE_SERVER_GRPC_PORT")){
+						Assert.assertEquals(getClusterManagerprops().getEngineGrpcContainerPort()+"",envVar.getValue());
+					}
+				}
+				for(V1.ContainerPort port:container.getPortsList()){
+					if(port.getName().contains("containerPort")) {
+						Assert.assertTrue(port.getContainerPort() == getClusterManagerprops().getEngineContainerPort());
+					}
+					if(port.getName().contains("grpc")) {
+						Assert.assertTrue(port.getContainerPort() == getClusterManagerprops().getEngineGrpcContainerPort());
+					}
+				}
+			}
+		}
+
 		d = argument.getAllValues().get(1);
 		Assert.assertTrue(d.getMetadata().getName().startsWith("test-deployment-abtest"));
 		Assert.assertEquals(1, d.getSpec().getReplicas());
 		Assert.assertEquals(1, d.getSpec().getTemplate().getSpec().getContainersCount());
+
 		System.out.println(d.getMetadata().getName());
 	}
 	

--- a/cluster-manager/src/test/resources/application.properties
+++ b/cluster-manager/src/test/resources/application.properties
@@ -1,7 +1,7 @@
 # Test ClusterManagerProperites
-io.seldon.clustermanager.engine-container-port=9999
+io.seldon.clustermanager.engine-container-port=8000
 io.seldon.clustermanager.engine-container-image-and-version=gsunner/putest:0.1
-io.seldon.clustermanager.pu-container-port-base=9009
+io.seldon.clustermanager.pu-container-port-base=9000
 io.seldon.clustermanager.istio-enabled=false
 
 #logging.file=myapp.log

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -6,6 +6,7 @@ management.metrics.web.server.requests-metric-name=seldon.api.engine.server.requ
 management.metrics.web.client.requests-metric-name=seldon.api.engine.client.requests
 management.metrics.distribution.percentiles.all=0.5, 0.75, 0.95, 0.98, 0.99
 management.metrics.distribution.percentiles-histogram.all=true
+endpoints.prometheus.id=${ENGINE_PROMETHEUS_PATH:prometheus}
 endpoints.prometheus.sensitive=false
 
 spring.jmx.enabled = false

--- a/helm-charts/seldon-core/templates/apife-deployment.yaml
+++ b/helm-charts/seldon-core/templates/apife-deployment.yaml
@@ -34,6 +34,10 @@ spec:
           value: kafka:9092
         - name: SELDON_CLUSTER_MANAGER_REDIS_HOST
           value: {{ .Release.Name }}-redis
+        - name: ENGINE_SERVER_GRPC_PORT
+          value: {{ .Values.engine.grpc.port }}
+        - name: ENGINE_SERVER_PORT
+          value: {{ .Values.engine.port }}
         - name: SELDON_SINGLE_NAMESPACE
           value: '{{ .Values.single_namespace }}'
         - name: SELDON_CLUSTER_MANAGER_POD_NAMESPACE

--- a/helm-charts/seldon-core/templates/apife-deployment.yaml
+++ b/helm-charts/seldon-core/templates/apife-deployment.yaml
@@ -35,9 +35,9 @@ spec:
         - name: SELDON_CLUSTER_MANAGER_REDIS_HOST
           value: {{ .Release.Name }}-redis
         - name: ENGINE_SERVER_GRPC_PORT
-          value: {{ .Values.engine.grpc.port }}
+          value: '{{ .Values.engine.grpc.port }}'
         - name: ENGINE_SERVER_PORT
-          value: {{ .Values.engine.port }}
+          value: '{{ .Values.engine.port }}'
         - name: SELDON_SINGLE_NAMESPACE
           value: '{{ .Values.single_namespace }}'
         - name: SELDON_CLUSTER_MANAGER_POD_NAMESPACE

--- a/helm-charts/seldon-core/templates/cluster-manager-deployment.yaml
+++ b/helm-charts/seldon-core/templates/cluster-manager-deployment.yaml
@@ -41,6 +41,12 @@ spec:
           value: '{{ .Values.single_namespace }}'
         - name: ENGINE_CONTAINER_USER
           value: '{{ .Values.engine.user }}'
+        - name: PREDICTIVE_UNIT_SERVICE_PORT
+          value: {{ .Values.predictive_unit.port }}
+        - name: ENGINE_SERVER_GRPC_PORT
+          value: {{ .Values.engine.grpc.port }}
+        - name: ENGINE_SERVER_PORT
+          value: {{ .Values.engine.port }}
         - name: SELDON_CLUSTER_MANAGER_POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/helm-charts/seldon-core/templates/cluster-manager-deployment.yaml
+++ b/helm-charts/seldon-core/templates/cluster-manager-deployment.yaml
@@ -42,11 +42,11 @@ spec:
         - name: ENGINE_CONTAINER_USER
           value: '{{ .Values.engine.user }}'
         - name: PREDICTIVE_UNIT_SERVICE_PORT
-          value: {{ .Values.predictive_unit.port }}
+          value: '{{ .Values.predictive_unit.port }}'
         - name: ENGINE_SERVER_GRPC_PORT
-          value: {{ .Values.engine.grpc.port }}
+          value: '{{ .Values.engine.grpc.port }}'
         - name: ENGINE_SERVER_PORT
-          value: {{ .Values.engine.port }}
+          value: '{{ .Values.engine.port }}'
         - name: SELDON_CLUSTER_MANAGER_POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/helm-charts/seldon-core/templates/cluster-manager-deployment.yaml
+++ b/helm-charts/seldon-core/templates/cluster-manager-deployment.yaml
@@ -47,6 +47,8 @@ spec:
           value: '{{ .Values.engine.grpc.port }}'
         - name: ENGINE_SERVER_PORT
           value: '{{ .Values.engine.port }}'
+        - name: ENGINE_PROMETHEUS_PATH
+          value: {{ .Values.engine.prometheus.path }}
         - name: SELDON_CLUSTER_MANAGER_POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/helm-charts/seldon-core/values.yaml
+++ b/helm-charts/seldon-core/values.yaml
@@ -38,6 +38,11 @@ engine:
   service_account:
     name: default
   user: 8888
+  port: 8000
+  grpc:
+    port: 5001
+predictive_unit:
+  port: 9000
 rbac:
   enabled: true
   rolebinding:

--- a/helm-charts/seldon-core/values.yaml
+++ b/helm-charts/seldon-core/values.yaml
@@ -41,6 +41,8 @@ engine:
   port: 8000
   grpc:
     port: 5001
+  prometheus:
+    path: "prometheus"
 predictive_unit:
   port: 9000
 rbac:


### PR DESCRIPTION
fixes https://github.com/SeldonIO/seldon-core/issues/484

Checked this by adding parameters to helm install for seldon-core - `--set engine.port=14040 --set engine.grpc.port=14041 --set engine.prometheus.path="micrometheus"`. Then installed a model and was able to validate that the pod spec contained:

```
kind: Pod
metadata:
  annotations:
    prometheus.io/path: /micrometheus
    prometheus.io/port: "14040"
    prometheus.io/scrape: "true"
...
    - name: ENGINE_SERVER_PORT
      value: "14040"
    - name: ENGINE_SERVER_GRPC_PORT
      value: "14041"
...
   ports:
    - containerPort: 14040
      protocol: TCP
    - containerPort: 14041
      name: grpc
      protocol: TCP

```
Also ran the E2E tests
