### PR TITLE
Fix title of custom ambassador notebook, fix prerequistes typo

### DIFF
--- a/doc/source/examples/notebooks.rst
+++ b/doc/source/examples/notebooks.rst
@@ -6,7 +6,6 @@ Notebooks
    :maxdepth: 1
 
    Ambassador Canary <ambassador_canary>
-   Ambassador Canary <ambassador_canary>
    Ambassador Shadow <ambassador_shadow>
    Ambassador Headers <ambassador_headers>
    Ambassador Custom Config <ambassador_custom>

--- a/examples/ambassador/canary/ambassador_canary.ipynb
+++ b/examples/ambassador/canary/ambassador_canary.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "\n",
     "You will need\n",
     "\n",

--- a/examples/ambassador/custom/ambassador_custom.ipynb
+++ b/examples/ambassador/custom/ambassador_custom.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Custom Header Routing with Seldon and Ambassador\n",
+    "# Custom URL prefix with Seldon and Ambassador\n",
     "\n",
     "This notebook shows how you can deploy Seldon Deployments with custom Ambassador configuration."
    ]
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "\n",
     "You will need\n",
     "\n",

--- a/examples/ambassador/headers/ambassador_headers.ipynb
+++ b/examples/ambassador/headers/ambassador_headers.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "\n",
     "You will need\n",
     "\n",

--- a/examples/ambassador/shadow/ambassador_shadow.ipynb
+++ b/examples/ambassador/shadow/ambassador_shadow.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "\n",
     "You will need\n",
     "\n",

--- a/examples/istio/canary_update/canary.ipynb
+++ b/examples/istio/canary_update/canary.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "You will need\n",
     " - [Git clone of Seldon Core](https://github.com/SeldonIO/seldon-core)\n",
     " - A running Kubernetes cluster with kubectl authenticated\n",

--- a/examples/models/autoscaling/autoscaling_example.ipynb
+++ b/examples/models/autoscaling/autoscaling_example.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "\n",
     "You will need\n",
     "\n",

--- a/notebooks/helm_examples.ipynb
+++ b/notebooks/helm_examples.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "You will need\n",
     " - [Git clone of Seldon Core](https://github.com/SeldonIO/seldon-core)\n",
     " - A running Kubernetes cluster with kubectl authenticated\n",

--- a/notebooks/istio_example.ipynb
+++ b/notebooks/istio_example.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "You will need\n",
     " - [Git clone of Seldon Core](https://github.com/SeldonIO/seldon-core)\n",
     " - A running Kubernetes cluster with kubectl authenticated\n",

--- a/notebooks/max_grpc_msg_size.ipynb
+++ b/notebooks/max_grpc_msg_size.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "\n",
     "You will need\n",
     "\n",

--- a/notebooks/timeouts.ipynb
+++ b/notebooks/timeouts.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "\n",
     "You will need\n",
     "\n",

--- a/testing/notebooks/helm_tests.ipynb
+++ b/testing/notebooks/helm_tests.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prerequistes\n",
+    "## Prerequisites\n",
     "You will need\n",
     " - [Git clone of Seldon Core](https://github.com/SeldonIO/seldon-core)\n",
     " - A running Kubernetes cluster with kubectl authenticated\n",


### PR DESCRIPTION
I was slightly too late putting in a review for #896 - the 'prerequistes' typos appears throughout the notebooks, so I've fixed it for the rest of them.

Also, the `Ambassador Canary` notebook was being linked to twice, and the title for `examples/ambassador_custom` was the same as that for `examples/ambassador_header`.