### PR TITLE
Update e2e tests s2i python image version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -31,7 +31,7 @@ setup(name='seldon-core',
           'tensorflow',
           'Flask-OpenTracing==0.2.0',
           'opentracing>=1.2.2,<2',
-          'jaeger-client',
+          'jaeger-client==3.13.0',
           'grpcio-opentracing',
           'pyyaml'
       ],

--- a/testing/scripts/test_s2i_python.py
+++ b/testing/scripts/test_s2i_python.py
@@ -6,7 +6,7 @@ from seldon_utils import *
 from k8s_utils import *
 import numpy as np
 
-S2I_CREATE = "cd ../s2i/python/#TYPE# && s2i build -E environment_#API# . seldonio/seldon-core-s2i-python2:#VERSION# 127.0.0.1:5000/seldonio/test#TYPE#_#API#:0.1"
+S2I_CREATE = "cd ../s2i/python/#TYPE# && s2i build -E environment_#API# . seldonio/seldon-core-s2i-python3:#VERSION# 127.0.0.1:5000/seldonio/test#TYPE#_#API#:0.1"
 IMAGE_NAME = "127.0.0.1:5000/seldonio/test#TYPE#_#API#:0.1"
 
 def create_s2I_image(s2i_python_version,component_type,api_type):


### PR DESCRIPTION
fixes
* s2i test updated to use python3 version of the image (seldonio/seldon-core-s2i-python3)
* jaeger-client to use fixed version