### PR TITLE
Allow class_names as method or attribute (deprecated) in Python module

### DIFF
--- a/python/seldon_core/user_model.py
+++ b/python/seldon_core/user_model.py
@@ -4,7 +4,10 @@ import json
 from typing import Dict, List, Union, Iterable, Callable, Optional
 import numpy as np
 from seldon_core.proto import prediction_pb2
+import inspect
+import logging
 
+logger = logging.getLogger(__name__)
 
 class SeldonComponent(object):
 
@@ -101,7 +104,11 @@ def client_class_names(user_model: SeldonComponent, predictions: np.ndarray) -> 
     """
     if len(predictions.shape) > 1:
         try:
-            return user_model.class_names()
+            if inspect.ismethod(getattr(user_model, 'class_names')):
+                return user_model.class_names()
+            else:
+                logger.info("class_names attribute is deprecated. Please define a class_names method")
+                return user_model.class_names
         except (NotImplementedError, AttributeError):
             n_targets = predictions.shape[1]
             return ["t:{}".format(i) for i in range(n_targets)]

--- a/python/tests/test_user_model.py
+++ b/python/tests/test_user_model.py
@@ -1,0 +1,28 @@
+import numpy as np
+from seldon_core.user_model import SeldonComponent, client_class_names
+import logging
+
+class UserObjectClassAttr(SeldonComponent):
+    def __init__(self, metrics_ok=True, ret_nparray=False, ret_meta=False):
+        self.class_names = ["a","b"]
+
+
+class UserObjectClassMethod(SeldonComponent):
+    def class_names(self):
+        return ["x","y"]
+
+def test_class_names_attr(caplog):
+    caplog.set_level(logging.INFO)
+    user_object = UserObjectClassAttr()
+    predictions = np.array([[1,2],[3,4]])
+    names = client_class_names(user_object,predictions)
+    assert names == ["a","b"]
+    assert "class_names attribute is deprecated. Please define a class_names method" in caplog.text
+
+def test_class_names_method(caplog):
+    caplog.set_level(logging.INFO)
+    user_object = UserObjectClassMethod()
+    predictions = np.array([[1, 2], [3, 4]])
+    names = client_class_names(user_object, predictions)
+    assert names == ["x", "y"]
+    assert not "class_names attribute is deprecated. Please define a class_names method" in caplog.text


### PR DESCRIPTION
Fixes #462 