### PR TITLE
downgrade ambassador version due to grpc reliability

### DIFF
--- a/helm-charts/seldon-core/values.yaml
+++ b/helm-charts/seldon-core/values.yaml
@@ -1,5 +1,7 @@
 ambassador:
   enabled: false
+  image:
+    tag: 0.40.2
   replicaCount: 1
   resources:
     limits:


### PR DESCRIPTION
We upgraded ambassador in https://github.com/SeldonIO/seldon-core/pull/480

But it has caused problems with grpc calls on ambassador startup, recorded in https://github.com/SeldonIO/seldon-core/pull/492

There was perhaps an intermittent problem already but it is much more serious in the new ambassador version (0.52.0) than it was in 0.40.2. To get the new version working we'd have to put long retry timeouts in our tests