### PR TITLE
option for anonymous access to grafana

### DIFF
--- a/helm-charts/seldon-core-analytics/templates/grafana-prom-deployment.json
+++ b/helm-charts/seldon-core-analytics/templates/grafana-prom-deployment.json
@@ -28,7 +28,13 @@
                                                 "name": "grafana-prom-secret"
                                             }
                                         }
+                                    },
+                                    {{ if .Values.grafana_anonymous_auth }}
+                                    {
+                                        "name": "GF_AUTH_ANONYMOUS_ENABLED",
+                                        "value": "true"
                                     }
+                                    {{ end }}
                                 ],
                                 "image": "grafana/grafana:5.3.4",
                                 "name": "grafana",

--- a/helm-charts/seldon-core-analytics/values.yaml
+++ b/helm-charts/seldon-core-analytics/values.yaml
@@ -3,6 +3,7 @@ alertmanager:
     enabled: false
 grafana_prom_service_type: NodePort
 grafana_prom_admin_password: admin
+grafana_anonymous_auth: false
 persistence:
   enabled: false
 rbac:


### PR DESCRIPTION
got the merge wrong with https://github.com/SeldonIO/seldon-core/pull/534

This actually contains the changes to enable anonymous access to grafana ui (but authenticate for import of dashboards)