### PR TITLE
TFServing Enabled Text Response and Fixed JSON Parse

### DIFF
--- a/integrations/tfserving/Makefile
+++ b/integrations/tfserving/Makefile
@@ -1,4 +1,4 @@
-IMAGE_VERSION=0.4
+IMAGE_VERSION=0.5
 IMAGE_NAME = docker.io/seldonio/tfserving-proxy
 
 SELDON_CORE_DIR=../../..


### PR DESCRIPTION
An issue arised when testing with NLP models that leverage more complex interfaces. This PR supports error responses from TFX server, and enhances the print with logs (which can be configured with env variable for log level. This also uncovered an issue with json objects being sent, which now is outlined in #703 - for now TFservers will have to be configured to accept Float instead of int32 for numbers.