### PR TITLE
Remove v1alpha3 and revert to v1alpha2

### DIFF
--- a/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/SeldonDeploymentWatcher.java
+++ b/cluster-manager/src/main/java/io/seldon/clustermanager/k8s/SeldonDeploymentWatcher.java
@@ -62,7 +62,7 @@ import io.seldon.protos.DeploymentProtos.SeldonDeployment;
 public class SeldonDeploymentWatcher  {
 	protected static Logger logger = LoggerFactory.getLogger(SeldonDeploymentWatcher.class.getName());
 	
-	public static final String[] VERSIONS = {"v1alpha2","v1alpha3"};
+	public static final String[] VERSIONS = {"v1alpha2"};
 	
 	private final SeldonDeploymentController seldonDeploymentController;
 	private final SeldonDeploymentCache mlCache;
@@ -274,12 +274,14 @@ public class SeldonDeploymentWatcher  {
         runWatch(version);
     }
 
+	/*
 	@Scheduled(fixedDelay = 5000)
     public void watchv1alpha3() throws JsonProcessingException, ApiException, IOException {
         logger.debug("The time is now {}", dateFormat.format(new Date()));
         final String version = VERSIONS[1];
         runWatch(version);
     }
+    */
 
 	
 

--- a/cluster-manager/src/main/resources/crd.json
+++ b/cluster-manager/src/main/resources/crd.json
@@ -4406,19 +4406,7 @@
                 }
             }
         },
-        "version": "v1alpha3",
-	"versions": [
-	    {
-		"name": "v1alpha3",
-		"served": true,
-		"storage": true
-	    },
-	    {
-		"name": "v1alpha2",
-		"served": true,
-		"storage": false
-	    }
-	],
+        "version": "v1alpha2",
 	"subresources": {
 	    "status": {}
 	}

--- a/cluster-manager/src/test/java/io/seldon/clustermanager/k8s/SeldonDeploymentStatusUpdateTest.java
+++ b/cluster-manager/src/test/java/io/seldon/clustermanager/k8s/SeldonDeploymentStatusUpdateTest.java
@@ -72,7 +72,7 @@ public class SeldonDeploymentStatusUpdateTest extends AppTest {
 		SeldonDeploymentStatusUpdate supdate = new SeldonDeploymentStatusUpdateImpl(mockCrdHandler, mockSeldonDeploymentController, props);
 		
 		final String selDepName = "SeldonDep1";
-		final String version = "v1alpha1";
+		final String version = "v1alpha2";
 		final String namespace = "seldon";
 		
 		supdate.updateStatus(selDepName, version, "test-deployment-fx-market-predictor-8e1d76f", 1, 1, namespace);

--- a/cluster-manager/src/test/resources/model_failed.json
+++ b/cluster-manager/src/test/resources/model_failed.json
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "machinelearning.seldon.io/v1alpha3",
+    "apiVersion": "machinelearning.seldon.io/v1alpha2",
     "kind": "SeldonDeployment",
     "metadata": {
         "creationTimestamp": "2019-04-04T14:33:08Z",

--- a/helm-charts/seldon-core-crd/templates/seldon-deployment-crd.json
+++ b/helm-charts/seldon-core-crd/templates/seldon-deployment-crd.json
@@ -398,19 +398,7 @@
                 }
             }
         },
-        "version": "v1alpha3",
-	"versions": [
-	    {
-		"name": "v1alpha3",
-		"served": true,
-		"storage": true
-	    },
-	    {
-		"name": "v1alpha2",
-		"served": true,
-		"storage": false
-	    }
-	],
+        "version": "v1alpha2",
 	"subresources": {
 	    "status": {}
 	}

--- a/seldon-core/seldon-core/crd.libsonnet
+++ b/seldon-core/seldon-core/crd.libsonnet
@@ -666,19 +666,7 @@ local k = import "k.libsonnet";
             },
           },
         },
-        version: "v1alpha3",
-        versions: [
-          {
-            name: "v1alpha3",
-            served: true,
-            storage: true,
-          },
-          {
-            name: "v1alpha2",
-            served: true,
-            storage: false,
-          },
-        ],
+        version: "v1alpha2",
         subresources: {
           status: {},
         },


### PR DESCRIPTION
 As CRD multi-version support is still very early for K8S this change reverts the v1alpha3 tag back to v1alpha2. The changes for Autoscaling are backwards compatible at the CRD resource level.
