### PR TITLE
config for explainer

### DIFF
--- a/helm-charts/seldon-core-operator/templates/crd.yaml
+++ b/helm-charts/seldon-core-operator/templates/crd.yaml
@@ -630,6 +630,7 @@ spec:
                                         properties:
                                           gmsaCredentialSpec: {type: string}
                                           gmsaCredentialSpecName: {type: string}
+                                          runAsUserName: {type: string}
                                         type: object
                                     type: object
                                   stdin: {type: boolean}
@@ -685,6 +686,295 @@ spec:
                               type: object
                             dnsPolicy: {type: string}
                             enableServiceLinks: {type: boolean}
+                            ephemeralContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items: {type: string}
+                                    type: array
+                                  command:
+                                    items: {type: string}
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name: {type: string}
+                                        value: {type: string}
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key: {type: string}
+                                                name: {type: string}
+                                                optional: {type: boolean}
+                                              required: [key]
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion: {type: string}
+                                                fieldPath: {type: string}
+                                              required: [fieldPath]
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName: {type: string}
+                                                divisor: {type: string}
+                                                resource: {type: string}
+                                              required: [resource]
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key: {type: string}
+                                                name: {type: string}
+                                                optional: {type: boolean}
+                                              required: [key]
+                                              type: object
+                                          type: object
+                                      required: [name]
+                                      type: object
+                                    type: array
+                                    x-kubernetes-patch-merge-key: name
+                                    x-kubernetes-patch-strategy: merge
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name: {type: string}
+                                            optional: {type: boolean}
+                                          type: object
+                                        prefix: {type: string}
+                                        secretRef:
+                                          properties:
+                                            name: {type: string}
+                                            optional: {type: boolean}
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image: {type: string}
+                                  imagePullPolicy: {type: string}
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items: {type: string}
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host: {type: string}
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name: {type: string}
+                                                    value: {type: string}
+                                                  required: [name, value]
+                                                  type: object
+                                                type: array
+                                              path: {type: string}
+                                              port: {format: int-or-string, type: string}
+                                              scheme: {type: string}
+                                            required: [port]
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host: {type: string}
+                                              port: {format: int-or-string, type: string}
+                                            required: [port]
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items: {type: string}
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host: {type: string}
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name: {type: string}
+                                                    value: {type: string}
+                                                  required: [name, value]
+                                                  type: object
+                                                type: array
+                                              path: {type: string}
+                                              port: {format: int-or-string, type: string}
+                                              scheme: {type: string}
+                                            required: [port]
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host: {type: string}
+                                              port: {format: int-or-string, type: string}
+                                            required: [port]
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items: {type: string}
+                                            type: array
+                                        type: object
+                                      failureThreshold: {format: int32, type: integer}
+                                      httpGet:
+                                        properties:
+                                          host: {type: string}
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name: {type: string}
+                                                value: {type: string}
+                                              required: [name, value]
+                                              type: object
+                                            type: array
+                                          path: {type: string}
+                                          port: {format: int-or-string, type: string}
+                                          scheme: {type: string}
+                                        required: [port]
+                                        type: object
+                                      initialDelaySeconds: {format: int32, type: integer}
+                                      periodSeconds: {format: int32, type: integer}
+                                      successThreshold: {format: int32, type: integer}
+                                      tcpSocket:
+                                        properties:
+                                          host: {type: string}
+                                          port: {format: int-or-string, type: string}
+                                        required: [port]
+                                        type: object
+                                      timeoutSeconds: {format: int32, type: integer}
+                                    type: object
+                                  name: {type: string}
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort: {format: int32, type: integer}
+                                        hostIP: {type: string}
+                                        hostPort: {format: int32, type: integer}
+                                        name: {type: string}
+                                        protocol: {type: string}
+                                      required: [containerPort]
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items: {type: string}
+                                            type: array
+                                        type: object
+                                      failureThreshold: {format: int32, type: integer}
+                                      httpGet:
+                                        properties:
+                                          host: {type: string}
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name: {type: string}
+                                                value: {type: string}
+                                              required: [name, value]
+                                              type: object
+                                            type: array
+                                          path: {type: string}
+                                          port: {format: int-or-string, type: string}
+                                          scheme: {type: string}
+                                        required: [port]
+                                        type: object
+                                      initialDelaySeconds: {format: int32, type: integer}
+                                      periodSeconds: {format: int32, type: integer}
+                                      successThreshold: {format: int32, type: integer}
+                                      tcpSocket:
+                                        properties:
+                                          host: {type: string}
+                                          port: {format: int-or-string, type: string}
+                                        required: [port]
+                                        type: object
+                                      timeoutSeconds: {format: int32, type: integer}
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits: {type: object}
+                                      requests: {type: object}
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation: {type: boolean}
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items: {type: string}
+                                            type: array
+                                          drop:
+                                            items: {type: string}
+                                            type: array
+                                        type: object
+                                      privileged: {type: boolean}
+                                      procMount: {type: string}
+                                      readOnlyRootFilesystem: {type: boolean}
+                                      runAsGroup: {format: int64, type: integer}
+                                      runAsNonRoot: {type: boolean}
+                                      runAsUser: {format: int64, type: integer}
+                                      seLinuxOptions:
+                                        properties:
+                                          level: {type: string}
+                                          role: {type: string}
+                                          type: {type: string}
+                                          user: {type: string}
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec: {type: string}
+                                          gmsaCredentialSpecName: {type: string}
+                                          runAsUserName: {type: string}
+                                        type: object
+                                    type: object
+                                  stdin: {type: boolean}
+                                  stdinOnce: {type: boolean}
+                                  targetContainerName: {type: string}
+                                  terminationMessagePath: {type: string}
+                                  terminationMessagePolicy: {type: string}
+                                  tty: {type: boolean}
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath: {type: string}
+                                        name: {type: string}
+                                      required: [name, devicePath]
+                                      type: object
+                                    type: array
+                                    x-kubernetes-patch-merge-key: devicePath
+                                    x-kubernetes-patch-strategy: merge
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath: {type: string}
+                                        mountPropagation: {type: string}
+                                        name: {type: string}
+                                        readOnly: {type: boolean}
+                                        subPath: {type: string}
+                                        subPathExpr: {type: string}
+                                      required: [name, mountPath]
+                                      type: object
+                                    type: array
+                                    x-kubernetes-patch-merge-key: mountPath
+                                    x-kubernetes-patch-strategy: merge
+                                  workingDir: {type: string}
+                                required: [name]
+                                type: object
+                              type: array
+                              x-kubernetes-patch-merge-key: name
+                              x-kubernetes-patch-strategy: merge
                             hostAliases:
                               items:
                                 properties:
