### PR TITLE
Add missing additionProperties to openAPI specs for CRDS

### DIFF
--- a/helm-charts/seldon-core-crd/templates/_hpa-spec-validation.tpl
+++ b/helm-charts/seldon-core-crd/templates/_hpa-spec-validation.tpl
@@ -44,7 +44,9 @@
                             "type": "array"
                         },
                         "matchLabels": {
-                            "additionalProperties": true,
+                            "additionalProperties": {
+                                "type": "string"
+                            },
                             "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object"
                         }
@@ -111,7 +113,9 @@
                             "type": "array"
                         },
                         "matchLabels": {
-                            "additionalProperties": true,
+                            "additionalProperties": {
+                                "type": "string"
+                            },
                             "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object"
                         }
@@ -194,7 +198,9 @@
                             "type": "array"
                         },
                         "matchLabels": {
-                            "additionalProperties": true,
+                            "additionalProperties": {
+                                "type": "string"
+                            },
                             "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object"
                         }

--- a/helm-charts/seldon-core-crd/templates/_object-meta-validation.tpl
+++ b/helm-charts/seldon-core-crd/templates/_object-meta-validation.tpl
@@ -3,7 +3,9 @@
     "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
     "properties": {
         "annotations": {
-            "additionalProperties": true,
+            "additionalProperties": {
+                "type": "string"
+            },
             "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
             "type": "object"
         },
@@ -177,7 +179,9 @@
             "type": "object"
         },
         "labels": {
-            "additionalProperties": true,
+            "additionalProperties": {
+                "type": "string"
+            },
             "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
             "type": "object"
         },

--- a/helm-charts/seldon-core-crd/templates/_pod-spec-validation.tpl
+++ b/helm-charts/seldon-core-crd/templates/_pod-spec-validation.tpl
@@ -222,7 +222,9 @@
                                                         "type": "array"
                                                     },
                                                     "matchLabels": {
-                                                        "additionalProperties": true,
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
                                                         "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                         "type": "object"
                                                     }
@@ -300,7 +302,9 @@
                                                 "type": "array"
                                             },
                                             "matchLabels": {
-                                                "additionalProperties": true,
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                },
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                 "type": "object"
                                             }
@@ -375,7 +379,9 @@
                                                         "type": "array"
                                                     },
                                                     "matchLabels": {
-                                                        "additionalProperties": true,
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
                                                         "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                         "type": "object"
                                                     }
@@ -453,7 +459,9 @@
                                                 "type": "array"
                                             },
                                             "matchLabels": {
-                                                "additionalProperties": true,
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                },
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                 "type": "object"
                                             }
@@ -2218,7 +2226,9 @@
             "type": "string"
         },
         "nodeSelector": {
-            "additionalProperties": true,
+            "additionalProperties": {
+                "type": "string"
+            },
             "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
             "type": "object"
         },
@@ -2621,7 +2631,9 @@
                                 "type": "boolean"
                             },
                             "volumeAttributes": {
-                                "additionalProperties": true,
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
                                 "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                                 "type": "object"
                             }
@@ -2761,7 +2773,9 @@
                                 "type": "string"
                             },
                             "options": {
-                                "additionalProperties": true,
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
                                 "description": "Optional: Extra command options if any.",
                                 "type": "object"
                             },

--- a/seldon-core/seldon-core/json/hpa-validation.json
+++ b/seldon-core/seldon-core/json/hpa-validation.json
@@ -43,7 +43,9 @@
                             "type": "array"
                         },
                         "matchLabels": {
-                            "additionalProperties": true,
+                            "additionalProperties": {
+                                "type": "string"
+                            },
                             "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object"
                         }
@@ -110,7 +112,9 @@
                             "type": "array"
                         },
                         "matchLabels": {
-                            "additionalProperties": true,
+                            "additionalProperties": {
+                                "type": "string"
+                            },
                             "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object"
                         }
@@ -193,7 +197,9 @@
                             "type": "array"
                         },
                         "matchLabels": {
-                            "additionalProperties": true,
+                            "additionalProperties": {
+                                "type": "string"
+                            },
                             "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object"
                         }

--- a/seldon-core/seldon-core/json/object-meta-validation.json
+++ b/seldon-core/seldon-core/json/object-meta-validation.json
@@ -2,7 +2,9 @@
     "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
     "properties": {
         "annotations": {
-            "additionalProperties": true,
+            "additionalProperties": {
+                "type": "string"
+            },
             "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
             "type": "object"
         },
@@ -176,7 +178,9 @@
             "type": "object"
         },
         "labels": {
-            "additionalProperties": true,
+            "additionalProperties": {
+                "type": "string"
+            },
             "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
             "type": "object"
         },

--- a/seldon-core/seldon-core/json/pod-spec-validation.json
+++ b/seldon-core/seldon-core/json/pod-spec-validation.json
@@ -221,7 +221,9 @@
                                                         "type": "array"
                                                     },
                                                     "matchLabels": {
-                                                        "additionalProperties": true,
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
                                                         "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                         "type": "object"
                                                     }
@@ -299,7 +301,9 @@
                                                 "type": "array"
                                             },
                                             "matchLabels": {
-                                                "additionalProperties": true,
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                },
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                 "type": "object"
                                             }
@@ -374,7 +378,9 @@
                                                         "type": "array"
                                                     },
                                                     "matchLabels": {
-                                                        "additionalProperties": true,
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
                                                         "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                         "type": "object"
                                                     }
@@ -452,7 +458,9 @@
                                                 "type": "array"
                                             },
                                             "matchLabels": {
-                                                "additionalProperties": true,
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                },
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                                 "type": "object"
                                             }
@@ -2217,7 +2225,9 @@
             "type": "string"
         },
         "nodeSelector": {
-            "additionalProperties": true,
+            "additionalProperties": {
+                "type": "string"
+            },
             "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
             "type": "object"
         },
@@ -2620,7 +2630,9 @@
                                 "type": "boolean"
                             },
                             "volumeAttributes": {
-                                "additionalProperties": true,
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
                                 "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                                 "type": "object"
                             }
@@ -2760,7 +2772,9 @@
                                 "type": "string"
                             },
                             "options": {
-                                "additionalProperties": true,
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
                                 "description": "Optional: Extra command options if any.",
                                 "type": "object"
                             },

--- a/util/custom-resource-definitions/expand-validation.py
+++ b/util/custom-resource-definitions/expand-validation.py
@@ -22,7 +22,9 @@ def expand(defn,root):
 def simplifyAdditionalProperties(defn):
     if isinstance(defn, dict):
         if "additionalProperties" in defn.keys():
-            defn["additionalProperties"] = True
+            if isinstance(defn["additionalProperties"], dict):
+                if "$ref" in defn["additionalProperties"].keys():
+                    defn["additionalProperties"] = True
         for k in defn.keys():
             simplifyAdditionalProperties(defn[k])
 


### PR DESCRIPTION

The scripts to create the OpenAPI validation specs for the CRDs was incorrectly removing "additionalProperties" fields for maps making the spec invalid.