### PR TITLE
[Docs] Fix formatting of s2i docs page

### DIFF
--- a/doc/source/wrappers/s2i.md
+++ b/doc/source/wrappers/s2i.md
@@ -5,13 +5,19 @@
 The general work flow is:
 
  1. [Download and install s2i](https://github.com/openshift/source-to-image#installation)
+
  1. Choose the builder image that is most appropriate for your code and get usage instructions, for example:
+
     ```bash
     s2i usage seldonio/seldon-core-s2i-python3
     ```
+
  1. Create a source code repo in the form acceptable for the builder image and build your docker container from it. Below we show an example using our seldon-core git repo which has some template examples for python models.
+
     ```
-    s2i build https://github.com/seldonio/seldon-core.git --context-dir=wrappers/s2i/python/test/model-template-app seldonio/seldon-core-s2i-python seldon-core-template-model
+    s2i build https://github.com/seldonio/seldon-core.git \
+        --context-dir=wrappers/s2i/python/test/model-template-app seldonio/seldon-core-s2i-python \
+        seldon-core-template-model
     ```
 
 At present we have s2i builder images for


### PR DESCRIPTION
The md2rst converter is not quite compatible with code blocks that don't have a linebreak prior to them.

The live docs page at https://docs.seldon.io/projects/seldon-core/en/latest/wrappers/s2i.html has malformed code blocks:

![image](https://user-images.githubusercontent.com/1400247/60194479-45c41600-97ee-11e9-9a53-a7f4de9c14a2.png)

Building the docs locally after this PR seems to fix them (this is the result of `cd doc && make html`:

![image](https://user-images.githubusercontent.com/1400247/60194533-5d030380-97ee-11e9-8d30-a70a449d6fdc.png)

