### PR TITLE
Standardisation of rest apis

### DIFF
--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -487,6 +487,8 @@ def extract_request_parts_json(request: Union[Dict, List]
        Key parts of the request extracted
 
     """
+    if not isinstance(request, dict):
+        raise SeldonMicroserviceException(f"Invalid request data type: {request}")
     meta = request.get("meta", None)
     datadef_type = None
     datadef = None

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 from google.protobuf.struct_pb2 import ListValue
 from seldon_core.user_model import client_class_names, client_custom_metrics, client_custom_tags, client_feature_names, \
     SeldonComponent
-from typing import Tuple, Dict, Union, List, Optional, Iterable, Any
+from typing import Tuple, Dict, Union, List, Optional, Iterable
 import base64
 
 

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -83,11 +83,10 @@ def get_rest_microservice(user_model):
     def Aggregate():
         requestJson = get_request()
         logger.debug("REST Request: %s", request)
-        requestProto = json_to_seldon_messages(requestJson)
-        logger.debug("Proto Request: %s", request)
-        responseProto = seldon_core.seldon_methods.aggregate(user_model, requestProto)
-        jsonDict = seldon_message_to_json(responseProto)
-        return jsonify(jsonDict)
+        response = seldon_core.seldon_methods.aggregate(
+            user_model, requestJson)
+        logger.debug("REST Response: %s", response)
+        return jsonify(response)
 
     return app
 

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -57,11 +57,10 @@ def get_rest_microservice(user_model):
     def TransformInput():
         requestJson = get_request()
         logger.debug("REST Request: %s", request)
-        requestProto = json_to_seldon_message(requestJson)
-        logger.debug("Proto Request: %s", request)
-        responseProto = seldon_core.seldon_methods.transform_input(user_model, requestProto)
-        jsonDict = seldon_message_to_json(responseProto)
-        return jsonify(jsonDict)
+        response = seldon_core.seldon_methods.transform_input(
+            user_model, requestJson)
+        logger.debug("REST Response: %s", response)
+        return jsonify(response)
 
     @app.route("/transform-output", methods=["GET", "POST"])
     def TransformOutput():

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -42,7 +42,6 @@ def get_rest_microservice(user_model):
         logger.debug("REST Response: %s", response)
         return jsonify(response)
 
-
     @app.route("/send-feedback", methods=["GET", "POST"])
     def SendFeedback():
         requestJson = get_request()
@@ -66,21 +65,19 @@ def get_rest_microservice(user_model):
     def TransformOutput():
         requestJson = get_request()
         logger.debug("REST Request: %s", request)
-        requestProto = json_to_seldon_message(requestJson)
-        logger.debug("Proto Request: %s", request)
-        responseProto = seldon_core.seldon_methods.transform_output(user_model, requestProto)
-        jsonDict = seldon_message_to_json(responseProto)
-        return jsonify(jsonDict)
+        response = seldon_core.seldon_methods.transform_output(
+            user_model, requestJson)
+        logger.debug("REST Response: %s", response)
+        return jsonify(response)
 
     @app.route("/route", methods=["GET", "POST"])
     def Route():
         requestJson = get_request()
         logger.debug("REST Request: %s", request)
-        requestProto = json_to_seldon_message(requestJson)
-        logger.debug("Proto Request: %s", request)
-        responseProto = seldon_core.seldon_methods.route(user_model, requestProto)
-        jsonDict = seldon_message_to_json(responseProto)
-        return jsonify(jsonDict)
+        response = seldon_core.seldon_methods.route(
+            user_model, requestJson)
+        logger.debug("REST Response: %s", response)
+        return jsonify(response)
 
     @app.route("/aggregate", methods=["GET", "POST"])
     def Aggregate():

--- a/python/tests/test_combiner_microservice.py
+++ b/python/tests/test_combiner_microservice.py
@@ -6,6 +6,9 @@ import base64
 
 from seldon_core.wrapper import get_rest_microservice, SeldonModelGRPC, get_grpc_server
 from seldon_core.proto import prediction_pb2
+from seldon_core.utils import seldon_message_to_json
+
+from typing import List, Dict, Union
 
 
 class UserObject(object):
@@ -41,7 +44,13 @@ class UserObjectLowLevel(object):
     def aggregate_rest(self, Xs):
         return {"data": {"ndarray": [9, 9]}}
 
-    def aggregate_grpc(self, X):
+    def aggregate_grpc(
+            self,
+            request: Union[prediction_pb2.SeldonMessage, List, Dict]) \
+            -> Union[prediction_pb2.SeldonMessage, List, Dict]:
+
+        is_proto = isinstance(request, prediction_pb2.SeldonMessage)
+
         arr = np.array([9, 9])
         datadef = prediction_pb2.DefaultData(
             tensor=prediction_pb2.Tensor(
@@ -49,8 +58,11 @@ class UserObjectLowLevel(object):
                 values=arr
             )
         )
-        request = prediction_pb2.SeldonMessage(data=datadef)
-        return request
+        response = prediction_pb2.SeldonMessage(data=datadef)
+        if is_proto:
+            return response
+        else:
+            return seldon_message_to_json(response)
 
 
 class UserObjectLowLevelGrpc(object):
@@ -158,6 +170,7 @@ def test_aggreate_ok_bindata():
     bdata_base64 = base64.b64encode(bdata).decode('utf-8')
     rv = client.get(
         '/aggregate?json={"seldonMessages":[{"binData":"' + bdata_base64 + '"},{"binData":"' + bdata_base64 + '"}]}')
+    bdata_base64_result = base64.b64encode(base64.b64encode(bdata)).decode('utf-8')
     print(rv)
     j = json.loads(rv.data)
     print(j)
@@ -165,7 +178,7 @@ def test_aggreate_ok_bindata():
     assert j["meta"]["tags"] == {"mytag": 1}
     assert j["meta"]["metrics"][0]["key"] == user_object.metrics()[0]["key"]
     assert j["meta"]["metrics"][0]["value"] == user_object.metrics()[0]["value"]
-    assert j["binData"] == bdata_base64
+    assert j["binData"] == bdata_base64_result
 
 
 def test_aggreate_ok_strdata():

--- a/python/tests/test_model_microservice.py
+++ b/python/tests/test_model_microservice.py
@@ -10,7 +10,7 @@ import io
 from seldon_core.wrapper import get_rest_microservice, SeldonModelGRPC, get_grpc_server
 from seldon_core.proto import prediction_pb2
 from seldon_core.user_model import SeldonComponent
-from seldon_core.utils import (seldon_message_to_json,json_to_seldon_message)
+from seldon_core.utils import seldon_message_to_json, json_to_seldon_message
 
 from flask import jsonify
 

--- a/python/tests/test_router_microservice.py
+++ b/python/tests/test_router_microservice.py
@@ -3,6 +3,8 @@ import numpy as np
 from google.protobuf import json_format
 from seldon_core.wrapper import get_rest_microservice, SeldonModelGRPC, get_grpc_server
 from seldon_core.proto import prediction_pb2
+from seldon_core.utils import seldon_message_to_json
+from typing import Dict, List, Union
 
 
 class UserObject(object):
@@ -79,7 +81,13 @@ class UserObjectLowLevelRaw(object):
         self.ret_nparray = ret_nparray
         self.nparray = np.array([1, 2, 3])
 
-    def route_raw(self, request):
+    def route_raw(
+            self,
+            request: Union[prediction_pb2.SeldonMessage, List, Dict]) \
+            -> Union[prediction_pb2.SeldonMessage, List, Dict]:
+
+        is_proto = isinstance(request, prediction_pb2.SeldonMessage)
+
         arr = np.array([1])
         datadef = prediction_pb2.DefaultData(
             tensor=prediction_pb2.Tensor(
@@ -87,8 +95,11 @@ class UserObjectLowLevelRaw(object):
                 values=arr
             )
         )
-        request = prediction_pb2.SeldonMessage(data=datadef)
-        return request
+        response = prediction_pb2.SeldonMessage(data=datadef)
+        if is_proto:
+            return response
+        else:
+            return seldon_message_to_json(response)
 
     def send_feedback_raw(self, request):
         print("Feedback called")

--- a/python/tests/test_transformer_microservice.py
+++ b/python/tests/test_transformer_microservice.py
@@ -7,6 +7,9 @@ import base64
 from seldon_core.wrapper import get_rest_microservice, SeldonModelGRPC, get_grpc_server
 from seldon_core.proto import prediction_pb2
 from seldon_core.user_model import SeldonComponent
+from seldon_core.utils import seldon_message_to_json
+
+from typing import Dict, List, Union
 
 
 class UserObject(object):
@@ -119,18 +122,13 @@ class UserObjectLowLevelRaw(object):
         self.ret_nparray = ret_nparray
         self.nparray = np.array([1, 2, 3])
 
-    def transform_input_raw(self, X):
-        arr = np.array([9, 9])
-        datadef = prediction_pb2.DefaultData(
-            tensor=prediction_pb2.Tensor(
-                shape=(2, 1),
-                values=arr
-            )
-        )
-        request = prediction_pb2.SeldonMessage(data=datadef)
-        return request
+    def transform_input_raw(
+            self,
+            request: Union[prediction_pb2.SeldonMessage, List, Dict]) \
+            -> Union[prediction_pb2.SeldonMessage, List, Dict]:
 
-    def transform_output_raw(self, X):
+        is_proto = isinstance(request, prediction_pb2.SeldonMessage)
+
         arr = np.array([9, 9])
         datadef = prediction_pb2.DefaultData(
             tensor=prediction_pb2.Tensor(
@@ -138,8 +136,32 @@ class UserObjectLowLevelRaw(object):
                 values=arr
             )
         )
-        request = prediction_pb2.SeldonMessage(data=datadef)
-        return request
+        response = prediction_pb2.SeldonMessage(data=datadef)
+        if is_proto:
+            return response
+        else:
+            return seldon_message_to_json(response)
+
+    def transform_output_raw(
+            self,
+            request: Union[prediction_pb2.SeldonMessage, List, Dict]) \
+            -> Union[prediction_pb2.SeldonMessage, List, Dict]:
+
+        is_proto = isinstance(request, prediction_pb2.SeldonMessage)
+
+        arr = np.array([9, 9])
+        datadef = prediction_pb2.DefaultData(
+            tensor=prediction_pb2.Tensor(
+                shape=(2, 1),
+                values=arr
+            )
+        )
+        response = prediction_pb2.SeldonMessage(data=datadef)
+
+        if is_proto:
+            return response
+        else:
+            return seldon_message_to_json(response)
 
 
 class UserObjectLowLevelRawInherited(SeldonComponent):
@@ -148,18 +170,13 @@ class UserObjectLowLevelRawInherited(SeldonComponent):
         self.ret_nparray = ret_nparray
         self.nparray = np.array([1, 2, 3])
 
-    def transform_input_raw(self, X):
-        arr = np.array([9, 9])
-        datadef = prediction_pb2.DefaultData(
-            tensor=prediction_pb2.Tensor(
-                shape=(2, 1),
-                values=arr
-            )
-        )
-        request = prediction_pb2.SeldonMessage(data=datadef)
-        return request
+    def transform_input_raw(
+            self,
+            request: Union[prediction_pb2.SeldonMessage, List, Dict]) \
+            -> Union[prediction_pb2.SeldonMessage, List, Dict]:
 
-    def transform_output_raw(self, X):
+        is_proto = isinstance(request, prediction_pb2.SeldonMessage)
+
         arr = np.array([9, 9])
         datadef = prediction_pb2.DefaultData(
             tensor=prediction_pb2.Tensor(
@@ -167,8 +184,31 @@ class UserObjectLowLevelRawInherited(SeldonComponent):
                 values=arr
             )
         )
-        request = prediction_pb2.SeldonMessage(data=datadef)
-        return request
+        response = prediction_pb2.SeldonMessage(data=datadef)
+        if is_proto:
+            return response
+        else:
+            return seldon_message_to_json(response)
+
+    def transform_output_raw(
+            self,
+            request: Union[prediction_pb2.SeldonMessage, List, Dict]) \
+            -> Union[prediction_pb2.SeldonMessage, List, Dict]:
+
+        is_proto = isinstance(request, prediction_pb2.SeldonMessage)
+
+        arr = np.array([9, 9])
+        datadef = prediction_pb2.DefaultData(
+            tensor=prediction_pb2.Tensor(
+                shape=(2, 1),
+                values=arr
+            )
+        )
+        response = prediction_pb2.SeldonMessage(data=datadef)
+        if is_proto:
+            return response
+        else:
+            return seldon_message_to_json(response)
 
 
 def test_transformer_input_ok():
@@ -212,6 +252,7 @@ def test_transformer_input_lowlevel_raw_ingerited_ok():
     app = get_rest_microservice(user_object)
     client = app.test_client()
     rv = client.get('/transform-input?json={"data":{"ndarray":[1]}}')
+    print(rv.data)
     j = json.loads(rv.data)
     print(j)
     assert rv.status_code == 200


### PR DESCRIPTION
Fixes #739 

When a REST request gets parsed into a Proto, all the integers get converted to floats, which ends up changing the requests. This was fixed for the /predict endpoint in #707. This has now been done with all the APIs **except the feedback API** as that uses a different GRPC object.