### PR TITLE
Replace sed flag incompatible with macOS

### DIFF
--- a/proto/k8s/Makefile
+++ b/proto/k8s/Makefile
@@ -2,7 +2,8 @@ SHELL=/bin/bash
 
 create_protos:
 	./create-k8s-protos.sh
-	sed -i '' 's|import "k8s.io/apiextensions-apiserver/|//import "k8s.io/apiextensions-apiserver/|' k8s.io/api/core/v1/generated.proto
+	sed -i.bak 's|import "k8s.io/apiextensions-apiserver/|//import "k8s.io/apiextensions-apiserver/|' k8s.io/api/core/v1/generated.proto
+	rm k8s.io/api/core/v1/generated.proto.bak
 
 clean:
 	@rm -rfv k8s.io

--- a/proto/k8s/Makefile
+++ b/proto/k8s/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 
 create_protos:
 	./create-k8s-protos.sh
-	sed --in-place 's|import "k8s.io/apiextensions-apiserver/|//import "k8s.io/apiextensions-apiserver/|' k8s.io/api/core/v1/generated.proto
+	sed -i '' 's|import "k8s.io/apiextensions-apiserver/|//import "k8s.io/apiextensions-apiserver/|' k8s.io/api/core/v1/generated.proto
 
 clean:
 	@rm -rfv k8s.io


### PR DESCRIPTION
Fixes #894.

The `-i ''` flag should make `sed` behave exactly as with `--in-place`.

## Update

Turns out the GNU version is not allowed to have a space between `-i` and the extension. Whereas the macOS version requires it.

A solution is offered on this [SO answer](https://stackoverflow.com/a/22084103). The only drawback is that a `<fileName>.bak` backup file is now generated. To keep things clean, we remove this file on the next line of the `Makefile`.