### PR TITLE
Updating grafana to v6.1.6 in seldon core analytics

### DIFF
--- a/helm-charts/seldon-core-analytics/templates/grafana-prom-deployment.json
+++ b/helm-charts/seldon-core-analytics/templates/grafana-prom-deployment.json
@@ -36,7 +36,7 @@
                                     }
                                     {{ end }}
                                 ],
-                                "image": "grafana/grafana:5.3.4",
+                                "image": "grafana/grafana:6.1.6",
                                 "name": "grafana",
                                 "ports": [
                                     {

--- a/seldon-core/seldon-core-analytics/json/analytics.json
+++ b/seldon-core/seldon-core-analytics/json/analytics.json
@@ -256,7 +256,7 @@
                                         }
                                     }
                                 ],
-                                "image": "grafana/grafana:5.3.4",
+                                "image": "grafana/grafana:6.1.6",
                                 "name": "grafana",
                                 "ports": [
                                     {


### PR DESCRIPTION
Related to #540 