### PR TITLE
Fix for CVE-2018-1000654 in openjdk:8u201-jre-alpine3

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,8 +1,12 @@
-FROM openjdk:8u201-jre-alpine3.9
+FROM openjdk:8u222-jre-slim
 
 ARG APP_VERSION=UNKOWN_VERSION
 
-RUN apk add curl
+RUN \
+    apt-get update -y && \
+    apt-get install -y curl && \
+    apt-get remove -y --auto-remove && \
+    apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY /target/seldon-engine-${APP_VERSION}.jar app.jar
 COPY /target/generated-resources /licenses/


### PR DESCRIPTION
CVE-2018-1000654 security issue in openjdk:8u201-jre-alpine3.9  base image for engine.

Fix involves using another base image: openjdk:8u222-jre-slim



