### PR TITLE
Added Owners file and Jenkins X file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- axsaucedo
+- gsunner
+- cliveseldon
+- jklaise
+- ryandawsonuk
+- gipster
+- arnaudvl
+reviewers:
+- axsaucedo
+- gsunner
+- cliveseldon
+- jklaise
+- ryandawsonuk
+- gipster
+- arnaudvl

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,9 @@
+aliases:
+  seldon-approvers:
+    - axsaucedo
+    - gsunner
+    - cliveseldon
+    - jklaise
+    - ryandawsonuk
+    - gipster
+    - arnaudvl

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -1,0 +1,90 @@
+buildPack: none
+pipelineConfig:
+  pipelines:
+    pullRequest:
+      pipeline:
+        agent:
+          image: seldonio/core-builder:0.3
+        stages:
+          - name: build-and-test
+            parallel:
+              - name: seldon-python
+                agent:
+                  image: seldonio/python-builder:0.2
+                steps:
+                - name: test-python
+                  command: make
+                  args: 
+                    - -C
+                    - python
+                    - update_package &&
+                    - make
+                    - -C
+                    - python
+                    - install-dev &&
+                    - make 
+                    - -C
+                    - python
+                    - build_pypi &&
+                    - make 
+                    - -C
+                    - python
+                    - pip-install &&
+                    - make
+                    - -C
+                    - python
+                    - test
+              - name: seldon-engine
+                agent:
+                  image: seldonio/core-builder:0.3
+                steps:
+                - name: test-engine
+                  command: make
+                  args:
+                  - -C
+                  - engine
+                  - -f
+                  - Makefile.ci
+                  - build_jar
+    release:
+      pipeline:
+        stages:
+          - name: seldon-python
+            agent:
+              image: seldonio/python-builder:0.2
+            steps:
+            - name: test-python
+              command: make
+              args: 
+                - -C
+                - python
+                - update_package &&
+                - make
+                - -C
+                - python
+                - install-dev &&
+                - make 
+                - -C
+                - python
+                - build_pypi &&
+                - make 
+                - -C
+                - python
+                - pip-install &&
+                - make
+                - -C
+                - python
+                - test
+          - name: seldon-engine
+            agent:
+              image: seldonio/core-builder:0.3
+            steps:
+            - name: test-engine
+              command: make
+              args:
+              - -C
+              - engine
+              - -f
+              - Makefile.ci
+              - build_jar
+


### PR DESCRIPTION
This PR contains the functionality required to move our builds to Prow (enabling Github commands and OWNERS file), together with build job orchestration with Jenkins X.

## Benefits
* OWNERS file approvals
* Functionality for /lifecycle stale, /lgtm, /hold, etc
* Way to update version of Prow easily

## Overview
There is  a full analysis and breakdown into every component that Jenkins X deploys, which shows that Jenkins X is currently being built in a modular way, which works as a thin layer between Prow and Tekton (orchestrated by the jenkins X controller which is basically part of the CLI). Read more here: https://seldonio.atlassian.net/wiki/spaces/COMPANY/pages/7241745/Evaluation+of+CI+CD+Providers

To see an example PR that shows the expected workflow and commands available you can see https://github.com/SeldonIO/jenkins-x-seldon-core-sandbox/pull/5. You can also create your own PR and run any relevant tests in that repo. For background, this Jenkins Pipeline is currently connected to an Azure cluster. You can find the instructions used to set-up in the link above.

## Key things to bare in mind with current config
* @seldondev is not part of the org 
    * This could be safer from a security standpoint
    * The bot has to be added to each repo
    * When Jenkins is started, the env repo is created on @seldondev  

## Key actions to do after PR is merged
* Add @seldondev to the contributors of this repo (so it has access to comment/push/pull)
* Run the command to import repo to JenkinsX cluster as pipeline (i.e. jx import)
* Modify plugin config to enable plugins necessary

## Outstanding Todos
* Slack integration
* Ability to add links to the logs from containers