### PR TITLE
upgrade argocd and add detail for minikube

### DIFF
--- a/examples/cicd-argocd/argocd/argocd-app-create
+++ b/examples/cicd-argocd/argocd/argocd-app-create
@@ -17,6 +17,4 @@ argocd app create cicd-demo-argocd \
     --path demo-manifests \
     --dest-namespace default \
     --dest-server https://kubernetes.default.svc \
-    --sync-policy "${SYNC_POLICY}" \
-    --auto-prune
-
+    --sync-policy "${SYNC_POLICY}"

--- a/examples/cicd-argocd/argocd/get-argocd-browser-login
+++ b/examples/cicd-argocd/argocd/get-argocd-browser-login
@@ -11,7 +11,7 @@ source ${STARTUP_DIR}/../settings.sh
 KUBECTL="kubectl --context=${KUBE_CONTEXT}"
 
 EXTERNAL_IP=$(${KUBECTL} get svc -n argocd argocd-server -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-ADMIN_PASSWORD=$(${KUBECTL} get pods -n argocd -l app=argocd-server -o name | cut -d'/' -f 2)
+ADMIN_PASSWORD=$(${KUBECTL} get pods -n argocd -l app.kubernetes.io/name=argocd-server -o name | cut -d'/' -f 2)
 
 echo ""
 echo "url: https://${EXTERNAL_IP}/"

--- a/examples/cicd-argocd/argocd/get-argocd-cmd-line-login
+++ b/examples/cicd-argocd/argocd/get-argocd-cmd-line-login
@@ -11,7 +11,7 @@ source ${STARTUP_DIR}/../settings.sh
 KUBECTL="kubectl --context=${KUBE_CONTEXT}"
 
 EXTERNAL_IP=$(${KUBECTL} get svc -n argocd argocd-server -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-ADMIN_PASSWORD=$(${KUBECTL} get pods -n argocd -l app=argocd-server -o name | cut -d'/' -f 2)
+ADMIN_PASSWORD=$(${KUBECTL} get pods -n argocd -l app.kubernetes.io/name=argocd-server -o name | cut -d'/' -f 2)
 
 echo ""
 echo "argocd login ${EXTERNAL_IP} --name ${KUBE_CONTEXT} --username admin --password ${ADMIN_PASSWORD}"

--- a/examples/cicd-argocd/argocd/port-forward-argocd
+++ b/examples/cicd-argocd/argocd/port-forward-argocd
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+STARTUP_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+source ${STARTUP_DIR}/../settings.sh
+
+KUBECTL="kubectl --context=${KUBE_CONTEXT}"
+
+${KUBECTL} -n jenkins port-forward deployment.apps/jenkins 9091:8080
+

--- a/examples/cicd-argocd/argocd/show-argocd-logs
+++ b/examples/cicd-argocd/argocd/show-argocd-logs
@@ -11,5 +11,5 @@ source ${STARTUP_DIR}/../settings.sh
 KUBECTL="kubectl --context=${KUBE_CONTEXT}"
 
 NAMESPACE_NAME=argocd
-${KUBECTL} logs -f $(kubectl --context="${KUBE_CONTEXT}" get pods -n ${NAMESPACE_NAME} -l app=argocd-server -o jsonpath='{.items[0].metadata.name}') -n ${NAMESPACE_NAME}
+${KUBECTL} logs -f $(kubectl --context="${KUBE_CONTEXT}" get pods -n ${NAMESPACE_NAME} -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}') -n ${NAMESPACE_NAME}
 

--- a/examples/cicd-argocd/jenkins/start-jenkins
+++ b/examples/cicd-argocd/jenkins/start-jenkins
@@ -20,7 +20,9 @@ helm install --kube-context="${KUBE_CONTEXT}" stable/jenkins \
     --name jenkins \
     --namespace jenkins \
     --set rbac.install=true \
-    --version $JENKINS_CHART_VERSION
+    --version $JENKINS_CHART_VERSION \
+    --set Master.AdminUser=$JENKINS_USER_NAME \
+    --set Master.AdminPassword=$JENKINS_USER_PASSWORD
 
 # create a rolebing for jenkins
 ${KUBECTL} create rolebinding jenkins-admin --clusterrole=admin --serviceaccount=jenkins:default --namespace=default --dry-run -o yaml | \

--- a/examples/cicd-argocd/settings.sh.example
+++ b/examples/cicd-argocd/settings.sh.example
@@ -7,7 +7,7 @@ K8S_MANIFEST_FILES_DIR=/pathto/cicd-demo-k8s-manifest-files
 GITHUB_USER=<github user id>
 GITHUB_TOKEN=<github personal token>
 
-ARGOCD_VERSION=v0.10.6
+ARGOCD_VERSION=v0.12.0
 
 JENKINS_USER_NAME=admin
 JENKINS_USER_PASSWORD=admin

--- a/examples/cicd-argocd/settings.sh.example
+++ b/examples/cicd-argocd/settings.sh.example
@@ -9,6 +9,6 @@ GITHUB_TOKEN=<github personal token>
 
 ARGOCD_VERSION=v0.10.6
 
-JENKINS_USER_NAME=<jenkins user id>
-JENKINS_USER_PASSWORD=<jenkins password>
+JENKINS_USER_NAME=admin
+JENKINS_USER_PASSWORD=admin
 


### PR DESCRIPTION
Went through this on minikube. I took latest ArgoCD version so have included changes to upgrade to latest ArgoCD. That includes changes to their labels (https://github.com/argoproj/argo-cd/pull/1168) and I also had to change the setting autoprune as that isn't allowed without autosycn in the new version. Otherwise the changes are extra notes.