### PR TITLE
Revert "option to use anonymous auth grafana"

### DIFF
--- a/helm-charts/seldon-core-analytics/templates/grafana-prom-deployment.json
+++ b/helm-charts/seldon-core-analytics/templates/grafana-prom-deployment.json
@@ -20,24 +20,6 @@
                         "containers": [
                             {
                                 "env": [
-                                    {{ if .Values.grafana_anonymous_auth }}
-                                    {
-                                        "name": "GF_AUTH_ANONYMOUS_ENABLED",
-                                        "value": "true"
-                                    },
-                                    {
-                                        "name": "GF_AUTH_BASIC_ENABLED",
-                                        "value": "false"
-                                    },
-                                    {
-                                        "name": "GF_AUTH_PROXY_ENABLED",
-                                        "value": "false"
-                                    },
-                                    {
-                                        "name": "GF_USERS_ALLOW_SIGN_UP",
-                                        "value": "false"
-                                    },
-                                    {{ else }}
                                     {
                                         "name": "GF_SECURITY_ADMIN_PASSWORD",
                                         "valueFrom": {
@@ -46,8 +28,7 @@
                                                 "name": "grafana-prom-secret"
                                             }
                                         }
-                                    },
-                                    {{ end}}
+                                    }
                                 ],
                                 "image": "grafana/grafana:5.3.4",
                                 "name": "grafana",

--- a/helm-charts/seldon-core-analytics/values.yaml
+++ b/helm-charts/seldon-core-analytics/values.yaml
@@ -3,7 +3,6 @@ alertmanager:
     enabled: false
 grafana_prom_service_type: NodePort
 grafana_prom_admin_password: admin
-grafana_anonymous_auth: false
 persistence:
   enabled: false
 rbac:


### PR DESCRIPTION
Reverts SeldonIO/seldon-core#530

Anonymous access breaks the dashboard import jobs

![image](https://user-images.githubusercontent.com/22754674/56909898-25ebcc80-6aa1-11e9-8cfc-546f80b0ce04.png)

I thought the problem might be that the auth details are added even when they're not wanted. So I tried removing them:

https://github.com/SeldonIO/seldon-core/commit/bb9ed7816ced330f048db4b122bc4ea47cad113b

Unfortunately that doesn't work either:

![image](https://user-images.githubusercontent.com/22754674/56911603-32722400-6aa5-11e9-9366-154a012c54a8.png)

![image](https://user-images.githubusercontent.com/22754674/56911625-3ef67c80-6aa5-11e9-9639-8eebc7b36f75.png)
