### PR TITLE
Improve error handling

### DIFF
--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -37,15 +37,17 @@ def predict(
         try:
             return user_model.predict_raw(request)
         except (NotImplementedError, AttributeError):
-            if is_proto:
-                (features, meta, datadef, data_type) = extract_request_parts(request)
-                client_response = client_predict(user_model, features, datadef.names, meta=meta)
-                return construct_response(user_model, False, request, client_response)
-            else:
-                (features, meta, datadef, data_type) = extract_request_parts_json(request)
-                client_response = client_predict(user_model, features, datadef.names, meta=meta)
-                print(client_response)
-                return construct_response_json(user_model, False, request, client_response)
+            pass
+
+        if is_proto:
+            (features, meta, datadef, data_type) = extract_request_parts(request)
+            client_response = client_predict(user_model, features, datadef.names, meta=meta)
+            return construct_response(user_model, False, request, client_response)
+        else:
+            (features, meta, datadef, data_type) = extract_request_parts_json(request)
+            client_response = client_predict(user_model, features, datadef.names, meta=meta)
+            print(client_response)
+            return construct_response_json(user_model, False, request, client_response)
 
 
 def send_feedback(user_model: Any, request: prediction_pb2.Feedback,


### PR DESCRIPTION
I found a confusing error message while I was trying to create a new model with the Seldon image. My code raised an exception but the flask app prints an `AttributeError` first and my error next because my error occurred in the error handling of `predict_raw` call.

```
2019-08-14 10:19:22,603 - flask.app:log_exception:1780 - ERROR:  Exception on /predict [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/seldon_core/seldon_methods.py", line 35, in predict
    return user_model.predict_raw(request)
AttributeError: 'MnistClassifier' object has no attribute 'predict_raw'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 2311, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1834, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
...
```

Could you consider merging this improvement?