### PR TITLE
WIP: Proposed changes to ensure JSON REST Consistency (Fixes  #703)

### DIFF
--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -3,12 +3,15 @@ from seldon_core.utils import *
 from seldon_core.user_model import *
 from google.protobuf import json_format
 from seldon_core.proto import prediction_pb2
-from typing import Any
+from typing import Any, Union, List, Dict
 
 logger = logging.getLogger(__name__)
 
 
-def predict(user_model: Any, request: prediction_pb2.SeldonMessage) -> prediction_pb2.SeldonMessage:
+def predict(
+            user_model: Any, 
+            request: Union[prediction_pb2.SeldonMessage, List, Dict]
+        ) -> prediction_pb2.SeldonMessage:
     """
     Call the user model to get a prediction and package the response
 
@@ -22,22 +25,28 @@ def predict(user_model: Any, request: prediction_pb2.SeldonMessage) -> predictio
     -------
       The prediction
     """
-    if hasattr(user_model, "predict_rest"):
+    is_proto = isinstance(request, prediction_pb2.SeldonMessage)
+
+    if hasattr(user_model, "predict_rest") and not is_proto:
         logger.warning("predict_rest is deprecated. Please use predict_raw")
-        request_json = json_format.MessageToJson(request)
-        response_json = user_model.predict_rest(request_json)
-        return json_to_seldon_message(response_json)
-    elif hasattr(user_model, "predict_grpc"):
+        return user_model.predict_rest(request)
+    elif hasattr(user_model, "predict_grpc") and is_proto:
         logger.warning("predict_grpc is deprecated. Please use predict_raw")
         return user_model.predict_grpc(request)
     else:
         try:
             return user_model.predict_raw(request)
         except (NotImplementedError, AttributeError):
-            (features, meta, datadef, data_type) = extract_request_parts(request)
-            client_response = client_predict(user_model, features, datadef.names, meta=meta)
-
-            return construct_response(user_model, False, request, client_response)
+            logger.warning("ATTEMPTINGTORUN")
+            if is_proto:
+                (features, meta, datadef, data_type) = extract_request_parts(request)
+                client_response = client_predict(user_model, features, datadef.names, meta=meta)
+                return construct_response(user_model, False, request, client_response)
+            else:
+                (features, meta, datadef, data_type) = extract_request_parts_json(request)
+                client_response = client_predict(user_model, features, datadef.names, meta=meta)
+                print(client_response)
+                return construct_response_json(user_model, False, request, client_response)
 
 
 def send_feedback(user_model: Any, request: prediction_pb2.Feedback,

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -37,7 +37,6 @@ def predict(
         try:
             return user_model.predict_raw(request)
         except (NotImplementedError, AttributeError):
-            logger.warning("ATTEMPTINGTORUN")
             if is_proto:
                 (features, meta, datadef, data_type) = extract_request_parts(request)
                 client_response = client_predict(user_model, features, datadef.names, meta=meta)

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -12,7 +12,7 @@ from seldon_core.user_model import client_class_names, client_custom_metrics, cl
 from typing import Tuple, Dict, Union, List, Optional, Iterable, Any
 
 
-def json_to_seldon_message(message_json: Dict) -> prediction_pb2.SeldonMessage:
+def json_to_seldon_message(message_json: Union[List, Dict]) -> prediction_pb2.SeldonMessage:
     """
     Parses JSON input to a SeldonMessage proto
 

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -314,8 +314,8 @@ def construct_response_json(user_model: SeldonComponent, is_request: bool, clien
        Client user class
     is_request
        Whether this is part of the request flow as opposed to the response flow
-    client_request
-       The request received
+    client_request_raw
+       The request received in JSON format
     client_raw_response
        The raw client response from their model
 

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -38,11 +38,10 @@ def get_rest_microservice(user_model):
     def Predict():
         requestJson = get_request()
         logger.debug("REST Request: %s", request)
-        requestProto = json_to_seldon_message(requestJson)
-        logger.debug("Proto Request: %s", requestProto)
-        responseProto = seldon_core.seldon_methods.predict(user_model, requestProto)
-        jsonDict = seldon_message_to_json(responseProto)
-        return jsonify(jsonDict)
+        response = seldon_core.seldon_methods.predict(user_model, requestJson)
+        logger.debug("REST Response: %s", response)
+        return jsonify(response)
+
 
     @app.route("/send-feedback", methods=["GET", "POST"])
     def SendFeedback():


### PR DESCRIPTION
# WIP: Proposed changes to ensure JSON REST Consistency (Fixes  #703)

This pull request contains the proposed changes to modify the microservice API such that for REST requests, it is ensured that the JSON requests stay intact as per the request in #703, as currently the google proto changes int representations into floats (i.e. 9 to 9.0), which modifies the original JSON in ways that then seem to affect potential proxies such like the TFServing proxy.

Once this is agreed, it would be applied across the rest of the APIs. It would also be necessary to assess that it wouldn't affect other wrappers, etc.