### PR TITLE
microservice: Fix get annotations format

### DIFF
--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -106,7 +106,7 @@ def load_annotations() -> Dict:
                         logger.info("Found annotation %s:%s ", parts[0], parts[1])
                         annotations[parts[0]] = parts[1]
                     else:
-                        logger.info("bad annotation [%s]", line)
+                        logger.info("Bad annotation [%s]", line)
     except:
         logger.error("Failed to open annotations file %s", ANNOTATIONS_FILE)
     return annotations

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -101,11 +101,10 @@ def load_annotations() -> Dict:
             with open(ANNOTATIONS_FILE, "r") as ins:
                 for line in ins:
                     line = line.rstrip()
-                    parts = line.split("=")
+                    parts = list(map(str.strip, line.split("=", 1)))
                     if len(parts) == 2:
-                        value = parts[1][1:-1]
-                        logger.info("Found annotation %s:%s ", parts[0], value)
-                        annotations[parts[0]] = value
+                        logger.info("Found annotation %s:%s ", parts[0], parts[1])
+                        annotations[parts[0]] = parts[1]
                     else:
                         logger.info("bad annotation [%s]", line)
     except:

--- a/python/tests/test_microservice.py
+++ b/python/tests/test_microservice.py
@@ -13,7 +13,7 @@ from seldon_core.flask_utils import SeldonMicroserviceException
 import grpc
 import numpy as np
 import signal
-import unittest
+import unittest.mock as mock
 
 @contextmanager
 def start_microservice(app_location,tracing=False,grpc=False,envs={}):
@@ -162,14 +162,31 @@ def test_model_template_app_tracing_config():
 
 
 def test_model_template_bad_params():
-
     params = [join(dirname(__file__), "model-template-app"),"seldon-core-microservice","REST","--parameters",'[{"type":"FLOAT","name":"foo","value":"abc"}]']
-    with unittest.mock.patch('sys.argv',params):
+    with mock.patch('sys.argv',params):
         with pytest.raises(SeldonMicroserviceException):
             microservice.main()
+
 
 def test_model_template_bad_params_type():
     params = [join(dirname(__file__), "model-template-app"),"seldon-core-microservice","REST","--parameters",'[{"type":"FOO","name":"foo","value":"abc"}]']
-    with unittest.mock.patch('sys.argv',params):
+    with mock.patch('sys.argv',params):
         with pytest.raises(SeldonMicroserviceException):
             microservice.main()
+
+
+@mock.patch('seldon_core.microservice.os.path.isfile', return_value=True)
+def test_load_annotations(mock_isfile):
+    from io import StringIO
+    read_data = [
+        ('foo=bar', {'foo': 'bar'}),
+        ('foo=bar\nx =y', {'foo': 'bar', 'x': 'y'}),
+        ('foo=bar\nfoo=baz\n', {'foo': 'baz'}),
+        (' foo  =   bar ', {'foo': 'bar'}),
+        ('key =  assign===', {'key': 'assign==='}),
+        ('foo=\nfoo', {'foo': ''}),
+    ]
+    for data, expected_annotation in read_data:
+        m = mock.mock_open(read_data=data)
+        with mock.patch('seldon_core.microservice.open', return_value=StringIO(data)):
+            assert microservice.load_annotations() == expected_annotation


### PR DESCRIPTION
- Only split at the first occurence of '=', this allow values containing
  '=' character.
- Strip splitted parts, so we can have following forms:
  `key = value`, or `key= value `
- Also fix wrong index access annotation value, [1:-1] slices the content
  from 1 to second last, which leads to incompleted values.