### PR TITLE
Add initial Makefile for GPU Python Image

### DIFF
--- a/wrappers/s2i/python-gpu/python-gpu/Dockerfile
+++ b/wrappers/s2i/python-gpu/python-gpu/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /microservice
 COPY ./s2i/bin/ /s2i/bin
 
 # keep install of seldon-core after the COPY to force re-build of layer
-RUN pip3 install tensorflow-gpu==1.13.1
+RUN pip3 install tensorflow-gpu==1.14.0
 RUN pip3 install seldon-core
 
 EXPOSE 5000

--- a/wrappers/s2i/python-gpu/python-gpu/Makefile
+++ b/wrappers/s2i/python-gpu/python-gpu/Makefile
@@ -1,0 +1,12 @@
+VERSION=0.12-SNAPSHOT
+
+#TODO
+# Need to pass version into Dockerfile to get matching seldon-core version
+# Need to ensure tensorflow version installed is the same as that for python library
+# or wait until tensorflow is removed from python library
+
+docker-build:
+	docker build -t seldonio/seldon-core-s2i-python3-tf-gpu:${VERSION} .
+
+docker-push:
+	docker push seldonio/seldon-core-s2i-python3-tf-gpu:${VERSION}


### PR DESCRIPTION
Fixes #850 

Adds initial Makefile for GPU image. Will need more refactoring. Will open a new issue for this.