### PR TITLE
Update all servers to use 0.12-SNAPSHOT and update to 0.2

### DIFF
--- a/servers/mlflowserver/Makefile
+++ b/servers/mlflowserver/Makefile
@@ -1,14 +1,14 @@
-VERSION=0.1
+VERSION=0.2
 IMAGE_BASE=seldonio/mlflowserver
 
 build_rest:
-	s2i build -E environment_rest ./mlflowserver seldonio/seldon-core-s2i-python37:0.11-SNAPSHOT ${IMAGE_BASE}_rest:${VERSION}
+	s2i build -E environment_rest ./mlflowserver seldonio/seldon-core-s2i-python37:0.12-SNAPSHOT ${IMAGE_BASE}_rest:${VERSION}
 
 push_rest:
 	docker push ${IMAGE_BASE}_rest:${VERSION}
 
 build_grpc:
-	s2i build -E environment_grpc ./mlflowserver seldonio/seldon-core-s2i-python37:0.11-SNAPSHOT ${IMAGE_BASE}_grpc:${VERSION}
+	s2i build -E environment_grpc ./mlflowserver seldonio/seldon-core-s2i-python37:0.12-SNAPSHOT ${IMAGE_BASE}_grpc:${VERSION}
 
 push_grpc:
 	docker push ${IMAGE_BASE}_grpc:${VERSION}

--- a/servers/mlflowserver/mlflowserver/requirements.txt
+++ b/servers/mlflowserver/mlflowserver/requirements.txt
@@ -1,4 +1,4 @@
 mlflow==1.1.0
-sklearn==0.21.3
+scikit-learn==0.21.3
 pandas==0.25.0
 numpy==1.16.4

--- a/servers/sklearnserver/Makefile
+++ b/servers/sklearnserver/Makefile
@@ -1,14 +1,14 @@
-VERSION=0.1
+VERSION=0.2
 IMAGE_BASE=seldonio/sklearnserver
 
 build_rest:
-	s2i build -E environment_rest ./sklearnserver seldonio/seldon-core-s2i-python37:0.11-SNAPSHOT ${IMAGE_BASE}_rest:${VERSION}
+	s2i build -E environment_rest ./sklearnserver seldonio/seldon-core-s2i-python37:0.12-SNAPSHOT ${IMAGE_BASE}_rest:${VERSION}
 
 push_rest:
 	docker push ${IMAGE_BASE}_rest:${VERSION}
 
 build_grpc:
-	s2i build -E environment_grpc ./sklearnserver seldonio/seldon-core-s2i-python37:0.11-SNAPSHOT ${IMAGE_BASE}_grpc:${VERSION}
+	s2i build -E environment_grpc ./sklearnserver seldonio/seldon-core-s2i-python37:0.12-SNAPSHOT ${IMAGE_BASE}_grpc:${VERSION}
 
 push_grpc:
 	docker push ${IMAGE_BASE}_grpc:${VERSION}

--- a/servers/xgboostserver/Makefile
+++ b/servers/xgboostserver/Makefile
@@ -1,14 +1,14 @@
-VERSION=0.1
+VERSION=0.2
 IMAGE_BASE=seldonio/xgboostserver
 
 build_rest:
-	s2i build -E environment_rest ./xgboostserver seldonio/seldon-core-s2i-python37:0.11-SNAPSHOT ${IMAGE_BASE}_rest:${VERSION}
+	s2i build -E environment_rest ./xgboostserver seldonio/seldon-core-s2i-python37:0.12-SNAPSHOT ${IMAGE_BASE}_rest:${VERSION}
 
 push_rest:
 	docker push ${IMAGE_BASE}_rest:${VERSION}
 
 build_grpc:
-	s2i build -E environment_grpc ./xgboostserver seldonio/seldon-core-s2i-python37:0.11-SNAPSHOT ${IMAGE_BASE}_grpc:${VERSION}
+	s2i build -E environment_grpc ./xgboostserver seldonio/seldon-core-s2i-python37:0.12-SNAPSHOT ${IMAGE_BASE}_grpc:${VERSION}
 
 push_grpc:
 	docker push ${IMAGE_BASE}_grpc:${VERSION}


### PR DESCRIPTION

 * New 0.2 images using 0.12-SNAPSHOT
 * mlflowserver - changed pip command to install scikit-learn. Did not work with `sklearn` name.

Operator for 0.4.1-SNAPSHOT has been updated