@@ -962,6 +1252,7 @@ spec:
                                         properties:
                                           gmsaCredentialSpec: {type: string}
                                           gmsaCredentialSpecName: {type: string}
+                                          runAsUserName: {type: string}
                                         type: object
                                     type: object
                                   stdin: {type: boolean}
@@ -1045,6 +1336,7 @@ spec:
                                   properties:
                                     gmsaCredentialSpec: {type: string}
                                     gmsaCredentialSpecName: {type: string}
+                                    runAsUserName: {type: string}
                                   type: object
                               type: object
                             serviceAccount: {type: string}
@@ -1062,6 +1354,37 @@ spec:
                                   value: {type: string}
                                 type: object
                               type: array
+                            topologySpreadConstraints:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key: {type: string, x-kubernetes-patch-merge-key: key,
+                                                  x-kubernetes-patch-strategy: merge}
+                                            operator: {type: string}
+                                            values:
+                                              items: {type: string}
+                                              type: array
+                                          required: [key, operator]
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties: {type: string}
+                                        type: object
+                                    type: object
+                                  maxSkew: {format: int32, type: integer}
+                                  topologyKey: {type: string}
+                                  whenUnsatisfiable: {type: string}
+                                required: [maxSkew, topologyKey, whenUnsatisfiable]
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys: [topologyKey, whenUnsatisfiable]
+                              x-kubernetes-list-type: map
+                              x-kubernetes-patch-merge-key: topologyKey
+                              x-kubernetes-patch-strategy: merge
                             volumes:
                               items:
                                 properties:
@@ -1333,6 +1656,7 @@ spec:
                     type: array
                   explainer:
                     properties:
+                      config: {additionalProperties: true, type: object}
                       containerSpec:
                         properties:
                           args:
@@ -1586,6 +1910,7 @@ spec:
                                 properties:
                                   gmsaCredentialSpec: {type: string}
                                   gmsaCredentialSpecName: {type: string}
+                                  runAsUserName: {type: string}
                                 type: object
                             type: object
                           stdin: {type: boolean}
@@ -1620,6 +1945,13 @@ spec:
                           workingDir: {type: string}
                         required: [name]
                         type: object
+                      endpoint:
+                        properties:
+                          service_host: {type: string}
+                          service_port: {type: integer}
+                          type:
+                            enum: [REST, GRPC]
+                            type: string
                       modelUri: {type: string}
                       serviceAccountName: {type: string}
                       type: {type: string}

--- a/util/custom-resource-definitions/crd.tpl.json
+++ b/util/custom-resource-definitions/crd.tpl.json
@@ -293,6 +293,28 @@
 							},
 							"type": {
 								"type": "string"
+							},
+							"endpoint": {
+								"properties": {
+									"service_host": {
+										"type": "string"
+									},
+									"service_port": {
+										"type": "integer"
+									},
+									"type": {
+										"enum": [
+											"REST",
+											"GRPC"
+										],
+										"type": "string"
+									}
+								}
+							},
+							"config": {
+								"additionalProperties": true,
+								"description" : "Inline custom parameter settings for explainer",
+								"type" : "object"
 							}
 						}
 					},


### PR DESCRIPTION
for https://github.com/SeldonIO/seldon-core/issues/685

allows config to be set like https://github.com/kubeflow/kfserving/blob/e4be2c6f6b844c093ca5bd85048f3382c54e4f37/docs/samples/explanation/income/README.md#running-without-a-pretrained-explainer