### PR TITLE
option to not set engine user

### DIFF
--- a/helm-charts/seldon-core-operator/templates/controller.yaml
+++ b/helm-charts/seldon-core-operator/templates/controller.yaml
@@ -199,8 +199,10 @@ spec:
           value: {{ .Values.engine.image.pullPolicy }}
         - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
           value: {{ .Values.engine.serviceAccount.name }}
+        {{- if .Values.engine.securityContext.enabled }}
         - name: ENGINE_CONTAINER_USER
           value: '{{ .Values.engine.user }}'
+        {{- end }}
         - name: PREDICTIVE_UNIT_SERVICE_PORT
           value: '{{ .Values.predictiveUnit.port }}'
         - name: ENGINE_SERVER_GRPC_PORT

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -21,7 +21,7 @@ engine:
   user: 8888
 image:
   pullPolicy: IfNotPresent
-  repository: ryandawsonuk/seldon-core-operator
+  repository: seldonio/seldon-core-operator
   tag: 0.2.8-SNAPSHOT
 predictiveUnit:
   port: 9000

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -16,10 +16,12 @@ engine:
     path: prometheus
   serviceAccount:
     name: default
+  securityContext:
+    enabled: true
   user: 8888
 image:
   pullPolicy: IfNotPresent
-  repository: seldonio/seldon-core-operator
+  repository: ryandawsonuk/seldon-core-operator
   tag: 0.2.8-SNAPSHOT
 predictiveUnit:
   port: 9000


### PR DESCRIPTION
fixes https://github.com/SeldonIO/seldon-core/issues/527
depends on https://github.com/SeldonIO/seldon-operator/pull/8

Tested by deploying following [steps in helm notebook](https://github.com/SeldonIO/seldon-core/blob/master/notebooks/helm_examples.ipynb) and using `--set engine.securityContext.enabled=false` to not set any engine user when deploying seldon-core operator. After deploying model verify by checking podspec of model with `kubectl get pod <pod> -o yaml`.

Without overriding the flag the default is to set engine user as 8888