### PR TITLE
Helm upgrade 0.4.0

### DIFF
--- a/helm-charts/seldon-core-operator/templates/crd.yaml
+++ b/helm-charts/seldon-core-operator/templates/crd.yaml
@@ -3213,4 +3213,7 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
 

--- a/kustomize/seldon-core-operator/base/seldondeployments.machinelearning.seldon.io-crd.yaml
+++ b/kustomize/seldon-core-operator/base/seldondeployments.machinelearning.seldon.io-crd.yaml
@@ -3213,4 +3213,7 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
+  - name: v1alpha3
+    served: true
+    storage: false
 

--- a/util/custom-resource-definitions/crd.tpl.json
+++ b/util/custom-resource-definitions/crd.tpl.json
@@ -465,6 +465,11 @@
 		"name": "v1alpha2",
 		"served": true,
 		"storage": true
+	    },
+	    {
+		"name": "v1alpha3",
+		"served": true,
+		"storage": false
 	    }
 	],
 	"subresources": {


### PR DESCRIPTION
0.3.1 of the helm chart contained v1alpha3 as a possible version of the CRD. This was removed in 0.4.0 as we never actually updated the CRD version. However, this break upgrades from the previous version of the chart.

This change adds v1alpha3 back in as a storage=false valid version.

To upgrade from 0.3.1 in helm
 1. Delete the webhook-server-service service (this is a helm issue: https://github.com/helm/helm/issues/1193#issuecomment-419555433)
 1. run helm upgrade using the helm chart in this PR. e.g.  running `helm upgrade seldon-core .` in the seldon-core-operator helm chart folder. If you wish to use the 0.4.0 images you can override the values in the upgrade.