### PR TITLE
Update Java dependencies

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -26,6 +26,7 @@
 		<jaeger.version>1.0.0</jaeger.version>
     <opentracing.version>0.33.0</opentracing.version>
     <curator.version>4.2.0</curator.version>
+    <jackson.version>2.9.10</jackson.version>
 	</properties>
 
 	<build>
@@ -229,17 +230,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.9.10</version>
+      <version>${jackson.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10</version>
+			<version>${jackson.version}</version>
 		</dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.10</version>
+            <version>${jackson.version}</version>
         </dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>
@@ -250,7 +251,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.5</version>
+			<version>3.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -317,13 +317,13 @@
 		<dependency>
     		<groupId>io.opentracing.contrib</groupId>
     		<artifactId>opentracing-grpc</artifactId>
-    		<version>0.0.10</version>
+    		<version>0.2.0</version>
 		</dependency>
 	
 		<dependency>
   			<groupId>io.opentracing.contrib</groupId>
   			<artifactId>opentracing-spring-web</artifactId>
-  			<version>0.3.4</version>
+  			<version>2.1.3</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -303,7 +303,7 @@
 		<dependency>
     		<groupId>io.kubernetes</groupId>
     		<artifactId>client-java</artifactId>
-    		<version>4.0.0</version>
+    		<version>5.0.0</version>
     		<scope>compile</scope>
 		</dependency>
 		

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -268,7 +268,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.6</version>
+			<version>4.5.8</version>
 		</dependency>
 
 	

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -191,6 +191,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-properties-migrator</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -303,7 +303,7 @@
 		<dependency>
     		<groupId>io.kubernetes</groupId>
     		<artifactId>client-java</artifactId>
-    		<version>3.0.0</version>
+    		<version>4.0.0</version>
     		<scope>compile</scope>
 		</dependency>
 		

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -303,7 +303,7 @@
 		<dependency>
     		<groupId>io.kubernetes</groupId>
     		<artifactId>client-java</artifactId>
-    		<version>5.0.0</version>
+    		<version>6.0.1</version>
     		<scope>compile</scope>
 		</dependency>
 		

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -21,7 +21,7 @@
 		<java.version>1.8</java.version>
 		<grpc.version>1.23.0</grpc.version>
     <pb.version>3.9.2</pb.version>
-		<micrometer.version>1.1.0</micrometer.version>
+		<micrometer.version>1.1.7</micrometer.version>
 		<start-class>io.seldon.engine.App</start-class>
 		<jaeger.version>1.0.0</jaeger.version>
     <opentracing.version>0.33.0</opentracing.version>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -20,6 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<grpc.version>1.23.0</grpc.version>
+    <pb.version>3.9.2</pb.version>
 		<micrometer.version>1.1.0</micrometer.version>
 		<start-class>io.seldon.engine.App</start-class>
 		<jaeger.version>0.32.0</jaeger.version>
@@ -136,7 +137,7 @@
 				<artifactId>protobuf-maven-plugin</artifactId>
 				<version>0.5.0</version>
 				<configuration>
-					<protocArtifact>com.google.protobuf:protoc:3.1.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${pb.version}:exe:${os.detected.classifier}</protocArtifact>
 					<pluginId>grpc-java</pluginId>
 					<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
 					<clearOutputDirectory>false</clearOutputDirectory>
@@ -276,12 +277,12 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.2.0</version>
+      <version>${pb.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java-util</artifactId>
-			<version>3.2.0rc2</version>
+      <version>${pb.version}</version>
 		</dependency>
 		<dependency>
    	 		<groupId>com.google.guava</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.9.RELEASE</version>
+		<version>2.1.8.RELEASE</version>
 	</parent>
 
 	<groupId>io.seldon.engine</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.17.RELEASE</version>
+		<version>1.5.22.RELEASE</version>
 	</parent>
 
 	<groupId>io.seldon.engine</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -215,17 +215,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.9.9</version>
+			<version>2.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.9</version>
+			<version>2.9.10</version>
 		</dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.10</version>
         </dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -176,7 +176,7 @@
 		<dependency>
    			<groupId>org.ojalgo</groupId>
     		<artifactId>ojalgo</artifactId>
-    		<version>47.0.0</version>
+    		<version>47.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -24,6 +24,7 @@
 		<micrometer.version>1.1.0</micrometer.version>
 		<start-class>io.seldon.engine.App</start-class>
 		<jaeger.version>1.0.0</jaeger.version>
+    <opentracing.version>0.33.0</opentracing.version>
 	</properties>
 
 	<build>
@@ -188,6 +189,17 @@
 			  </exclusion>
 			</exclusions> 
 		</dependency>
+		<dependency>
+			<groupId>io.opentracing</groupId>
+			<artifactId>opentracing-mock</artifactId>
+      <version>${opentracing.version}</version>
+			<scope>test</scope>
+    </dependency>
+		<dependency>
+			<groupId>io.opentracing</groupId>
+			<artifactId>opentracing-api</artifactId>
+      <version>${opentracing.version}</version>
+    </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -23,7 +23,7 @@
     <pb.version>3.9.2</pb.version>
 		<micrometer.version>1.1.0</micrometer.version>
 		<start-class>io.seldon.engine.App</start-class>
-		<jaeger.version>0.32.0</jaeger.version>
+		<jaeger.version>1.0.0</jaeger.version>
 	</properties>
 
 	<build>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -286,7 +286,7 @@
 		<dependency>
    	 		<groupId>com.google.guava</groupId>
    		 	<artifactId>guava</artifactId>
-    		<version>22.0</version>
+    		<version>28.1-jre</version>
 		</dependency>
 		
 		<dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.22.RELEASE</version>
+		<version>2.0.9.RELEASE</version>
 	</parent>
 
 	<groupId>io.seldon.engine</groupId>
@@ -185,8 +185,20 @@
 			    <groupId>org.json</groupId>
 			    <artifactId>json</artifactId>
 			  </exclusion>
+        <exclusion>
+          <!-- TODO: Remove once we upgrade spring-starter-boot-parent to 2.1.x -->
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+        </exclusion>
 			</exclusions> 
 		</dependency>
+    <dependency>
+      <!-- TODO: Remove once we upgrade spring-starter-boot-parent to 2.1.x -->
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
+      <scope>test</scope>
+    </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -25,6 +25,7 @@
 		<start-class>io.seldon.engine.App</start-class>
 		<jaeger.version>1.0.0</jaeger.version>
     <opentracing.version>0.33.0</opentracing.version>
+    <curator.version>4.2.0</curator.version>
 	</properties>
 
 	<build>
@@ -217,12 +218,12 @@
 		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-framework</artifactId>
-			<version>2.7.1</version>
+      <version>${curator.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-recipes</artifactId>
-			<version>2.7.1</version>
+			<version>${curator.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -185,20 +185,8 @@
 			    <groupId>org.json</groupId>
 			    <artifactId>json</artifactId>
 			  </exclusion>
-        <exclusion>
-          <!-- TODO: Remove once we upgrade spring-starter-boot-parent to 2.1.x -->
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-        </exclusion>
 			</exclusions> 
 		</dependency>
-    <dependency>
-      <!-- TODO: Remove once we upgrade spring-starter-boot-parent to 2.1.x -->
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
-      <scope>test</scope>
-    </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>
@@ -305,12 +293,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
-		<dependency>
-  			<groupId>io.micrometer</groupId>
-  			<artifactId>micrometer-spring-legacy</artifactId>
-  			<version>${micrometer.version}</version>
-		</dependency>
 		
 		<dependency>
 		  	<groupId>io.micrometer</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<grpc.version>1.14.0</grpc.version>
+		<grpc.version>1.23.0</grpc.version>
 		<micrometer.version>1.1.0</micrometer.version>
 		<start-class>io.seldon.engine.App</start-class>
 		<jaeger.version>0.32.0</jaeger.version>

--- a/engine/src/main/java/io/seldon/engine/App.java
+++ b/engine/src/main/java/io/seldon/engine/App.java
@@ -33,13 +33,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduled;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import io.seldon.engine.config.AppConfig;
 
 @SpringBootApplication
 @EnableAsync
-@EnableScheduled
+@EnableScheduling
 @Import({ AppConfig.class })
 public class App {
     public static void main(String[] args) throws Exception {

--- a/engine/src/main/java/io/seldon/engine/App.java
+++ b/engine/src/main/java/io/seldon/engine/App.java
@@ -24,10 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatConnectorCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -50,16 +50,11 @@ public class App {
     }
     
     @Bean
-    public EmbeddedServletContainerCustomizer tomcatCustomizer() {
-        return new EmbeddedServletContainerCustomizer() {
-
+    public WebServerFactoryCustomizer tomcatCustomizer() {
+        return new WebServerFactoryCustomizer<TomcatServletWebServerFactory>() {
             @Override
-            public void customize(ConfigurableEmbeddedServletContainer container) {
-                if (container instanceof TomcatEmbeddedServletContainerFactory) {
-                    ((TomcatEmbeddedServletContainerFactory) container)
-                            .addConnectorCustomizers(gracefulShutdown());
-                }
-
+            public void customize(TomcatServletWebServerFactory factory) {
+              factory.addConnectorCustomizers(gracefulShutdown());
             }
         };
     }

--- a/engine/src/main/java/io/seldon/engine/App.java
+++ b/engine/src/main/java/io/seldon/engine/App.java
@@ -33,11 +33,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduled;
 
 import io.seldon.engine.config.AppConfig;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduled
 @Import({ AppConfig.class })
 public class App {
     public static void main(String[] args) throws Exception {

--- a/engine/src/main/java/io/seldon/engine/api/rest/RestClientController.java
+++ b/engine/src/main/java/io/seldon/engine/api/rest/RestClientController.java
@@ -15,19 +15,26 @@
  *******************************************************************************/
 package io.seldon.engine.api.rest;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import io.micrometer.core.annotation.Timed;
+
+import io.opentracing.Span;
+
 import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.annotation.PostConstruct;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -37,10 +44,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.micrometer.core.annotation.Timed;
-import io.opentracing.Scope;
 import io.seldon.engine.exception.APIException;
 import io.seldon.engine.exception.APIException.ApiExceptionType;
 import io.seldon.engine.pb.ProtoBufUtils;
@@ -137,17 +140,17 @@ public class RestClientController {
     public ResponseEntity<String> predictions_json(RequestEntity<String> requestEntity)
 	{
 		logger.debug("Received predict request");
-		Scope tracingScope = null;
+		Span tracingSpan = null;
 		if (tracingProvider.isActive())
-			tracingScope = tracingProvider.getTracer().buildSpan("/api/v0.1/predictions").startActive(true);
+			tracingSpan = tracingProvider.getTracer().buildSpan("/api/v0.1/predictions").start();
 		try
 		{
 			return _predictions(requestEntity.getBody());
 		}
 		finally
 		{
-			if (tracingScope != null)
-				tracingScope.close();
+			if (tracingSpan != null)
+				tracingSpan.finish();
 		}
 
 	}
@@ -159,9 +162,9 @@ public class RestClientController {
 	public ResponseEntity<String> predictions_multiform(MultipartHttpServletRequest requestEntity)
 	{
 		logger.debug("Received predict request");
-		Scope tracingScope = null;
+		Span tracingSpan = null;
 		if (tracingProvider.isActive())
-			tracingScope = tracingProvider.getTracer().buildSpan("/api/v0.1/predictions").startActive(true);
+			tracingSpan = tracingProvider.getTracer().buildSpan("/api/v0.1/predictions").start();
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			Map<String,Object> mergedParamMap = new HashMap<String,Object>();
@@ -191,8 +194,8 @@ public class RestClientController {
 
 		} finally
 		{
-			if (tracingScope != null)
-				tracingScope.close();
+			if (tracingSpan != null)
+				tracingSpan.finish();
 		}
 
 	}
@@ -244,9 +247,9 @@ public class RestClientController {
 	@RequestMapping(value= "/api/v0.1/feedback", method = RequestMethod.POST, consumes = "application/json; charset=utf-8", produces = "application/json; charset=utf-8")
 	public ResponseEntity<String>  feedback(RequestEntity<String> requestEntity) {
 		logger.debug("Received feedback request");
-		Scope tracingScope = null;
+		Span tracingSpan = null;
 		if (tracingProvider.isActive())
-			tracingScope = tracingProvider.getTracer().buildSpan("/api/v0.1/feedback").startActive(true);
+			tracingSpan = tracingProvider.getTracer().buildSpan("/api/v0.1/feedback").start();
 		try
 		{
 		Feedback feedback;	
@@ -284,8 +287,8 @@ public class RestClientController {
 		}
 		finally
 		{
-			if (tracingScope != null)
-				tracingScope.close();
+			if (tracingSpan != null)
+				tracingSpan.finish();
 		}
 
     }

--- a/engine/src/main/java/io/seldon/engine/api/rest/RestClientController.java
+++ b/engine/src/main/java/io/seldon/engine/api/rest/RestClientController.java
@@ -20,6 +20,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.micrometer.core.annotation.Timed;
 
 import io.opentracing.Span;
+import io.opentracing.Tracer;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -141,8 +142,11 @@ public class RestClientController {
 	{
 		logger.debug("Received predict request");
 		Span tracingSpan = null;
-		if (tracingProvider.isActive())
-			tracingSpan = tracingProvider.getTracer().buildSpan("/api/v0.1/predictions").start();
+		if (tracingProvider.isActive()) {
+      Tracer tracer = tracingProvider.getTracer();
+			tracingSpan = tracer.buildSpan("/api/v0.1/predictions").start();
+      tracer.scopeManager().activate(tracingSpan);
+    }
 		try
 		{
 			return _predictions(requestEntity.getBody());
@@ -163,8 +167,11 @@ public class RestClientController {
 	{
 		logger.debug("Received predict request");
 		Span tracingSpan = null;
-		if (tracingProvider.isActive())
-			tracingSpan = tracingProvider.getTracer().buildSpan("/api/v0.1/predictions").start();
+		if (tracingProvider.isActive()) {
+      Tracer tracer = tracingProvider.getTracer();
+			tracingSpan = tracer.buildSpan("/api/v0.1/predictions").start();
+      tracer.scopeManager().activate(tracingSpan);
+    }
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			Map<String,Object> mergedParamMap = new HashMap<String,Object>();
@@ -248,8 +255,11 @@ public class RestClientController {
 	public ResponseEntity<String>  feedback(RequestEntity<String> requestEntity) {
 		logger.debug("Received feedback request");
 		Span tracingSpan = null;
-		if (tracingProvider.isActive())
-			tracingSpan = tracingProvider.getTracer().buildSpan("/api/v0.1/feedback").start();
+		if (tracingProvider.isActive()) {
+      Tracer tracer = tracingProvider.getTracer();
+			tracingSpan = tracer.buildSpan("/api/v0.1/feedback").start();
+      tracer.scopeManager().activate(tracingSpan);
+    }
 		try
 		{
 		Feedback feedback;	

--- a/engine/src/main/java/io/seldon/engine/config/AppConfig.java
+++ b/engine/src/main/java/io/seldon/engine/config/AppConfig.java
@@ -16,7 +16,7 @@
 package io.seldon.engine.config;
 
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 
@@ -26,7 +26,7 @@ public class AppConfig {
 
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-    public EmbeddedServletContainerCustomizer containerCustomizer() {
+    public WebServerFactoryCustomizer containerCustomizer() {
         return new CustomizationBean();
     }
 

--- a/engine/src/main/java/io/seldon/engine/config/CustomizationBean.java
+++ b/engine/src/main/java/io/seldon/engine/config/CustomizationBean.java
@@ -18,10 +18,10 @@ package io.seldon.engine.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 
-public class CustomizationBean implements EmbeddedServletContainerCustomizer {
+public class CustomizationBean implements WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> {
 
     private final static Logger logger = LoggerFactory.getLogger(CustomizationBean.class);
     private final static String ENGINE_SERVER_PORT_KEY = "ENGINE_SERVER_PORT";
@@ -30,7 +30,7 @@ public class CustomizationBean implements EmbeddedServletContainerCustomizer {
     private Integer defaultServerPort;
 
     @Override
-    public void customize(ConfigurableEmbeddedServletContainer container) {
+    public void customize(ConfigurableServletWebServerFactory factory) {
         logger.info("Customizing EmbeddedServlet");
 
         Integer serverPort;
@@ -46,7 +46,7 @@ public class CustomizationBean implements EmbeddedServletContainerCustomizer {
         }
 
         logger.info("setting serverPort[{}]", serverPort);
-        container.setPort(serverPort);
+        factory.setPort(serverPort);
     }
 
 }

--- a/engine/src/main/java/io/seldon/engine/config/TomcatConfig.java
+++ b/engine/src/main/java/io/seldon/engine/config/TomcatConfig.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import org.apache.catalina.connector.Connector;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -48,15 +48,14 @@ public class TomcatConfig {
 
 
   @Bean
-  public EmbeddedServletContainerFactory servletContainer() {
-
-    TomcatEmbeddedServletContainerFactory tomcat = new TomcatEmbeddedServletContainerFactory();
+  public ServletWebServerFactory servletContainer() {
+    TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory();
     Connector[] additionalConnectors = this.additionalConnector();
     if (additionalConnectors != null && additionalConnectors.length > 0) {
       tomcat.addAdditionalTomcatConnectors(additionalConnectors);
     }
 
-   return tomcat;
+    return tomcat;
   }
 
 

--- a/engine/src/main/java/io/seldon/engine/grpc/GrpcChannelHandler.java
+++ b/engine/src/main/java/io/seldon/engine/grpc/GrpcChannelHandler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.opentracing.contrib.grpc.ClientTracingInterceptor;
+import io.opentracing.contrib.grpc.TracingClientInterceptor;
 import io.seldon.engine.tracing.TracingProvider;
 import io.seldon.protos.DeploymentProtos.Endpoint;
 
@@ -30,7 +30,10 @@ public class GrpcChannelHandler {
 			
 			if (tracingProvider != null && tracingProvider.isActive())
 			{
-				ClientTracingInterceptor tracingInterceptor = new ClientTracingInterceptor(this.tracingProvider.getTracer());
+				TracingClientInterceptor tracingInterceptor = TracingClientInterceptor
+          .newBuilder()
+          .withTracer(this.tracingProvider.getTracer())
+          .build();
 				store.putIfAbsent(endpoint, tracingInterceptor.intercept(channel));
 			}
 			else

--- a/engine/src/main/java/io/seldon/engine/grpc/GrpcChannelHandler.java
+++ b/engine/src/main/java/io/seldon/engine/grpc/GrpcChannelHandler.java
@@ -1,8 +1,8 @@
 package io.seldon.engine.grpc;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.jboss.netty.util.internal.ConcurrentHashMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/engine/src/main/java/io/seldon/engine/grpc/SeldonGrpcServer.java
+++ b/engine/src/main/java/io/seldon/engine/grpc/SeldonGrpcServer.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 
 import io.grpc.Server;
 import io.grpc.netty.NettyServerBuilder;
-import io.opentracing.contrib.grpc.ServerTracingInterceptor;
+import io.opentracing.contrib.grpc.TracingServerInterceptor;
 import io.seldon.engine.config.AnnotationsConfig;
 import io.seldon.engine.service.PredictionService;
 import io.seldon.engine.tracing.TracingProvider;
@@ -66,7 +66,10 @@ public class SeldonGrpcServer  {
         NettyServerBuilder builder;
         if (tracingProvider.isActive())
         {
-        	ServerTracingInterceptor tracingInterceptor = new ServerTracingInterceptor(tracingProvider.getTracer());
+        	TracingServerInterceptor tracingInterceptor = TracingServerInterceptor
+            .newBuilder()
+            .withTracer(tracingProvider.getTracer())
+            .build();
         	builder = NettyServerBuilder
         			.forPort(port)
         			.addService(tracingInterceptor.intercept(seldonService));

--- a/engine/src/main/java/io/seldon/engine/metrics/MetricsConfig.java
+++ b/engine/src/main/java/io/seldon/engine/metrics/MetricsConfig.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package io.seldon.engine.metrics;
 
-import io.micrometer.spring.web.client.RestTemplateExchangeTagsProvider;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
 
 //@Configuration
 public class MetricsConfig {

--- a/engine/src/main/java/io/seldon/engine/metrics/SeldonRestTemplateExchangeTagsProvider.java
+++ b/engine/src/main/java/io/seldon/engine/metrics/SeldonRestTemplateExchangeTagsProvider.java
@@ -24,10 +24,11 @@ import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTags;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
 
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.spring.web.client.RestTemplateExchangeTags;
-import io.micrometer.spring.web.client.RestTemplateExchangeTagsProvider;
+
 import io.seldon.engine.predictors.EnginePredictor;
 import io.seldon.engine.predictors.PredictiveUnitState;
 import io.seldon.engine.service.InternalPredictionService;

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
@@ -115,7 +115,7 @@ public class PredictiveUnitBean extends PredictiveUnitImpl {
 		String puid = input.getMeta().getPuid();
 		
 		if (activeSpan != null && tracing != null)
-			tracing.getTracer().scopeManager().activate(activeSpan, true);
+			tracing.getTracer().scopeManager().activate(activeSpan);
 		
 		// This element to the request path
 		requestPathDict.put(state.name, state.image);

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -6,8 +6,9 @@ management.metrics.web.server.requests-metric-name=seldon.api.engine.server.requ
 management.metrics.web.client.requests-metric-name=seldon.api.engine.client.requests
 management.metrics.distribution.percentiles.all=0.5, 0.75, 0.95, 0.98, 0.99
 management.metrics.distribution.percentiles-histogram.all=true
-endpoints.prometheus.id=${ENGINE_PROMETHEUS_PATH:prometheus}
-endpoints.prometheus.sensitive=false
+management.endpoints.web.base-path=/
+management.endpoints.web.exposure.include=info, health, prometheus
+management.endpoint.prometheus.enabled=true
 
 spring.jmx.enabled = false
 #server.compression.enabled=true

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -8,7 +8,6 @@ management.metrics.distribution.percentiles.all=0.5, 0.75, 0.95, 0.98, 0.99
 management.metrics.distribution.percentiles-histogram.all=true
 management.endpoints.web.base-path=/
 management.endpoints.web.exposure.include=info, health, prometheus
-management.endpoint.prometheus.enabled=true
 
 spring.jmx.enabled = false
 #server.compression.enabled=true

--- a/engine/src/test/java/io/seldon/engine/api/rest/TestRandomABTest.java
+++ b/engine/src/test/java/io/seldon/engine/api/rest/TestRandomABTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;

--- a/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientController.java
+++ b/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientController.java
@@ -15,15 +15,25 @@
  *******************************************************************************/
 package io.seldon.engine.api.rest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.seldon.engine.pb.ProtoBufUtils;
+import io.seldon.engine.tracing.TracingProvider;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockSpan;
+import java.util.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,27 +43,30 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
-
-import io.seldon.engine.pb.ProtoBufUtils;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-
-import java.util.*;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 //@AutoConfigureMockMvc
 public class TestRestClientController {
+	private final static Logger logger = LoggerFactory.getLogger(TestRestClientController.class);
 	
 	@Autowired
 	private WebApplicationContext context;
-	
+
+  @MockBean
+  private TracingProvider mockTracingProvider;
+
+  private MockTracer tracer;
 	
     //@Autowired
     private MockMvc mvc;
-    
-    
+
     @Before
 	public void setup() {
+    tracer = new MockTracer();
+    when(mockTracingProvider.getTracer()).thenReturn(tracer);
+    when(mockTracingProvider.isActive()).thenReturn(true);
 		mvc = MockMvcBuilders
 				.webAppContextSetup(context)
 				.build();
@@ -72,7 +85,22 @@ public class TestRestClientController {
     	Assert.assertEquals(200, res.getResponse().getStatus());
     }
     
-    
+    @Test
+    public void testPredict_activateSpan() throws Exception
+    {
+        final String predictJson = "{" +
+        	    "\"request\": {" + 
+        	    "\"ndarray\": [[1.0]]}" +
+        		"}";
+
+    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
+    			.accept(MediaType.APPLICATION_JSON_UTF8)
+    			.content(predictJson)
+    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
+      List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+      Assert.assertEquals(1, finishedSpans.size());
+    }
     
     @Test
     public void testPredict_11dim_ndarry() throws Exception

--- a/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientController.java
+++ b/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientController.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;

--- a/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientControllerExternalGraphs.java
+++ b/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientControllerExternalGraphs.java
@@ -12,7 +12,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;

--- a/engine/src/test/java/io/seldon/engine/config/TestConfig.java
+++ b/engine/src/test/java/io/seldon/engine/config/TestConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.http.client.ClientHttpRequestFactory;
 
 import java.io.IOException;
 
@@ -20,7 +21,6 @@ import static org.mockito.Mockito.when;
 @Configuration
 @Profile("test")
 public class TestConfig {
-
     @Autowired
     private AnnotationsConfig annotationsConfig;
 
@@ -36,9 +36,12 @@ public class TestConfig {
 
         RestTemplateBuilder rtb = mock(RestTemplateBuilder.class);
         RestTemplate restTemplate = mock(RestTemplate.class);
+        ClientHttpRequestFactory requestFactory = mock(ClientHttpRequestFactory.class);
         when(rtb.setConnectTimeout(anyInt())).thenReturn(rtb);
         when(rtb.setReadTimeout(anyInt())).thenReturn(rtb);
         when(rtb.build()).thenReturn(restTemplate);
+        when(restTemplate.getRequestFactory()).thenReturn(requestFactory);
+
         return rtb;
     }
 

--- a/engine/src/test/resources/application.properties
+++ b/engine/src/test/resources/application.properties
@@ -10,4 +10,3 @@ log.messages.externally=${SELDON_LOG_MESSAGES_EXTERNALLY:false}
 
 management.endpoints.web.base-path=/
 management.endpoints.web.exposure.include=info, health, prometheus
-management.endpoint.prometheus.enabled=true

--- a/engine/src/test/resources/application.properties
+++ b/engine/src/test/resources/application.properties
@@ -7,3 +7,7 @@ log.feedback.requests=${SELDON_LOG_FEEDBACK_REQUESTS:true}
 #send request-response pairs to be processed and logged outside engine
 message.logging.service=${SELDON_MESSAGE_LOGGING_SERVICE:http://default-broker.default.svc.cluster.local}
 log.messages.externally=${SELDON_LOG_MESSAGES_EXTERNALLY:false}
+
+management.endpoints.web.base-path=/
+management.endpoints.web.exposure.include=info, health, prometheus
+management.endpoint.prometheus.enabled=true


### PR DESCRIPTION
This PR addresses issue #902.

## Changelog

We will split the changelog by the update increments shown in issue #902. Changes are only shown for version updates which required changes on the source code other than just a version change in `pom.xml`.

### Update `spring` and `spring-boot`

#### Update to `spring-boot@v2.0.9`

- Add `spring-boot-properties-migrator` to help migrating application properties. This is recommended on the [upgrade guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide).
- Something on the internal structure of `RestTemplate` has changed. As a consequence, on the tests, we now need to mock the `restTemplate.getRequestFactory()` method as well.
- Changes related to embedded web servers and containers:
  - All the `org.springframework.boot.context.embedded` imports now point to `org.springframework.boot.web.servlet` and `org.springframework.boot.web.embedded`. This is more detailed in [this section of the upgrade guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#embedded-containers-package-structure).
  -  The `*Customizer` classes have also changed slightly in its structure. More info can be [found here](https://www.baeldung.com/embeddedservletcontainercustomizer-configurableembeddedservletcontainer-spring-boot).
- `micrometer-spring-legacy` is no longer required, since it's already included into `spring@v5.x`. All the `io.micrometer.spring` imports now point to `org.springframework.boot.actuate.metrics`.
- Changes to `spring-boot-actuator` endpoints:
  - The configuration of [actuator endpoints has changed](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#endpoints). There is no longer a `endpoints.prometheus.sensitive` attribute, since that's now handled explicitly by `spring-security`. Since we don't use `spring-security`, we can remove that line. Likewise, there is no longer a `endpoints.prometheus.id` attribute, since the `id` is now considered immutable.
  - To add back the previous `/prometheus` endpoint, we enabled it by adding it to the `management.endpoints.web.exposure.include` list and changed the base path of the actuator endpoints to `/` with `management.endpoints.web.base-path`.
  - Besides `/health`, `/info` and `/prometheus`, every other `spring-boot-actuator` endpoint will now return a `404`. Before, this used to be a `401`. To bring back the `401`s, we would need to introduce `spring-security`, enable these endpoints and configure the `401` there.
- It seems that before, `@Scheduled` tasks were enabled indirectly by some other piece of config. However, after the update, we are required to enable them explicitly adding the `@EnableScheduling` annotation. This affects the `SeldonGraphReadyChecker`, since it checks periodically if the inference graph is ready. https://github.com/SeldonIO/seldon-core-mirror1/blob/ca4ae76a9379cdb47eaa1ecc211eb43e34f874dd/engine/src/main/java/io/seldon/engine/api/rest/SeldonGraphReadyChecker.java#L111-L118

## Update `com.google.protobuf` packages

- Introduce `${grpc.version}` variable to `pom.xml` and set to `v3.9.2`.

## Update `opentracing-grpc`, `opentracing-rest` and `opentracing-api` packages

- Rename `TracingClientInterceptor` and `TracingServerInterceptor` as per https://github.com/opentracing-contrib/java-grpc/pull/45.
- Use `newBuilder` to construct new interceptor instances as per https://github.com/opentracing-contrib/java-grpc/pull/47.
- Change how `Span` is created as some methods [have been deprecated]( https://github.com/opentracing/opentracing-java#deprecated-members-since-031).

## Update `org.apache.curator` packages

- Introduce `${curator.version}` variable to `pom.xml` and set to `v4.2.0`.
- Replace internal `org.jboss.netty.util.internal.ConcurrentHashMap` for `java.util.concurrent.ConcurrentHashMap`.