### PR TITLE
Tidy up Java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public
 cluster-manager/.m2/
 .mypy_cache
+.cache
 
 .ipynb_checkpoints
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/maltzj/google-style-precommit-hook
+    sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
+    hooks:
+      - id: google-style-java

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,6 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/maltzj/google-style-precommit-hook
-    sha: b7e9e7fcba4a5aea463e72fe9964c14877bd8130
+    rev: 9d0e0fe8f89e40928b99ff2e1c9d35abbb743640
     hooks:
       - id: google-style-java

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,43 @@
-## Contributing to Seldon Core
+# Contributing to Seldon Core
 
-*Before opening a pull request* consider:
+_Before opening a pull request_ consider:
 
 - Is the change important and ready enough to ask the community to spend time reviewing?
 - Have you searched for existing, related issues and pull requests?
 - Is the change being proposed clearly explained and motivated?
 
-When you contribute code, you affirm that the contribution is your original work and that you 
-license the work to the project under the project's open source license. Whether or not you 
-state this explicitly, by submitting any copyrighted material via pull request, email, or 
-other means you agree to license the material under the project's open source license and 
+When you contribute code, you affirm that the contribution is your original work and that you
+license the work to the project under the project's open source license. Whether or not you
+state this explicitly, by submitting any copyrighted material via pull request, email, or
+other means you agree to license the material under the project's open source license and
 warrant that you have the legal authority to do so.
+
+## Coding conventions
+
+We use [`pre-commit`](https://pre-commit.com/) to handle a number of Git hooks
+which ensure that all changes to the codebase follow Seldon's code conventions.
+It is recommended to set these up before making any change to the codebase.
+Extra checks down the line will stop the build if the code is not compliant to
+the style guide of each language in the repository.
+
+To install it, follow the [official instructions](https://pre-commit.com/#install).
+Once installed, run:
+
+```console
+$ pre-commit install
+```
+
+This will read the hooks defined in `.pre-commit-config.yaml` and install them
+accordingly on your local repository.
+
+### Java
+
+To format our Java code we follow [Google's Java style
+guide](https://google.github.io/styleguide/javaguide.html).
+To make sure that the codebase remains consistent, we use
+[`checkstyle`](https://github.com/checkstyle/checkstyle) as part of the `mvn validate` lifecycle.
+
+To integrate these on your local editor, you can follow the official
+instructions to [configure `checkstyle`
+locally](https://checkstyle.org/beginning_development.html) and to [set-up
+`google-java-format`](https://github.com/google/google-java-format#using-the-formatter).

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -169,6 +169,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <source>1.8</source>
           <target>1.8</target>
           <encoding>UTF-8</encoding>
+          <compilerArgs>
+            <arg>-Xlint</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -175,6 +175,26 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <configLocation>google_checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+          <linkXRef>false</linkXRef>
+        </configuration>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -26,6 +26,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <opentracing.version>0.33.0</opentracing.version>
     <curator.version>4.2.0</curator.version>
     <jackson.version>2.9.10</jackson.version>
+    <kubernetes.version>6.0.1</kubernetes.version>
   </properties>
   <build>
     <finalName>${project.artifactId}-${project.version}</finalName>
@@ -268,28 +269,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-properties-migrator</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-framework</artifactId>
-      <version>${curator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-recipes</artifactId>
-      <version>${curator.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -306,11 +287,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
     </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-    </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -326,13 +302,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.8</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -347,6 +324,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
       <version>${grpc.version}</version>
     </dependency>
     <dependency>
@@ -370,18 +352,23 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>${micrometer.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
       <version>${micrometer.version}</version>
     </dependency>
     <dependency>
       <groupId>io.kubernetes</groupId>
-      <artifactId>client-java</artifactId>
-      <version>6.0.1</version>
+      <artifactId>client-java-proto</artifactId>
+      <version>${kubernetes.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
-      <artifactId>jaeger-client</artifactId>
+      <artifactId>jaeger-core</artifactId>
       <version>${jaeger.version}</version>
     </dependency>
     <dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -1,343 +1,375 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.8.RELEASE</version>
-	</parent>
-
-	<groupId>io.seldon.engine</groupId>
-	<artifactId>seldon-engine</artifactId>
-	<version>0.5.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
-
-	<name>engine</name>
-	<url>http://maven.apache.org</url>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
-		<grpc.version>1.23.0</grpc.version>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.8.RELEASE</version>
+  </parent>
+  <groupId>io.seldon.engine</groupId>
+  <artifactId>seldon-engine</artifactId>
+  <version>0.5.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>engine</name>
+  <url>http://maven.apache.org</url>
+  <properties>
+    <project.build.sourceEncoding>
+    UTF-8</project.build.sourceEncoding>
+    <java.version>1.8</java.version>
+    <grpc.version>1.23.0</grpc.version>
     <pb.version>3.9.2</pb.version>
-		<micrometer.version>1.1.7</micrometer.version>
-		<start-class>io.seldon.engine.App</start-class>
-		<jaeger.version>1.0.0</jaeger.version>
+    <micrometer.version>1.1.7</micrometer.version>
+    <start-class>io.seldon.engine.App</start-class>
+    <jaeger.version>1.0.0</jaeger.version>
     <opentracing.version>0.33.0</opentracing.version>
     <curator.version>4.2.0</curator.version>
     <jackson.version>2.9.10</jackson.version>
-	</properties>
-
-	<build>
-		<finalName>${project.artifactId}-${project.version}</finalName>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.4.1.Final</version>
-			</extension>
-		</extensions>
-		<plugins>
-			<plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
-                <configuration>
-       				<excludes>
-            			<exclude>**/io/seldon/protos/**/*.class</exclude>
-            			<exclude>**/org/tensorflow/framework/**/*.class</exclude>
-        			</excludes>
-    			</configuration>
-                <executions>
-                    <execution>
-                        <id>jacoco-initialize</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>jacoco-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<version>1.13</version>
-				<inherited>false</inherited>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-						  <goal>add-third-party</goal>
-						  <goal>download-licenses</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${root.basedir}</outputDirectory>
-							<thirdPartyFilename>LICENSES_THIRD_PARTY</thirdPartyFilename>
-							<!-- Use the template which groups all dependencies by their License 
-								type (easier to read!). -->
-							<!-- SEE: https://fisheye.codehaus.org/browse/mojo/trunk/mojo/license-maven-plugin/src/main/resources/org/codehaus/mojo/license -->
-							<!-- <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByLicense.ftl</fileTemplate> -->
-							<fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByLicense.ftl</fileTemplate>
-							<!-- License names that should all be merged into the *first* listed 
-								name -->
-							<licenseMerges>
-								<licenseMerge>MIT License|MIT|The MIT License|MIT LICENSE|MIT license</licenseMerge>							  
-								<licenseMerge>Apache Software License, Version 2.0|The Apache Software License, Version 2.0|Apache License Version 2.0|Apache License, Version 2.0|Apache Public License 2.0|Apache License 2.0|Apache Software License - Version 2.0|Apache 2.0 License|Apache 2.0 license|Apache License V2.0|Apache 2|Apache License|Apache|ASF 2.0|Apache 2.0|Apache License, version 2.0|Apache Software Licenses|Apache-2.0|The Apache License, Version 2.0</licenseMerge>
-								<!-- Ant-contrib is an Apache License -->
-								<licenseMerge>Apache Software License, Version 2.0|http://ant-contrib.sourceforge.net/tasks/LICENSE.txt</licenseMerge>
-								<licenseMerge>BSD License|The BSD License|BSD licence|BSD license|BSD|BSD-style license|New BSD License|New BSD license|Revised BSD License</licenseMerge>
-								<!-- DuraSpace uses a BSD License for DSpace -->
-								<licenseMerge>BSD License|DuraSpace BSD License|DuraSpace Sourcecode License</licenseMerge>
-								<!-- Coverity uses modified BSD: https://github.com/coverity/coverity-security-library -->
-								<licenseMerge>BSD License|BSD style modified by Coverity</licenseMerge>
-								<licenseMerge>Common Development and Distribution License (CDDL)|Common Development and Distribution License (CDDL) v1.0|COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0|CDDL, v1.0|CDDL 1.0 license|CDDL 1.0|CDDL 1.1</licenseMerge>
-								<!-- Jersey / Java Servlet API claims this license, but is actually 
-									CDDL 1.0: http://servlet-spec.java.net -->
-								<licenseMerge>Common Development and Distribution License (CDDL)|CDDL + GPLv2 with classpath exception</licenseMerge>
-								<!-- Jersey claims this license, but it is dual licensed with CDDL 
-									1.0 being one: https://jersey.java.net/license.html -->
-								<licenseMerge>Common Development and Distribution License (CDDL)|GPL2 w/ CPE</licenseMerge>
-								<licenseMerge>Eclipse Public License|Eclipse Public License - Version 1.0|Eclipse Public License - v 1.0|EPL 1.0 license</licenseMerge>
-								<!-- JUnit claims this license but is actually Eclipse Public License: 
-									http://junit.org/license.html -->
-								<licenseMerge>Eclipse Public License|Common Public License Version 1.0|Eclipse Public License 1.0</licenseMerge>
-								<licenseMerge>GNU Lesser General Public License (LGPL)|GNU Lesser General Public License (LGPL), Version 2.1|GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1|GNU Lesser General Public License|GNU Lesser Public License|GNU Lesser General Public License, Version 2.1|Lesser General Public License (LGPL) v 2.1|LGPL 2.1|LGPL 2.1 license|LGPL 3.0 license|LGPL, v2.1 or later|LGPL</licenseMerge>
-								<licenseMerge>Mozilla Public License|Mozilla Public License version 1.1|Mozilla Public License 1.1 (MPL 1.1)|MPL 1.1</licenseMerge>
-								<!-- H2 Database claims this license, but for our purposes it's MPL: 
-									http://www.h2database.com -->
-								<licenseMerge>Mozilla Public License|MPL 2.0, and EPL 1.0</licenseMerge>
-								<!-- BouncyCastle uses a modified MIT License: http://www.bouncycastle.org/license.html -->
-								<licenseMerge>MIT License|Bouncy Castle Licence</licenseMerge>
-							</licenseMerges>
-							<!-- For Licenses which are "Unknown" by Maven, load them from a properties 
-								file -->
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.xolstice.maven.plugins</groupId>
-				<artifactId>protobuf-maven-plugin</artifactId>
-				<version>0.5.0</version>
-				<configuration>
-          <protocArtifact>com.google.protobuf:protoc:${pb.version}:exe:${os.detected.classifier}</protocArtifact>
-					<pluginId>grpc-java</pluginId>
-					<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-					<clearOutputDirectory>false</clearOutputDirectory>
-					<checkStaleness>true</checkStaleness>
-					<excludes>
-						<exclude>k8s.io/**/*.proto</exclude>
-					</excludes>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-							<goal>compile-custom</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-     	 <plugin>
-            <!-- 
+  </properties>
+  <build>
+    <finalName>${project.artifactId}-${project.version}</finalName>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.4.1.Final</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.2</version>
+        <configuration>
+          <excludes>
+            <exclude>**/io/seldon/protos/**/*.class</exclude>
+            <exclude>
+            **/org/tensorflow/framework/**/*.class</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>jacoco-initialize</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>1.13</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>add-third-party</goal>
+              <goal>download-licenses</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${root.basedir}</outputDirectory>
+              <thirdPartyFilename>
+              LICENSES_THIRD_PARTY</thirdPartyFilename>
+              <!-- Use the template which groups all dependencies by their License 
+                                                                type (easier to read!). -->
+              <!-- SEE: https://fisheye.codehaus.org/browse/mojo/trunk/mojo/license-maven-plugin/src/main/resources/org/codehaus/mojo/license -->
+              <!-- <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByLicense.ftl</fileTemplate> -->
+              <fileTemplate>
+              /org/codehaus/mojo/license/third-party-file-groupByLicense.ftl</fileTemplate>
+              <!-- License names that should all be merged into the *first* listed 
+                                                                name -->
+              <licenseMerges>
+                <licenseMerge>MIT License|MIT|The MIT License|MIT
+                LICENSE|MIT license</licenseMerge>
+                <licenseMerge>Apache Software License, Version
+                2.0|The Apache Software License, Version 2.0|Apache
+                License Version 2.0|Apache License, Version
+                2.0|Apache Public License 2.0|Apache License
+                2.0|Apache Software License - Version 2.0|Apache
+                2.0 License|Apache 2.0 license|Apache License
+                V2.0|Apache 2|Apache License|Apache|ASF 2.0|Apache
+                2.0|Apache License, version 2.0|Apache Software
+                Licenses|Apache-2.0|The Apache License, Version
+                2.0</licenseMerge>
+                <!-- Ant-contrib is an Apache License -->
+                <licenseMerge>Apache Software License, Version
+                2.0|http://ant-contrib.sourceforge.net/tasks/LICENSE.txt</licenseMerge>
+                <licenseMerge>BSD License|The BSD License|BSD
+                licence|BSD license|BSD|BSD-style license|New BSD
+                License|New BSD license|Revised BSD
+                License</licenseMerge>
+                <!-- DuraSpace uses a BSD License for DSpace -->
+                <licenseMerge>BSD License|DuraSpace BSD
+                License|DuraSpace Sourcecode License</licenseMerge>
+                <!-- Coverity uses modified BSD: https://github.com/coverity/coverity-security-library -->
+                <licenseMerge>BSD License|BSD style modified by
+                Coverity</licenseMerge>
+                <licenseMerge>Common Development and Distribution
+                License (CDDL)|Common Development and Distribution
+                License (CDDL) v1.0|COMMON DEVELOPMENT AND
+                DISTRIBUTION LICENSE (CDDL) Version 1.0|CDDL,
+                v1.0|CDDL 1.0 license|CDDL 1.0|CDDL
+                1.1</licenseMerge>
+                <!-- Jersey / Java Servlet API claims this license, but is actually 
+                                                                        CDDL 1.0: http://servlet-spec.java.net -->
+                <licenseMerge>Common Development and Distribution
+                License (CDDL)|CDDL + GPLv2 with classpath
+                exception</licenseMerge>
+                <!-- Jersey claims this license, but it is dual licensed with CDDL 
+                                                                        1.0 being one: https://jersey.java.net/license.html -->
+                <licenseMerge>Common Development and Distribution
+                License (CDDL)|GPL2 w/ CPE</licenseMerge>
+                <licenseMerge>Eclipse Public License|Eclipse Public
+                License - Version 1.0|Eclipse Public License - v
+                1.0|EPL 1.0 license</licenseMerge>
+                <!-- JUnit claims this license but is actually Eclipse Public License: 
+                                                                        http://junit.org/license.html -->
+                <licenseMerge>Eclipse Public License|Common Public
+                License Version 1.0|Eclipse Public License
+                1.0</licenseMerge>
+                <licenseMerge>GNU Lesser General Public License
+                (LGPL)|GNU Lesser General Public License (LGPL),
+                Version 2.1|GNU LESSER GENERAL PUBLIC LICENSE,
+                Version 2.1|GNU Lesser General Public License|GNU
+                Lesser Public License|GNU Lesser General Public
+                License, Version 2.1|Lesser General Public License
+                (LGPL) v 2.1|LGPL 2.1|LGPL 2.1 license|LGPL 3.0
+                license|LGPL, v2.1 or later|LGPL</licenseMerge>
+                <licenseMerge>Mozilla Public License|Mozilla Public
+                License version 1.1|Mozilla Public License 1.1 (MPL
+                1.1)|MPL 1.1</licenseMerge>
+                <!-- H2 Database claims this license, but for our purposes it's MPL: 
+                                                                        http://www.h2database.com -->
+                <licenseMerge>Mozilla Public License|MPL 2.0, and
+                EPL 1.0</licenseMerge>
+                <!-- BouncyCastle uses a modified MIT License: http://www.bouncycastle.org/license.html -->
+                <licenseMerge>MIT License|Bouncy Castle
+                Licence</licenseMerge>
+              </licenseMerges>
+              <!-- For Licenses which are "Unknown" by Maven, load them from a properties 
+                                                                file -->
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.5.0</version>
+        <configuration>
+          <protocArtifact>
+          com.google.protobuf:protoc:${pb.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>
+          io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <clearOutputDirectory>false</clearOutputDirectory>
+          <checkStaleness>true</checkStaleness>
+          <excludes>
+            <exclude>k8s.io/**/*.proto</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>compile-custom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- 
                 Needed due to  https://issues.apache.org/jira/browse/SUREFIRE-1588
                 Should be removed when fixed 
                 -->
-      
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-                <useSystemClassLoader>false</useSystemClassLoader>
-            </configuration>
-        </plugin>
-			
-		</plugins>
-	</build>
-	<dependencies>
-		<!-- https://mvnrepository.com/artifact/org.nd4j/nd4j-native -->
-		<dependency>
-   			<groupId>org.ojalgo</groupId>
-    		<artifactId>ojalgo</artifactId>
-    		<version>47.3.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-			<exclusions>
-			  <exclusion>  <!-- Excluded due to nn standard license -->
-			    <groupId>org.json</groupId>
-			    <artifactId>json</artifactId>
-			  </exclusion>
-			</exclusions> 
-		</dependency>
-		<dependency>
-			<groupId>io.opentracing</groupId>
-			<artifactId>opentracing-mock</artifactId>
-      <version>${opentracing.version}</version>
-			<scope>test</scope>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <!-- https://mvnrepository.com/artifact/org.nd4j/nd4j-native -->
+    <dependency>
+      <groupId>org.ojalgo</groupId>
+      <artifactId>ojalgo</artifactId>
+      <version>47.3.1</version>
     </dependency>
-		<dependency>
-			<groupId>io.opentracing</groupId>
-			<artifactId>opentracing-api</artifactId>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Excluded due to nn standard license -->
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+      <version>${opentracing.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
       <version>${opentracing.version}</version>
     </dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
-		</dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-properties-migrator</artifactId>
       <scope>runtime</scope>
     </dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.curator</groupId>
-			<artifactId>curator-framework</artifactId>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
       <version>${curator.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.curator</groupId>
-			<artifactId>curator-recipes</artifactId>
-			<version>${curator.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-recipes</artifactId>
+      <version>${curator.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
-		</dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.9</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.8</version>
-		</dependency>
-
-	
-		<dependency>
-      		<groupId>io.grpc</groupId>
-      		<artifactId>grpc-netty</artifactId>
-      		<version>${grpc.version}</version>
-    	</dependency>
-   		<dependency>
-      		<groupId>io.grpc</groupId>
-      		<artifactId>grpc-stub</artifactId>
-      		<version>${grpc.version}</version>
-    	</dependency>
-		<dependency>
-			<groupId>io.grpc</groupId>
-			<artifactId>grpc-protobuf</artifactId>
-			<version>${grpc.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.8</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
       <version>${pb.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
       <version>${pb.version}</version>
-		</dependency>
-		<dependency>
-   	 		<groupId>com.google.guava</groupId>
-   		 	<artifactId>guava</artifactId>
-    		<version>28.1-jre</version>
-		</dependency>
-		
-		<dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-		
-		<dependency>
-		  	<groupId>io.micrometer</groupId>
-  			<artifactId>micrometer-registry-prometheus</artifactId>
-  			<version>${micrometer.version}</version>
-		</dependency>
-
-		<dependency>
-    		<groupId>io.kubernetes</groupId>
-    		<artifactId>client-java</artifactId>
-    		<version>6.0.1</version>
-    		<scope>compile</scope>
-		</dependency>
-		
-		<dependency>
-    		<groupId>io.jaegertracing</groupId>
-    		<artifactId>jaeger-client</artifactId>
-    		<version>${jaeger.version}</version>
-		</dependency>
-		
-		<dependency>
-    		<groupId>io.opentracing.contrib</groupId>
-    		<artifactId>opentracing-grpc</artifactId>
-    		<version>0.2.0</version>
-		</dependency>
-	
-		<dependency>
-  			<groupId>io.opentracing.contrib</groupId>
-  			<artifactId>opentracing-spring-web</artifactId>
-  			<version>2.1.3</version>
-		</dependency>
-	</dependencies>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.1-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>${micrometer.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>6.0.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jaegertracing</groupId>
+      <artifactId>jaeger-client</artifactId>
+      <version>${jaeger.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-grpc</artifactId>
+      <version>0.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-web</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -169,8 +169,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <source>1.8</source>
           <target>1.8</target>
           <encoding>UTF-8</encoding>
+          <showWarnings>true</showWarnings>
           <compilerArgs>
-            <arg>-Xlint</arg>
+            <arg>-Xlint:all</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -181,8 +182,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <configuration>
           <configLocation>google_checks.xml</configLocation>
           <consoleOutput>true</consoleOutput>
-          <failsOnError>true</failsOnError>
-          <linkXRef>false</linkXRef>
+          <failOnViolation>true</failOnViolation>
         </configuration>
         <executions>
           <execution>

--- a/engine/src/main/java/io/seldon/engine/App.java
+++ b/engine/src/main/java/io/seldon/engine/App.java
@@ -1,33 +1,32 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine;
 
+import io.seldon.engine.config.AppConfig;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.catalina.connector.Connector;
 import org.apache.tomcat.util.threads.ThreadPoolExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
-import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -35,70 +34,64 @@ import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import io.seldon.engine.config.AppConfig;
-
 @SpringBootApplication
 @EnableAsync
 @EnableScheduling
-@Import({ AppConfig.class })
+@Import({AppConfig.class})
 public class App {
-    public static void main(String[] args) throws Exception {
-        SpringApplication.run(App.class, args);
+  public static void main(String[] args) throws Exception {
+    SpringApplication.run(App.class, args);
+  }
+
+  @Bean
+  public GracefulShutdown gracefulShutdown() {
+    return new GracefulShutdown();
+  }
+
+  @Bean
+  public WebServerFactoryCustomizer tomcatCustomizer() {
+    return new WebServerFactoryCustomizer<TomcatServletWebServerFactory>() {
+      @Override
+      public void customize(TomcatServletWebServerFactory factory) {
+        factory.addConnectorCustomizers(gracefulShutdown());
+      }
+    };
+  }
+
+  private static class GracefulShutdown
+      implements TomcatConnectorCustomizer, ApplicationListener<ContextClosedEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(GracefulShutdown.class);
+
+    private volatile Connector connector;
+
+    @Override
+    public void customize(Connector connector) {
+      this.connector = connector;
     }
-    
-    @Bean
-    public GracefulShutdown gracefulShutdown() {
-        return new GracefulShutdown();
-    }
-    
-    @Bean
-    public WebServerFactoryCustomizer tomcatCustomizer() {
-        return new WebServerFactoryCustomizer<TomcatServletWebServerFactory>() {
-            @Override
-            public void customize(TomcatServletWebServerFactory factory) {
-              factory.addConnectorCustomizers(gracefulShutdown());
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+      log.info("Starting graceful shutdown of Tomcat");
+      if (this.connector != null) {
+        this.connector.pause();
+        Executor executor = this.connector.getProtocolHandler().getExecutor();
+        if (executor instanceof ThreadPoolExecutor) {
+          try {
+            ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
+            threadPoolExecutor.shutdown();
+            if (!threadPoolExecutor.awaitTermination(20, TimeUnit.SECONDS)) {
+              log.warn(
+                  "Tomcat thread pool did not shut down gracefully within "
+                      + "20 seconds. Proceeding with forceful shutdown");
+            } else {
+              log.info("Thread pool has closed");
             }
-        };
-    }
-
-    private static class GracefulShutdown implements TomcatConnectorCustomizer,
-            ApplicationListener<ContextClosedEvent> {
-
-        private static final Logger log = LoggerFactory.getLogger(GracefulShutdown.class);
-
-        private volatile Connector connector;
-
-        @Override
-        public void customize(Connector connector) {
-            this.connector = connector;
+          } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+          }
         }
-
-        @Override
-        public void onApplicationEvent(ContextClosedEvent event) {
-        	log.info("Starting graceful shutdown of Tomcat");
-        	if (this.connector != null)
-        	{
-        		this.connector.pause();
-                Executor executor = this.connector.getProtocolHandler().getExecutor();
-                if (executor instanceof ThreadPoolExecutor) {
-                    try {
-                        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
-                        threadPoolExecutor.shutdown();
-                        if (!threadPoolExecutor.awaitTermination(20, TimeUnit.SECONDS)) {
-                            log.warn("Tomcat thread pool did not shut down gracefully within "
-                                    + "20 seconds. Proceeding with forceful shutdown");
-                        }
-                        else
-                        {
-                            log.info("Thread pool has closed");
-                        }
-                    }
-                    catch (InterruptedException ex) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
-        	}
-        }
-
+      }
     }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/ExceptionControllerAdvice.java
+++ b/engine/src/main/java/io/seldon/engine/ExceptionControllerAdvice.java
@@ -1,51 +1,46 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.seldon.engine.exception.APIException;
+import io.seldon.engine.pb.ProtoBufUtils;
+import io.seldon.protos.PredictionProtos.Status;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.seldon.engine.exception.APIException;
-import io.seldon.engine.pb.ProtoBufUtils;
-import io.seldon.protos.PredictionProtos.Status;
-
-
 @ControllerAdvice
 public class ExceptionControllerAdvice {
 
-	@ExceptionHandler(APIException.class)
-	public ResponseEntity<String> handleUnauthorizedException(APIException exception) throws InvalidProtocolBufferException {
+  @ExceptionHandler(APIException.class)
+  public ResponseEntity<String> handleUnauthorizedException(APIException exception)
+      throws InvalidProtocolBufferException {
 
-		
-		Status.Builder statusBuilder = Status.newBuilder();
-		statusBuilder.setCode(exception.getApiExceptionType().getId());
-		statusBuilder.setReason(exception.getApiExceptionType().getMessage());
-		statusBuilder.setInfo(exception.getInfo());
-		statusBuilder.setStatus(Status.StatusFlag.FAILURE);		
-		
-		Status status = statusBuilder.build();
-		String json;
-		json = ProtoBufUtils.toJson(status);
-		return new ResponseEntity<String>(json,HttpStatus.valueOf(exception.getApiExceptionType().getHttpCode())); 
+    Status.Builder statusBuilder = Status.newBuilder();
+    statusBuilder.setCode(exception.getApiExceptionType().getId());
+    statusBuilder.setReason(exception.getApiExceptionType().getMessage());
+    statusBuilder.setInfo(exception.getInfo());
+    statusBuilder.setStatus(Status.StatusFlag.FAILURE);
 
-
-	}
-
+    Status status = statusBuilder.build();
+    String json;
+    json = ProtoBufUtils.toJson(status);
+    return new ResponseEntity<String>(
+        json, HttpStatus.valueOf(exception.getApiExceptionType().getHttpCode()));
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/api/rest/RestClientController.java
+++ b/engine/src/main/java/io/seldon/engine/api/rest/RestClientController.java
@@ -1,41 +1,41 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.api.rest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import io.micrometer.core.annotation.Timed;
-
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-
+import io.seldon.engine.exception.APIException;
+import io.seldon.engine.exception.APIException.ApiExceptionType;
+import io.seldon.engine.pb.ProtoBufUtils;
+import io.seldon.engine.service.PredictionService;
+import io.seldon.engine.tracing.TracingProvider;
+import io.seldon.protos.PredictionProtos.Feedback;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.PostConstruct;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
@@ -44,263 +44,231 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.seldon.engine.exception.APIException;
-import io.seldon.engine.exception.APIException.ApiExceptionType;
-import io.seldon.engine.pb.ProtoBufUtils;
-import io.seldon.engine.service.PredictionService;
-import io.seldon.engine.tracing.TracingProvider;
-import io.seldon.protos.PredictionProtos.Feedback;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
 @RestController
 public class RestClientController {
-	
-	private static Logger logger = LoggerFactory.getLogger(RestClientController.class.getName());
 
+  private static Logger logger = LoggerFactory.getLogger(RestClientController.class.getName());
 
-	@Autowired
-	private PredictionService predictionService;
-	
-	@Autowired
-	SeldonGraphReadyChecker readyChecker;
-	
-	@Autowired
-	TracingProvider tracingProvider;
-	
-	private AtomicBoolean ready = new AtomicBoolean(false);
-	
-	 @PostConstruct
-	 public void init(){
-		 ready.set(true);
-	 }	
-	
-	@RequestMapping("/")
-    String home() {
-        return "Hello World!!";
+  @Autowired private PredictionService predictionService;
+
+  @Autowired SeldonGraphReadyChecker readyChecker;
+
+  @Autowired TracingProvider tracingProvider;
+
+  private AtomicBoolean ready = new AtomicBoolean(false);
+
+  @PostConstruct
+  public void init() {
+    ready.set(true);
+  }
+
+  @RequestMapping("/")
+  String home() {
+    return "Hello World!!";
+  }
+
+  @RequestMapping(value = "/ping", method = RequestMethod.GET)
+  String ping() {
+    return "pong";
+  }
+
+  @RequestMapping("/ready")
+  ResponseEntity<String> ready() {
+
+    HttpHeaders responseHeaders = new HttpHeaders();
+    HttpStatus httpStatus;
+    String ret;
+    if (ready.get() && readyChecker.getReady()) {
+      httpStatus = HttpStatus.OK;
+      ret = "ready";
+    } else {
+      logger.warn(
+          "Not ready graph checker {}, controller {}", readyChecker.getReady(), ready.get());
+      httpStatus = HttpStatus.SERVICE_UNAVAILABLE;
+      ret = "Service unavailable";
     }
-	
-	@RequestMapping(value = "/ping", method = RequestMethod.GET)
-    String ping() {
-        return "pong";
-    }
-	
-	@RequestMapping("/ready")
-	ResponseEntity<String> ready() {
-		
-		HttpHeaders responseHeaders = new HttpHeaders();
-		HttpStatus httpStatus;
-		String ret;
-		if (ready.get() && readyChecker.getReady())
-		{
-			httpStatus = HttpStatus.OK;
-			ret = "ready";
-		}
-		else
-		{
-			logger.warn("Not ready graph checker {}, controller {}",readyChecker.getReady(),ready.get());
-			httpStatus = HttpStatus.SERVICE_UNAVAILABLE;
-			ret = "Service unavailable";
-		}
-		ResponseEntity<String> responseEntity = new ResponseEntity<String>(ret, responseHeaders, httpStatus);
-		return responseEntity;
-    }
+    ResponseEntity<String> responseEntity =
+        new ResponseEntity<String>(ret, responseHeaders, httpStatus);
+    return responseEntity;
+  }
 
-	@RequestMapping("/live")
-	ResponseEntity<String> live() {
+  @RequestMapping("/live")
+  ResponseEntity<String> live() {
 
-		HttpHeaders responseHeaders = new HttpHeaders();
-		HttpStatus httpStatus;
-		String ret  = "live";
-		httpStatus = HttpStatus.OK;
+    HttpHeaders responseHeaders = new HttpHeaders();
+    HttpStatus httpStatus;
+    String ret = "live";
+    httpStatus = HttpStatus.OK;
 
-		ResponseEntity<String> responseEntity = new ResponseEntity<String>(ret, responseHeaders, httpStatus);
-		return responseEntity;
-	}
+    ResponseEntity<String> responseEntity =
+        new ResponseEntity<String>(ret, responseHeaders, httpStatus);
+    return responseEntity;
+  }
 
+  @RequestMapping("/pause")
+  String pause() {
+    ready.set(false);
+    logger.warn("App Paused");
+    return "paused";
+  }
 
-	@RequestMapping("/pause")
-    String pause() {	    
-		ready.set(false);
-        logger.warn("App Paused");
-        return "paused";
-    }
-	
-	@RequestMapping("/unpause")
-    String unpause() {	    
-		ready.set(true);
-        logger.warn("App UnPaused");		
-        return "unpaused";
-    }
+  @RequestMapping("/unpause")
+  String unpause() {
+    ready.set(true);
+    logger.warn("App UnPaused");
+    return "unpaused";
+  }
 
-	@Timed
-	@CrossOrigin(origins = "*")
-	@RequestMapping(value = "/api/v0.1/predictions", method = RequestMethod.POST, consumes = "application/json; charset=utf-8", produces = "application/json; charset=utf-8")
-    public ResponseEntity<String> predictions_json(RequestEntity<String> requestEntity)
-	{
-		logger.debug("Received predict request");
-		Span tracingSpan = null;
-		if (tracingProvider.isActive()) {
+  @Timed
+  @CrossOrigin(origins = "*")
+  @RequestMapping(
+      value = "/api/v0.1/predictions",
+      method = RequestMethod.POST,
+      consumes = "application/json; charset=utf-8",
+      produces = "application/json; charset=utf-8")
+  public ResponseEntity<String> predictions_json(RequestEntity<String> requestEntity) {
+    logger.debug("Received predict request");
+    Span tracingSpan = null;
+    if (tracingProvider.isActive()) {
       Tracer tracer = tracingProvider.getTracer();
-			tracingSpan = tracer.buildSpan("/api/v0.1/predictions").start();
+      tracingSpan = tracer.buildSpan("/api/v0.1/predictions").start();
       tracer.scopeManager().activate(tracingSpan);
     }
-		try
-		{
-			return _predictions(requestEntity.getBody());
-		}
-		finally
-		{
-			if (tracingSpan != null)
-				tracingSpan.finish();
-		}
+    try {
+      return _predictions(requestEntity.getBody());
+    } finally {
+      if (tracingSpan != null) tracingSpan.finish();
+    }
+  }
 
-	}
-
-
-	@Timed
-	@CrossOrigin(origins = "*")
-	@RequestMapping(value = "/api/v0.1/predictions", method = RequestMethod.POST, consumes = "multipart/form-data", produces = "application/json; charset=utf-8")
-	public ResponseEntity<String> predictions_multiform(MultipartHttpServletRequest requestEntity)
-	{
-		logger.debug("Received predict request");
-		Span tracingSpan = null;
-		if (tracingProvider.isActive()) {
+  @Timed
+  @CrossOrigin(origins = "*")
+  @RequestMapping(
+      value = "/api/v0.1/predictions",
+      method = RequestMethod.POST,
+      consumes = "multipart/form-data",
+      produces = "application/json; charset=utf-8")
+  public ResponseEntity<String> predictions_multiform(MultipartHttpServletRequest requestEntity) {
+    logger.debug("Received predict request");
+    Span tracingSpan = null;
+    if (tracingProvider.isActive()) {
       Tracer tracer = tracingProvider.getTracer();
-			tracingSpan = tracer.buildSpan("/api/v0.1/predictions").start();
+      tracingSpan = tracer.buildSpan("/api/v0.1/predictions").start();
       tracer.scopeManager().activate(tracingSpan);
     }
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			Map<String,Object> mergedParamMap = new HashMap<String,Object>();
-			if(requestEntity.getParameterMap() != null){
-				for(Map.Entry<String,String[]> formEntry: requestEntity.getParameterMap().entrySet()){
-					if(formEntry.getKey().equalsIgnoreCase(SeldonMessage.DataOneofCase.STRDATA.name())){
-						mergedParamMap.put(formEntry.getKey(),formEntry.getValue()[0]);
-					}else{
-                        mergedParamMap.put(formEntry.getKey(),mapper.readTree(formEntry.getValue()[0]));
-					}
-				}
-			}
-			if(requestEntity.getFileMap() != null){
-				for(Map.Entry<String ,MultipartFile> fileEntry: requestEntity.getFileMap().entrySet()){
-					if(fileEntry.getKey().equalsIgnoreCase(SeldonMessage.DataOneofCase.STRDATA.name())){
-						mergedParamMap.put(fileEntry.getKey(),new String(fileEntry.getValue().getBytes()));
-					}else{
-						mergedParamMap.put(fileEntry.getKey(),fileEntry.getValue().getBytes());
-					}
-				}
-			}
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      Map<String, Object> mergedParamMap = new HashMap<String, Object>();
+      if (requestEntity.getParameterMap() != null) {
+        for (Map.Entry<String, String[]> formEntry : requestEntity.getParameterMap().entrySet()) {
+          if (formEntry.getKey().equalsIgnoreCase(SeldonMessage.DataOneofCase.STRDATA.name())) {
+            mergedParamMap.put(formEntry.getKey(), formEntry.getValue()[0]);
+          } else {
+            mergedParamMap.put(formEntry.getKey(), mapper.readTree(formEntry.getValue()[0]));
+          }
+        }
+      }
+      if (requestEntity.getFileMap() != null) {
+        for (Map.Entry<String, MultipartFile> fileEntry : requestEntity.getFileMap().entrySet()) {
+          if (fileEntry.getKey().equalsIgnoreCase(SeldonMessage.DataOneofCase.STRDATA.name())) {
+            mergedParamMap.put(fileEntry.getKey(), new String(fileEntry.getValue().getBytes()));
+          } else {
+            mergedParamMap.put(fileEntry.getKey(), fileEntry.getValue().getBytes());
+          }
+        }
+      }
 
-			return _predictions(mapper.writeValueAsString(mergedParamMap));
-		} catch (IOException e) {
-			logger.error("Bad request",e);
-			throw new APIException(ApiExceptionType.REQUEST_IO_EXCEPTION,e.getMessage());
+      return _predictions(mapper.writeValueAsString(mergedParamMap));
+    } catch (IOException e) {
+      logger.error("Bad request", e);
+      throw new APIException(ApiExceptionType.REQUEST_IO_EXCEPTION, e.getMessage());
 
-		} finally
-		{
-			if (tracingSpan != null)
-				tracingSpan.finish();
-		}
+    } finally {
+      if (tracingSpan != null) tracingSpan.finish();
+    }
+  }
 
-	}
+  /**
+   * It calls the prediction service for the input json. It is the base function for all forms of
+   * request Content-type
+   *
+   * @param json - Input JSON to predict REST api
+   * @return The response for prediction service
+   */
+  private ResponseEntity<String> _predictions(String json) {
+    SeldonMessage request;
+    try {
+      SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+      ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
+      request = builder.build();
+    } catch (InvalidProtocolBufferException e) {
+      logger.error("Bad request", e);
+      throw new APIException(ApiExceptionType.ENGINE_INVALID_JSON, json);
+    }
 
-	/**
-	 * It calls the prediction service for the input json.
-	 * It is the base function for all forms of request Content-type
-	 * @param json - Input JSON to predict REST api
-	 * @return The response for prediction service
-	 */
-	private ResponseEntity<String> _predictions(String json)
-	{
-			SeldonMessage request;
-			try
-			{
-				SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-				ProtoBufUtils.updateMessageBuilderFromJson(builder, json );
-				request = builder.build();
-			}
-			catch (InvalidProtocolBufferException e)
-			{
-				logger.error("Bad request",e);
-				throw new APIException(ApiExceptionType.ENGINE_INVALID_JSON,json);
-			}
+    try {
+      SeldonMessage response = predictionService.predict(request);
+      String responseJson = ProtoBufUtils.toJson(response);
+      return new ResponseEntity<String>(responseJson, HttpStatus.OK);
+    } catch (InterruptedException e) {
+      throw new APIException(ApiExceptionType.ENGINE_INTERRUPTED, e.getMessage());
+    } catch (ExecutionException e) {
+      if (e.getCause().getClass() == APIException.class) {
+        throw (APIException) e.getCause();
+      } else {
+        throw new APIException(ApiExceptionType.ENGINE_EXECUTION_FAILURE, e.getMessage());
+      }
+    } catch (InvalidProtocolBufferException e) {
+      throw new APIException(ApiExceptionType.ENGINE_INVALID_RESPONSE_JSON, "");
+    }
+  }
 
-			try
-			{
-				SeldonMessage response = predictionService.predict(request);
-				String responseJson = ProtoBufUtils.toJson(response);
-				return new ResponseEntity<String>(responseJson,HttpStatus.OK);
-			}
-			catch (InterruptedException e) {
-				throw new APIException(ApiExceptionType.ENGINE_INTERRUPTED,e.getMessage());
-			} catch (ExecutionException e) {
-				if (e.getCause().getClass() == APIException.class){
-					throw (APIException) e.getCause();
-				}
-				else
-				{
-					throw new APIException(ApiExceptionType.ENGINE_EXECUTION_FAILURE,e.getMessage());
-				}
-			} catch (InvalidProtocolBufferException e) {
-				throw new APIException(ApiExceptionType.ENGINE_INVALID_RESPONSE_JSON,"");
-			}
-	}
-
-	@Timed
-	@CrossOrigin(origins = "*")
-	@RequestMapping(value= "/api/v0.1/feedback", method = RequestMethod.POST, consumes = "application/json; charset=utf-8", produces = "application/json; charset=utf-8")
-	public ResponseEntity<String>  feedback(RequestEntity<String> requestEntity) {
-		logger.debug("Received feedback request");
-		Span tracingSpan = null;
-		if (tracingProvider.isActive()) {
+  @Timed
+  @CrossOrigin(origins = "*")
+  @RequestMapping(
+      value = "/api/v0.1/feedback",
+      method = RequestMethod.POST,
+      consumes = "application/json; charset=utf-8",
+      produces = "application/json; charset=utf-8")
+  public ResponseEntity<String> feedback(RequestEntity<String> requestEntity) {
+    logger.debug("Received feedback request");
+    Span tracingSpan = null;
+    if (tracingProvider.isActive()) {
       Tracer tracer = tracingProvider.getTracer();
-			tracingSpan = tracer.buildSpan("/api/v0.1/feedback").start();
+      tracingSpan = tracer.buildSpan("/api/v0.1/feedback").start();
       tracer.scopeManager().activate(tracingSpan);
     }
-		try
-		{
-		Feedback feedback;	
-		try
-		{
-			Feedback.Builder builder = Feedback.newBuilder();
-			ProtoBufUtils.updateMessageBuilderFromJson(builder, requestEntity.getBody() );
-			feedback = builder.build();
-		} 
-		catch (InvalidProtocolBufferException e) 
-		{
-			logger.error("Bad request",e);
-			throw new APIException(ApiExceptionType.ENGINE_INVALID_JSON,requestEntity.getBody());
-		}
-		
-		try
-		{
-			predictionService.sendFeedback(feedback);
-			String json = "{}";
-			return new ResponseEntity<String>(json,HttpStatus.OK);
-		}
-		 catch (InterruptedException e) {
-			throw new APIException(ApiExceptionType.ENGINE_INTERRUPTED,e.getMessage());
-		} catch (ExecutionException e) {
-			if (e.getCause().getClass() == APIException.class){
-				throw (APIException) e.getCause();
-			}
-			else
-			{
-				throw new APIException(ApiExceptionType.ENGINE_EXECUTION_FAILURE,e.getMessage());
-			}
-		} catch (InvalidProtocolBufferException e) {
-			throw new APIException(ApiExceptionType.ENGINE_INVALID_RESPONSE_JSON,"");
-		} 
-		}
-		finally
-		{
-			if (tracingSpan != null)
-				tracingSpan.finish();
-		}
+    try {
+      Feedback feedback;
+      try {
+        Feedback.Builder builder = Feedback.newBuilder();
+        ProtoBufUtils.updateMessageBuilderFromJson(builder, requestEntity.getBody());
+        feedback = builder.build();
+      } catch (InvalidProtocolBufferException e) {
+        logger.error("Bad request", e);
+        throw new APIException(ApiExceptionType.ENGINE_INVALID_JSON, requestEntity.getBody());
+      }
 
+      try {
+        predictionService.sendFeedback(feedback);
+        String json = "{}";
+        return new ResponseEntity<String>(json, HttpStatus.OK);
+      } catch (InterruptedException e) {
+        throw new APIException(ApiExceptionType.ENGINE_INTERRUPTED, e.getMessage());
+      } catch (ExecutionException e) {
+        if (e.getCause().getClass() == APIException.class) {
+          throw (APIException) e.getCause();
+        } else {
+          throw new APIException(ApiExceptionType.ENGINE_EXECUTION_FAILURE, e.getMessage());
+        }
+      } catch (InvalidProtocolBufferException e) {
+        throw new APIException(ApiExceptionType.ENGINE_INVALID_RESPONSE_JSON, "");
+      }
+    } finally {
+      if (tracingSpan != null) tracingSpan.finish();
     }
-
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/api/rest/SeldonGraphReadyChecker.java
+++ b/engine/src/main/java/io/seldon/engine/api/rest/SeldonGraphReadyChecker.java
@@ -1,16 +1,5 @@
 package io.seldon.engine.api.rest;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
 import io.seldon.engine.predictors.EnginePredictor;
 import io.seldon.engine.predictors.PredictiveUnitBean;
 import io.seldon.engine.predictors.PredictiveUnitImpl;
@@ -19,101 +8,97 @@ import io.seldon.engine.predictors.PredictorBean;
 import io.seldon.engine.predictors.PredictorConfigBean;
 import io.seldon.engine.predictors.PredictorState;
 import io.seldon.protos.DeploymentProtos.Endpoint;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 
 @Component
 public class SeldonGraphReadyChecker extends PredictiveUnitImpl {
 
-	private final static Logger logger = LoggerFactory.getLogger(SeldonGraphReadyChecker.class);
-	@Autowired
-	EnginePredictor enginePredictor;
-	
-	@Autowired
-	PredictorBean predictorBean;
-	
-	@Autowired
-	PredictiveUnitBean pcb;
-	
-	@Autowired
-	public PredictorConfigBean predictorConfig;
-	
-	private AtomicBoolean ready = new AtomicBoolean();
-	
-	public SeldonGraphReadyChecker() {
-		ready.set(false);
-	}
-	
-	public boolean checkReady(PredictiveUnitState state)
-	{
-		PredictiveUnitImpl implementation = predictorConfig.getImplementation(state);
-		if (implementation == null){ implementation = this; }
-		
-		if (!implementation.ready(state))
-		{
-			logger.info("{} not ready!",state.name);
-			return false;
-		}
-		else
-		{
-			if (state.children.isEmpty())
-				return true;
-			else
-			{
-				for (PredictiveUnitState childState : state.children)
-				{
-					if (!checkReady(childState))
-						return false;
-				}
-				return true;
-			}
-		}
-	}
-	
-	public boolean ready(PredictiveUnitState state) {
-		if (predictorConfig.hasMethod(state))
-			return pingHost(state.endpoint);
-		else
-			return false;
-	}
-	
-	private boolean pingHost(Endpoint endpoint) {
-		for(int i=0;i<3;i++)
-    	{
-			Socket socket = null;
-			try 
-			{
-				socket = new Socket();
-	    		socket.connect(new InetSocketAddress(endpoint.getServiceHost(), endpoint.getServicePort()), 500);
-	    		socket.close();
-	    		socket = null;
-	    		return true;
-			} catch (IOException e) {
-				logger.warn("Failed to connect to {}:{}",endpoint.getServiceHost(),endpoint.getServicePort());
-			}
-			finally {
-				if (socket != null)
-				{
-					try {
-						socket.close();
-					} catch (IOException e) {
-						logger.error("Failed to close socket",e);
-					}
-				}
-			}
-    	}
-		logger.warn("Failing {}:{}",endpoint.getServiceHost(),endpoint.getServicePort());
-		return false;
-	}
-	
-	public boolean getReady() {
-		return ready.get();
-	}
+  private static final Logger logger = LoggerFactory.getLogger(SeldonGraphReadyChecker.class);
+  @Autowired EnginePredictor enginePredictor;
 
-	@Scheduled(fixedDelay = 5000)
-    public void checkReady() {
-		PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(enginePredictor.getPredictorSpec());
-		PredictiveUnitState state = predictorState.rootState; 
-		boolean graphReady = checkReady(state);
-		logger.debug("Seldon graph ready: {}",ready);
-		ready.set(graphReady);
-	}
+  @Autowired PredictorBean predictorBean;
+
+  @Autowired PredictiveUnitBean pcb;
+
+  @Autowired public PredictorConfigBean predictorConfig;
+
+  private AtomicBoolean ready = new AtomicBoolean();
+
+  public SeldonGraphReadyChecker() {
+    ready.set(false);
+  }
+
+  public boolean checkReady(PredictiveUnitState state) {
+    PredictiveUnitImpl implementation = predictorConfig.getImplementation(state);
+    if (implementation == null) {
+      implementation = this;
+    }
+
+    if (!implementation.ready(state)) {
+      logger.info("{} not ready!", state.name);
+      return false;
+    } else {
+      if (state.children.isEmpty()) return true;
+      else {
+        for (PredictiveUnitState childState : state.children) {
+          if (!checkReady(childState)) return false;
+        }
+        return true;
+      }
+    }
+  }
+
+  public boolean ready(PredictiveUnitState state) {
+    if (predictorConfig.hasMethod(state)) return pingHost(state.endpoint);
+    else return false;
+  }
+
+  private boolean pingHost(Endpoint endpoint) {
+    for (int i = 0; i < 3; i++) {
+      Socket socket = null;
+      try {
+        socket = new Socket();
+        socket.connect(
+            new InetSocketAddress(endpoint.getServiceHost(), endpoint.getServicePort()), 500);
+        socket.close();
+        socket = null;
+        return true;
+      } catch (IOException e) {
+        logger.warn(
+            "Failed to connect to {}:{}", endpoint.getServiceHost(), endpoint.getServicePort());
+      } finally {
+        if (socket != null) {
+          try {
+            socket.close();
+          } catch (IOException e) {
+            logger.error("Failed to close socket", e);
+          }
+        }
+      }
+    }
+    logger.warn("Failing {}:{}", endpoint.getServiceHost(), endpoint.getServicePort());
+    return false;
+  }
+
+  public boolean getReady() {
+    return ready.get();
+  }
+
+  @Scheduled(fixedDelay = 5000)
+  public void checkReady() {
+    PredictorState predictorState =
+        predictorBean.predictorStateFromPredictorSpec(enginePredictor.getPredictorSpec());
+    PredictiveUnitState state = predictorState.rootState;
+    boolean graphReady = checkReady(state);
+    logger.debug("Seldon graph ready: {}", ready);
+    ready.set(graphReady);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/config/AnnotationsConfig.java
+++ b/engine/src/main/java/io/seldon/engine/config/AnnotationsConfig.java
@@ -9,73 +9,59 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * 
- * @author clive
- * Utility class to load annotations from kubernetes file for use by other components as config during startup
- *
+ * @author clive Utility class to load annotations from kubernetes file for use by other components
+ *     as config during startup
  */
 @Component
 public class AnnotationsConfig {
-	protected static Logger logger = LoggerFactory.getLogger(AnnotationsConfig.class.getName());
-	final String ANNOTATIONS_FILE = "/etc/podinfo/annotations";
-	
-	final Map<String,String> annotations = new ConcurrentHashMap<>();
-	
-	String readFile(String path, Charset encoding) throws IOException 
-	{
-		byte[] encoded = Files.readAllBytes(Paths.get(path));
-		return new String(encoded, encoding);
-	}
-	
-	public AnnotationsConfig() throws IOException
-	{
-		loadAnnotations();
-	}
-	
-	private void processAnnotation(String line)
-	{
-		final String[] parts = line.split("=");
-		if (parts.length == 2)
-		{
-			final String value = parts[1].substring(1, parts[1].length()-1); //remove start and end quote
-			annotations.put(parts[0], value);
-		}
-		else
-			logger.warn("Failed to parse annotation {}",line);
-	}
-	
-	private void loadAnnotations()
-	{
-		try
-		{
-			File f = new File(ANNOTATIONS_FILE);
-			if(f.exists() && !f.isDirectory()) 
-			{ 
-				try (BufferedReader r = Files.newBufferedReader(Paths.get(ANNOTATIONS_FILE), StandardCharsets.UTF_8)) 
-				{
-					r.lines().forEach(this::processAnnotation);
-				}
-			}
-			} catch (IOException e) {
-				logger.error("Failed to load annotations file {}",ANNOTATIONS_FILE,e);
-			}
-		logger.info("Annotations {}",annotations);
-	}
-	
-	public boolean has(String key)
-	{
-		return annotations.containsKey(key);
-	}
-	
-	public String get(String key)
-	{
-		return annotations.get(key);
-	}
-	
+  protected static Logger logger = LoggerFactory.getLogger(AnnotationsConfig.class.getName());
+  final String ANNOTATIONS_FILE = "/etc/podinfo/annotations";
+
+  final Map<String, String> annotations = new ConcurrentHashMap<>();
+
+  String readFile(String path, Charset encoding) throws IOException {
+    byte[] encoded = Files.readAllBytes(Paths.get(path));
+    return new String(encoded, encoding);
+  }
+
+  public AnnotationsConfig() throws IOException {
+    loadAnnotations();
+  }
+
+  private void processAnnotation(String line) {
+    final String[] parts = line.split("=");
+    if (parts.length == 2) {
+      final String value =
+          parts[1].substring(1, parts[1].length() - 1); // remove start and end quote
+      annotations.put(parts[0], value);
+    } else logger.warn("Failed to parse annotation {}", line);
+  }
+
+  private void loadAnnotations() {
+    try {
+      File f = new File(ANNOTATIONS_FILE);
+      if (f.exists() && !f.isDirectory()) {
+        try (BufferedReader r =
+            Files.newBufferedReader(Paths.get(ANNOTATIONS_FILE), StandardCharsets.UTF_8)) {
+          r.lines().forEach(this::processAnnotation);
+        }
+      }
+    } catch (IOException e) {
+      logger.error("Failed to load annotations file {}", ANNOTATIONS_FILE, e);
+    }
+    logger.info("Annotations {}", annotations);
+  }
+
+  public boolean has(String key) {
+    return annotations.containsKey(key);
+  }
+
+  public String get(String key) {
+    return annotations.get(key);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/config/AppConfig.java
+++ b/engine/src/main/java/io/seldon/engine/config/AppConfig.java
@@ -1,38 +1,37 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.config;
 
+import io.seldon.engine.predictors.EnginePredictor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 
-import io.seldon.engine.predictors.EnginePredictor;
-
 public class AppConfig {
 
-    @Bean
-    @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-    public WebServerFactoryCustomizer containerCustomizer() {
-        return new CustomizationBean();
-    }
+  @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+  public WebServerFactoryCustomizer containerCustomizer() {
+    return new CustomizationBean();
+  }
 
-    @Bean(initMethod = "init", destroyMethod = "cleanup")
-    @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-    public EnginePredictor enginePredictor() {
-        return new EnginePredictor();
-    }
+  @Bean(initMethod = "init", destroyMethod = "cleanup")
+  @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+  public EnginePredictor enginePredictor() {
+    return new EnginePredictor();
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/config/CustomizationBean.java
+++ b/engine/src/main/java/io/seldon/engine/config/CustomizationBean.java
@@ -1,52 +1,54 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 
-public class CustomizationBean implements WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> {
+public class CustomizationBean
+    implements WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> {
 
-    private final static Logger logger = LoggerFactory.getLogger(CustomizationBean.class);
-    private final static String ENGINE_SERVER_PORT_KEY = "ENGINE_SERVER_PORT";
+  private static final Logger logger = LoggerFactory.getLogger(CustomizationBean.class);
+  private static final String ENGINE_SERVER_PORT_KEY = "ENGINE_SERVER_PORT";
 
-    @Value("${server.port}")
-    private Integer defaultServerPort;
+  @Value("${server.port}")
+  private Integer defaultServerPort;
 
-    @Override
-    public void customize(ConfigurableServletWebServerFactory factory) {
-        logger.info("Customizing EmbeddedServlet");
+  @Override
+  public void customize(ConfigurableServletWebServerFactory factory) {
+    logger.info("Customizing EmbeddedServlet");
 
-        Integer serverPort;
-        { // setup the server port using the env vars
-            String engineServerPortString = System.getenv().get(ENGINE_SERVER_PORT_KEY);
-            if (engineServerPortString == null) {
-                logger.warn("FAILED to find env var [{}], will use defaults for engine server port", ENGINE_SERVER_PORT_KEY);
-                serverPort = defaultServerPort;
-            } else {
-                logger.info("FOUND env var [{}], will use for engine server port", ENGINE_SERVER_PORT_KEY);
-                serverPort = Integer.parseInt(engineServerPortString);
-            }
-        }
-
-        logger.info("setting serverPort[{}]", serverPort);
-        factory.setPort(serverPort);
+    Integer serverPort;
+    { // setup the server port using the env vars
+      String engineServerPortString = System.getenv().get(ENGINE_SERVER_PORT_KEY);
+      if (engineServerPortString == null) {
+        logger.warn(
+            "FAILED to find env var [{}], will use defaults for engine server port",
+            ENGINE_SERVER_PORT_KEY);
+        serverPort = defaultServerPort;
+      } else {
+        logger.info("FOUND env var [{}], will use for engine server port", ENGINE_SERVER_PORT_KEY);
+        serverPort = Integer.parseInt(engineServerPortString);
+      }
     }
 
+    logger.info("setting serverPort[{}]", serverPort);
+    factory.setPort(serverPort);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/config/RestTemplateConfig.java
+++ b/engine/src/main/java/io/seldon/engine/config/RestTemplateConfig.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.config;
 
 import org.apache.http.client.HttpClient;
@@ -28,45 +28,48 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class RestTemplateConfig {
 
-	private static final int DEFAULT_REQ_TIMEOUT = 1000;
-    private static final int DEFAULT_CON_TIMEOUT = 1000;
-    private static final int DEFAULT_SOCKET_TIMEOUT = 2000;
-    private static final int DEFAULT_POOL_MAX_TOTAL = 150;
-    private static final int DEFAULT_POOL_MAX_PER_ROUTE = 25;
+  private static final int DEFAULT_REQ_TIMEOUT = 1000;
+  private static final int DEFAULT_CON_TIMEOUT = 1000;
+  private static final int DEFAULT_SOCKET_TIMEOUT = 2000;
+  private static final int DEFAULT_POOL_MAX_TOTAL = 150;
+  private static final int DEFAULT_POOL_MAX_PER_ROUTE = 25;
 
-	
-	@Bean
-	public PoolingHttpClientConnectionManager poolingHttpClientConnectionManager() {
-		PoolingHttpClientConnectionManager result = new PoolingHttpClientConnectionManager();
-		result.setMaxTotal(DEFAULT_POOL_MAX_TOTAL);
-		result.setDefaultMaxPerRoute(DEFAULT_POOL_MAX_PER_ROUTE);
-	    return result;
-	}
+  @Bean
+  public PoolingHttpClientConnectionManager poolingHttpClientConnectionManager() {
+    PoolingHttpClientConnectionManager result = new PoolingHttpClientConnectionManager();
+    result.setMaxTotal(DEFAULT_POOL_MAX_TOTAL);
+    result.setDefaultMaxPerRoute(DEFAULT_POOL_MAX_PER_ROUTE);
+    return result;
+  }
 
-	@Bean
-	public RequestConfig requestConfig() {
-		RequestConfig result = RequestConfig.custom()
-	      .setConnectionRequestTimeout(DEFAULT_REQ_TIMEOUT)
-	      .setConnectTimeout(DEFAULT_CON_TIMEOUT)
-	      .setSocketTimeout(DEFAULT_SOCKET_TIMEOUT)
-	      .build();
-	    return result;
-	}
+  @Bean
+  public RequestConfig requestConfig() {
+    RequestConfig result =
+        RequestConfig.custom()
+            .setConnectionRequestTimeout(DEFAULT_REQ_TIMEOUT)
+            .setConnectTimeout(DEFAULT_CON_TIMEOUT)
+            .setSocketTimeout(DEFAULT_SOCKET_TIMEOUT)
+            .build();
+    return result;
+  }
 
-	@Bean
-	public CloseableHttpClient httpClient(PoolingHttpClientConnectionManager poolingHttpClientConnectionManager, RequestConfig requestConfig) {
-		CloseableHttpClient result = HttpClientBuilder
-	      .create()
-	      .setConnectionManager(poolingHttpClientConnectionManager)
-	      .setDefaultRequestConfig(requestConfig)
-	      .build();
-	    return result;
-	}
+  @Bean
+  public CloseableHttpClient httpClient(
+      PoolingHttpClientConnectionManager poolingHttpClientConnectionManager,
+      RequestConfig requestConfig) {
+    CloseableHttpClient result =
+        HttpClientBuilder.create()
+            .setConnectionManager(poolingHttpClientConnectionManager)
+            .setDefaultRequestConfig(requestConfig)
+            .build();
+    return result;
+  }
 
-	@Bean
-	public RestTemplate restTemplate(HttpClient httpClient) {
-		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
-	    requestFactory.setHttpClient(httpClient);
-	    return new RestTemplate(requestFactory);
-	}
+  @Bean
+  public RestTemplate restTemplate(HttpClient httpClient) {
+    HttpComponentsClientHttpRequestFactory requestFactory =
+        new HttpComponentsClientHttpRequestFactory();
+    requestFactory.setHttpClient(httpClient);
+    return new RestTemplate(requestFactory);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/config/TomcatConfig.java
+++ b/engine/src/main/java/io/seldon/engine/config/TomcatConfig.java
@@ -1,51 +1,43 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.config;
 
+import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
 import org.apache.catalina.connector.Connector;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.google.common.collect.Sets;
-
 @Configuration
 public class TomcatConfig {
-	
+
   @Value("${server.port}")
   private String serverPort;
-
-
 
   @Value("${management.port:${server.port}}")
   private String managementPort;
 
-
-
   @Value("${server.additionalPorts:}")
   private String additionalPorts;
-
-
 
   @Bean
   public ServletWebServerFactory servletContainer() {
@@ -57,8 +49,6 @@ public class TomcatConfig {
 
     return tomcat;
   }
-
-
 
   private Connector[] additionalConnector() {
     if (StringUtils.isBlank(this.additionalPorts)) {
@@ -75,11 +65,8 @@ public class TomcatConfig {
         connector.setPort(Integer.valueOf(port));
         result.add(connector);
       }
-
     }
 
     return result.toArray(new Connector[] {});
-
   }
-
 }

--- a/engine/src/main/java/io/seldon/engine/exception/APIException.java
+++ b/engine/src/main/java/io/seldon/engine/exception/APIException.java
@@ -25,67 +25,63 @@ package io.seldon.engine.exception;
 
 public class APIException extends RuntimeException {
 
-	public enum ApiExceptionType { 
-		
-		ENGINE_INVALID_JSON(201,"Invalid JSON",400),
-		ENGINE_INVALID_RESPONSE_JSON(201,"Invalid Response JSON",500),
-		ENGINE_INVALID_ENDPOINT_URL(202,"Invalid Endpoint URL",500),	
-		ENGINE_MICROSERVICE_ERROR(203,"Microservice error",500),
-		ENGINE_INVALID_ABTEST(204,"Error happened in AB Test Routing",500),
-		ENGINE_INVALID_COMBINER_RESPONSE(204,"Invalid number of predictions from combiner",500),
-		ENGINE_INTERRUPTED(205,"API call interrupted",500),
-		ENGINE_EXECUTION_FAILURE(206,"Execution failure",500),
-		ENGINE_INVALID_ROUTING(207,"Invalid Routing",500),
-		REQUEST_IO_EXCEPTION(208,"IO Exception",500);
-		
-		int id;
-		String message;
-		int httpCode;
+  public enum ApiExceptionType {
+    ENGINE_INVALID_JSON(201, "Invalid JSON", 400),
+    ENGINE_INVALID_RESPONSE_JSON(201, "Invalid Response JSON", 500),
+    ENGINE_INVALID_ENDPOINT_URL(202, "Invalid Endpoint URL", 500),
+    ENGINE_MICROSERVICE_ERROR(203, "Microservice error", 500),
+    ENGINE_INVALID_ABTEST(204, "Error happened in AB Test Routing", 500),
+    ENGINE_INVALID_COMBINER_RESPONSE(204, "Invalid number of predictions from combiner", 500),
+    ENGINE_INTERRUPTED(205, "API call interrupted", 500),
+    ENGINE_EXECUTION_FAILURE(206, "Execution failure", 500),
+    ENGINE_INVALID_ROUTING(207, "Invalid Routing", 500),
+    REQUEST_IO_EXCEPTION(208, "IO Exception", 500);
 
-		ApiExceptionType(int id,String message,int httpCode) {
-		    this.id = id;
-		    this.message = message;
-		    this.httpCode = httpCode;
-		  }
+    int id;
+    String message;
+    int httpCode;
 
-		public int getId() {
-			return id;
-		}
+    ApiExceptionType(int id, String message, int httpCode) {
+      this.id = id;
+      this.message = message;
+      this.httpCode = httpCode;
+    }
 
-		public String getMessage() {
-			return message;
-		}
+    public int getId() {
+      return id;
+    }
 
-		public int getHttpCode() {
-			return httpCode;
-		}
+    public String getMessage() {
+      return message;
+    }
 
-		
-	};
+    public int getHttpCode() {
+      return httpCode;
+    }
+  };
 
-   ApiExceptionType apiExceptionType;
-   String info;
+  ApiExceptionType apiExceptionType;
+  String info;
 
-   public APIException(ApiExceptionType apiExceptionType,String info) {
-	   super();
-	   this.apiExceptionType = apiExceptionType;
-	   this.info = info;
-   }
+  public APIException(ApiExceptionType apiExceptionType, String info) {
+    super();
+    this.apiExceptionType = apiExceptionType;
+    this.info = info;
+  }
 
-   public ApiExceptionType getApiExceptionType() {
-	   return apiExceptionType;
-   }
+  public ApiExceptionType getApiExceptionType() {
+    return apiExceptionType;
+  }
 
-   public void setApiExceptionType(ApiExceptionType apiExceptionType) {
-	   this.apiExceptionType = apiExceptionType;
-   }
+  public void setApiExceptionType(ApiExceptionType apiExceptionType) {
+    this.apiExceptionType = apiExceptionType;
+  }
 
-   public String getInfo() {
-	   return info;
-   }
+  public String getInfo() {
+    return info;
+  }
 
-   public void setInfo(String info) {
-	   this.info = info;
-   }	
-
+  public void setInfo(String info) {
+    this.info = info;
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/filters/XSSFilter.java
+++ b/engine/src/main/java/io/seldon/engine/filters/XSSFilter.java
@@ -1,25 +1,22 @@
 package io.seldon.engine.filters;
 
 import java.io.IOException;
-
-import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.stereotype.Component;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 public class XSSFilter extends OncePerRequestFilter {
-    @Override
-    protected void doFilterInternal(
-        HttpServletRequest request,
-        HttpServletResponse response, 
-        FilterChain filterChain)  throws ServletException, IOException {
-      // Add nosniff option to avoid content sniffing by the browser
-      response.addHeader("X-Content-Type-Options", "nosniff");
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    // Add nosniff option to avoid content sniffing by the browser
+    response.addHeader("X-Content-Type-Options", "nosniff");
 
-      filterChain.doFilter(request, response);
-    }
+    filterChain.doFilter(request, response);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/grpc/GrpcChannelHandler.java
+++ b/engine/src/main/java/io/seldon/engine/grpc/GrpcChannelHandler.java
@@ -1,49 +1,43 @@
 package io.seldon.engine.grpc;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.opentracing.contrib.grpc.TracingClientInterceptor;
 import io.seldon.engine.tracing.TracingProvider;
 import io.seldon.protos.DeploymentProtos.Endpoint;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class GrpcChannelHandler {
 
-	private Map<Endpoint,Channel> store = new ConcurrentHashMap<>();
-	
-	@Autowired
-	TracingProvider tracingProvider;
-	
-	public Channel get(Endpoint endpoint) {
-		if (store.containsKey(endpoint))
-			return store.get(endpoint);
-		else
-		{
-			ManagedChannel channel = ManagedChannelBuilder.forAddress(endpoint.getServiceHost(), endpoint.getServicePort()).usePlaintext(true).build();
-			
-			if (tracingProvider != null && tracingProvider.isActive())
-			{
-				TracingClientInterceptor tracingInterceptor = TracingClientInterceptor
-          .newBuilder()
-          .withTracer(this.tracingProvider.getTracer())
-          .build();
-				store.putIfAbsent(endpoint, tracingInterceptor.intercept(channel));
-			}
-			else
-				store.putIfAbsent(endpoint, channel);
-			return store.get(endpoint);
-		}
-	}
-	
-	public int size() {
-		return store.size();
-	}
-	
+  private Map<Endpoint, Channel> store = new ConcurrentHashMap<>();
+
+  @Autowired TracingProvider tracingProvider;
+
+  public Channel get(Endpoint endpoint) {
+    if (store.containsKey(endpoint)) return store.get(endpoint);
+    else {
+      ManagedChannel channel =
+          ManagedChannelBuilder.forAddress(endpoint.getServiceHost(), endpoint.getServicePort())
+              .usePlaintext(true)
+              .build();
+
+      if (tracingProvider != null && tracingProvider.isActive()) {
+        TracingClientInterceptor tracingInterceptor =
+            TracingClientInterceptor.newBuilder()
+                .withTracer(this.tracingProvider.getTracer())
+                .build();
+        store.putIfAbsent(endpoint, tracingInterceptor.intercept(channel));
+      } else store.putIfAbsent(endpoint, channel);
+      return store.get(endpoint);
+    }
+  }
+
+  public int size() {
+    return store.size();
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/grpc/SeldonGrpcServer.java
+++ b/engine/src/main/java/io/seldon/engine/grpc/SeldonGrpcServer.java
@@ -1,27 +1,19 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.grpc;
-
-import java.io.IOException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
 
 import io.grpc.Server;
 import io.grpc.netty.NettyServerBuilder;
@@ -29,118 +21,115 @@ import io.opentracing.contrib.grpc.TracingServerInterceptor;
 import io.seldon.engine.config.AnnotationsConfig;
 import io.seldon.engine.service.PredictionService;
 import io.seldon.engine.tracing.TracingProvider;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
 
 @Component
-public class SeldonGrpcServer  {
-    protected static Logger logger = LoggerFactory.getLogger(SeldonGrpcServer.class.getName());
-	
-    private final static String ENGINE_SERVER_PORT_KEY = "ENGINE_SERVER_GRPC_PORT";
-    public static final int SERVER_PORT = 5000;
-    
-    public final static String ANNOTATION_MAX_MESSAGE_SIZE = "seldon.io/grpc-max-message-size";
-    
-    private final int port;
-    private final Server server;
-	
-    private final PredictionService predictionService;
+public class SeldonGrpcServer {
+  protected static Logger logger = LoggerFactory.getLogger(SeldonGrpcServer.class.getName());
 
-    private int maxMessageSize = io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
-    
-    @Autowired
-    public SeldonGrpcServer(PredictionService predictionService,AnnotationsConfig annotations,TracingProvider tracingProvider)
-    {
-    	
-    	
-        { // setup the server port using the env vars
-            String engineServerPortString = System.getenv().get(ENGINE_SERVER_PORT_KEY);
-            if (engineServerPortString == null) {
-                logger.warn("FAILED to find env var [{}], will use defaults for engine server port {}", ENGINE_SERVER_PORT_KEY,SERVER_PORT);
-                port = SERVER_PORT;
-            } else {
-                port = Integer.parseInt(engineServerPortString);
-                logger.info("FOUND env var [{}], will use engine server port {}", ENGINE_SERVER_PORT_KEY,port);
-            }
-        }
-        this.predictionService = predictionService;
-        SeldonService seldonService = new SeldonService(this);
-        NettyServerBuilder builder;
-        if (tracingProvider.isActive())
-        {
-        	TracingServerInterceptor tracingInterceptor = TracingServerInterceptor
-            .newBuilder()
-            .withTracer(tracingProvider.getTracer())
-            .build();
-        	builder = NettyServerBuilder
-        			.forPort(port)
-        			.addService(tracingInterceptor.intercept(seldonService));
-        }
-        else
-        {
-        	builder = NettyServerBuilder
-        			.forPort(port)
-        			.addService(seldonService);        	
-        }
-        if (annotations.has(ANNOTATION_MAX_MESSAGE_SIZE))
-        {
-        	try 
-        	{
-        		maxMessageSize =Integer.parseInt(annotations.get(ANNOTATION_MAX_MESSAGE_SIZE));
-        		logger.info("Setting max message to {}",maxMessageSize);
-        		builder.maxMessageSize(maxMessageSize);
-        	}
-        	catch(NumberFormatException e)
-        	{
-        		logger.warn("Failed to parse {} with value {}",ANNOTATION_MAX_MESSAGE_SIZE,annotations.get(ANNOTATION_MAX_MESSAGE_SIZE),e);
-        	}
-        }
-        server = builder.build();
-    }
-   
-    
-    
-    public PredictionService getPredictionService() {
-        return predictionService;
-    }
+  private static final String ENGINE_SERVER_PORT_KEY = "ENGINE_SERVER_GRPC_PORT";
+  public static final int SERVER_PORT = 5000;
 
-    @Async
-    public void runServer() throws InterruptedException, IOException
-    {
-        logger.info("Starting grpc server");
-        start();
-        blockUntilShutdown();
-    }
-    
-    /** 
-     * Start serving requests. 
-     */
-    public void start() throws IOException {
-      server.start();
-      logger.info("Server started, listening on {}",port);
-      Runtime.getRuntime().addShutdownHook(new Thread() {
-        @Override
-        public void run() {
-          // Use stderr here since the logger may has been reset by its JVM shutdown hook.
-          System.err.println("*** shutting down gRPC server since JVM is shutting down");
-          SeldonGrpcServer.this.stop();
-          System.err.println("*** server shut down");
-        }
-      });
-    }
+  public static final String ANNOTATION_MAX_MESSAGE_SIZE = "seldon.io/grpc-max-message-size";
 
-    /** Stop serving requests and shutdown resources. */
-    public void stop() {
-      if (server != null) {
-        server.shutdown();
+  private final int port;
+  private final Server server;
+
+  private final PredictionService predictionService;
+
+  private int maxMessageSize = io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+
+  @Autowired
+  public SeldonGrpcServer(
+      PredictionService predictionService,
+      AnnotationsConfig annotations,
+      TracingProvider tracingProvider) {
+
+    { // setup the server port using the env vars
+      String engineServerPortString = System.getenv().get(ENGINE_SERVER_PORT_KEY);
+      if (engineServerPortString == null) {
+        logger.warn(
+            "FAILED to find env var [{}], will use defaults for engine server port {}",
+            ENGINE_SERVER_PORT_KEY,
+            SERVER_PORT);
+        port = SERVER_PORT;
+      } else {
+        port = Integer.parseInt(engineServerPortString);
+        logger.info(
+            "FOUND env var [{}], will use engine server port {}", ENGINE_SERVER_PORT_KEY, port);
       }
     }
-
-    /**
-     * Await termination on the main thread since the grpc library uses daemon threads.
-     */
-    private void blockUntilShutdown() throws InterruptedException {
-      if (server != null) {
-        server.awaitTermination();
+    this.predictionService = predictionService;
+    SeldonService seldonService = new SeldonService(this);
+    NettyServerBuilder builder;
+    if (tracingProvider.isActive()) {
+      TracingServerInterceptor tracingInterceptor =
+          TracingServerInterceptor.newBuilder().withTracer(tracingProvider.getTracer()).build();
+      builder =
+          NettyServerBuilder.forPort(port).addService(tracingInterceptor.intercept(seldonService));
+    } else {
+      builder = NettyServerBuilder.forPort(port).addService(seldonService);
+    }
+    if (annotations.has(ANNOTATION_MAX_MESSAGE_SIZE)) {
+      try {
+        maxMessageSize = Integer.parseInt(annotations.get(ANNOTATION_MAX_MESSAGE_SIZE));
+        logger.info("Setting max message to {}", maxMessageSize);
+        builder.maxMessageSize(maxMessageSize);
+      } catch (NumberFormatException e) {
+        logger.warn(
+            "Failed to parse {} with value {}",
+            ANNOTATION_MAX_MESSAGE_SIZE,
+            annotations.get(ANNOTATION_MAX_MESSAGE_SIZE),
+            e);
       }
     }
-    
+    server = builder.build();
+  }
+
+  public PredictionService getPredictionService() {
+    return predictionService;
+  }
+
+  @Async
+  public void runServer() throws InterruptedException, IOException {
+    logger.info("Starting grpc server");
+    start();
+    blockUntilShutdown();
+  }
+
+  /** Start serving requests. */
+  public void start() throws IOException {
+    server.start();
+    logger.info("Server started, listening on {}", port);
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread() {
+              @Override
+              public void run() {
+                // Use stderr here since the logger may has been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                SeldonGrpcServer.this.stop();
+                System.err.println("*** server shut down");
+              }
+            });
+  }
+
+  /** Stop serving requests and shutdown resources. */
+  public void stop() {
+    if (server != null) {
+      server.shutdown();
+    }
+  }
+
+  /** Await termination on the main thread since the grpc library uses daemon threads. */
+  private void blockUntilShutdown() throws InterruptedException {
+    if (server != null) {
+      server.awaitTermination();
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/grpc/SeldonGrpcServerInitializer.java
+++ b/engine/src/main/java/io/seldon/engine/grpc/SeldonGrpcServerInitializer.java
@@ -1,24 +1,22 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.grpc;
 
 import java.io.IOException;
-
 import javax.annotation.PostConstruct;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,21 +25,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class SeldonGrpcServerInitializer {
 
-    protected static Logger logger = LoggerFactory.getLogger(SeldonGrpcServerInitializer.class.getName());
-    
-    @Autowired
-    SeldonGrpcServer server;
-    
-    @PostConstruct
-    public void initialise() {
-        try
-        {
-            server.runServer();
-        } catch (InterruptedException e) {
-            logger.error("Failed to start grc server",e);
-        } catch (IOException e) {
-            logger.error("Failed to start grc server",e);
-        }
+  protected static Logger logger =
+      LoggerFactory.getLogger(SeldonGrpcServerInitializer.class.getName());
+
+  @Autowired SeldonGrpcServer server;
+
+  @PostConstruct
+  public void initialise() {
+    try {
+      server.runServer();
+    } catch (InterruptedException e) {
+      logger.error("Failed to start grc server", e);
+    } catch (IOException e) {
+      logger.error("Failed to start grc server", e);
     }
-    
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/grpc/SeldonService.java
+++ b/engine/src/main/java/io/seldon/engine/grpc/SeldonService.java
@@ -1,81 +1,79 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.grpc;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
+import io.seldon.protos.SeldonGrpc;
 import java.util.concurrent.ExecutionException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-import io.seldon.protos.SeldonGrpc;
-
 /**
  * Passes gRPC requests on to the engine.
- * @author clive
  *
+ * @author clive
  */
 public class SeldonService extends SeldonGrpc.SeldonImplBase {
-    
-    protected static Logger logger = LoggerFactory.getLogger(SeldonService.class.getName());
-    
-    private SeldonGrpcServer server;
-    
-    public SeldonService(SeldonGrpcServer server) {
-        super();
-        this.server = server;
-    }
 
-    @Override
-    public void predict(io.seldon.protos.PredictionProtos.SeldonMessage request,
-                io.grpc.stub.StreamObserver<io.seldon.protos.PredictionProtos.SeldonMessage> responseObserver) {
-        logger.debug("Received predict request");
-        try
-        {
-            responseObserver.onNext(server.getPredictionService().predict(request));
-        } catch (InterruptedException e) {
-            responseObserver.onError(e);
-        } catch (ExecutionException e) {
-            responseObserver.onError(e);
-        } catch (InvalidProtocolBufferException e) {
-        	responseObserver.onError(e);
-		}
-        finally {}
-        responseObserver.onCompleted();
-     }
-    
-    @Override
-    public void sendFeedback(io.seldon.protos.PredictionProtos.Feedback request,
-            io.grpc.stub.StreamObserver<io.seldon.protos.PredictionProtos.SeldonMessage> responseObserver) {
-        logger.debug("Received feedback request");
-        try
-        {
-            server.getPredictionService().sendFeedback(request);
-            responseObserver.onNext(SeldonMessage.newBuilder().build());
-        } catch (InterruptedException e) {
-            responseObserver.onError(e);
-        } catch (ExecutionException e) {
-            responseObserver.onError(e);
-        } catch (InvalidProtocolBufferException e) {
-        	responseObserver.onError(e);
-		}
-        finally {}
-        responseObserver.onCompleted();
+  protected static Logger logger = LoggerFactory.getLogger(SeldonService.class.getName());
+
+  private SeldonGrpcServer server;
+
+  public SeldonService(SeldonGrpcServer server) {
+    super();
+    this.server = server;
+  }
+
+  @Override
+  public void predict(
+      io.seldon.protos.PredictionProtos.SeldonMessage request,
+      io.grpc.stub.StreamObserver<io.seldon.protos.PredictionProtos.SeldonMessage>
+          responseObserver) {
+    logger.debug("Received predict request");
+    try {
+      responseObserver.onNext(server.getPredictionService().predict(request));
+    } catch (InterruptedException e) {
+      responseObserver.onError(e);
+    } catch (ExecutionException e) {
+      responseObserver.onError(e);
+    } catch (InvalidProtocolBufferException e) {
+      responseObserver.onError(e);
+    } finally {
     }
-    
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void sendFeedback(
+      io.seldon.protos.PredictionProtos.Feedback request,
+      io.grpc.stub.StreamObserver<io.seldon.protos.PredictionProtos.SeldonMessage>
+          responseObserver) {
+    logger.debug("Received feedback request");
+    try {
+      server.getPredictionService().sendFeedback(request);
+      responseObserver.onNext(SeldonMessage.newBuilder().build());
+    } catch (InterruptedException e) {
+      responseObserver.onError(e);
+    } catch (ExecutionException e) {
+      responseObserver.onError(e);
+    } catch (InvalidProtocolBufferException e) {
+      responseObserver.onError(e);
+    } finally {
+    }
+    responseObserver.onCompleted();
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/metrics/CustomMetricsManager.java
+++ b/engine/src/main/java/io/seldon/engine/metrics/CustomMetricsManager.java
@@ -1,13 +1,6 @@
 package io.seldon.engine.metrics;
 
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-
 import com.google.common.util.concurrent.AtomicDouble;
-
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Meter.Type;
@@ -16,70 +9,62 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.seldon.protos.PredictionProtos.Metric;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
-/**
- * 
- * @author clive
- * Handles the storage of gauges for custom metrics.
- *
- */
+/** @author clive Handles the storage of gauges for custom metrics. */
 @Component
 public class CustomMetricsManager {
 
-	private final static Logger logger = LoggerFactory.getLogger(CustomMetricsManager.class);
-	private ConcurrentHashMap<Meter.Id,AtomicDouble> gauges = new ConcurrentHashMap<>();
+  private static final Logger logger = LoggerFactory.getLogger(CustomMetricsManager.class);
+  private ConcurrentHashMap<Meter.Id, AtomicDouble> gauges = new ConcurrentHashMap<>();
 
-	public AtomicDouble getGaugeValue(Iterable<Tag> tags,Metric metric)
-	{
-		Tags tagsObj = Tags.concat(tags);
-		Meter.Id id = new Meter.Id(metric.getKey(), tagsObj, "", "", Type.GAUGE);
-		if (gauges.containsKey(id))
-			return gauges.get(id);
-		else
-		{
-			logger.info("Creating new metric Id for {}",metric.toString());
-			try
-			{	
-				AtomicDouble d = new AtomicDouble();
-				gauges.put(id, d);
-				Metrics.gauge(metric.getKey(), tags, d);
-				return d;
-			}
-			catch (IllegalArgumentException e)
-			{
-				logger.warn("Can't create gauge Metric. Probably same name exists with different number of tags. Not allowed in Prometheus Registry. Key {}",metric.getKey(),e);
-				throw e;
-			}
-		}
-	}
-	
-	public Counter getCounter(Iterable<Tag> tags,Metric metric)
-	{
-		try
-		{
-			Counter counter = Metrics.counter(metric.getKey(), tags);
-			return counter;
-		}
-		catch (IllegalArgumentException e)
-		{
-			logger.warn("Can't create counter Metric. Probably same name exists with different number of tags. Not allowed in Prometheus Registry. Key {}",metric.getKey(),e);
-			throw e;
-		}
-	}
+  public AtomicDouble getGaugeValue(Iterable<Tag> tags, Metric metric) {
+    Tags tagsObj = Tags.concat(tags);
+    Meter.Id id = new Meter.Id(metric.getKey(), tagsObj, "", "", Type.GAUGE);
+    if (gauges.containsKey(id)) return gauges.get(id);
+    else {
+      logger.info("Creating new metric Id for {}", metric.toString());
+      try {
+        AtomicDouble d = new AtomicDouble();
+        gauges.put(id, d);
+        Metrics.gauge(metric.getKey(), tags, d);
+        return d;
+      } catch (IllegalArgumentException e) {
+        logger.warn(
+            "Can't create gauge Metric. Probably same name exists with different number of tags. Not allowed in Prometheus Registry. Key {}",
+            metric.getKey(),
+            e);
+        throw e;
+      }
+    }
+  }
 
-	public Timer getTimer(Iterable<Tag> tags,Metric metric)
-	{
-		try
-		{
-			Timer timer = Metrics.timer(metric.getKey(), tags);
-			return timer;
-		}
-			catch (IllegalArgumentException e)
-		{
-			logger.warn("Can't create Timer Metric. Probably same name exists with different number of tags. Not allowed in Prometheus Registry. Key: {}",metric.getKey(),e);
-			throw e;
-		}
-	}
-	
-	
+  public Counter getCounter(Iterable<Tag> tags, Metric metric) {
+    try {
+      Counter counter = Metrics.counter(metric.getKey(), tags);
+      return counter;
+    } catch (IllegalArgumentException e) {
+      logger.warn(
+          "Can't create counter Metric. Probably same name exists with different number of tags. Not allowed in Prometheus Registry. Key {}",
+          metric.getKey(),
+          e);
+      throw e;
+    }
+  }
+
+  public Timer getTimer(Iterable<Tag> tags, Metric metric) {
+    try {
+      Timer timer = Metrics.timer(metric.getKey(), tags);
+      return timer;
+    } catch (IllegalArgumentException e) {
+      logger.warn(
+          "Can't create Timer Metric. Probably same name exists with different number of tags. Not allowed in Prometheus Registry. Key: {}",
+          metric.getKey(),
+          e);
+      throw e;
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/metrics/MetricsConfig.java
+++ b/engine/src/main/java/io/seldon/engine/metrics/MetricsConfig.java
@@ -1,29 +1,27 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.metrics;
 
 import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
 
-//@Configuration
+// @Configuration
 public class MetricsConfig {
-	
-	//@Bean
-	RestTemplateExchangeTagsProvider getSeldonTagProvider()
-	{
-		return new SeldonRestTemplateExchangeTagsProvider();
-	}
 
+  // @Bean
+  RestTemplateExchangeTagsProvider getSeldonTagProvider() {
+    return new SeldonRestTemplateExchangeTagsProvider();
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/metrics/SeldonRestTemplateExchangeTagsProvider.java
+++ b/engine/src/main/java/io/seldon/engine/metrics/SeldonRestTemplateExchangeTagsProvider.java
@@ -1,159 +1,139 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.metrics;
 
+import io.micrometer.core.instrument.Tag;
+import io.seldon.engine.predictors.EnginePredictor;
+import io.seldon.engine.predictors.PredictiveUnitState;
+import io.seldon.engine.service.InternalPredictionService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTags;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTags;
-import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
-
-import io.micrometer.core.instrument.Tag;
-
-import io.seldon.engine.predictors.EnginePredictor;
-import io.seldon.engine.predictors.PredictiveUnitState;
-import io.seldon.engine.service.InternalPredictionService;
 
 @Component
 public class SeldonRestTemplateExchangeTagsProvider implements RestTemplateExchangeTagsProvider {
 
-	private final static String DEPLOYMENT_NAME_METRIC = "deployment_name";
-	private final static String PREDICTOR_NAME_METRIC = "predictor_name";
-	private final static String PREDICTOR_VERSION_METRIC = "predictor_version";
-	private final static String MODEL_NAME_METRIC = "model_name";
-	private final static String MODEL_IMAGE_METRIC = "model_image";
-	private final static String MODEL_VERSION_METRIC = "model_version";
+  private static final String DEPLOYMENT_NAME_METRIC = "deployment_name";
+  private static final String PREDICTOR_NAME_METRIC = "predictor_name";
+  private static final String PREDICTOR_VERSION_METRIC = "predictor_version";
+  private static final String MODEL_NAME_METRIC = "model_name";
+  private static final String MODEL_IMAGE_METRIC = "model_image";
+  private static final String MODEL_VERSION_METRIC = "model_version";
 
-	@Autowired
-	EnginePredictor enginePredictor;
-	
-	@Override
-	public Iterable<Tag> getTags(String urlTemplate, HttpRequest request, ClientHttpResponse response) 
-	{
-		Tag uriTag = StringUtils.hasText(urlTemplate)? RestTemplateExchangeTags.uri(urlTemplate): RestTemplateExchangeTags.uri(request);
-		
-		
-	            
-		return Arrays.asList(RestTemplateExchangeTags.method(request), uriTag,
-				RestTemplateExchangeTags.status(response),
-	            RestTemplateExchangeTags.clientName(request),
-	            deploymentName(),
-	            modelName(request),
-	            modelImage(request),
-	            modelVersion(request),
-		        predictorName(),
-	            predictorVersion());
-	}
-	
-	public Iterable<Tag> getModelMetrics(PredictiveUnitState state, Map<String,String> customTags)
-	{
-		ArrayList<Tag> customTagsList = new ArrayList<>();
-		if (customTags != null)
-			for(Map.Entry<String, String> e : customTags.entrySet())
-			{
-				customTagsList.add(Tag.of(e.getKey(), e.getValue()));
-			}
-		for(Tag t : getModelMetrics(state))
-		{
-			customTagsList.add(t);
-		}
-		return customTagsList;
-	}
-	
-	public Iterable<Tag> getModelMetrics(PredictiveUnitState state)
-	{
-		return Arrays.asList(
-				 deploymentName(),
-				 predictorName(),
-				 predictorVersion(),
-				 modelName(state.name),
-				 modelImage(state.imageName),
-				 modelVersion(state.imageVersion));
-	}
-	
-	
-    private Tag deploymentName()
-    {
-    	return Tag.of(DEPLOYMENT_NAME_METRIC, enginePredictor.getDeploymentName());
+  @Autowired EnginePredictor enginePredictor;
+
+  @Override
+  public Iterable<Tag> getTags(
+      String urlTemplate, HttpRequest request, ClientHttpResponse response) {
+    Tag uriTag =
+        StringUtils.hasText(urlTemplate)
+            ? RestTemplateExchangeTags.uri(urlTemplate)
+            : RestTemplateExchangeTags.uri(request);
+
+    return Arrays.asList(
+        RestTemplateExchangeTags.method(request),
+        uriTag,
+        RestTemplateExchangeTags.status(response),
+        RestTemplateExchangeTags.clientName(request),
+        deploymentName(),
+        modelName(request),
+        modelImage(request),
+        modelVersion(request),
+        predictorName(),
+        predictorVersion());
+  }
+
+  public Iterable<Tag> getModelMetrics(PredictiveUnitState state, Map<String, String> customTags) {
+    ArrayList<Tag> customTagsList = new ArrayList<>();
+    if (customTags != null)
+      for (Map.Entry<String, String> e : customTags.entrySet()) {
+        customTagsList.add(Tag.of(e.getKey(), e.getValue()));
+      }
+    for (Tag t : getModelMetrics(state)) {
+      customTagsList.add(t);
     }
-	
-	
-	private Tag predictorName()
-	{
-		if (!StringUtils.hasText(enginePredictor.getPredictorSpec().getName()))
-			return Tag.of(PREDICTOR_NAME_METRIC, "unknown");
-		else
-			return Tag.of(PREDICTOR_NAME_METRIC,enginePredictor.getPredictorSpec().getName()); 
-	}
-	
-	private Tag predictorVersion()
-	{
-		if (!StringUtils.hasText(enginePredictor.getPredictorSpec().getLabelsOrDefault("version", "")))
-			return Tag.of(PREDICTOR_VERSION_METRIC, "unknown");
-		else
-			return Tag.of(PREDICTOR_VERSION_METRIC, enginePredictor.getPredictorSpec().getLabelsOrDefault("version", ""));
-	}
+    return customTagsList;
+  }
 
-	private Tag modelName(HttpRequest request)
-	{
-		String modelName = request.getHeaders().getFirst(InternalPredictionService.MODEL_NAME_HEADER);
-		return modelName(modelName);
-	}
-	
-	private Tag modelName(String modelName)
-	{
-		if (!StringUtils.hasText(modelName))
-			modelName = "unknown";
-		return Tag.of(MODEL_NAME_METRIC, modelName);
-	}
-	
-	private Tag modelImage(HttpRequest request)
-	{
-		String modelImage = request.getHeaders().getFirst(InternalPredictionService.MODEL_IMAGE_HEADER);
-		return modelImage(modelImage);
-	}
-	
-	private Tag modelImage(String modelImage)
-	{
-		if (!StringUtils.hasText(modelImage))
-			modelImage = "unknown";
-		
-		return Tag.of(MODEL_IMAGE_METRIC, modelImage);
-	}
+  public Iterable<Tag> getModelMetrics(PredictiveUnitState state) {
+    return Arrays.asList(
+        deploymentName(),
+        predictorName(),
+        predictorVersion(),
+        modelName(state.name),
+        modelImage(state.imageName),
+        modelVersion(state.imageVersion));
+  }
 
-	private Tag modelVersion(HttpRequest request)
-	{
-		String modelVersion = request.getHeaders().getFirst(InternalPredictionService.MODEL_VERSION_HEADER);
-		return modelVersion(modelVersion);
-	}
-	
-	private Tag modelVersion(String modelVersion)
-	{
-		if (!StringUtils.hasText(modelVersion))
-			modelVersion = "latest";
-		
-		return Tag.of(MODEL_VERSION_METRIC, modelVersion);
-	}
-	
-	
+  private Tag deploymentName() {
+    return Tag.of(DEPLOYMENT_NAME_METRIC, enginePredictor.getDeploymentName());
+  }
 
+  private Tag predictorName() {
+    if (!StringUtils.hasText(enginePredictor.getPredictorSpec().getName()))
+      return Tag.of(PREDICTOR_NAME_METRIC, "unknown");
+    else return Tag.of(PREDICTOR_NAME_METRIC, enginePredictor.getPredictorSpec().getName());
+  }
+
+  private Tag predictorVersion() {
+    if (!StringUtils.hasText(enginePredictor.getPredictorSpec().getLabelsOrDefault("version", "")))
+      return Tag.of(PREDICTOR_VERSION_METRIC, "unknown");
+    else
+      return Tag.of(
+          PREDICTOR_VERSION_METRIC,
+          enginePredictor.getPredictorSpec().getLabelsOrDefault("version", ""));
+  }
+
+  private Tag modelName(HttpRequest request) {
+    String modelName = request.getHeaders().getFirst(InternalPredictionService.MODEL_NAME_HEADER);
+    return modelName(modelName);
+  }
+
+  private Tag modelName(String modelName) {
+    if (!StringUtils.hasText(modelName)) modelName = "unknown";
+    return Tag.of(MODEL_NAME_METRIC, modelName);
+  }
+
+  private Tag modelImage(HttpRequest request) {
+    String modelImage = request.getHeaders().getFirst(InternalPredictionService.MODEL_IMAGE_HEADER);
+    return modelImage(modelImage);
+  }
+
+  private Tag modelImage(String modelImage) {
+    if (!StringUtils.hasText(modelImage)) modelImage = "unknown";
+
+    return Tag.of(MODEL_IMAGE_METRIC, modelImage);
+  }
+
+  private Tag modelVersion(HttpRequest request) {
+    String modelVersion =
+        request.getHeaders().getFirst(InternalPredictionService.MODEL_VERSION_HEADER);
+    return modelVersion(modelVersion);
+  }
+
+  private Tag modelVersion(String modelVersion) {
+    if (!StringUtils.hasText(modelVersion)) modelVersion = "latest";
+
+    return Tag.of(MODEL_VERSION_METRIC, modelVersion);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/pb/IntOrStringUtils.java
+++ b/engine/src/main/java/io/seldon/engine/pb/IntOrStringUtils.java
@@ -1,21 +1,19 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
-
-import java.io.IOException;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
@@ -24,52 +22,47 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.Message.Builder;
 import com.google.protobuf.MessageOrBuilder;
-
 import io.kubernetes.client.proto.IntStr.IntOrString;
 import io.seldon.engine.pb.JsonFormat.TypeConverter;
 import io.seldon.engine.pb.JsonFormat.TypeParser;
+import java.io.IOException;
 
 public class IntOrStringUtils {
 
-	public static class IntOrStringConverter implements TypeConverter
-	{
-		private ByteString toByteString(MessageOrBuilder message) {
-		      if (message instanceof Message) {
-		        return ((Message) message).toByteString();
-		      } else {
-		        return ((Message.Builder) message).build().toByteString();
-		      }
-		    }
+  public static class IntOrStringConverter implements TypeConverter {
+    private ByteString toByteString(MessageOrBuilder message) {
+      if (message instanceof Message) {
+        return ((Message) message).toByteString();
+      } else {
+        return ((Message.Builder) message).build().toByteString();
+      }
+    }
 
-		@Override
-		public String convert(MessageOrBuilder message) throws IOException {
-			IntOrString is = IntOrString.parseFrom(toByteString(message));
-			if (is.hasStrVal())
-				return "\"" + is.getStrVal() + "\"";
-			else
-				return ""+is.getIntVal();
-			
-		}
-		
-	}
-	
-	public static class IntOrStringParser implements TypeParser {
-		@Override
-		public void merge(JsonElement json, Builder builder) throws InvalidProtocolBufferException {
-			if (json instanceof JsonPrimitive) {
-		        JsonPrimitive primitive = (JsonPrimitive) json;
-		        if (primitive.isString())
-		        {
-		        	IntOrString.Builder b = IntOrString.newBuilder().setType(1).setStrVal(primitive.getAsString());
-		        	builder.mergeFrom(b.build().toByteArray());
-		        }
-		        else if (primitive.isNumber())
-		        {
-		        	IntOrString.Builder b = IntOrString.newBuilder().setType(0).setIntVal(primitive.getAsInt());
-		        	builder.mergeFrom(b.build().toByteArray());
-		        }	
-		        }
-			else throw new InvalidProtocolBufferException("Can't decode io.kubernetes.client.proto.IntOrSting from "+json.toString());
-		}
-	}
+    @Override
+    public String convert(MessageOrBuilder message) throws IOException {
+      IntOrString is = IntOrString.parseFrom(toByteString(message));
+      if (is.hasStrVal()) return "\"" + is.getStrVal() + "\"";
+      else return "" + is.getIntVal();
+    }
+  }
+
+  public static class IntOrStringParser implements TypeParser {
+    @Override
+    public void merge(JsonElement json, Builder builder) throws InvalidProtocolBufferException {
+      if (json instanceof JsonPrimitive) {
+        JsonPrimitive primitive = (JsonPrimitive) json;
+        if (primitive.isString()) {
+          IntOrString.Builder b =
+              IntOrString.newBuilder().setType(1).setStrVal(primitive.getAsString());
+          builder.mergeFrom(b.build().toByteArray());
+        } else if (primitive.isNumber()) {
+          IntOrString.Builder b =
+              IntOrString.newBuilder().setType(0).setIntVal(primitive.getAsInt());
+          builder.mergeFrom(b.build().toByteArray());
+        }
+      } else
+        throw new InvalidProtocolBufferException(
+            "Can't decode io.kubernetes.client.proto.IntOrSting from " + json.toString());
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/pb/JsonFormat.java
+++ b/engine/src/main/java/io/seldon/engine/pb/JsonFormat.java
@@ -1,34 +1,19 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.ParseException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.logging.Logger;
 
 import com.google.common.io.BaseEncoding;
 import com.google.gson.Gson;
@@ -71,53 +56,65 @@ import com.google.protobuf.Value;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.FieldMaskUtil;
 import com.google.protobuf.util.Timestamps;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.logging.Logger;
 
 /**
- * Utility classes to convert protobuf messages to/from JSON format. The JSON
- * format follows Proto3 JSON specification and only proto3 features are
- * supported. Proto2 only features (e.g., extensions and unknown fields) will
- * be discarded in the conversion. That is, when converting proto2 messages
- * to JSON format, extensions and unknown fields will be treated as if they
- * do not exist. This applies to proto2 messages embedded in proto3 messages
- * as well.
+ * Utility classes to convert protobuf messages to/from JSON format. The JSON format follows Proto3
+ * JSON specification and only proto3 features are supported. Proto2 only features (e.g., extensions
+ * and unknown fields) will be discarded in the conversion. That is, when converting proto2 messages
+ * to JSON format, extensions and unknown fields will be treated as if they do not exist. This
+ * applies to proto2 messages embedded in proto3 messages as well.
  */
 public class JsonFormat {
   private static final Logger logger = Logger.getLogger(JsonFormat.class.getName());
 
   public interface TypeConverter {
-	  public String convert(MessageOrBuilder message) throws IOException;
+    public String convert(MessageOrBuilder message) throws IOException;
   }
-  
+
   public interface TypeParser {
-      void merge(JsonElement json, Message.Builder builder)
-          throws InvalidProtocolBufferException;
-    }
-  
+    void merge(JsonElement json, Message.Builder builder) throws InvalidProtocolBufferException;
+  }
+
   private JsonFormat() {}
 
-  /**
-   * Creates a {@link Printer} with default configurations.
-   */
+  /** Creates a {@link Printer} with default configurations. */
   public static Printer printer() {
-    return new Printer(TypeRegistry.getEmptyTypeRegistry(), false, false, false,new HashMap<String,TypeConverter>());
+    return new Printer(
+        TypeRegistry.getEmptyTypeRegistry(),
+        false,
+        false,
+        false,
+        new HashMap<String, TypeConverter>());
   }
 
-  /**
-   * A Printer converts protobuf message to JSON format.
-   */
+  /** A Printer converts protobuf message to JSON format. */
   public static class Printer {
     private final TypeRegistry registry;
     private final boolean includingDefaultValueFields;
     private final boolean preservingProtoFieldNames;
     private final boolean omittingInsignificantWhitespace;
-    private final Map<String,TypeConverter> customTypeConverters;
+    private final Map<String, TypeConverter> customTypeConverters;
 
     private Printer(
         TypeRegistry registry,
         boolean includingDefaultValueFields,
         boolean preservingProtoFieldNames,
         boolean omittingInsignificantWhitespace,
-        Map<String,TypeConverter> customTypeConverters) {
+        Map<String, TypeConverter> customTypeConverters) {
       this.registry = registry;
       this.includingDefaultValueFields = includingDefaultValueFields;
       this.preservingProtoFieldNames = preservingProtoFieldNames;
@@ -125,23 +122,20 @@ public class JsonFormat {
       this.customTypeConverters = customTypeConverters;
     }
 
-    /**
-     * Adds a custom TypeConverter
-     */
-    public Printer usingTypeConverter(String type,TypeConverter converter)
-    {
-    	this.customTypeConverters.put(type,converter);
-    	return new Printer(
-    	          registry,
-    	          includingDefaultValueFields,
-    	          preservingProtoFieldNames,
-    	          omittingInsignificantWhitespace,
-    	          customTypeConverters);
+    /** Adds a custom TypeConverter */
+    public Printer usingTypeConverter(String type, TypeConverter converter) {
+      this.customTypeConverters.put(type, converter);
+      return new Printer(
+          registry,
+          includingDefaultValueFields,
+          preservingProtoFieldNames,
+          omittingInsignificantWhitespace,
+          customTypeConverters);
     }
-    
+
     /**
-     * Creates a new {@link Printer} using the given registry. The new Printer
-     * clones all other configurations from the current {@link Printer}.
+     * Creates a new {@link Printer} using the given registry. The new Printer clones all other
+     * configurations from the current {@link Printer}.
      *
      * @throws IllegalArgumentException if a registry is already set.
      */
@@ -158,33 +152,39 @@ public class JsonFormat {
     }
 
     /**
-     * Creates a new {@link Printer} that will also print fields set to their
-     * defaults. Empty repeated fields and map fields will be printed as well.
-     * The new Printer clones all other configurations from the current
-     * {@link Printer}.
+     * Creates a new {@link Printer} that will also print fields set to their defaults. Empty
+     * repeated fields and map fields will be printed as well. The new Printer clones all other
+     * configurations from the current {@link Printer}.
      */
     public Printer includingDefaultValueFields() {
       return new Printer(
-          registry, true, preservingProtoFieldNames, omittingInsignificantWhitespace,customTypeConverters);
+          registry,
+          true,
+          preservingProtoFieldNames,
+          omittingInsignificantWhitespace,
+          customTypeConverters);
     }
 
     /**
-     * Creates a new {@link Printer} that is configured to use the original proto
-     * field names as defined in the .proto file rather than converting them to
-     * lowerCamelCase. The new Printer clones all other configurations from the
-     * current {@link Printer}.
+     * Creates a new {@link Printer} that is configured to use the original proto field names as
+     * defined in the .proto file rather than converting them to lowerCamelCase. The new Printer
+     * clones all other configurations from the current {@link Printer}.
      */
     public Printer preservingProtoFieldNames() {
       return new Printer(
-          registry, includingDefaultValueFields, true, omittingInsignificantWhitespace,customTypeConverters);
+          registry,
+          includingDefaultValueFields,
+          true,
+          omittingInsignificantWhitespace,
+          customTypeConverters);
     }
 
-
     /**
-     * Create a new  {@link Printer}  that will omit all insignificant whitespace
-     * in the JSON output. This new Printer clones all other configurations from the
-     * current Printer. Insignificant whitespace is defined by the JSON spec as whitespace
-     * that appear between JSON structural elements:
+     * Create a new {@link Printer} that will omit all insignificant whitespace in the JSON output.
+     * This new Printer clones all other configurations from the current Printer. Insignificant
+     * whitespace is defined by the JSON spec as whitespace that appear between JSON structural
+     * elements:
+     *
      * <pre>
      * ws = *(
      * %x20 /              ; Space
@@ -192,18 +192,24 @@ public class JsonFormat {
      * %x0A /              ; Line feed or New line
      * %x0D )              ; Carriage return
      * </pre>
+     *
      * See <a href="https://tools.ietf.org/html/rfc7159">https://tools.ietf.org/html/rfc7159</a>
      * current {@link Printer}.
      */
     public Printer omittingInsignificantWhitespace() {
-      return new Printer(registry, includingDefaultValueFields, preservingProtoFieldNames, true,customTypeConverters);
+      return new Printer(
+          registry,
+          includingDefaultValueFields,
+          preservingProtoFieldNames,
+          true,
+          customTypeConverters);
     }
 
     /**
      * Converts a protobuf message to JSON format.
      *
-     * @throws InvalidProtocolBufferException if the message contains Any types
-     *         that can't be resolved.
+     * @throws InvalidProtocolBufferException if the message contains Any types that can't be
+     *     resolved.
      * @throws IOException if writing to the output fails.
      */
     public void appendTo(MessageOrBuilder message, Appendable output) throws IOException {
@@ -220,8 +226,8 @@ public class JsonFormat {
     }
 
     /**
-     * Converts a protobuf message to JSON format. Throws exceptions if there
-     * are unknown Any types in the message.
+     * Converts a protobuf message to JSON format. Throws exceptions if there are unknown Any types
+     * in the message.
      */
     public String print(MessageOrBuilder message) throws InvalidProtocolBufferException {
       try {
@@ -237,44 +243,45 @@ public class JsonFormat {
     }
   }
 
-  /**
-   * Creates a {@link Parser} with default configuration.
-   */
+  /** Creates a {@link Parser} with default configuration. */
   public static Parser parser() {
-    return new Parser(TypeRegistry.getEmptyTypeRegistry(), false, Parser.DEFAULT_RECURSION_LIMIT,new HashMap<String,TypeParser>());
+    return new Parser(
+        TypeRegistry.getEmptyTypeRegistry(),
+        false,
+        Parser.DEFAULT_RECURSION_LIMIT,
+        new HashMap<String, TypeParser>());
   }
 
-  /**
-   * A Parser parses JSON to protobuf message.
-   */
+  /** A Parser parses JSON to protobuf message. */
   public static class Parser {
     private final TypeRegistry registry;
-    private final Map<String,TypeParser> typeParsers;
+    private final Map<String, TypeParser> typeParsers;
     private final boolean ignoringUnknownFields;
     private final int recursionLimit;
 
     // The default parsing recursion limit is aligned with the proto binary parser.
     private static final int DEFAULT_RECURSION_LIMIT = 100;
 
-    private Parser(TypeRegistry registry, boolean ignoreUnknownFields, int recursionLimit,Map<String,TypeParser> typeParsers) {
+    private Parser(
+        TypeRegistry registry,
+        boolean ignoreUnknownFields,
+        int recursionLimit,
+        Map<String, TypeParser> typeParsers) {
       this.registry = registry;
       this.ignoringUnknownFields = ignoreUnknownFields;
       this.recursionLimit = recursionLimit;
       this.typeParsers = typeParsers;
     }
 
-    /**
-     * Adds a {@link TypeParser} for the given type
-     */
-    public Parser usingTypeParser(String type,TypeParser parser)
-    {
-    	this.typeParsers.put(type, parser);
-    	return new Parser(registry, ignoringUnknownFields, recursionLimit,typeParsers);
+    /** Adds a {@link TypeParser} for the given type */
+    public Parser usingTypeParser(String type, TypeParser parser) {
+      this.typeParsers.put(type, parser);
+      return new Parser(registry, ignoringUnknownFields, recursionLimit, typeParsers);
     }
-    
+
     /**
-     * Creates a new {@link Parser} using the given registry. The new Parser
-     * clones all other configurations from this Parser.
+     * Creates a new {@link Parser} using the given registry. The new Parser clones all other
+     * configurations from this Parser.
      *
      * @throws IllegalArgumentException if a registry is already set.
      */
@@ -282,7 +289,7 @@ public class JsonFormat {
       if (this.registry != TypeRegistry.getEmptyTypeRegistry()) {
         throw new IllegalArgumentException("Only one registry is allowed.");
       }
-      return new Parser(registry, ignoringUnknownFields, recursionLimit,typeParsers);
+      return new Parser(registry, ignoringUnknownFields, recursionLimit, typeParsers);
     }
 
     /**
@@ -290,45 +297,46 @@ public class JsonFormat {
      * encountered. The new Parser clones all other configurations from this Parser.
      */
     public Parser ignoringUnknownFields() {
-      return new Parser(this.registry, true, recursionLimit,typeParsers);
+      return new Parser(this.registry, true, recursionLimit, typeParsers);
     }
 
     /**
      * Parses from JSON into a protobuf message.
      *
-     * @throws InvalidProtocolBufferException if the input is not valid JSON
-     *         format or there are unknown fields in the input.
+     * @throws InvalidProtocolBufferException if the input is not valid JSON format or there are
+     *     unknown fields in the input.
      */
     public void merge(String json, Message.Builder builder) throws InvalidProtocolBufferException {
       // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
-      new ParserImpl(registry, ignoringUnknownFields, recursionLimit,typeParsers).merge(json, builder);
+      new ParserImpl(registry, ignoringUnknownFields, recursionLimit, typeParsers)
+          .merge(json, builder);
     }
 
     /**
      * Parses from JSON into a protobuf message.
      *
-     * @throws InvalidProtocolBufferException if the input is not valid JSON
-     *         format or there are unknown fields in the input.
+     * @throws InvalidProtocolBufferException if the input is not valid JSON format or there are
+     *     unknown fields in the input.
      * @throws IOException if reading from the input throws.
      */
     public void merge(Reader json, Message.Builder builder) throws IOException {
       // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
-      new ParserImpl(registry, ignoringUnknownFields, recursionLimit,typeParsers).merge(json, builder);
+      new ParserImpl(registry, ignoringUnknownFields, recursionLimit, typeParsers)
+          .merge(json, builder);
     }
 
     // For testing only.
     Parser usingRecursionLimit(int recursionLimit) {
-      return new Parser(registry, ignoringUnknownFields, recursionLimit,typeParsers);
+      return new Parser(registry, ignoringUnknownFields, recursionLimit, typeParsers);
     }
   }
 
   /**
-   * A TypeRegistry is used to resolve Any messages in the JSON conversion.
-   * You must provide a TypeRegistry containing all message types used in
-   * Any message fields, or the JSON conversion will fail because data
-   * in Any message fields is unrecognizable. You don't need to supply a
+   * A TypeRegistry is used to resolve Any messages in the JSON conversion. You must provide a
+   * TypeRegistry containing all message types used in Any message fields, or the JSON conversion
+   * will fail because data in Any message fields is unrecognizable. You don't need to supply a
    * TypeRegistry if you don't use Any message fields.
    */
   public static class TypeRegistry {
@@ -346,8 +354,8 @@ public class JsonFormat {
     }
 
     /**
-     * Find a type by its full name. Returns null if it cannot be found in
-     * this {@link TypeRegistry}.
+     * Find a type by its full name. Returns null if it cannot be found in this {@link
+     * TypeRegistry}.
      */
     public Descriptor find(String name) {
       return types.get(name);
@@ -359,15 +367,13 @@ public class JsonFormat {
       this.types = types;
     }
 
-    /**
-     * A Builder is used to build {@link TypeRegistry}.
-     */
+    /** A Builder is used to build {@link TypeRegistry}. */
     public static class Builder {
       private Builder() {}
 
       /**
-       * Adds a message type and all types defined in the same .proto file as
-       * well as all transitively imported .proto files to this {@link Builder}.
+       * Adds a message type and all types defined in the same .proto file as well as all
+       * transitively imported .proto files to this {@link Builder}.
        */
       public Builder add(Descriptor messageType) {
         if (types == null) {
@@ -378,8 +384,8 @@ public class JsonFormat {
       }
 
       /**
-       * Adds message types and all types defined in the same .proto file as
-       * well as all transitively imported .proto files to this {@link Builder}.
+       * Adds message types and all types defined in the same .proto file as well as all
+       * transitively imported .proto files to this {@link Builder}.
        */
       public Builder add(Iterable<Descriptor> messageTypes) {
         if (types == null) {
@@ -391,10 +397,7 @@ public class JsonFormat {
         return this;
       }
 
-      /**
-       * Builds a {@link TypeRegistry}. This method can only be called once for
-       * one Builder.
-       */
+      /** Builds a {@link TypeRegistry}. This method can only be called once for one Builder. */
       public TypeRegistry build() {
         TypeRegistry result = new TypeRegistry(types);
         // Make sure the built {@link TypeRegistry} is immutable.
@@ -434,8 +437,8 @@ public class JsonFormat {
   }
 
   /**
-   * An interface for json formatting that can be used in
-   * combination with the omittingInsignificantWhitespace() method
+   * An interface for json formatting that can be used in combination with the
+   * omittingInsignificantWhitespace() method
    */
   interface TextGenerator {
     void indent();
@@ -445,9 +448,7 @@ public class JsonFormat {
     void print(final CharSequence text) throws IOException;
   }
 
-  /**
-   * Format the json without indentation
-   */
+  /** Format the json without indentation */
   private static final class CompactTextGenerator implements TextGenerator {
     private final Appendable output;
 
@@ -455,26 +456,18 @@ public class JsonFormat {
       this.output = output;
     }
 
-    /**
-     * ignored by compact printer
-     */
+    /** ignored by compact printer */
     public void indent() {}
 
-    /**
-     * ignored by compact printer
-     */
+    /** ignored by compact printer */
     public void outdent() {}
 
-    /**
-     * Print text to the output stream.
-     */
+    /** Print text to the output stream. */
     public void print(final CharSequence text) throws IOException {
       output.append(text);
     }
   }
-  /**
-   * A TextGenerator adds indentation when writing formatted text.
-   */
+  /** A TextGenerator adds indentation when writing formatted text. */
   private static final class PrettyTextGenerator implements TextGenerator {
     private final Appendable output;
     private final StringBuilder indent = new StringBuilder();
@@ -485,18 +478,15 @@ public class JsonFormat {
     }
 
     /**
-     * Indent text by two spaces.  After calling Indent(), two spaces will be
-     * inserted at the beginning of each line of text.  Indent() may be called
-     * multiple times to produce deeper indents.
+     * Indent text by two spaces. After calling Indent(), two spaces will be inserted at the
+     * beginning of each line of text. Indent() may be called multiple times to produce deeper
+     * indents.
      */
     public void indent() {
       indent.append("  ");
     }
 
-    /**
-     * Reduces the current indent level by two spaces, or crashes if the indent
-     * level is zero.
-     */
+    /** Reduces the current indent level by two spaces, or crashes if the indent level is zero. */
     public void outdent() {
       final int length = indent.length();
       if (length < 2) {
@@ -505,9 +495,7 @@ public class JsonFormat {
       indent.delete(length - 2, length);
     }
 
-    /**
-     * Print text to the output stream.
-     */
+    /** Print text to the output stream. */
     public void print(final CharSequence text) throws IOException {
       final int size = text.length();
       int pos = 0;
@@ -534,12 +522,10 @@ public class JsonFormat {
     }
   }
 
-  /**
-   * A Printer converts protobuf messages to JSON format.
-   */
+  /** A Printer converts protobuf messages to JSON format. */
   private static final class PrinterImpl {
     private final TypeRegistry registry;
-    private final Map<String,TypeConverter> typeConverters;
+    private final Map<String, TypeConverter> typeConverters;
     private final boolean includingDefaultValueFields;
     private final boolean preservingProtoFieldNames;
     private final TextGenerator generator;
@@ -558,7 +544,7 @@ public class JsonFormat {
         boolean preservingProtoFieldNames,
         Appendable jsonOutput,
         boolean omittingInsignificantWhitespace,
-        Map<String,TypeConverter> typeConverters) {
+        Map<String, TypeConverter> typeConverters) {
       this.registry = registry;
       this.includingDefaultValueFields = includingDefaultValueFields;
       this.preservingProtoFieldNames = preservingProtoFieldNames;
@@ -577,21 +563,21 @@ public class JsonFormat {
     }
 
     void print(MessageOrBuilder message) throws IOException {
-        if (typeConverters.containsKey(message.getDescriptorForType().getFullName()))
-        {
-            String msg = typeConverters.get(message.getDescriptorForType().getFullName()).convert(message);
-            generator.print(msg);
-            return;  
-        } 
-            
-        WellKnownTypePrinter specialPrinter =
+      if (typeConverters.containsKey(message.getDescriptorForType().getFullName())) {
+        String msg =
+            typeConverters.get(message.getDescriptorForType().getFullName()).convert(message);
+        generator.print(msg);
+        return;
+      }
+
+      WellKnownTypePrinter specialPrinter =
           wellKnownTypePrinters.get(message.getDescriptorForType().getFullName());
-        if (specialPrinter != null) {
-            specialPrinter.print(this, message);
-            return;
-        }
-      
-        print(message, null);
+      if (specialPrinter != null) {
+        specialPrinter.print(this, message);
+        return;
+      }
+
+      print(message, null);
     }
 
     private interface WellKnownTypePrinter {
@@ -824,14 +810,14 @@ public class JsonFormat {
         for (FieldDescriptor field : message.getDescriptorForType().getFields()) {
           if (field.isOptional()) {
             if (field.getJavaType() == FieldDescriptor.JavaType.MESSAGE
-                && !message.hasField(field)){
+                && !message.hasField(field)) {
               // Always skip empty optional message fields. If not we will recurse indefinitely if
               // a message has itself as a sub-field.
               continue;
             }
             OneofDescriptor oneof = field.getContainingOneof();
             if (oneof != null && !message.hasField(field)) {
-                // Skip all oneof fields except the one that is actually set
+              // Skip all oneof fields except the one that is actually set
               continue;
             }
           }
@@ -927,8 +913,7 @@ public class JsonFormat {
     /**
      * Prints a field's value in JSON format.
      *
-     * @param alwaysWithQuotes whether to always add double-quotes to primitive
-     *        types.
+     * @param alwaysWithQuotes whether to always add double-quotes to primitive types.
      */
     private void printSingleFieldValue(
         final FieldDescriptor field, final Object value, boolean alwaysWithQuotes)
@@ -950,11 +935,11 @@ public class JsonFormat {
         case SINT64:
         case SFIXED64:
           if (alwaysWithQuotes) {
-                generator.print("\"");
+            generator.print("\"");
           }
           generator.print(((Long) value).toString());
           if (alwaysWithQuotes) {
-                generator.print("\"");
+            generator.print("\"");
           }
           break;
 
@@ -1098,13 +1083,17 @@ public class JsonFormat {
 
   private static class ParserImpl {
     private final TypeRegistry registry;
-    private final Map<String,TypeParser> typeParsers;
+    private final Map<String, TypeParser> typeParsers;
     private final JsonParser jsonParser;
     private final boolean ignoringUnknownFields;
     private final int recursionLimit;
     private int currentDepth;
 
-    ParserImpl(TypeRegistry registry, boolean ignoreUnknownFields, int recursionLimit,Map<String,TypeParser> typeParsers) {
+    ParserImpl(
+        TypeRegistry registry,
+        boolean ignoreUnknownFields,
+        int recursionLimit,
+        Map<String, TypeParser> typeParsers) {
       this.registry = registry;
       this.ignoringUnknownFields = ignoreUnknownFields;
       this.jsonParser = new JsonParser();
@@ -1235,21 +1224,20 @@ public class JsonFormat {
 
     private void merge(JsonElement json, Message.Builder builder)
         throws InvalidProtocolBufferException {
-        
-        if (typeParsers.containsKey(builder.getDescriptorForType().getFullName()))
-        {
-            typeParsers.get(builder.getDescriptorForType().getFullName()).merge(json, builder);
-            return;
-        }
-        
-        WellKnownTypeParser specialParser =
-                wellKnownTypeParsers.get(builder.getDescriptorForType().getFullName());
-        if (specialParser != null) {
-            specialParser.merge(this, json, builder);
-            return;
-        }
-      
-        mergeMessage(json, builder, false);
+
+      if (typeParsers.containsKey(builder.getDescriptorForType().getFullName())) {
+        typeParsers.get(builder.getDescriptorForType().getFullName()).merge(json, builder);
+        return;
+      }
+
+      WellKnownTypeParser specialParser =
+          wellKnownTypeParsers.get(builder.getDescriptorForType().getFullName());
+      if (specialParser != null) {
+        specialParser.merge(this, json, builder);
+        return;
+      }
+
+      mergeMessage(json, builder, false);
     }
 
     // Maps from camel-case field names to FieldDescriptor.
@@ -1492,9 +1480,8 @@ public class JsonFormat {
     }
 
     /**
-     * Gets the default value for a field type. Note that we use proto3
-     * language defaults and ignore any default values set through the
-     * proto "default" option.
+     * Gets the default value for a field type. Note that we use proto3 language defaults and ignore
+     * any default values set through the proto "default" option.
      */
     private Object getDefaultValue(FieldDescriptor field, Message.Builder builder) {
       switch (field.getType()) {

--- a/engine/src/main/java/io/seldon/engine/pb/ProtoBufUtils.java
+++ b/engine/src/main/java/io/seldon/engine/pb/ProtoBufUtils.java
@@ -1,23 +1,22 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-
 import io.kubernetes.client.proto.IntStr.IntOrString;
 import io.kubernetes.client.proto.Meta.Time;
 import io.kubernetes.client.proto.Meta.Timestamp;
@@ -26,52 +25,53 @@ import io.seldon.engine.pb.JsonFormat.Printer;
 
 public class ProtoBufUtils {
 
-    private ProtoBufUtils() {
+  private ProtoBufUtils() {}
+
+  /**
+   * Serialize a protobuf message to JSON, indicating if whitespace needs to be stripped.
+   *
+   * @param message The protobuf message to serialize.
+   * @param omittingInsignificantWhitespace True if needs to be stripped of whitespace.
+   * @return json string
+   * @throws InvalidProtocolBufferException
+   */
+  public static String toJson(Message message, boolean omittingInsignificantWhitespace)
+      throws InvalidProtocolBufferException {
+    String json = null;
+    // json =
+    // JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames().print(message);
+    // json =
+    // JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames().omittingInsignificantWhitespace().print(message);
+
+    Printer jsonPrinter =
+        JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames();
+    if (omittingInsignificantWhitespace) {
+      jsonPrinter = jsonPrinter.omittingInsignificantWhitespace();
     }
+    return jsonPrinter.print(message);
+  }
 
-    /**
-     * Serialize a protobuf message to JSON, indicating if whitespace needs to be stripped.
-     * 
-     * @param message
-     *            The protobuf message to serialize.
-     * @param omittingInsignificantWhitespace
-     *            True if needs to be stripped of whitespace.
-     * @return json string
-     * @throws InvalidProtocolBufferException
-     */
-    public static String toJson(Message message, boolean omittingInsignificantWhitespace) throws InvalidProtocolBufferException {
-        String json = null;
-        // json = JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames().print(message);
-        // json =
-        // JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames().omittingInsignificantWhitespace().print(message);
+  /**
+   * Serialize a protobuf message to JSON, allowing the inclusion of whitespace.
+   *
+   * @param message The protobuf message to serialize.
+   * @return json string
+   * @throws InvalidProtocolBufferException
+   */
+  public static String toJson(Message message) throws InvalidProtocolBufferException {
+    boolean omittingInsignificantWhitespace = false;
+    return toJson(message, omittingInsignificantWhitespace);
+  }
 
-        Printer jsonPrinter = JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames();
-        if (omittingInsignificantWhitespace) {
-            jsonPrinter = jsonPrinter.omittingInsignificantWhitespace();
-        }
-        return jsonPrinter.print(message);
-    }
-
-    /**
-     * Serialize a protobuf message to JSON, allowing the inclusion of whitespace.
-     * 
-     * @param message
-     *            The protobuf message to serialize.
-     * @return json string
-     * @throws InvalidProtocolBufferException
-     */
-    public static String toJson(Message message) throws InvalidProtocolBufferException {
-        boolean omittingInsignificantWhitespace = false;
-        return toJson(message, omittingInsignificantWhitespace);
-    }
-
-    public static <T extends Message.Builder> void updateMessageBuilderFromJson(T messageBuilder, String json) throws InvalidProtocolBufferException {
-    	JsonFormat.parser().ignoringUnknownFields()
-    	.usingTypeParser(IntOrString.getDescriptor().getFullName(), new IntOrStringUtils.IntOrStringParser())
+  public static <T extends Message.Builder> void updateMessageBuilderFromJson(
+      T messageBuilder, String json) throws InvalidProtocolBufferException {
+    JsonFormat.parser()
+        .ignoringUnknownFields()
+        .usingTypeParser(
+            IntOrString.getDescriptor().getFullName(), new IntOrStringUtils.IntOrStringParser())
         .usingTypeParser(Quantity.getDescriptor().getFullName(), new QuantityUtils.QuantityParser())
         .usingTypeParser(Time.getDescriptor().getFullName(), new TimeUtils.TimeParser())
-        .usingTypeParser(Timestamp.getDescriptor().getFullName(), new TimeUtils.TimeParser()) 
-    	.merge(json, messageBuilder);
-    }
-
+        .usingTypeParser(Timestamp.getDescriptor().getFullName(), new TimeUtils.TimeParser())
+        .merge(json, messageBuilder);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/pb/QuantityUtils.java
+++ b/engine/src/main/java/io/seldon/engine/pb/QuantityUtils.java
@@ -1,21 +1,19 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
-
-import java.io.IOException;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
@@ -24,45 +22,42 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.Message.Builder;
 import com.google.protobuf.MessageOrBuilder;
-
 import io.kubernetes.client.proto.Resource.Quantity;
 import io.seldon.engine.pb.JsonFormat.TypeConverter;
 import io.seldon.engine.pb.JsonFormat.TypeParser;
+import java.io.IOException;
 
 public class QuantityUtils {
 
-	public static class QuantityConverter implements TypeConverter
-	{
-		private ByteString toByteString(MessageOrBuilder message) {
-		      if (message instanceof Message) {
-		        return ((Message) message).toByteString();
-		      } else {
-		        return ((Message.Builder) message).build().toByteString();
-		      }
-		    }
+  public static class QuantityConverter implements TypeConverter {
+    private ByteString toByteString(MessageOrBuilder message) {
+      if (message instanceof Message) {
+        return ((Message) message).toByteString();
+      } else {
+        return ((Message.Builder) message).build().toByteString();
+      }
+    }
 
-		@Override
-		public String convert(MessageOrBuilder message) throws IOException {
-			Quantity q = Quantity.parseFrom(toByteString(message));
-			return "\"" + q.getString() + "\"";
-		}
-		
-	}
-	
-	public static class QuantityParser implements TypeParser {
+    @Override
+    public String convert(MessageOrBuilder message) throws IOException {
+      Quantity q = Quantity.parseFrom(toByteString(message));
+      return "\"" + q.getString() + "\"";
+    }
+  }
 
-		@Override
-		public void merge(JsonElement json, Builder builder) throws InvalidProtocolBufferException {
-			if (json instanceof JsonPrimitive) {
-		        JsonPrimitive primitive = (JsonPrimitive) json;
-		        if (primitive.isString())
-                {
-		            Quantity.Builder b = Quantity.newBuilder().setString(primitive.getAsString());
-		            builder.mergeFrom(b.build().toByteArray());
-                }
-                else throw new InvalidProtocolBufferException("Can't decode io.kubernetes.client.proto.resource.Quantity from "+json.toString());
-			}
-		}
-		
-	}
+  public static class QuantityParser implements TypeParser {
+
+    @Override
+    public void merge(JsonElement json, Builder builder) throws InvalidProtocolBufferException {
+      if (json instanceof JsonPrimitive) {
+        JsonPrimitive primitive = (JsonPrimitive) json;
+        if (primitive.isString()) {
+          Quantity.Builder b = Quantity.newBuilder().setString(primitive.getAsString());
+          builder.mergeFrom(b.build().toByteArray());
+        } else
+          throw new InvalidProtocolBufferException(
+              "Can't decode io.kubernetes.client.proto.resource.Quantity from " + json.toString());
+      }
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/pb/TimeUtils.java
+++ b/engine/src/main/java/io/seldon/engine/pb/TimeUtils.java
@@ -1,22 +1,19 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
-
-import java.io.IOException;
-import java.text.ParseException;
 
 import com.google.gson.JsonElement;
 import com.google.protobuf.ByteString;
@@ -26,41 +23,39 @@ import com.google.protobuf.Message.Builder;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
-
 import io.seldon.engine.pb.JsonFormat.TypeConverter;
 import io.seldon.engine.pb.JsonFormat.TypeParser;
+import java.io.IOException;
+import java.text.ParseException;
 
 public class TimeUtils {
 
-    public static class TimeConverter implements TypeConverter
-    {
-        private ByteString toByteString(MessageOrBuilder message) {
-              if (message instanceof Message) {
-                return ((Message) message).toByteString();
-              } else {
-                return ((Message.Builder) message).build().toByteString();
-              }
-            }
-
-        @Override
-        public String convert(MessageOrBuilder message) throws IOException {
-            Timestamp value = Timestamp.parseFrom(toByteString(message));
-            return ("\"" + Timestamps.toString(value) + "\"");
-        }
+  public static class TimeConverter implements TypeConverter {
+    private ByteString toByteString(MessageOrBuilder message) {
+      if (message instanceof Message) {
+        return ((Message) message).toByteString();
+      } else {
+        return ((Message.Builder) message).build().toByteString();
+      }
     }
-    
-    public static class TimeParser implements TypeParser {
 
-        @Override
-        public void merge(JsonElement json, Builder builder) throws InvalidProtocolBufferException {
-            try {
-                Timestamp value = Timestamps.parse(json.getAsString());
-                builder.mergeFrom(value.toByteString());
-              } catch (ParseException e) {
-                throw new InvalidProtocolBufferException("Failed to parse timestamp: " + json);
-              }
-        }
-        
+    @Override
+    public String convert(MessageOrBuilder message) throws IOException {
+      Timestamp value = Timestamp.parseFrom(toByteString(message));
+      return ("\"" + Timestamps.toString(value) + "\"");
     }
-    
+  }
+
+  public static class TimeParser implements TypeParser {
+
+    @Override
+    public void merge(JsonElement json, Builder builder) throws InvalidProtocolBufferException {
+      try {
+        Timestamp value = Timestamps.parse(json.getAsString());
+        builder.mergeFrom(value.toByteString());
+      } catch (ParseException e) {
+        throw new InvalidProtocolBufferException("Failed to parse timestamp: " + json);
+      }
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/AverageCombinerUnit.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/AverageCombinerUnit.java
@@ -1,81 +1,93 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
-import java.util.Iterator;
-import java.util.List;
-
 import static org.ojalgo.function.PrimitiveFunction.*;
-import org.ojalgo.matrix.PrimitiveMatrix;
-import org.springframework.stereotype.Component;
 
 import io.seldon.engine.exception.APIException;
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
+import java.util.Iterator;
+import java.util.List;
+import org.ojalgo.matrix.PrimitiveMatrix;
+import org.springframework.stereotype.Component;
 
 @Component
 public class AverageCombinerUnit extends PredictiveUnitImpl {
-	
-	public AverageCombinerUnit() {}
 
-	@Override
-	public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state){
-		
-		if (outputs.size()==0){
-			throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE, String.format("Combiner received no inputs"));
-		}
-		
-		int[] shape = PredictorUtils.getShape(outputs.get(0).getData());
-		
-		if (shape == null){
-			throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE, String.format("Combiner cannot extract data shape"));
-		}
-		
-		if (shape.length!=2){
-			throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE, String.format("Combiner received data that is not 2 dimensional"));
-		}
-        PrimitiveMatrix.DenseReceiver currentSum = PrimitiveMatrix.FACTORY.makeDense(shape[0], shape[1]);
-		SeldonMessage.Builder respBuilder = SeldonMessage.newBuilder();
-		
-		for (Iterator<SeldonMessage> i = outputs.iterator(); i.hasNext();)
-		{
-			DefaultData inputData = i.next().getData();
-			int[] inputShape = PredictorUtils.getShape(inputData);
-			if (inputShape == null){
-				throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE, String.format("Combiner cannot extract data shape"));
-			}
-			if (inputShape.length!=2){
-				throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE, String.format("Combiner received data that is not 2 dimensional"));
-			}
-			if (inputShape[0] != shape[0]){
-				throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE, String.format("Expected batch length %d but found %d",shape[0],inputShape[0]));
-			}
-			if (inputShape[1] != shape[1]){
-				throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE, String.format("Expected batch length %d but found %d",shape[1],inputShape[1]));
-			}
-            PredictorUtils.add(inputData, currentSum);
-		}
-        currentSum.modifyAll(DIVIDE.by(outputs.size()));
-		
-        DefaultData newData = PredictorUtils.updateData(outputs.get(0).getData(), currentSum.get());
-		respBuilder.setData(newData);
-		respBuilder.setMeta(outputs.get(0).getMeta());
-		respBuilder.setStatus(outputs.get(0).getStatus());
-		
-		return respBuilder.build();
-	}
+  public AverageCombinerUnit() {}
 
+  @Override
+  public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state) {
+
+    if (outputs.size() == 0) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE,
+          String.format("Combiner received no inputs"));
+    }
+
+    int[] shape = PredictorUtils.getShape(outputs.get(0).getData());
+
+    if (shape == null) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE,
+          String.format("Combiner cannot extract data shape"));
+    }
+
+    if (shape.length != 2) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE,
+          String.format("Combiner received data that is not 2 dimensional"));
+    }
+    PrimitiveMatrix.DenseReceiver currentSum =
+        PrimitiveMatrix.FACTORY.makeDense(shape[0], shape[1]);
+    SeldonMessage.Builder respBuilder = SeldonMessage.newBuilder();
+
+    for (Iterator<SeldonMessage> i = outputs.iterator(); i.hasNext(); ) {
+      DefaultData inputData = i.next().getData();
+      int[] inputShape = PredictorUtils.getShape(inputData);
+      if (inputShape == null) {
+        throw new APIException(
+            APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE,
+            String.format("Combiner cannot extract data shape"));
+      }
+      if (inputShape.length != 2) {
+        throw new APIException(
+            APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE,
+            String.format("Combiner received data that is not 2 dimensional"));
+      }
+      if (inputShape[0] != shape[0]) {
+        throw new APIException(
+            APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE,
+            String.format("Expected batch length %d but found %d", shape[0], inputShape[0]));
+      }
+      if (inputShape[1] != shape[1]) {
+        throw new APIException(
+            APIException.ApiExceptionType.ENGINE_INVALID_COMBINER_RESPONSE,
+            String.format("Expected batch length %d but found %d", shape[1], inputShape[1]));
+      }
+      PredictorUtils.add(inputData, currentSum);
+    }
+    currentSum.modifyAll(DIVIDE.by(outputs.size()));
+
+    DefaultData newData = PredictorUtils.updateData(outputs.get(0).getData(), currentSum.get());
+    respBuilder.setData(newData);
+    respBuilder.setMeta(outputs.get(0).getMeta());
+    respBuilder.setStatus(outputs.get(0).getStatus());
+
+    return respBuilder.build();
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/EnginePredictor.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/EnginePredictor.java
@@ -1,160 +1,159 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
-
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Base64;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-
 import io.kubernetes.client.proto.IntStr.IntOrString;
 import io.kubernetes.client.proto.Meta.Time;
 import io.kubernetes.client.proto.Meta.Timestamp;
 import io.kubernetes.client.proto.Resource.Quantity;
-import io.kubernetes.client.proto.V1.PodTemplateSpec;
 import io.seldon.engine.pb.IntOrStringUtils;
 import io.seldon.engine.pb.JsonFormat;
 import io.seldon.engine.pb.JsonFormat.Printer;
 import io.seldon.engine.pb.QuantityUtils;
 import io.seldon.engine.pb.TimeUtils;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit;
-import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitType;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitImplementation;
+import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitType;
 import io.seldon.protos.DeploymentProtos.PredictorSpec;
-import io.seldon.protos.DeploymentProtos.SeldonDeployment;
 import io.seldon.protos.DeploymentProtos.SeldonPodSpec;
-
-
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EnginePredictor {
 
-    private final static Logger logger = LoggerFactory.getLogger(EnginePredictor.class);
-    private final static String ENGINE_PREDICTOR_KEY = "ENGINE_PREDICTOR";
-    private final static String ENGINE_SELDON_DEPLOYMENT_KEY = "ENGINE_SELDON_DEPLOYMENT";
-    private final static String DEPLOYMENT_NAME_KEY = "DEPLOYMENT_NAME";
+  private static final Logger logger = LoggerFactory.getLogger(EnginePredictor.class);
+  private static final String ENGINE_PREDICTOR_KEY = "ENGINE_PREDICTOR";
+  private static final String ENGINE_SELDON_DEPLOYMENT_KEY = "ENGINE_SELDON_DEPLOYMENT";
+  private static final String DEPLOYMENT_NAME_KEY = "DEPLOYMENT_NAME";
 
-    private PredictorSpec predictorSpec = null;
-    private String deploymentName = "None";
+  private PredictorSpec predictorSpec = null;
+  private String deploymentName = "None";
 
-    public void init() throws Exception {
-        logger.info("init");
+  public void init() throws Exception {
+    logger.info("init");
 
-        { // setup the PredictorSpec using the env vars
-            String enginePredictorBase64Encoded = System.getenv().get(ENGINE_PREDICTOR_KEY);
-            if (enginePredictorBase64Encoded == null) {
-            	String filePath = "./deploymentdef.json";
-            	File deploymentFile = new File(filePath);
-            	if (deploymentFile.exists()){
-            		logger.warn("FAILED to find env var [{}], will use json file", ENGINE_PREDICTOR_KEY);
-            		byte[] encoded = Files.readAllBytes(Paths.get(filePath));
-            		String enginePredictorJson = new String(encoded);
-            		PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-	                try {
-	                    updateMessageBuilderFromJson(PredictorSpecBuilder, enginePredictorJson);
-	                } catch (Exception e) {
-	                    logger.error("FAILED building PredictorSpec from file content", ENGINE_PREDICTOR_KEY,e);
-	                    throw e;
-	                }
-	                predictorSpec = PredictorSpecBuilder.build();
-            	}
-            	else {	
-            		logger.warn("FAILED to find env var [{}], will use defaults for engine predictor", ENGINE_PREDICTOR_KEY);
-            		predictorSpec = buildDefaultPredictorSpec();
-            	}
-            } else {
-                logger.info("FOUND env var [{}], will use for engine predictor", ENGINE_PREDICTOR_KEY);
-                byte[] enginePredictorBytes = Base64.getDecoder().decode(enginePredictorBase64Encoded);
-                String enginePredictorJson = new String(enginePredictorBytes);
-                PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-                try {
-                    updateMessageBuilderFromJson(PredictorSpecBuilder, enginePredictorJson);
-                } catch (Exception e) {
-                    logger.error("FAILED extracting PredictorSpec from env var [{}]", ENGINE_PREDICTOR_KEY,e);
-                    throw e;
-                }
-                predictorSpec = PredictorSpecBuilder.build();
-            }
-            
-            String depName = System.getenv().get(DEPLOYMENT_NAME_KEY);
-            if (depName != null)
-            {
-            	this.deploymentName = depName;
-            	logger.info("Setting deployment name to {}",deploymentName);
-            }
-            else
-            	logger.warn("No deployment name found in environment!");
+    { // setup the PredictorSpec using the env vars
+      String enginePredictorBase64Encoded = System.getenv().get(ENGINE_PREDICTOR_KEY);
+      if (enginePredictorBase64Encoded == null) {
+        String filePath = "./deploymentdef.json";
+        File deploymentFile = new File(filePath);
+        if (deploymentFile.exists()) {
+          logger.warn("FAILED to find env var [{}], will use json file", ENGINE_PREDICTOR_KEY);
+          byte[] encoded = Files.readAllBytes(Paths.get(filePath));
+          String enginePredictorJson = new String(encoded);
+          PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+          try {
+            updateMessageBuilderFromJson(PredictorSpecBuilder, enginePredictorJson);
+          } catch (Exception e) {
+            logger.error(
+                "FAILED building PredictorSpec from file content", ENGINE_PREDICTOR_KEY, e);
+            throw e;
+          }
+          predictorSpec = PredictorSpecBuilder.build();
+        } else {
+          logger.warn(
+              "FAILED to find env var [{}], will use defaults for engine predictor",
+              ENGINE_PREDICTOR_KEY);
+          predictorSpec = buildDefaultPredictorSpec();
         }
-
-        logger.info("Installed engine predictor: {}", toJson(predictorSpec, true));
-    }
-
-    public void cleanup() throws Exception {
-        logger.info("cleanup");
-    }
-
-    public PredictorSpec getPredictorSpec() {
-        return predictorSpec;
-    }
-
-    public String getDeploymentName() {
-		return deploymentName;
-	}
-
-	private static PredictorSpec buildDefaultPredictorSpec() {
-
-        //@formatter:off
-        PredictorSpec.Builder predictorSpecBuilder = PredictorSpec.newBuilder()
-                .setName("basic-predictor")
-                .addComponentSpecs(SeldonPodSpec.newBuilder());
-        //@formatter:on
-
-        { // Add predictorGraph
-            //@formatter:off
-        	PredictiveUnit.Builder PredictiveUnitBuilder = PredictiveUnit.newBuilder()
-        			.setName("basic-pu")
-        			.setType(PredictiveUnitType.MODEL)
-        			.setImplementation(PredictiveUnitImplementation.SIMPLE_MODEL);
-            //@formatter:on
-
-        	predictorSpecBuilder.setGraph(PredictiveUnitBuilder);
+      } else {
+        logger.info("FOUND env var [{}], will use for engine predictor", ENGINE_PREDICTOR_KEY);
+        byte[] enginePredictorBytes = Base64.getDecoder().decode(enginePredictorBase64Encoded);
+        String enginePredictorJson = new String(enginePredictorBytes);
+        PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+        try {
+          updateMessageBuilderFromJson(PredictorSpecBuilder, enginePredictorJson);
+        } catch (Exception e) {
+          logger.error(
+              "FAILED extracting PredictorSpec from env var [{}]", ENGINE_PREDICTOR_KEY, e);
+          throw e;
         }
-        return predictorSpecBuilder.build();
+        predictorSpec = PredictorSpecBuilder.build();
+      }
+
+      String depName = System.getenv().get(DEPLOYMENT_NAME_KEY);
+      if (depName != null) {
+        this.deploymentName = depName;
+        logger.info("Setting deployment name to {}", deploymentName);
+      } else logger.warn("No deployment name found in environment!");
     }
 
-    private static String toJson(Message message, boolean omittingInsignificantWhitespace) throws InvalidProtocolBufferException {
-        Printer jsonPrinter = JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames();
-        if (omittingInsignificantWhitespace) {
-            jsonPrinter = jsonPrinter.omittingInsignificantWhitespace();
-        }
-        return jsonPrinter.print(message);
-    }
+    logger.info("Installed engine predictor: {}", toJson(predictorSpec, true));
+  }
 
-    public static <T extends Message.Builder> void updateMessageBuilderFromJson(T messageBuilder, String json) throws InvalidProtocolBufferException {
-        JsonFormat.parser().ignoringUnknownFields()
-        .usingTypeParser(IntOrString.getDescriptor().getFullName(), new IntOrStringUtils.IntOrStringParser())
+  public void cleanup() throws Exception {
+    logger.info("cleanup");
+  }
+
+  public PredictorSpec getPredictorSpec() {
+    return predictorSpec;
+  }
+
+  public String getDeploymentName() {
+    return deploymentName;
+  }
+
+  private static PredictorSpec buildDefaultPredictorSpec() {
+
+    // @formatter:off
+    PredictorSpec.Builder predictorSpecBuilder =
+        PredictorSpec.newBuilder()
+            .setName("basic-predictor")
+            .addComponentSpecs(SeldonPodSpec.newBuilder());
+    // @formatter:on
+
+    { // Add predictorGraph
+      // @formatter:off
+      PredictiveUnit.Builder PredictiveUnitBuilder =
+          PredictiveUnit.newBuilder()
+              .setName("basic-pu")
+              .setType(PredictiveUnitType.MODEL)
+              .setImplementation(PredictiveUnitImplementation.SIMPLE_MODEL);
+      // @formatter:on
+
+      predictorSpecBuilder.setGraph(PredictiveUnitBuilder);
+    }
+    return predictorSpecBuilder.build();
+  }
+
+  private static String toJson(Message message, boolean omittingInsignificantWhitespace)
+      throws InvalidProtocolBufferException {
+    Printer jsonPrinter =
+        JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames();
+    if (omittingInsignificantWhitespace) {
+      jsonPrinter = jsonPrinter.omittingInsignificantWhitespace();
+    }
+    return jsonPrinter.print(message);
+  }
+
+  public static <T extends Message.Builder> void updateMessageBuilderFromJson(
+      T messageBuilder, String json) throws InvalidProtocolBufferException {
+    JsonFormat.parser()
+        .ignoringUnknownFields()
+        .usingTypeParser(
+            IntOrString.getDescriptor().getFullName(), new IntOrStringUtils.IntOrStringParser())
         .usingTypeParser(Quantity.getDescriptor().getFullName(), new QuantityUtils.QuantityParser())
         .usingTypeParser(Time.getDescriptor().getFullName(), new TimeUtils.TimeParser())
-        .usingTypeParser(Timestamp.getDescriptor().getFullName(), new TimeUtils.TimeParser()) 
+        .usingTypeParser(Timestamp.getDescriptor().getFullName(), new TimeUtils.TimeParser())
         .merge(json, messageBuilder);
-    }
-
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/InternalEndpoint.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/InternalEndpoint.java
@@ -1,25 +1,23 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
 public class InternalEndpoint {
-	public String host;
-	public Integer port;
-	
-	public InternalEndpointType type;
-	
-	
+  public String host;
+  public Integer port;
+
+  public InternalEndpointType type;
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/InternalEndpointType.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/InternalEndpointType.java
@@ -1,25 +1,25 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum InternalEndpointType {
-	@JsonProperty("REST")
-	REST, 
-	@JsonProperty("RPC")
-	RPC
+  @JsonProperty("REST")
+  REST,
+  @JsonProperty("RPC")
+  RPC
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBean.java
@@ -1,38 +1,21 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
-import org.ojalgo.matrix.PrimitiveMatrix;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.AsyncResult;
-import org.springframework.stereotype.Component;
-
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
@@ -48,333 +31,359 @@ import io.seldon.protos.PredictionProtos.Feedback;
 import io.seldon.protos.PredictionProtos.Meta;
 import io.seldon.protos.PredictionProtos.Metric;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.ojalgo.matrix.PrimitiveMatrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.stereotype.Component;
 
 @Component
 public class PredictiveUnitBean extends PredictiveUnitImpl {
 
-	private final static Logger logger = LoggerFactory.getLogger(PredictiveUnitBean.class);
-	
-	@Autowired
-	InternalPredictionService internalPredictionService;
-	
-	@Autowired
-	private SeldonRestTemplateExchangeTagsProvider tagsProvider;
-	
-	@Autowired
-	public PredictorConfigBean predictorConfig;
-	
-	@Autowired
-	private CustomMetricsManager customMetricsManager;
-	
-	@Autowired
-	private TracingProvider tracing;
-	
-	private PredictiveUnitBeanProxy predictiveUnitBeanProxy;
-	
-	public PredictiveUnitBean(){}
+  private static final Logger logger = LoggerFactory.getLogger(PredictiveUnitBean.class);
 
-	public void setProxy(PredictiveUnitBeanProxy proxy)
-	{
-		this.predictiveUnitBeanProxy = proxy;
-	}
-	
-	public SeldonMessage getOutput(SeldonMessage request, PredictiveUnitState state) throws InterruptedException, ExecutionException, InvalidProtocolBufferException{
-		Map<String,Integer> routingDict = new ConcurrentHashMap<String,Integer>();
-		Map<String,String> requestPathDict = new ConcurrentHashMap<String,String>();
-		Map<String,List<Metric>> metrics = new ConcurrentHashMap<String,List<Metric>>();
-		Span activeSpan = null;
-		if (tracing != null && tracing.isActive())
-			activeSpan = tracing.getTracer().activeSpan();
-		SeldonMessage response = predictiveUnitBeanProxy.getOutputAsync(request, state, routingDict,requestPathDict,metrics,activeSpan).get();
-		List<Metric> metricList = new ArrayList<>();
-		for(List<Metric> mlist: metrics.values())
-			metricList.addAll(mlist);
-		SeldonMessage.Builder builder = SeldonMessage
-			.newBuilder(response)
-			.setMeta(Meta
-					.newBuilder(response.getMeta()).putAllRouting(routingDict).putAllRequestPath(requestPathDict).addAllMetrics(metricList));
-		return builder.build();
-	}
-	
-	private void addMetrics(SeldonMessage msg,PredictiveUnitState state,Map<String,List<Metric>> metrics)
-	{
-		if (msg.hasMeta())
-		{
-			addCustomMetrics(msg.getMeta().getMetricsList(),state);
-			if (!metrics.containsKey(state.name))
-				metrics.putIfAbsent(state.name,new ArrayList<>());
-			List<Metric> current = metrics.get(state.name);
-			current.addAll(msg.getMeta().getMetricsList());
-			metrics.put(state.name,current);
-		}
-	}
-	
-	@Async
-	public Future<SeldonMessage> getOutputAsync(SeldonMessage input, PredictiveUnitState state, Map<String,Integer> routingDict,Map<String,String> requestPathDict,Map<String,List<Metric>> metrics,Span activeSpan) throws InterruptedException, ExecutionException, InvalidProtocolBufferException{
+  @Autowired InternalPredictionService internalPredictionService;
 
-		logger.debug("Calling getOutputAsync");
-		String puid = input.getMeta().getPuid();
-		
-		if (activeSpan != null && tracing != null)
-			tracing.getTracer().scopeManager().activate(activeSpan);
-		
-		// This element to the request path
-		requestPathDict.put(state.name, state.image);
-		
-		// Getting the actual implementation (microservice or hardcoded? )
-		PredictiveUnitImpl implementation = predictorConfig.getImplementation(state);
-		if (implementation == null)
-		{
-			logger.debug("No implementation");
-			implementation = this; 
-		}
-		
-		// Compute the transformed Input
-		logger.debug("Call transform input");
-		SeldonMessage transformedInput = implementation.transformInput(input, state);
-		
-		addMetrics(transformedInput,state,metrics);
+  @Autowired private SeldonRestTemplateExchangeTagsProvider tagsProvider;
 
-		// Override the input metadata with the new metadata from transformed input
-		transformedInput = mergeMeta(transformedInput, input, puid);
+  @Autowired public PredictorConfigBean predictorConfig;
 
-		
-		if (state.children.isEmpty()){
-			// If this unit has no children, the transformed input becomes the output
-			return new AsyncResult<>(transformedInput);
-		}
-		
-		List<PredictiveUnitState> selectedChildren = new ArrayList<PredictiveUnitState>();
-		List<Future<SeldonMessage>> deferredChildrenOutputs = new ArrayList<Future<SeldonMessage>>();
-		List<SeldonMessage> childrenOutputs = new ArrayList<SeldonMessage>();
-		
-		// Get the routing. -1 means all children
-		SeldonMessage routingMessage = implementation.route(transformedInput, state);
-		int routing;
-		if (routingMessage != null) {
-			routing = getBranchIndex(routingMessage, state);
-			sanityCheckRouting(routing, state);
-			addMetrics(routingMessage,state,metrics);
-		} else {
-			routing = -1;
-		}
-		// Update the routing dictionary
-		routingDict.put(state.name, routing);
-		
-		
-		if (routing == -1){
-			// No routing, propagate to all children
-			selectedChildren = state.children;
-		}
-		else
-		{
-			// Propagate to selected child only
-			selectedChildren.add(state.children.get(routing));
-		}
-		
-		// Get all the children outputs asynchronously
-		int childIdx = 0;
-		for (PredictiveUnitState childState : selectedChildren){
-			deferredChildrenOutputs.add(predictiveUnitBeanProxy.getOutputAsync(transformedInput,childState,routingDict,requestPathDict,metrics,activeSpan));
-			childIdx++;
-		}
-		childIdx = 0;
-		for (Future<SeldonMessage> deferredOutput : deferredChildrenOutputs){
-			SeldonMessage m = deferredOutput.get();
-			childrenOutputs.add(m);
-			childIdx++;
-		}
-		
-		// Compute the backward transformation of all children outputs
-		SeldonMessage aggregatedOutput = implementation.aggregate(childrenOutputs, state);
-		addMetrics(aggregatedOutput,state,metrics);
-		
-		// Merge all the outputs metadata
-		aggregatedOutput = mergeMeta(aggregatedOutput, childrenOutputs, puid);
-		SeldonMessage transformedOutput = implementation.transformOutput(aggregatedOutput, state);
-		addMetrics(transformedOutput,state,metrics);
+  @Autowired private CustomMetricsManager customMetricsManager;
 
-		// Override the input metadata with the new metadata from transformed input
-		transformedOutput = mergeMeta(transformedOutput, aggregatedOutput, puid);
+  @Autowired private TracingProvider tracing;
 
-		
-		return new AsyncResult<>(transformedOutput);
-		
-	}
-	
-	public void sendFeedback(Feedback feedback, PredictiveUnitState state) throws InterruptedException, ExecutionException, InvalidProtocolBufferException{
-		sendFeedbackAsync(feedback,state).get();
-	}
-	
-	@Async
-	private Future<Boolean> sendFeedbackAsync(Feedback feedback, PredictiveUnitState state) throws InterruptedException, ExecutionException, InvalidProtocolBufferException{
-		System.out.println("NODE " + state.name + ": entered feedback");
-		List<PredictiveUnitState> children = new ArrayList<PredictiveUnitState>();
-		List<Future<Boolean>> returns = new ArrayList<Future<Boolean>>();
-		
-		// Getting the actual implementation (microservice or hardcoded? )
-		PredictiveUnitImpl implementation = predictorConfig.getImplementation(state);
-		if (implementation == null){ implementation = this; }
-				
-		// First we determine children we will send feedback to according to routingDict info
-		int routing = feedback.getResponse().getMeta().getRoutingMap().getOrDefault(state.name, -1);
-		
-		// TODO: Throw exception if routing is invalid (<-1 or > n_children)
-		if (routing == -1){
-			children = state.children;
-		}
-		else if (routing>=0) {
-			children.add(state.children.get(routing));
-		}
-		
-		// First we call sendFeebackAsync on children
-		for (PredictiveUnitState child : children){
-			returns.add(sendFeedbackAsync(feedback,child));
-		}
-		
-		// Then we wait for our own feedback
-		implementation.doSendFeedback(feedback, state);
-		
-		//Then we wait for children feedback
-		for (Future<Boolean> ret : returns){
-			ret.get();
-		}
-		
-		// Finally we store the feedback metrics
-		doStoreFeedbackMetrics(feedback,state);
-		
-		return new AsyncResult<>(true);
-	}
-	
-	// -----------------------------
-	// The "predictive unit methods"
-	// -----------------------------
-	
-	public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		// Transforms the input of a predictive unit into a new message. 
-		// The result will become the input of the children, or the output if no children
-		if (predictorConfig.hasMethod(PredictiveUnitMethod.TRANSFORM_INPUT, state)) {
-			return internalPredictionService.transformInput(input, state);
-		}
-		return input;
-	}
-	
-	public SeldonMessage transformOutput(SeldonMessage output, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		// Transforms the aggregated output into a new message.
-		if (predictorConfig.hasMethod(PredictiveUnitMethod.TRANSFORM_OUTPUT, state)) {
-			return internalPredictionService.transformOutput(output, state);
-		}
-		return output;
-	}
-	
-	public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		// Aggregates the outputs of all children into a new message. 
-		// If there are several outputs, this implementation needs to be overridden.
-		
-		
-		if (predictorConfig.hasMethod(PredictiveUnitMethod.AGGREGATE, state)) {
-			return internalPredictionService.aggregate(outputs,state);
-		}
-		
-		// TODO: Throw exception if length(outputs) != 1
-		return outputs.get(0);
-	}
-	
-	public SeldonMessage route(SeldonMessage input, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		// Returns a branch number in SeldonMessage
-		
-		if (predictorConfig.hasMethod(PredictiveUnitMethod.ROUTE, state)){
-			return internalPredictionService.route(input, state);
-		}
-		
-		// Return default routing
-		return null;
-	}
-	
-	public void doSendFeedback(Feedback feedback, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		// Sends feedback to the microservice 
-		
-		if (predictorConfig.hasMethod(PredictiveUnitMethod.SEND_FEEDBACK, state)){
-			internalPredictionService.sendFeedback(feedback, state);
-		}
-		return;
-	}
-	
-	// -------------------------------------------
-	//
-	// -------------------------------------------
-	
-	private int getBranchIndex(SeldonMessage routerReturn, PredictiveUnitState state){
-		int branchIndex = 0;
-		try {
-			PrimitiveMatrix dataArray = PredictorUtils.getOJMatrix(routerReturn.getData());
-			branchIndex = dataArray.get(0).intValue();
-		}
-		catch (IndexOutOfBoundsException e) {
-			throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_ROUTING,"Router that caused the exception: id="+state.name+" name="+state.name);
-		}
-		return branchIndex;
-	}
-	
-	protected void doStoreFeedbackMetrics(Feedback feedback, PredictiveUnitState state){
-		Counter.builder("seldon_api_model_feedback_reward").tags(tagsProvider.getModelMetrics(state)).register(Metrics.globalRegistry).increment(feedback.getReward());
-		Counter.builder("seldon_api_model_feedback").tags(tagsProvider.getModelMetrics(state)).register(Metrics.globalRegistry).increment();
-	}
-	
-	private void addCustomMetrics(List<Metric> metrics, PredictiveUnitState state)
-	{
-		logger.debug("Add metrics");
-		for(Metric metric : metrics)
-		{
-			Iterable<Tag> tags = tagsProvider.getModelMetrics(state, metric.getTagsMap());
-			switch(metric.getType())
-			{
-			case COUNTER:
-				logger.debug("Adding counter {} for {}",metric.getKey(),state.name);
-				Counter counter = customMetricsManager.getCounter(tags, metric);
-				counter.increment(metric.getValue());
-				break;
-			case GAUGE:
-				logger.debug("Adding gauge {} for {}",metric.getKey(),state.name);		
-				customMetricsManager.getGaugeValue(tags, metric).set(metric.getValue());
-				break;
-			case TIMER:
-				logger.debug("Adding timer {} for {}",metric.getKey(),state.name);
-				Timer timer = customMetricsManager.getTimer(tags, metric);
-				timer.record((long) metric.getValue(), TimeUnit.MILLISECONDS);
-				break;
-			case UNRECOGNIZED:
-				break;
-			}
-		}
-	}		
-		
-	private void sanityCheckRouting(Integer branchIndex, PredictiveUnitState state){
-		if (branchIndex < -1 | branchIndex >= state.children.size()){
-			throw new APIException(
-					APIException.ApiExceptionType.ENGINE_INVALID_ROUTING,
-					"Invalid branch index. Router that caused the exception: id="+state.name+" name="+state.name);
-		}
-	}
+  private PredictiveUnitBeanProxy predictiveUnitBeanProxy;
 
-	private SeldonMessage mergeMeta(SeldonMessage latest, List<SeldonMessage> previous, String puid) {
-		Meta.Builder metaBuilder = Meta.newBuilder();
-		metaBuilder.setPuid(puid);
-		for (SeldonMessage originalMessage : previous){
-			metaBuilder.putAllTags(originalMessage.getMeta().getTagsMap());
-		}
-		metaBuilder.putAllTags(latest.getMeta().getTagsMap());
-		metaBuilder.clearMetrics();
-		return SeldonMessage.newBuilder(latest).setMeta(metaBuilder).build();
-	}
-	
-	private SeldonMessage mergeMeta(SeldonMessage latest, SeldonMessage previous, String puid) {
-		Meta.Builder metaBuilder = Meta.newBuilder();
-		metaBuilder.setPuid(puid);
-		metaBuilder.putAllTags(previous.getMeta().getTagsMap());
-		metaBuilder.putAllTags(latest.getMeta().getTagsMap());
-		metaBuilder.clearMetrics();
-		return SeldonMessage.newBuilder(latest).setMeta(metaBuilder).build();
-	}
+  public PredictiveUnitBean() {}
 
+  public void setProxy(PredictiveUnitBeanProxy proxy) {
+    this.predictiveUnitBeanProxy = proxy;
+  }
+
+  public SeldonMessage getOutput(SeldonMessage request, PredictiveUnitState state)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    Map<String, Integer> routingDict = new ConcurrentHashMap<String, Integer>();
+    Map<String, String> requestPathDict = new ConcurrentHashMap<String, String>();
+    Map<String, List<Metric>> metrics = new ConcurrentHashMap<String, List<Metric>>();
+    Span activeSpan = null;
+    if (tracing != null && tracing.isActive()) activeSpan = tracing.getTracer().activeSpan();
+    SeldonMessage response =
+        predictiveUnitBeanProxy
+            .getOutputAsync(request, state, routingDict, requestPathDict, metrics, activeSpan)
+            .get();
+    List<Metric> metricList = new ArrayList<>();
+    for (List<Metric> mlist : metrics.values()) metricList.addAll(mlist);
+    SeldonMessage.Builder builder =
+        SeldonMessage.newBuilder(response)
+            .setMeta(
+                Meta.newBuilder(response.getMeta())
+                    .putAllRouting(routingDict)
+                    .putAllRequestPath(requestPathDict)
+                    .addAllMetrics(metricList));
+    return builder.build();
+  }
+
+  private void addMetrics(
+      SeldonMessage msg, PredictiveUnitState state, Map<String, List<Metric>> metrics) {
+    if (msg.hasMeta()) {
+      addCustomMetrics(msg.getMeta().getMetricsList(), state);
+      if (!metrics.containsKey(state.name)) metrics.putIfAbsent(state.name, new ArrayList<>());
+      List<Metric> current = metrics.get(state.name);
+      current.addAll(msg.getMeta().getMetricsList());
+      metrics.put(state.name, current);
+    }
+  }
+
+  @Async
+  public Future<SeldonMessage> getOutputAsync(
+      SeldonMessage input,
+      PredictiveUnitState state,
+      Map<String, Integer> routingDict,
+      Map<String, String> requestPathDict,
+      Map<String, List<Metric>> metrics,
+      Span activeSpan)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+
+    logger.debug("Calling getOutputAsync");
+    String puid = input.getMeta().getPuid();
+
+    if (activeSpan != null && tracing != null)
+      tracing.getTracer().scopeManager().activate(activeSpan);
+
+    // This element to the request path
+    requestPathDict.put(state.name, state.image);
+
+    // Getting the actual implementation (microservice or hardcoded? )
+    PredictiveUnitImpl implementation = predictorConfig.getImplementation(state);
+    if (implementation == null) {
+      logger.debug("No implementation");
+      implementation = this;
+    }
+
+    // Compute the transformed Input
+    logger.debug("Call transform input");
+    SeldonMessage transformedInput = implementation.transformInput(input, state);
+
+    addMetrics(transformedInput, state, metrics);
+
+    // Override the input metadata with the new metadata from transformed input
+    transformedInput = mergeMeta(transformedInput, input, puid);
+
+    if (state.children.isEmpty()) {
+      // If this unit has no children, the transformed input becomes the output
+      return new AsyncResult<>(transformedInput);
+    }
+
+    List<PredictiveUnitState> selectedChildren = new ArrayList<PredictiveUnitState>();
+    List<Future<SeldonMessage>> deferredChildrenOutputs = new ArrayList<Future<SeldonMessage>>();
+    List<SeldonMessage> childrenOutputs = new ArrayList<SeldonMessage>();
+
+    // Get the routing. -1 means all children
+    SeldonMessage routingMessage = implementation.route(transformedInput, state);
+    int routing;
+    if (routingMessage != null) {
+      routing = getBranchIndex(routingMessage, state);
+      sanityCheckRouting(routing, state);
+      addMetrics(routingMessage, state, metrics);
+    } else {
+      routing = -1;
+    }
+    // Update the routing dictionary
+    routingDict.put(state.name, routing);
+
+    if (routing == -1) {
+      // No routing, propagate to all children
+      selectedChildren = state.children;
+    } else {
+      // Propagate to selected child only
+      selectedChildren.add(state.children.get(routing));
+    }
+
+    // Get all the children outputs asynchronously
+    int childIdx = 0;
+    for (PredictiveUnitState childState : selectedChildren) {
+      deferredChildrenOutputs.add(
+          predictiveUnitBeanProxy.getOutputAsync(
+              transformedInput, childState, routingDict, requestPathDict, metrics, activeSpan));
+      childIdx++;
+    }
+    childIdx = 0;
+    for (Future<SeldonMessage> deferredOutput : deferredChildrenOutputs) {
+      SeldonMessage m = deferredOutput.get();
+      childrenOutputs.add(m);
+      childIdx++;
+    }
+
+    // Compute the backward transformation of all children outputs
+    SeldonMessage aggregatedOutput = implementation.aggregate(childrenOutputs, state);
+    addMetrics(aggregatedOutput, state, metrics);
+
+    // Merge all the outputs metadata
+    aggregatedOutput = mergeMeta(aggregatedOutput, childrenOutputs, puid);
+    SeldonMessage transformedOutput = implementation.transformOutput(aggregatedOutput, state);
+    addMetrics(transformedOutput, state, metrics);
+
+    // Override the input metadata with the new metadata from transformed input
+    transformedOutput = mergeMeta(transformedOutput, aggregatedOutput, puid);
+
+    return new AsyncResult<>(transformedOutput);
+  }
+
+  public void sendFeedback(Feedback feedback, PredictiveUnitState state)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    sendFeedbackAsync(feedback, state).get();
+  }
+
+  @Async
+  private Future<Boolean> sendFeedbackAsync(Feedback feedback, PredictiveUnitState state)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    System.out.println("NODE " + state.name + ": entered feedback");
+    List<PredictiveUnitState> children = new ArrayList<PredictiveUnitState>();
+    List<Future<Boolean>> returns = new ArrayList<Future<Boolean>>();
+
+    // Getting the actual implementation (microservice or hardcoded? )
+    PredictiveUnitImpl implementation = predictorConfig.getImplementation(state);
+    if (implementation == null) {
+      implementation = this;
+    }
+
+    // First we determine children we will send feedback to according to routingDict info
+    int routing = feedback.getResponse().getMeta().getRoutingMap().getOrDefault(state.name, -1);
+
+    // TODO: Throw exception if routing is invalid (<-1 or > n_children)
+    if (routing == -1) {
+      children = state.children;
+    } else if (routing >= 0) {
+      children.add(state.children.get(routing));
+    }
+
+    // First we call sendFeebackAsync on children
+    for (PredictiveUnitState child : children) {
+      returns.add(sendFeedbackAsync(feedback, child));
+    }
+
+    // Then we wait for our own feedback
+    implementation.doSendFeedback(feedback, state);
+
+    // Then we wait for children feedback
+    for (Future<Boolean> ret : returns) {
+      ret.get();
+    }
+
+    // Finally we store the feedback metrics
+    doStoreFeedbackMetrics(feedback, state);
+
+    return new AsyncResult<>(true);
+  }
+
+  // -----------------------------
+  // The "predictive unit methods"
+  // -----------------------------
+
+  public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    // Transforms the input of a predictive unit into a new message.
+    // The result will become the input of the children, or the output if no children
+    if (predictorConfig.hasMethod(PredictiveUnitMethod.TRANSFORM_INPUT, state)) {
+      return internalPredictionService.transformInput(input, state);
+    }
+    return input;
+  }
+
+  public SeldonMessage transformOutput(SeldonMessage output, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    // Transforms the aggregated output into a new message.
+    if (predictorConfig.hasMethod(PredictiveUnitMethod.TRANSFORM_OUTPUT, state)) {
+      return internalPredictionService.transformOutput(output, state);
+    }
+    return output;
+  }
+
+  public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    // Aggregates the outputs of all children into a new message.
+    // If there are several outputs, this implementation needs to be overridden.
+
+    if (predictorConfig.hasMethod(PredictiveUnitMethod.AGGREGATE, state)) {
+      return internalPredictionService.aggregate(outputs, state);
+    }
+
+    // TODO: Throw exception if length(outputs) != 1
+    return outputs.get(0);
+  }
+
+  public SeldonMessage route(SeldonMessage input, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    // Returns a branch number in SeldonMessage
+
+    if (predictorConfig.hasMethod(PredictiveUnitMethod.ROUTE, state)) {
+      return internalPredictionService.route(input, state);
+    }
+
+    // Return default routing
+    return null;
+  }
+
+  public void doSendFeedback(Feedback feedback, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    // Sends feedback to the microservice
+
+    if (predictorConfig.hasMethod(PredictiveUnitMethod.SEND_FEEDBACK, state)) {
+      internalPredictionService.sendFeedback(feedback, state);
+    }
+    return;
+  }
+
+  // -------------------------------------------
+  //
+  // -------------------------------------------
+
+  private int getBranchIndex(SeldonMessage routerReturn, PredictiveUnitState state) {
+    int branchIndex = 0;
+    try {
+      PrimitiveMatrix dataArray = PredictorUtils.getOJMatrix(routerReturn.getData());
+      branchIndex = dataArray.get(0).intValue();
+    } catch (IndexOutOfBoundsException e) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_ROUTING,
+          "Router that caused the exception: id=" + state.name + " name=" + state.name);
+    }
+    return branchIndex;
+  }
+
+  protected void doStoreFeedbackMetrics(Feedback feedback, PredictiveUnitState state) {
+    Counter.builder("seldon_api_model_feedback_reward")
+        .tags(tagsProvider.getModelMetrics(state))
+        .register(Metrics.globalRegistry)
+        .increment(feedback.getReward());
+    Counter.builder("seldon_api_model_feedback")
+        .tags(tagsProvider.getModelMetrics(state))
+        .register(Metrics.globalRegistry)
+        .increment();
+  }
+
+  private void addCustomMetrics(List<Metric> metrics, PredictiveUnitState state) {
+    logger.debug("Add metrics");
+    for (Metric metric : metrics) {
+      Iterable<Tag> tags = tagsProvider.getModelMetrics(state, metric.getTagsMap());
+      switch (metric.getType()) {
+        case COUNTER:
+          logger.debug("Adding counter {} for {}", metric.getKey(), state.name);
+          Counter counter = customMetricsManager.getCounter(tags, metric);
+          counter.increment(metric.getValue());
+          break;
+        case GAUGE:
+          logger.debug("Adding gauge {} for {}", metric.getKey(), state.name);
+          customMetricsManager.getGaugeValue(tags, metric).set(metric.getValue());
+          break;
+        case TIMER:
+          logger.debug("Adding timer {} for {}", metric.getKey(), state.name);
+          Timer timer = customMetricsManager.getTimer(tags, metric);
+          timer.record((long) metric.getValue(), TimeUnit.MILLISECONDS);
+          break;
+        case UNRECOGNIZED:
+          break;
+      }
+    }
+  }
+
+  private void sanityCheckRouting(Integer branchIndex, PredictiveUnitState state) {
+    if (branchIndex < -1 | branchIndex >= state.children.size()) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_ROUTING,
+          "Invalid branch index. Router that caused the exception: id="
+              + state.name
+              + " name="
+              + state.name);
+    }
+  }
+
+  private SeldonMessage mergeMeta(SeldonMessage latest, List<SeldonMessage> previous, String puid) {
+    Meta.Builder metaBuilder = Meta.newBuilder();
+    metaBuilder.setPuid(puid);
+    for (SeldonMessage originalMessage : previous) {
+      metaBuilder.putAllTags(originalMessage.getMeta().getTagsMap());
+    }
+    metaBuilder.putAllTags(latest.getMeta().getTagsMap());
+    metaBuilder.clearMetrics();
+    return SeldonMessage.newBuilder(latest).setMeta(metaBuilder).build();
+  }
+
+  private SeldonMessage mergeMeta(SeldonMessage latest, SeldonMessage previous, String puid) {
+    Meta.Builder metaBuilder = Meta.newBuilder();
+    metaBuilder.setPuid(puid);
+    metaBuilder.putAllTags(previous.getMeta().getTagsMap());
+    metaBuilder.putAllTags(latest.getMeta().getTagsMap());
+    metaBuilder.clearMetrics();
+    return SeldonMessage.newBuilder(latest).setMeta(metaBuilder).build();
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBeanProxy.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitBeanProxy.java
@@ -1,42 +1,43 @@
 package io.seldon.engine.predictors;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.opentracing.Span;
+import io.seldon.protos.PredictionProtos.Metric;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
 import javax.annotation.PostConstruct;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.opentracing.Span;
-import io.seldon.protos.PredictionProtos.Metric;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-
 @Component
 public class PredictiveUnitBeanProxy {
 
-	private final PredictiveUnitBean predictiveUnitBean;
-	
-	@Autowired 
-	PredictiveUnitBeanProxy(PredictiveUnitBean predictiveUnitBean)
-	{
-		this.predictiveUnitBean =predictiveUnitBean;
-	}
-	
-	
-	 @PostConstruct
-	 public void init() {
-		predictiveUnitBean.setProxy(this);
-	 }
-	
-	@Async
-	public Future<SeldonMessage> getOutputAsync(SeldonMessage input, PredictiveUnitState state, Map<String,Integer> routingDict,Map<String,String> requestPathDict,Map<String,List<Metric>> metrics,Span activeSpan) throws InterruptedException, ExecutionException, InvalidProtocolBufferException{
-		return predictiveUnitBean.getOutputAsync(input, state, routingDict, requestPathDict, metrics,activeSpan);
-	}
-	
+  private final PredictiveUnitBean predictiveUnitBean;
+
+  @Autowired
+  PredictiveUnitBeanProxy(PredictiveUnitBean predictiveUnitBean) {
+    this.predictiveUnitBean = predictiveUnitBean;
+  }
+
+  @PostConstruct
+  public void init() {
+    predictiveUnitBean.setProxy(this);
+  }
+
+  @Async
+  public Future<SeldonMessage> getOutputAsync(
+      SeldonMessage input,
+      PredictiveUnitState state,
+      Map<String, Integer> routingDict,
+      Map<String, String> requestPathDict,
+      Map<String, List<Metric>> metrics,
+      Span activeSpan)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    return predictiveUnitBean.getOutputAsync(
+        input, state, routingDict, requestPathDict, metrics, activeSpan);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitImpl.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitImpl.java
@@ -1,52 +1,59 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
-import java.util.List;
-
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.Feedback;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Tensor;
+import java.util.List;
 
 public abstract class PredictiveUnitImpl {
-	
-	public boolean ready(PredictiveUnitState state) {
-		return true;
-	}
 
-	public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		return input;
-	}
-	
-	public SeldonMessage transformOutput(SeldonMessage output, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		return output;
-	}
-	
-	public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		return outputs.get(0);
-	}
-	
-	public SeldonMessage route(SeldonMessage input, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		return SeldonMessage.newBuilder().setData(DefaultData.newBuilder().setTensor(Tensor.newBuilder().addValues(-1).addShape(1).addShape(1))).build();
-	}
-	
-	public void doSendFeedback(Feedback feedback, PredictiveUnitState state) throws InvalidProtocolBufferException{
-		return;
-	}
+  public boolean ready(PredictiveUnitState state) {
+    return true;
+  }
+
+  public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    return input;
+  }
+
+  public SeldonMessage transformOutput(SeldonMessage output, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    return output;
+  }
+
+  public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    return outputs.get(0);
+  }
+
+  public SeldonMessage route(SeldonMessage input, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    return SeldonMessage.newBuilder()
+        .setData(
+            DefaultData.newBuilder()
+                .setTensor(Tensor.newBuilder().addValues(-1).addShape(1).addShape(1)))
+        .build();
+  }
+
+  public void doSendFeedback(Feedback feedback, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    return;
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitParameter.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitParameter.java
@@ -1,45 +1,44 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
 import io.seldon.protos.DeploymentProtos.Parameter;
-import io.seldon.engine.predictors.PredictiveUnitParameterInterface;
 
-public class PredictiveUnitParameter<T> extends PredictiveUnitParameterInterface{
-	public T value;
-	
-	public PredictiveUnitParameter(T value){
-		this.value = value;
-	}
-	
-	public static PredictiveUnitParameterInterface fromParameter(Parameter Parameter){
-		switch (Parameter.getType()){
-			case DOUBLE:
-				Double valueDouble = Double.parseDouble(Parameter.getValue());
-				return new PredictiveUnitParameter<Double>(valueDouble);
-			case FLOAT:
-				Float valueFloat = Float.parseFloat(Parameter.getValue());
-				return new PredictiveUnitParameter<Float>(valueFloat);
-			case INT:
-				Integer valueInt = Integer.parseInt(Parameter.getValue());
-				return new PredictiveUnitParameter<Integer>(valueInt);
-			case STRING:
-				return new PredictiveUnitParameter<String>(Parameter.getValue());			
-			default:
-				return new PredictiveUnitParameter<String>(Parameter.getValue());
-		}
-	}
+public class PredictiveUnitParameter<T> extends PredictiveUnitParameterInterface {
+  public T value;
+
+  public PredictiveUnitParameter(T value) {
+    this.value = value;
+  }
+
+  public static PredictiveUnitParameterInterface fromParameter(Parameter Parameter) {
+    switch (Parameter.getType()) {
+      case DOUBLE:
+        Double valueDouble = Double.parseDouble(Parameter.getValue());
+        return new PredictiveUnitParameter<Double>(valueDouble);
+      case FLOAT:
+        Float valueFloat = Float.parseFloat(Parameter.getValue());
+        return new PredictiveUnitParameter<Float>(valueFloat);
+      case INT:
+        Integer valueInt = Integer.parseInt(Parameter.getValue());
+        return new PredictiveUnitParameter<Integer>(valueInt);
+      case STRING:
+        return new PredictiveUnitParameter<String>(Parameter.getValue());
+      default:
+        return new PredictiveUnitParameter<String>(Parameter.getValue());
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitParameterInterface.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitParameterInterface.java
@@ -1,20 +1,18 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
-public class PredictiveUnitParameterInterface {
-	
-}
+public class PredictiveUnitParameterInterface {}

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitParameterType.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitParameterType.java
@@ -1,27 +1,27 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum PredictiveUnitParameterType {
-	@JsonProperty("STR")
-	STR, 
-	@JsonProperty("FLOAT")
-	FLOAT, 
-	@JsonProperty("INT")
-	INT
+  @JsonProperty("STR")
+  STR,
+  @JsonProperty("FLOAT")
+  FLOAT,
+  @JsonProperty("INT")
+  INT
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitState.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictiveUnitState.java
@@ -1,30 +1,21 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import io.kubernetes.client.proto.V1.Container;
 import io.seldon.protos.DeploymentProtos.Endpoint;
 import io.seldon.protos.DeploymentProtos.Parameter;
@@ -32,95 +23,91 @@ import io.seldon.protos.DeploymentProtos.PredictiveUnit;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitImplementation;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitMethod;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
-@JsonIgnoreProperties({"children","cluster_resources","id","subtype","type"})
+@JsonIgnoreProperties({"children", "cluster_resources", "id", "subtype", "type"})
 public class PredictiveUnitState {
-	public String name;
-	public Endpoint endpoint;
-	public List<PredictiveUnitState> children = new ArrayList<>();
-	public Map<String,PredictiveUnitParameterInterface>  parameters;
-	public String image = "";
-	public String imageName;
-	public String imageVersion;
-	public PredictiveUnitType type;
-	public PredictiveUnitImplementation implementation;
-	public List<PredictiveUnitMethod> methods;
-	
-	@Autowired
-	public PredictorBean predictorBean;
-	
-	public PredictiveUnitState(){}
-	
-	public PredictiveUnitState(
-			String name,
-			Endpoint endpoint,
-			List<PredictiveUnitState> children,
-			Map<String,PredictiveUnitParameterInterface> parameters,
-			String imageName,
-			String imageVersion,
-			PredictiveUnitType type,
-			PredictiveUnitImplementation implementation
-			){
-		this.name = name;
-		this.endpoint = endpoint;
-		this.children = children;
-		this.parameters = parameters;
-		this.imageName = imageName;
-		this.imageVersion = imageVersion;
-		if (!StringUtils.isEmpty(imageName) && !StringUtils.isEmpty(imageVersion))
-			this.image = imageName + ":" + imageVersion;
-		else if (!StringUtils.isEmpty(imageName))
-			this.image = imageName;
-		else
-			this.image = "";
-		this.type = type;
-		this.implementation = implementation;
-		
-	}
-	
-	public PredictiveUnitState(
-			PredictiveUnit predictiveUnit, 
-			Map<String,Container> containersMap){
-		this.name = predictiveUnit.getName();
-		this.endpoint = predictiveUnit.getEndpoint();
-		this.parameters = deserializeParameters(predictiveUnit.getParametersList());
-		
-		if (containersMap.containsKey(name)){
-			this.image = containersMap.get(name).getImage();
-			int i = image.lastIndexOf(":");
-			if (i >= 0)
-			{
-				this.imageName = StringUtils.substring(image, 0, i);
-				this.imageVersion = StringUtils.substring(image, i+1);
-			}
-			else
-			{
-				this.imageName = image;
-				this.imageVersion = "";
-			}
-		}
-		
-		this.children = new ArrayList<PredictiveUnitState>();
-		
-		for (PredictiveUnit childUnit : predictiveUnit.getChildrenList()){
-			this.children.add(new PredictiveUnitState(childUnit,containersMap));
-		}
-		
-		this.type = predictiveUnit.getType();
-		this.implementation = predictiveUnit.getImplementation();
-		this.methods = predictiveUnit.getMethodsList();
-	}
-	
-	public static Map<String,PredictiveUnitParameterInterface> deserializeParameters(List<Parameter> Parameters){
-		Map<String,PredictiveUnitParameterInterface> paramsMap = new HashMap<>();
-		for (Parameter Parameter : Parameters){
-			paramsMap.put(Parameter.getName(), PredictiveUnitParameter.fromParameter(Parameter));
-		}
-		return paramsMap;
-	}
-	
-	public void addChild(PredictiveUnitState predictiveUnitState){
-		this.children.add(predictiveUnitState);
-	}
+  public String name;
+  public Endpoint endpoint;
+  public List<PredictiveUnitState> children = new ArrayList<>();
+  public Map<String, PredictiveUnitParameterInterface> parameters;
+  public String image = "";
+  public String imageName;
+  public String imageVersion;
+  public PredictiveUnitType type;
+  public PredictiveUnitImplementation implementation;
+  public List<PredictiveUnitMethod> methods;
+
+  @Autowired public PredictorBean predictorBean;
+
+  public PredictiveUnitState() {}
+
+  public PredictiveUnitState(
+      String name,
+      Endpoint endpoint,
+      List<PredictiveUnitState> children,
+      Map<String, PredictiveUnitParameterInterface> parameters,
+      String imageName,
+      String imageVersion,
+      PredictiveUnitType type,
+      PredictiveUnitImplementation implementation) {
+    this.name = name;
+    this.endpoint = endpoint;
+    this.children = children;
+    this.parameters = parameters;
+    this.imageName = imageName;
+    this.imageVersion = imageVersion;
+    if (!StringUtils.isEmpty(imageName) && !StringUtils.isEmpty(imageVersion))
+      this.image = imageName + ":" + imageVersion;
+    else if (!StringUtils.isEmpty(imageName)) this.image = imageName;
+    else this.image = "";
+    this.type = type;
+    this.implementation = implementation;
+  }
+
+  public PredictiveUnitState(PredictiveUnit predictiveUnit, Map<String, Container> containersMap) {
+    this.name = predictiveUnit.getName();
+    this.endpoint = predictiveUnit.getEndpoint();
+    this.parameters = deserializeParameters(predictiveUnit.getParametersList());
+
+    if (containersMap.containsKey(name)) {
+      this.image = containersMap.get(name).getImage();
+      int i = image.lastIndexOf(":");
+      if (i >= 0) {
+        this.imageName = StringUtils.substring(image, 0, i);
+        this.imageVersion = StringUtils.substring(image, i + 1);
+      } else {
+        this.imageName = image;
+        this.imageVersion = "";
+      }
+    }
+
+    this.children = new ArrayList<PredictiveUnitState>();
+
+    for (PredictiveUnit childUnit : predictiveUnit.getChildrenList()) {
+      this.children.add(new PredictiveUnitState(childUnit, containersMap));
+    }
+
+    this.type = predictiveUnit.getType();
+    this.implementation = predictiveUnit.getImplementation();
+    this.methods = predictiveUnit.getMethodsList();
+  }
+
+  public static Map<String, PredictiveUnitParameterInterface> deserializeParameters(
+      List<Parameter> Parameters) {
+    Map<String, PredictiveUnitParameterInterface> paramsMap = new HashMap<>();
+    for (Parameter Parameter : Parameters) {
+      paramsMap.put(Parameter.getName(), PredictiveUnitParameter.fromParameter(Parameter));
+    }
+    return paramsMap;
+  }
+
+  public void addChild(PredictiveUnitState predictiveUnitState) {
+    this.children.add(predictiveUnitState);
+  }
 }
- 

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictorBean.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictorBean.java
@@ -1,86 +1,71 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import com.google.protobuf.InvalidProtocolBufferException;
-
+import io.kubernetes.client.proto.V1.Container;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit;
-import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitType;
-import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitImplementation;
-import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitMethod;
 import io.seldon.protos.DeploymentProtos.PredictorSpec;
 import io.seldon.protos.DeploymentProtos.SeldonPodSpec;
 import io.seldon.protos.PredictionProtos.Feedback;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
-import io.kubernetes.client.proto.V1;
-import io.kubernetes.client.proto.V1.Container;
-
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class PredictorBean {
-	
-	@Autowired
-	PredictiveUnitBean predictiveUnitBean;
-	
-    @Autowired
-	public PredictorBean(){
-    }
-   
-	public SeldonMessage predict(SeldonMessage request, PredictorState predictorState) throws InterruptedException, ExecutionException, InvalidProtocolBufferException
 
-	{
-		PredictiveUnitState rootState = predictorState.rootState;
-		return this.predictiveUnitBean.getOutput(request, rootState);
-	}
-	
-	public void sendFeedback(Feedback feedback, PredictorState predictorState) throws InterruptedException, ExecutionException, InvalidProtocolBufferException
+  @Autowired PredictiveUnitBean predictiveUnitBean;
 
-	{
-		PredictiveUnitState rootState = predictorState.rootState;
-		predictiveUnitBean.sendFeedback(feedback, rootState);
-		return;
-	}
-	
-	//TODO
-	public PredictorState predictorStateFromPredictorSpec(PredictorSpec predictorSpec){
+  @Autowired
+  public PredictorBean() {}
 
-        // Boolean enabled = PredictorSpec.getEnabled();
-		Boolean enabled = true;
-		PredictiveUnit rootUnit = predictorSpec.getGraph();
-		Map<String,Container> containersMap = new HashMap<String,Container>();
-		
-		for(SeldonPodSpec spec : predictorSpec.getComponentSpecsList())
-			for (Container container : spec.getSpec().getContainersList()){
-				containersMap.put(container.getName(), container);
-		}
-		
-		PredictiveUnitState rootState = new PredictiveUnitState(rootUnit,containersMap);
-		
-		return new PredictorState(rootUnit.getName(),rootState, enabled);
-	
-	}
-	
-	
+  public SeldonMessage predict(SeldonMessage request, PredictorState predictorState)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+
+    PredictiveUnitState rootState = predictorState.rootState;
+    return this.predictiveUnitBean.getOutput(request, rootState);
+  }
+
+  public void sendFeedback(Feedback feedback, PredictorState predictorState)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+
+    PredictiveUnitState rootState = predictorState.rootState;
+    predictiveUnitBean.sendFeedback(feedback, rootState);
+    return;
+  }
+
+  // TODO
+  public PredictorState predictorStateFromPredictorSpec(PredictorSpec predictorSpec) {
+
+    // Boolean enabled = PredictorSpec.getEnabled();
+    Boolean enabled = true;
+    PredictiveUnit rootUnit = predictorSpec.getGraph();
+    Map<String, Container> containersMap = new HashMap<String, Container>();
+
+    for (SeldonPodSpec spec : predictorSpec.getComponentSpecsList())
+      for (Container container : spec.getSpec().getContainersList()) {
+        containersMap.put(container.getName(), container);
+      }
+
+    PredictiveUnitState rootState = new PredictiveUnitState(rootUnit, containersMap);
+
+    return new PredictorState(rootUnit.getName(), rootState, enabled);
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictorConfigBean.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictorConfigBean.java
@@ -1,108 +1,105 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitImplementation;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitMethod;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class PredictorConfigBean {
-    public final Map<PredictiveUnitType,List<PredictiveUnitMethod>> typeMethodsMap;
-    public final Map<PredictiveUnitImplementation,PredictiveUnitImpl> nodeImplementationMap;
-    
-    @Autowired
-	public PredictorConfigBean(
-			SimpleModelUnit simpleModelUnit, 
-			SimpleRouterUnit simpleRouterUnit,
-			AverageCombinerUnit averageCombinerUnit,
-			RandomABTestUnit randomABTestUnit) {
-        
-        // ---------------------------
-        // DEFINITION OF DEFAULT TYPES
-    	// ---------------------------
-        typeMethodsMap = new HashMap<PredictiveUnitType, List<PredictiveUnitMethod>>();
-        
-        // MODEL -> TRANSFORM INPUT
-        List<PredictiveUnitMethod> modelMethods = new ArrayList<PredictiveUnitMethod>();
-        modelMethods.add(PredictiveUnitMethod.TRANSFORM_INPUT);
-        modelMethods.add(PredictiveUnitMethod.SEND_FEEDBACK);        
-        typeMethodsMap.put(PredictiveUnitType.MODEL, modelMethods);
-        
-        // TRANSFORMER -> TRANSFORM INPUT
-        List<PredictiveUnitMethod> transformerMethods = new ArrayList<PredictiveUnitMethod>();
-        transformerMethods.add(PredictiveUnitMethod.TRANSFORM_INPUT);
-        typeMethodsMap.put(PredictiveUnitType.TRANSFORMER, transformerMethods);
-        
-        // OUTPUT TRANSFORMER -> TRANSFORM OUTPUT
-        List<PredictiveUnitMethod> outTransformerMethods = new ArrayList<PredictiveUnitMethod>();
-        outTransformerMethods.add(PredictiveUnitMethod.TRANSFORM_OUTPUT);
-        typeMethodsMap.put(PredictiveUnitType.OUTPUT_TRANSFORMER, outTransformerMethods);
-        
-        // ROUTER -> ROUTE, SEND FEEDBACK
-        List<PredictiveUnitMethod> routerMethods = new ArrayList<PredictiveUnitMethod>();
-        routerMethods.add(PredictiveUnitMethod.ROUTE);
-        routerMethods.add(PredictiveUnitMethod.SEND_FEEDBACK);
-        typeMethodsMap.put(PredictiveUnitType.ROUTER, routerMethods);
-        
-        // COMBINER -> AGGREGATE
-        List<PredictiveUnitMethod> combinerMethods = new ArrayList<PredictiveUnitMethod>();
-        combinerMethods.add(PredictiveUnitMethod.AGGREGATE);
-        typeMethodsMap.put(PredictiveUnitType.COMBINER,combinerMethods);
-        
-        // -------------------------
-        // HARDCODED IMPLEMENTATIONS
-        // -------------------------
-        nodeImplementationMap = new HashMap<PredictiveUnitImplementation,PredictiveUnitImpl>();
-        nodeImplementationMap.put(PredictiveUnitImplementation.AVERAGE_COMBINER, averageCombinerUnit);
-        nodeImplementationMap.put(PredictiveUnitImplementation.SIMPLE_MODEL, simpleModelUnit);
-        nodeImplementationMap.put(PredictiveUnitImplementation.SIMPLE_ROUTER, simpleRouterUnit);
-        nodeImplementationMap.put(PredictiveUnitImplementation.RANDOM_ABTEST, randomABTestUnit);
+  public final Map<PredictiveUnitType, List<PredictiveUnitMethod>> typeMethodsMap;
+  public final Map<PredictiveUnitImplementation, PredictiveUnitImpl> nodeImplementationMap;
+
+  @Autowired
+  public PredictorConfigBean(
+      SimpleModelUnit simpleModelUnit,
+      SimpleRouterUnit simpleRouterUnit,
+      AverageCombinerUnit averageCombinerUnit,
+      RandomABTestUnit randomABTestUnit) {
+
+    // ---------------------------
+    // DEFINITION OF DEFAULT TYPES
+    // ---------------------------
+    typeMethodsMap = new HashMap<PredictiveUnitType, List<PredictiveUnitMethod>>();
+
+    // MODEL -> TRANSFORM INPUT
+    List<PredictiveUnitMethod> modelMethods = new ArrayList<PredictiveUnitMethod>();
+    modelMethods.add(PredictiveUnitMethod.TRANSFORM_INPUT);
+    modelMethods.add(PredictiveUnitMethod.SEND_FEEDBACK);
+    typeMethodsMap.put(PredictiveUnitType.MODEL, modelMethods);
+
+    // TRANSFORMER -> TRANSFORM INPUT
+    List<PredictiveUnitMethod> transformerMethods = new ArrayList<PredictiveUnitMethod>();
+    transformerMethods.add(PredictiveUnitMethod.TRANSFORM_INPUT);
+    typeMethodsMap.put(PredictiveUnitType.TRANSFORMER, transformerMethods);
+
+    // OUTPUT TRANSFORMER -> TRANSFORM OUTPUT
+    List<PredictiveUnitMethod> outTransformerMethods = new ArrayList<PredictiveUnitMethod>();
+    outTransformerMethods.add(PredictiveUnitMethod.TRANSFORM_OUTPUT);
+    typeMethodsMap.put(PredictiveUnitType.OUTPUT_TRANSFORMER, outTransformerMethods);
+
+    // ROUTER -> ROUTE, SEND FEEDBACK
+    List<PredictiveUnitMethod> routerMethods = new ArrayList<PredictiveUnitMethod>();
+    routerMethods.add(PredictiveUnitMethod.ROUTE);
+    routerMethods.add(PredictiveUnitMethod.SEND_FEEDBACK);
+    typeMethodsMap.put(PredictiveUnitType.ROUTER, routerMethods);
+
+    // COMBINER -> AGGREGATE
+    List<PredictiveUnitMethod> combinerMethods = new ArrayList<PredictiveUnitMethod>();
+    combinerMethods.add(PredictiveUnitMethod.AGGREGATE);
+    typeMethodsMap.put(PredictiveUnitType.COMBINER, combinerMethods);
+
+    // -------------------------
+    // HARDCODED IMPLEMENTATIONS
+    // -------------------------
+    nodeImplementationMap = new HashMap<PredictiveUnitImplementation, PredictiveUnitImpl>();
+    nodeImplementationMap.put(PredictiveUnitImplementation.AVERAGE_COMBINER, averageCombinerUnit);
+    nodeImplementationMap.put(PredictiveUnitImplementation.SIMPLE_MODEL, simpleModelUnit);
+    nodeImplementationMap.put(PredictiveUnitImplementation.SIMPLE_ROUTER, simpleRouterUnit);
+    nodeImplementationMap.put(PredictiveUnitImplementation.RANDOM_ABTEST, randomABTestUnit);
+  }
+
+  public boolean hasMethod(PredictiveUnitState state) {
+    return (state.implementation == PredictiveUnitImplementation.UNKNOWN_IMPLEMENTATION
+        || !nodeImplementationMap.containsKey(state.implementation));
+  }
+
+  public PredictiveUnitImpl getImplementation(PredictiveUnitState state) {
+    if (state.implementation != PredictiveUnitImplementation.UNKNOWN_IMPLEMENTATION) {
+      return nodeImplementationMap.get(state.implementation);
     }
-    
-    public boolean hasMethod(PredictiveUnitState state) {
-    	return (state.implementation == PredictiveUnitImplementation.UNKNOWN_IMPLEMENTATION || !nodeImplementationMap.containsKey(state.implementation));
+    return null;
+  }
+
+  public Boolean hasMethod(PredictiveUnitMethod method, PredictiveUnitState state) {
+    if (state.implementation != PredictiveUnitImplementation.UNKNOWN_IMPLEMENTATION
+        && nodeImplementationMap.containsKey(state.implementation)) {
+      return false;
     }
-    
-    public PredictiveUnitImpl getImplementation(PredictiveUnitState state){
-    	if (state.implementation != PredictiveUnitImplementation.UNKNOWN_IMPLEMENTATION){
-    		return nodeImplementationMap.get(state.implementation);
-    	}
-    	return null;
+    if (state.type == PredictiveUnitType.UNKNOWN_TYPE) {
+      return state.methods.contains(method);
+    } else {
+      return typeMethodsMap.get(state.type).contains(method);
     }
-    
-    public Boolean hasMethod(PredictiveUnitMethod method, PredictiveUnitState state){
-    	if (state.implementation != PredictiveUnitImplementation.UNKNOWN_IMPLEMENTATION &&
-    			nodeImplementationMap.containsKey(state.implementation)){
-    		return false;
-    	}
-    	if (state.type == PredictiveUnitType.UNKNOWN_TYPE) {
-    		return state.methods.contains(method);
-    	}
-    	else
-    	{
-    		return typeMethodsMap.get(state.type).contains(method);
-    	}
-    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictorState.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictorState.java
@@ -1,33 +1,33 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
 public class PredictorState {
-	
-	public PredictiveUnitState rootState;
-	public String rootName;
-	public Boolean enabled;
-	
-	public PredictorState(String rootName, PredictiveUnitState rootState, Boolean enabled){
-		this.rootName = rootName;
-		this.enabled = enabled;
-		this.rootState = rootState;
-	}
-	
-	public PredictiveUnitState getRootState(){
-		return this.rootState;
-	}
+
+  public PredictiveUnitState rootState;
+  public String rootName;
+  public Boolean enabled;
+
+  public PredictorState(String rootName, PredictiveUnitState rootState, Boolean enabled) {
+    this.rootName = rootName;
+    this.enabled = enabled;
+    this.rootState = rootState;
+  }
+
+  public PredictiveUnitState getRootState() {
+    return this.rootState;
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/PredictorUtils.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/PredictorUtils.java
@@ -1,199 +1,183 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
-
-import java.util.Iterator;
-import java.util.List;
-
-import org.ojalgo.matrix.PrimitiveMatrix;
 
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Value;
-
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.DefaultData.DataOneofCase;
 import io.seldon.protos.PredictionProtos.Tensor;
+import java.util.Iterator;
+import java.util.List;
+import org.ojalgo.matrix.PrimitiveMatrix;
 
 public class PredictorUtils {
-	
-	
-	
-	public static DefaultData nDArrayToTensor(DefaultData data){
-		if (data.getDataOneofCase() == DataOneofCase.TENSOR)
-		{
-			return data;
-			
-		}
-		else if (data.getDataOneofCase() == DataOneofCase.NDARRAY)
-		{
-			int bLength = data.getNdarray().getValuesCount();
-			int vLength = data.getNdarray().getValues(0).getListValue().getValuesCount();
-			
-			DefaultData.Builder dataBuilder = DefaultData.newBuilder();
-			Tensor.Builder tBuilder = Tensor.newBuilder().addShape(bLength).addShape(vLength);
-			
-			int index=0;
-			for (Iterator<String> i = data.getNamesList().iterator(); i.hasNext();){
-				dataBuilder.setNames(index, i.next());
-				index++;
-			}
-			
-			for (int i=0; i<bLength; ++i){
-				for (int j=0; j<vLength; ++j){
-					tBuilder.addValues(data.getNdarray().getValues(i).getListValue().getValues(j).getNumberValue());
-				}
-			}
-			
-			dataBuilder.setTensor(tBuilder);
-			
-			return dataBuilder.build();
-		}
-		return null;
-	}
 
-    public static void add(DefaultData data, PrimitiveMatrix.DenseReceiver receiver) {
+  public static DefaultData nDArrayToTensor(DefaultData data) {
+    if (data.getDataOneofCase() == DataOneofCase.TENSOR) {
+      return data;
 
-        if (data.getDataOneofCase() == DataOneofCase.TENSOR) {
+    } else if (data.getDataOneofCase() == DataOneofCase.NDARRAY) {
+      int bLength = data.getNdarray().getValuesCount();
+      int vLength = data.getNdarray().getValues(0).getListValue().getValuesCount();
 
-            List<Double> valuesList = data.getTensor().getValuesList();
-            List<Integer> shapeList = data.getTensor().getShapeList();
+      DefaultData.Builder dataBuilder = DefaultData.newBuilder();
+      Tensor.Builder tBuilder = Tensor.newBuilder().addShape(bLength).addShape(vLength);
 
-            int rows = shapeList.get(0);
-            int cols = shapeList.get(1);
+      int index = 0;
+      for (Iterator<String> i = data.getNamesList().iterator(); i.hasNext(); ) {
+        dataBuilder.setNames(index, i.next());
+        index++;
+      }
 
-            for (int i = 0; i < rows * cols; i++) {
-                receiver.add(i / cols, i % cols, valuesList.get(i));
-            }
-
-        } else if (data.getDataOneofCase() == DataOneofCase.NDARRAY) {
-
-            ListValue list = data.getNdarray();
-
-            int rows = list.getValuesCount();
-            int cols = list.getValues(0).getListValue().getValuesCount();
-
-            for (int i = 0; i < rows; ++i) {
-                ListValue rowListValue = list.getValues(i).getListValue();
-                for (int j = 0; j < cols; j++) {
-                    receiver.add(i, j, rowListValue.getValues(j).getNumberValue());
-                }
-            }
+      for (int i = 0; i < bLength; ++i) {
+        for (int j = 0; j < vLength; ++j) {
+          tBuilder.addValues(
+              data.getNdarray().getValues(i).getListValue().getValues(j).getNumberValue());
         }
+      }
+
+      dataBuilder.setTensor(tBuilder);
+
+      return dataBuilder.build();
     }
+    return null;
+  }
 
-	public static PrimitiveMatrix getOJMatrix(DefaultData data){
-        PrimitiveMatrix.Factory matrixFactory = PrimitiveMatrix.FACTORY;
-		if (data.getDataOneofCase() == DataOneofCase.TENSOR)
-		{
-			
-			List<Double> valuesList = data.getTensor().getValuesList();
-			List<Integer> shapeList = data.getTensor().getShapeList();
-			
-			int rows = shapeList.get(0);
-			int columns = shapeList.get(1);
-			
-			double[][] values = new double[rows][columns];
-			for (int i = 0; i < rows*columns; i++) {
-				values[i/columns][i%columns] = valuesList.get(i);
-			 }
-			
-			return matrixFactory.rows(values);
-		}
-		else if (data.getDataOneofCase() == DataOneofCase.NDARRAY)
-		{
-			ListValue list = data.getNdarray();
-			int rows = list.getValuesCount();
-			int cols = list.getValues(0).getListValue().getValuesCount();
-			
-			double[][] values = new double[rows][cols];
-			for (int i = 0; i < rows; ++i) {
-				for (int j = 0; j < cols; j++){
-					values[i][j] = list.getValues(i).getListValue().getValues(j).getNumberValue();
-				}
-			}
-			
-			return matrixFactory.rows(values);
-		}
-		return null;
-	}
+  public static void add(DefaultData data, PrimitiveMatrix.DenseReceiver receiver) {
 
-	public static int[] getShape(DefaultData data){
-		if (data.getDataOneofCase() == DataOneofCase.TENSOR){
-			List<Integer> shapeList = data.getTensor().getShapeList();
-			int[] shape = new int[shapeList.size()];
-			for (int i = 0; i < shape.length; ++i){
-				shape[i] = shapeList.get(i);
-			}
-			
-			return shape;
-		}
-		else if(data.getDataOneofCase() == DataOneofCase.NDARRAY){
-			int bLength = data.getNdarray().getValuesCount();
-			int vLength = data.getNdarray().getValues(0).getListValue().getValuesCount();
-			
-			int[] shape = {bLength,vLength};
-			return shape;
-		}
-		return null;
-	}
-	
-	public static DefaultData updateData(DefaultData oldData, PrimitiveMatrix newData){
-		DefaultData.Builder dataBuilder = DefaultData.newBuilder();
-		
-		dataBuilder.addAllNames(oldData.getNamesList());
-		
-//		int index=0;
-//		for (Iterator<String> i = oldData.getFeaturesList().iterator(); i.hasNext();){
-//			dataBuilder.setFeatures(index, i.next());
-//			index++;
-//		}
-		
-        int rows = (int) newData.countRows();
-        int cols = (int) newData.countColumns();
+    if (data.getDataOneofCase() == DataOneofCase.TENSOR) {
 
-		if (oldData.getDataOneofCase() == DataOneofCase.TENSOR){
-			Tensor.Builder tBuilder = Tensor.newBuilder();
+      List<Double> valuesList = data.getTensor().getValuesList();
+      List<Integer> shapeList = data.getTensor().getShapeList();
 
-            tBuilder.addShape(rows);
-            tBuilder.addShape(cols);
-			
-            for (int i = 0; i < rows; ++i) {
-                for (int j = 0; j < cols; ++j) {
-                    tBuilder.addValues(newData.doubleValue(i, j));
-				}
-			}
-			dataBuilder.setTensor(tBuilder);
-			return dataBuilder.build();
-		}
-		else if (oldData.getDataOneofCase() == DataOneofCase.NDARRAY){
-			ListValue.Builder b1 = ListValue.newBuilder();
-            for (int i = 0; i < rows; ++i) {
-				ListValue.Builder b2 = ListValue.newBuilder();
-                for (int j = 0; j < cols; j++) {
-                    b2.addValues(Value.newBuilder().setNumberValue(newData.doubleValue(i, j)));
-				}
-				b1.addValues(Value.newBuilder().setListValue(b2.build()));
-			}
-			dataBuilder.setNdarray(b1.build());
-			return dataBuilder.build();
-		}
-		return null;
-		
-	}
+      int rows = shapeList.get(0);
+      int cols = shapeList.get(1);
 
+      for (int i = 0; i < rows * cols; i++) {
+        receiver.add(i / cols, i % cols, valuesList.get(i));
+      }
 
+    } else if (data.getDataOneofCase() == DataOneofCase.NDARRAY) {
+
+      ListValue list = data.getNdarray();
+
+      int rows = list.getValuesCount();
+      int cols = list.getValues(0).getListValue().getValuesCount();
+
+      for (int i = 0; i < rows; ++i) {
+        ListValue rowListValue = list.getValues(i).getListValue();
+        for (int j = 0; j < cols; j++) {
+          receiver.add(i, j, rowListValue.getValues(j).getNumberValue());
+        }
+      }
+    }
+  }
+
+  public static PrimitiveMatrix getOJMatrix(DefaultData data) {
+    PrimitiveMatrix.Factory matrixFactory = PrimitiveMatrix.FACTORY;
+    if (data.getDataOneofCase() == DataOneofCase.TENSOR) {
+
+      List<Double> valuesList = data.getTensor().getValuesList();
+      List<Integer> shapeList = data.getTensor().getShapeList();
+
+      int rows = shapeList.get(0);
+      int columns = shapeList.get(1);
+
+      double[][] values = new double[rows][columns];
+      for (int i = 0; i < rows * columns; i++) {
+        values[i / columns][i % columns] = valuesList.get(i);
+      }
+
+      return matrixFactory.rows(values);
+    } else if (data.getDataOneofCase() == DataOneofCase.NDARRAY) {
+      ListValue list = data.getNdarray();
+      int rows = list.getValuesCount();
+      int cols = list.getValues(0).getListValue().getValuesCount();
+
+      double[][] values = new double[rows][cols];
+      for (int i = 0; i < rows; ++i) {
+        for (int j = 0; j < cols; j++) {
+          values[i][j] = list.getValues(i).getListValue().getValues(j).getNumberValue();
+        }
+      }
+
+      return matrixFactory.rows(values);
+    }
+    return null;
+  }
+
+  public static int[] getShape(DefaultData data) {
+    if (data.getDataOneofCase() == DataOneofCase.TENSOR) {
+      List<Integer> shapeList = data.getTensor().getShapeList();
+      int[] shape = new int[shapeList.size()];
+      for (int i = 0; i < shape.length; ++i) {
+        shape[i] = shapeList.get(i);
+      }
+
+      return shape;
+    } else if (data.getDataOneofCase() == DataOneofCase.NDARRAY) {
+      int bLength = data.getNdarray().getValuesCount();
+      int vLength = data.getNdarray().getValues(0).getListValue().getValuesCount();
+
+      int[] shape = {bLength, vLength};
+      return shape;
+    }
+    return null;
+  }
+
+  public static DefaultData updateData(DefaultData oldData, PrimitiveMatrix newData) {
+    DefaultData.Builder dataBuilder = DefaultData.newBuilder();
+
+    dataBuilder.addAllNames(oldData.getNamesList());
+
+    //		int index=0;
+    //		for (Iterator<String> i = oldData.getFeaturesList().iterator(); i.hasNext();){
+    //			dataBuilder.setFeatures(index, i.next());
+    //			index++;
+    //		}
+
+    int rows = (int) newData.countRows();
+    int cols = (int) newData.countColumns();
+
+    if (oldData.getDataOneofCase() == DataOneofCase.TENSOR) {
+      Tensor.Builder tBuilder = Tensor.newBuilder();
+
+      tBuilder.addShape(rows);
+      tBuilder.addShape(cols);
+
+      for (int i = 0; i < rows; ++i) {
+        for (int j = 0; j < cols; ++j) {
+          tBuilder.addValues(newData.doubleValue(i, j));
+        }
+      }
+      dataBuilder.setTensor(tBuilder);
+      return dataBuilder.build();
+    } else if (oldData.getDataOneofCase() == DataOneofCase.NDARRAY) {
+      ListValue.Builder b1 = ListValue.newBuilder();
+      for (int i = 0; i < rows; ++i) {
+        ListValue.Builder b2 = ListValue.newBuilder();
+        for (int j = 0; j < cols; j++) {
+          b2.addValues(Value.newBuilder().setNumberValue(newData.doubleValue(i, j)));
+        }
+        b1.addValues(Value.newBuilder().setListValue(b2.build()));
+      }
+      dataBuilder.setNdarray(b1.build());
+      return dataBuilder.build();
+    }
+    return null;
+  }
 }
-

--- a/engine/src/main/java/io/seldon/engine/predictors/RandomABTestUnit.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/RandomABTestUnit.java
@@ -1,60 +1,68 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
-
-import java.util.Random;
-
-import org.springframework.stereotype.Component;
 
 import io.seldon.engine.exception.APIException;
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Tensor;
-
+import java.util.Random;
+import org.springframework.stereotype.Component;
 
 @Component
-public class RandomABTestUnit extends PredictiveUnitImpl{
-	
-	Random rand = new Random(1337);
-	
-	public RandomABTestUnit() {}
+public class RandomABTestUnit extends PredictiveUnitImpl {
 
-	@Override
-	public SeldonMessage route(SeldonMessage input, PredictiveUnitState state){
-		@SuppressWarnings("unchecked")
-		PredictiveUnitParameter<Float> parameter = (PredictiveUnitParameter<Float>) state.parameters.get("ratioA");
-		
-		if (parameter == null){
-			throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_ABTEST,"Parameter 'ratioA' is missing.");
-		}
-		
-		Float ratioA = parameter.value;
-		Float comparator = rand.nextFloat();
-		
-		if (state.children.size() != 2){
-			throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_ABTEST,String.format("AB test has %d children ",state.children.size()));
-		}
-		
-		//FIXME Possible bug : keySet is not ordered as per the definition of the AB test
-		if (comparator<=ratioA){
-			// We select model A
-			return SeldonMessage.newBuilder().setData(DefaultData.newBuilder().setTensor(Tensor.newBuilder().addValues(0).addShape(1).addShape(1))).build();
-		}
-		else{
-			return SeldonMessage.newBuilder().setData(DefaultData.newBuilder().setTensor(Tensor.newBuilder().addValues(1).addShape(1).addShape(1))).build();
-		}
-	}
+  Random rand = new Random(1337);
+
+  public RandomABTestUnit() {}
+
+  @Override
+  public SeldonMessage route(SeldonMessage input, PredictiveUnitState state) {
+    @SuppressWarnings("unchecked")
+    PredictiveUnitParameter<Float> parameter =
+        (PredictiveUnitParameter<Float>) state.parameters.get("ratioA");
+
+    if (parameter == null) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_ABTEST, "Parameter 'ratioA' is missing.");
+    }
+
+    Float ratioA = parameter.value;
+    Float comparator = rand.nextFloat();
+
+    if (state.children.size() != 2) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_ABTEST,
+          String.format("AB test has %d children ", state.children.size()));
+    }
+
+    // FIXME Possible bug : keySet is not ordered as per the definition of the AB test
+    if (comparator <= ratioA) {
+      // We select model A
+      return SeldonMessage.newBuilder()
+          .setData(
+              DefaultData.newBuilder()
+                  .setTensor(Tensor.newBuilder().addValues(0).addShape(1).addShape(1)))
+          .build();
+    } else {
+      return SeldonMessage.newBuilder()
+          .setData(
+              DefaultData.newBuilder()
+                  .setTensor(Tensor.newBuilder().addValues(1).addShape(1).addShape(1)))
+          .build();
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/SimpleModelUnit.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/SimpleModelUnit.java
@@ -1,64 +1,79 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
-import java.util.Arrays;
-
-import com.google.protobuf.ByteString;
-import io.seldon.protos.PredictionProtos;
-import org.springframework.stereotype.Component;
-
 import io.seldon.protos.PredictionProtos.DefaultData;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Meta;
 import io.seldon.protos.PredictionProtos.Metric;
 import io.seldon.protos.PredictionProtos.Metric.MetricType;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Status;
 import io.seldon.protos.PredictionProtos.Tensor;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
 
 @Component
 public class SimpleModelUnit extends PredictiveUnitImpl {
-	
-	public SimpleModelUnit() {}
 
-	public static final Double[] values = {0.1,0.9,0.5};		
-	public static final String[] classes = {"class0","class1","class2"};
-	
-	@Override
-	public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state){
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder()
-				.setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setMeta(Meta.newBuilder()
-						.addMetrics(Metric.newBuilder().setKey("mymetric_counter").setType(MetricType.COUNTER).setValue(1))
-						.addMetrics(Metric.newBuilder().setKey("mymetric_gauge").setType(MetricType.GAUGE).setValue(100))
-						.addMetrics(Metric.newBuilder().setKey("mymetric_timer").setType(MetricType.TIMER).setValue(22.1F)));
+  public SimpleModelUnit() {}
 
-		// echo in case of strData and binData
-		if(input.getDataOneofCase().equals(SeldonMessage.DataOneofCase.BINDATA)){
-			builder.setBinData(input.getBinData());
-		} else if (input.getDataOneofCase().equals(SeldonMessage.DataOneofCase.STRDATA)){
-			builder.setStrData(input.getStrData());
-		}else{
-			builder.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(classes))
-					.setTensor(Tensor.newBuilder().addShape(1).addShape(values.length)
-							.addAllValues(Arrays.asList(values))));
-		}
+  public static final Double[] values = {0.1, 0.9, 0.5};
+  public static final String[] classes = {"class0", "class1", "class2"};
 
-		SeldonMessage output = builder.build();
-		System.out.println("Model " + state.name + " finishing computations");
-		return output;
-	}
+  @Override
+  public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state) {
+    SeldonMessage.Builder builder =
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setMeta(
+                Meta.newBuilder()
+                    .addMetrics(
+                        Metric.newBuilder()
+                            .setKey("mymetric_counter")
+                            .setType(MetricType.COUNTER)
+                            .setValue(1))
+                    .addMetrics(
+                        Metric.newBuilder()
+                            .setKey("mymetric_gauge")
+                            .setType(MetricType.GAUGE)
+                            .setValue(100))
+                    .addMetrics(
+                        Metric.newBuilder()
+                            .setKey("mymetric_timer")
+                            .setType(MetricType.TIMER)
+                            .setValue(22.1F)));
+
+    // echo in case of strData and binData
+    if (input.getDataOneofCase().equals(SeldonMessage.DataOneofCase.BINDATA)) {
+      builder.setBinData(input.getBinData());
+    } else if (input.getDataOneofCase().equals(SeldonMessage.DataOneofCase.STRDATA)) {
+      builder.setStrData(input.getStrData());
+    } else {
+      builder.setData(
+          DefaultData.newBuilder()
+              .addAllNames(Arrays.asList(classes))
+              .setTensor(
+                  Tensor.newBuilder()
+                      .addShape(1)
+                      .addShape(values.length)
+                      .addAllValues(Arrays.asList(values))));
+    }
+
+    SeldonMessage output = builder.build();
+    System.out.println("Model " + state.name + " finishing computations");
+    return output;
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/predictors/SimpleRouterUnit.java
+++ b/engine/src/main/java/io/seldon/engine/predictors/SimpleRouterUnit.java
@@ -1,33 +1,36 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
-
-import org.springframework.stereotype.Component;
 
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Tensor;
+import org.springframework.stereotype.Component;
 
 @Component
 public class SimpleRouterUnit extends PredictiveUnitImpl {
 
-    public SimpleRouterUnit() {}
+  public SimpleRouterUnit() {}
 
-	@Override
-	public SeldonMessage route(SeldonMessage input, PredictiveUnitState state){
-		return SeldonMessage.newBuilder().setData(DefaultData.newBuilder().setTensor(Tensor.newBuilder().addValues(0).addShape(1).addShape(1))).build();
-	}
+  @Override
+  public SeldonMessage route(SeldonMessage input, PredictiveUnitState state) {
+    return SeldonMessage.newBuilder()
+        .setData(
+            DefaultData.newBuilder()
+                .setTensor(Tensor.newBuilder().addValues(0).addShape(1).addShape(1)))
+        .build();
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/service/InternalPredictionService.java
+++ b/engine/src/main/java/io/seldon/engine/service/InternalPredictionService.java
@@ -1,48 +1,23 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.service;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-
 import io.opentracing.contrib.spring.web.client.TracingRestTemplateInterceptor;
 import io.seldon.engine.config.AnnotationsConfig;
 import io.seldon.engine.exception.APIException;
@@ -69,394 +44,430 @@ import io.seldon.protos.RouterGrpc;
 import io.seldon.protos.RouterGrpc.RouterBlockingStub;
 import io.seldon.protos.TransformerGrpc;
 import io.seldon.protos.TransformerGrpc.TransformerBlockingStub;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 public class InternalPredictionService {
-	
-	private static Logger logger = LoggerFactory.getLogger(InternalPredictionService.class.getName());
 
-	public static final String MODEL_NAME_HEADER = "Seldon-model-name"; 
-	public static final String MODEL_IMAGE_HEADER = "Seldon-model-image"; 
-	public static final String MODEL_VERSION_HEADER = "Seldon-model-version";
-	
-    public final static String ANNOTATION_REST_CONNECTION_TIMEOUT = "seldon.io/rest-connection-timeout";
-    public final static String ANNOTATION_REST_READ_TIMEOUT = "seldon.io/rest-read-timeout";
-    public final static String ANNOTATION_REST_RETRIES = "seldon.io/rest-connect-retries";    
-    public final static String ANNOTATION_GRPC_READ_TIMEOUT = "seldon.io/grpc-read-timeout";
+  private static Logger logger = LoggerFactory.getLogger(InternalPredictionService.class.getName());
 
-	private static final int DEFAULT_CONNECTION_TIMEOUT = 200;
-	private static final int DEFAULT_READ_TIMEOUT = 5000;
-	
-	public static final int DEFAULT_GRPC_READ_TIMEOUT = 5000;
-	public static final int DEFAULT_MAX_RETRIES = 3;
-	
-    ObjectMapper mapper = new ObjectMapper();
-    
-    RestTemplate restTemplate;
-    
-    private int grpcMaxMessageSize = io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
-    private int grpcReadTimeout = DEFAULT_GRPC_READ_TIMEOUT;
-    private int restRetries = DEFAULT_MAX_RETRIES;
-    
-    private final GrpcChannelHandler grpcChannelHandler;
-    
-    private final Map<String,HttpHeaders> headersCache = new ConcurrentHashMap<>();
-    private final Map<String,URI> uriCache = new ConcurrentHashMap<>();
-    
-    @Autowired
-    public InternalPredictionService(RestTemplateBuilder restTemplateBuilder,AnnotationsConfig annotations,GrpcChannelHandler grpcChannelHandler,TracingProvider tracingProvider){
-    	this.grpcChannelHandler = grpcChannelHandler;
-    	int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
-    	if (annotations.has(ANNOTATION_REST_CONNECTION_TIMEOUT))
-    	{
-    		try
-    		{
-    			logger.info("Setting REST connection timeout from annotation {}",ANNOTATION_REST_CONNECTION_TIMEOUT);
-    			connectionTimeout = Integer.parseInt(annotations.get(ANNOTATION_REST_CONNECTION_TIMEOUT));
-    		}
-    		catch(NumberFormatException e)
-    		{
-    			logger.error("Failed to parse REST connection timeout annotation {} with value {}",ANNOTATION_REST_CONNECTION_TIMEOUT,annotations.get(ANNOTATION_REST_CONNECTION_TIMEOUT));
-    		}
-    	}
-    	logger.info("REST Connection timeout set to {}",connectionTimeout);
-    	int readTimeout = DEFAULT_READ_TIMEOUT;
-    	if (annotations.has(ANNOTATION_REST_READ_TIMEOUT))
-    	{
-    		try
-    		{
-    			logger.info("Setting REST read timeout from annotation {}",ANNOTATION_REST_READ_TIMEOUT);
-    			readTimeout = Integer.parseInt(annotations.get(ANNOTATION_REST_READ_TIMEOUT));
-    		}
-    		catch(NumberFormatException e)
-    		{
-    			logger.error("Failed to parse REST read timeout annotation {} with value {}",ANNOTATION_REST_READ_TIMEOUT,annotations.get(ANNOTATION_REST_READ_TIMEOUT));
-    		}
-    	}
-    	logger.info("REST read timeout set to {}",readTimeout);
-    	this.restTemplate = restTemplateBuilder
-    	           .setConnectTimeout(connectionTimeout)
-    	           .setReadTimeout(readTimeout)
-    	           .build();
-    	if (tracingProvider.isActive())
-    	{
-    		restTemplate.setInterceptors(Collections.singletonList(new TracingRestTemplateInterceptor(tracingProvider.getTracer())));
-    	}
-    	if (annotations.has(SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE))
-        {
-        	try 
-        	{
-        		grpcMaxMessageSize =Integer.parseInt(annotations.get(SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE));
-        		logger.info("Setting max message to {} bytes",grpcMaxMessageSize);
-        	}
-        	catch(NumberFormatException e)
-        	{
-        		logger.error("Failed to parse {} with value {}",SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE,annotations.get(SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE),e);
-        	}
+  public static final String MODEL_NAME_HEADER = "Seldon-model-name";
+  public static final String MODEL_IMAGE_HEADER = "Seldon-model-image";
+  public static final String MODEL_VERSION_HEADER = "Seldon-model-version";
+
+  public static final String ANNOTATION_REST_CONNECTION_TIMEOUT =
+      "seldon.io/rest-connection-timeout";
+  public static final String ANNOTATION_REST_READ_TIMEOUT = "seldon.io/rest-read-timeout";
+  public static final String ANNOTATION_REST_RETRIES = "seldon.io/rest-connect-retries";
+  public static final String ANNOTATION_GRPC_READ_TIMEOUT = "seldon.io/grpc-read-timeout";
+
+  private static final int DEFAULT_CONNECTION_TIMEOUT = 200;
+  private static final int DEFAULT_READ_TIMEOUT = 5000;
+
+  public static final int DEFAULT_GRPC_READ_TIMEOUT = 5000;
+  public static final int DEFAULT_MAX_RETRIES = 3;
+
+  ObjectMapper mapper = new ObjectMapper();
+
+  RestTemplate restTemplate;
+
+  private int grpcMaxMessageSize = io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+  private int grpcReadTimeout = DEFAULT_GRPC_READ_TIMEOUT;
+  private int restRetries = DEFAULT_MAX_RETRIES;
+
+  private final GrpcChannelHandler grpcChannelHandler;
+
+  private final Map<String, HttpHeaders> headersCache = new ConcurrentHashMap<>();
+  private final Map<String, URI> uriCache = new ConcurrentHashMap<>();
+
+  @Autowired
+  public InternalPredictionService(
+      RestTemplateBuilder restTemplateBuilder,
+      AnnotationsConfig annotations,
+      GrpcChannelHandler grpcChannelHandler,
+      TracingProvider tracingProvider) {
+    this.grpcChannelHandler = grpcChannelHandler;
+    int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+    if (annotations.has(ANNOTATION_REST_CONNECTION_TIMEOUT)) {
+      try {
+        logger.info(
+            "Setting REST connection timeout from annotation {}",
+            ANNOTATION_REST_CONNECTION_TIMEOUT);
+        connectionTimeout = Integer.parseInt(annotations.get(ANNOTATION_REST_CONNECTION_TIMEOUT));
+      } catch (NumberFormatException e) {
+        logger.error(
+            "Failed to parse REST connection timeout annotation {} with value {}",
+            ANNOTATION_REST_CONNECTION_TIMEOUT,
+            annotations.get(ANNOTATION_REST_CONNECTION_TIMEOUT));
+      }
+    }
+    logger.info("REST Connection timeout set to {}", connectionTimeout);
+    int readTimeout = DEFAULT_READ_TIMEOUT;
+    if (annotations.has(ANNOTATION_REST_READ_TIMEOUT)) {
+      try {
+        logger.info("Setting REST read timeout from annotation {}", ANNOTATION_REST_READ_TIMEOUT);
+        readTimeout = Integer.parseInt(annotations.get(ANNOTATION_REST_READ_TIMEOUT));
+      } catch (NumberFormatException e) {
+        logger.error(
+            "Failed to parse REST read timeout annotation {} with value {}",
+            ANNOTATION_REST_READ_TIMEOUT,
+            annotations.get(ANNOTATION_REST_READ_TIMEOUT));
+      }
+    }
+    logger.info("REST read timeout set to {}", readTimeout);
+    this.restTemplate =
+        restTemplateBuilder
+            .setConnectTimeout(connectionTimeout)
+            .setReadTimeout(readTimeout)
+            .build();
+    if (tracingProvider.isActive()) {
+      restTemplate.setInterceptors(
+          Collections.singletonList(
+              new TracingRestTemplateInterceptor(tracingProvider.getTracer())));
+    }
+    if (annotations.has(SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE)) {
+      try {
+        grpcMaxMessageSize =
+            Integer.parseInt(annotations.get(SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE));
+        logger.info("Setting max message to {} bytes", grpcMaxMessageSize);
+      } catch (NumberFormatException e) {
+        logger.error(
+            "Failed to parse {} with value {}",
+            SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE,
+            annotations.get(SeldonGrpcServer.ANNOTATION_MAX_MESSAGE_SIZE),
+            e);
+      }
+    }
+    logger.info("gRPC max message size set to {}", grpcMaxMessageSize);
+    if (annotations.has(ANNOTATION_GRPC_READ_TIMEOUT)) {
+      try {
+        grpcReadTimeout = Integer.parseInt(annotations.get(ANNOTATION_GRPC_READ_TIMEOUT));
+        logger.info("Setting grpc read timeout to {}ms", grpcReadTimeout);
+      } catch (NumberFormatException e) {
+        logger.error(
+            "Failed to parse {} with value {}",
+            ANNOTATION_GRPC_READ_TIMEOUT,
+            annotations.get(ANNOTATION_GRPC_READ_TIMEOUT),
+            e);
+      }
+    }
+    logger.info("gRPC read timeout set to {}", grpcReadTimeout);
+    if (annotations.has(ANNOTATION_REST_RETRIES)) {
+      try {
+        restRetries = Integer.parseInt(annotations.get(ANNOTATION_REST_RETRIES));
+        logger.info("Setting rest retries to {}", restRetries);
+      } catch (NumberFormatException e) {
+        logger.error(
+            "Failed to parse {} with value {}",
+            ANNOTATION_REST_RETRIES,
+            annotations.get(ANNOTATION_REST_RETRIES),
+            e);
+      }
+    }
+    logger.info("REST retries set to {}", restRetries);
+  }
+
+  public SeldonMessage route(SeldonMessage input, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    final Endpoint endpoint = state.endpoint;
+    switch (endpoint.getType()) {
+      case REST:
+        String dataString = ProtoBufUtils.toJson(input);
+        return queryREST("route", dataString, state, endpoint, isDefaultData(input));
+
+      case GRPC:
+        if (state.type == PredictiveUnitType.UNKNOWN_TYPE) {
+          GenericBlockingStub stub =
+              GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return stub.route(input);
+        } else {
+          RouterBlockingStub stub =
+              RouterGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return stub.route(input);
         }
-    	logger.info("gRPC max message size set to {}",grpcMaxMessageSize);
-    	if (annotations.has(ANNOTATION_GRPC_READ_TIMEOUT))
-        {
-        	try 
-        	{
-        		grpcReadTimeout = Integer.parseInt(annotations.get(ANNOTATION_GRPC_READ_TIMEOUT));
-        		logger.info("Setting grpc read timeout to {}ms",grpcReadTimeout);
-        	}
-        	catch(NumberFormatException e)
-        	{
-        		logger.error("Failed to parse {} with value {}",ANNOTATION_GRPC_READ_TIMEOUT,annotations.get(ANNOTATION_GRPC_READ_TIMEOUT),e);
-        	}
-        }
-    	logger.info("gRPC read timeout set to {}",grpcReadTimeout);
-    	if (annotations.has(ANNOTATION_REST_RETRIES))
-        {
-        	try 
-        	{
-        		restRetries = Integer.parseInt(annotations.get(ANNOTATION_REST_RETRIES));
-        		logger.info("Setting rest retries to {}",restRetries);
-        	}
-        	catch(NumberFormatException e)
-        	{
-        		logger.error("Failed to parse {} with value {}",ANNOTATION_REST_RETRIES,annotations.get(ANNOTATION_REST_RETRIES),e);
-        	}
-        }
-    	logger.info("REST retries set to {}",restRetries);
     }
-    
-    public SeldonMessage route(SeldonMessage input, PredictiveUnitState state) throws InvalidProtocolBufferException
-    {
-    	final Endpoint endpoint = state.endpoint;
-		switch (endpoint.getType()){
-			case REST:
-				String dataString = ProtoBufUtils.toJson(input);
-				return queryREST("route", dataString, state, endpoint, isDefaultData(input));
-				
-			case GRPC:
-				if (state.type==PredictiveUnitType.UNKNOWN_TYPE){
-					GenericBlockingStub stub =  GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return stub.route(input);
-				}
-				else {
-					RouterBlockingStub stub =  RouterGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return stub.route(input);
-				}
-		}
-		throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,"no service available");
-    }
-    
-    public SeldonMessage sendFeedback(Feedback feedback, PredictiveUnitState state) throws InvalidProtocolBufferException
-    {
-    	final Endpoint endpoint = state.endpoint;
-		switch (endpoint.getType()){
-			case REST:
-				String dataString = ProtoBufUtils.toJson(feedback);
-				return queryREST("send-feedback", dataString, state, endpoint, true);
-				
-			case GRPC:
-				if (state.type==PredictiveUnitType.UNKNOWN_TYPE){
-					GenericBlockingStub stub =  GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return stub.sendFeedback(feedback);
-				}
-				else if (state.type == PredictiveUnitType.MODEL)
-				{
-					ModelBlockingStub modelStub = ModelGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-						return modelStub.sendFeedback(feedback);
-				}
-				else {
-					RouterBlockingStub routerStub =  RouterGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return routerStub.sendFeedback(feedback);
-				}
-		}
-		throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,"no service available");
-    }
-    
-    public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state) throws InvalidProtocolBufferException
-    {
-    	logger.info("Calling grpc for transform-input");
-    	final Endpoint endpoint = state.endpoint;
-		switch (endpoint.getType()){
-			case REST:
-				String dataString = ProtoBufUtils.toJson(input);
-				if (state.type == PredictiveUnitType.MODEL) {
-					return queryREST("predict", dataString, state, endpoint, isDefaultData(input));
-				}
-				else {
-					return queryREST("transform-input", dataString, state, endpoint, isDefaultData(input));
-				}
-				
-			case GRPC:
-				switch (state.type){
-					case UNKNOWN_TYPE:
-						GenericBlockingStub genStub = GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-						return genStub.transformInput(input);
-					case MODEL:
-						try
-						{
-							ModelBlockingStub modelStub = ModelGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-								.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-								.withMaxInboundMessageSize(grpcMaxMessageSize)
-								.withMaxOutboundMessageSize(grpcMaxMessageSize);
-							logger.info(modelStub.getCallOptions().toString());
-							return modelStub.predict(input);
-						}
-						catch (Exception e)
-						{
-							logger.error("grpc exception ",e);
-							throw e;
-						}
-					case TRANSFORMER:
-						try
-						{
-							TransformerBlockingStub transformerStub = TransformerGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-									.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-									.withMaxInboundMessageSize(grpcMaxMessageSize)
-									.withMaxOutboundMessageSize(grpcMaxMessageSize);
-							return transformerStub.transformInput(input);
-						}
-						catch (Exception e)
-						{
-							logger.error("grpc exception ",e);
-							throw e;
-						}
-					default:
-						throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,"Unhandled type");
-				}
-		}
-		throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,"no service available");
-    }
-    
-    public SeldonMessage transformOutput(SeldonMessage output, PredictiveUnitState state) throws InvalidProtocolBufferException
-    {
-    	final Endpoint endpoint = state.endpoint;
-		switch (endpoint.getType()){
-			case REST:
-				String dataString = ProtoBufUtils.toJson(output);
-				return queryREST("transform-output", dataString, state, endpoint, isDefaultData(output));
-				
-			case GRPC:
-				if (state.type==PredictiveUnitType.UNKNOWN_TYPE){
-					GenericBlockingStub stub =  GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return stub.transformOutput(output);
-				}
-				else {
-					OutputTransformerBlockingStub stub =  OutputTransformerGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return stub.transformOutput(output);
-				}
-		}
-		throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,"no service available");
-    }
-    
-    public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state) throws InvalidProtocolBufferException{
-    	final Endpoint endpoint = state.endpoint;
-    	SeldonMessageList outputsList = SeldonMessageList.newBuilder().addAllSeldonMessages(outputs).build();
-		switch (endpoint.getType()){
-			case REST:
-				String dataString = ProtoBufUtils.toJson(outputsList);
-				return queryREST("aggregate", dataString, state, endpoint, true);
-				
-			case GRPC:
-				if (state.type==PredictiveUnitType.UNKNOWN_TYPE){
-					GenericBlockingStub stub =  GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return stub.aggregate(outputsList);
-				}
-				else {
-					CombinerBlockingStub stub = CombinerGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
-							.withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
-							.withMaxInboundMessageSize(grpcMaxMessageSize)
-							.withMaxOutboundMessageSize(grpcMaxMessageSize);
-					return stub.aggregate(outputsList);
-				}
-		}
-		throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,"no service available");
-    }
-		
-    private boolean isDefaultData(SeldonMessage message){
-    	if (message.getDataOneofCase() == DataOneofCase.DATA)
-			return true;
-    	return false;
-    }
-    
-    public static String getUriKey(Endpoint endpoint,String path)
-    {
-    	StringBuilder sb = new StringBuilder();
-    	return sb.append(endpoint.getServiceHost()).append(":").append(endpoint.getServicePort()).append(path).toString();
-    }
-		
-	private SeldonMessage queryREST(String path, String dataString, PredictiveUnitState state, Endpoint endpoint, boolean isDefault)
-	{
-		long timeNow = System.currentTimeMillis();
-		URI uri;
-		try 
-		{
-			final String uriKey = getUriKey(endpoint, path);
-			if (uriCache.containsKey(uriKey))
-				uri = uriCache.get(uriKey);
-			else
-			{
-				URIBuilder builder = new URIBuilder().setScheme("http")
-						.setHost(endpoint.getServiceHost())
-						.setPort(endpoint.getServicePort())
-						.setPath("/"+path);
-				uri = builder.build();
-				uriCache.put(uriKey, uri);
-			}
-		} catch (URISyntaxException e) 
-		{
-			throw new APIException(APIException.ApiExceptionType.ENGINE_INVALID_ENDPOINT_URL,"Host: "+endpoint.getServiceHost()+" port:"+endpoint.getServicePort());
-		}
-		
-		
-		for(int i=0;i<restRetries;i++)
-		{
-			try  
-			{
-				HttpHeaders headers;
-				if (headersCache.containsKey(state.name))
-					headers = headersCache.get(state.name);
-				else
-				{
-					headers = new HttpHeaders();
-					headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-					headers.add(MODEL_NAME_HEADER, state.name);
-					headers.add(MODEL_IMAGE_HEADER, state.imageName);
-					headers.add(MODEL_VERSION_HEADER, state.imageVersion);
-					headersCache.put(state.name, headers);
-				}
-				
-				MultiValueMap<String, String> map= new LinkedMultiValueMap<String, String>();
-				map.add("json", dataString);
-				map.add("isDefault", Boolean.toString(isDefault));
+    throw new APIException(
+        APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, "no service available");
+  }
 
-				HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(map, headers);
+  public SeldonMessage sendFeedback(Feedback feedback, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    final Endpoint endpoint = state.endpoint;
+    switch (endpoint.getType()) {
+      case REST:
+        String dataString = ProtoBufUtils.toJson(feedback);
+        return queryREST("send-feedback", dataString, state, endpoint, true);
 
-				if (logger.isDebugEnabled())
-					logger.debug("Requesting {}",uri.toString());
-				ResponseEntity<String> httpResponse = restTemplate.postForEntity( uri, request , String.class );
-				try
-				{
-					if(httpResponse.getStatusCode().is2xxSuccessful()) 
-					{
-					    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-					    String response = httpResponse.getBody();
-					    logger.debug(response);
-					    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-					    return builder.build();
-					} 
-					else 
-					{
-						logger.error("Couldn't retrieve prediction from external prediction server -- bad http return code: " + httpResponse.getStatusCode());
-						throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,String.format("Bad return code %d", httpResponse.getStatusCode()));
-					}
-				}
-				finally
-				{
-					if (logger.isDebugEnabled())
-						logger.debug("External prediction server took "+(System.currentTimeMillis()-timeNow) + "ms");
-				}
-			} 
-			catch (ResourceAccessException e)
-			{
-				logger.warn("Caught resource access exception ",e);
-			}
-			catch (IOException e) 
-			{
-				logger.error("Couldn't retrieve prediction from external prediction server - ", e);
-				throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,e.toString());
-			}
-			catch (Exception e)
-	        {
-				logger.error("Couldn't retrieve prediction from external prediction server - ", e);
-				throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,e.toString());
-	        }
-		}
-		logger.error("Failed to retrueve predictions after {} attempts",restRetries);
-		throw new APIException(APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,String.format("Failed to retrieve predictions after %d attempts",restRetries));
-	}
+      case GRPC:
+        if (state.type == PredictiveUnitType.UNKNOWN_TYPE) {
+          GenericBlockingStub stub =
+              GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return stub.sendFeedback(feedback);
+        } else if (state.type == PredictiveUnitType.MODEL) {
+          ModelBlockingStub modelStub =
+              ModelGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return modelStub.sendFeedback(feedback);
+        } else {
+          RouterBlockingStub routerStub =
+              RouterGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return routerStub.sendFeedback(feedback);
+        }
+    }
+    throw new APIException(
+        APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, "no service available");
+  }
+
+  public SeldonMessage transformInput(SeldonMessage input, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    logger.info("Calling grpc for transform-input");
+    final Endpoint endpoint = state.endpoint;
+    switch (endpoint.getType()) {
+      case REST:
+        String dataString = ProtoBufUtils.toJson(input);
+        if (state.type == PredictiveUnitType.MODEL) {
+          return queryREST("predict", dataString, state, endpoint, isDefaultData(input));
+        } else {
+          return queryREST("transform-input", dataString, state, endpoint, isDefaultData(input));
+        }
+
+      case GRPC:
+        switch (state.type) {
+          case UNKNOWN_TYPE:
+            GenericBlockingStub genStub =
+                GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                    .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                    .withMaxInboundMessageSize(grpcMaxMessageSize)
+                    .withMaxOutboundMessageSize(grpcMaxMessageSize);
+            return genStub.transformInput(input);
+          case MODEL:
+            try {
+              ModelBlockingStub modelStub =
+                  ModelGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                      .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                      .withMaxInboundMessageSize(grpcMaxMessageSize)
+                      .withMaxOutboundMessageSize(grpcMaxMessageSize);
+              logger.info(modelStub.getCallOptions().toString());
+              return modelStub.predict(input);
+            } catch (Exception e) {
+              logger.error("grpc exception ", e);
+              throw e;
+            }
+          case TRANSFORMER:
+            try {
+              TransformerBlockingStub transformerStub =
+                  TransformerGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                      .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                      .withMaxInboundMessageSize(grpcMaxMessageSize)
+                      .withMaxOutboundMessageSize(grpcMaxMessageSize);
+              return transformerStub.transformInput(input);
+            } catch (Exception e) {
+              logger.error("grpc exception ", e);
+              throw e;
+            }
+          default:
+            throw new APIException(
+                APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, "Unhandled type");
+        }
+    }
+    throw new APIException(
+        APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, "no service available");
+  }
+
+  public SeldonMessage transformOutput(SeldonMessage output, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    final Endpoint endpoint = state.endpoint;
+    switch (endpoint.getType()) {
+      case REST:
+        String dataString = ProtoBufUtils.toJson(output);
+        return queryREST("transform-output", dataString, state, endpoint, isDefaultData(output));
+
+      case GRPC:
+        if (state.type == PredictiveUnitType.UNKNOWN_TYPE) {
+          GenericBlockingStub stub =
+              GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return stub.transformOutput(output);
+        } else {
+          OutputTransformerBlockingStub stub =
+              OutputTransformerGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return stub.transformOutput(output);
+        }
+    }
+    throw new APIException(
+        APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, "no service available");
+  }
+
+  public SeldonMessage aggregate(List<SeldonMessage> outputs, PredictiveUnitState state)
+      throws InvalidProtocolBufferException {
+    final Endpoint endpoint = state.endpoint;
+    SeldonMessageList outputsList =
+        SeldonMessageList.newBuilder().addAllSeldonMessages(outputs).build();
+    switch (endpoint.getType()) {
+      case REST:
+        String dataString = ProtoBufUtils.toJson(outputsList);
+        return queryREST("aggregate", dataString, state, endpoint, true);
+
+      case GRPC:
+        if (state.type == PredictiveUnitType.UNKNOWN_TYPE) {
+          GenericBlockingStub stub =
+              GenericGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return stub.aggregate(outputsList);
+        } else {
+          CombinerBlockingStub stub =
+              CombinerGrpc.newBlockingStub(grpcChannelHandler.get(endpoint))
+                  .withDeadlineAfter(grpcReadTimeout, TimeUnit.MILLISECONDS)
+                  .withMaxInboundMessageSize(grpcMaxMessageSize)
+                  .withMaxOutboundMessageSize(grpcMaxMessageSize);
+          return stub.aggregate(outputsList);
+        }
+    }
+    throw new APIException(
+        APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, "no service available");
+  }
+
+  private boolean isDefaultData(SeldonMessage message) {
+    if (message.getDataOneofCase() == DataOneofCase.DATA) return true;
+    return false;
+  }
+
+  public static String getUriKey(Endpoint endpoint, String path) {
+    StringBuilder sb = new StringBuilder();
+    return sb.append(endpoint.getServiceHost())
+        .append(":")
+        .append(endpoint.getServicePort())
+        .append(path)
+        .toString();
+  }
+
+  private SeldonMessage queryREST(
+      String path,
+      String dataString,
+      PredictiveUnitState state,
+      Endpoint endpoint,
+      boolean isDefault) {
+    long timeNow = System.currentTimeMillis();
+    URI uri;
+    try {
+      final String uriKey = getUriKey(endpoint, path);
+      if (uriCache.containsKey(uriKey)) uri = uriCache.get(uriKey);
+      else {
+        URIBuilder builder =
+            new URIBuilder()
+                .setScheme("http")
+                .setHost(endpoint.getServiceHost())
+                .setPort(endpoint.getServicePort())
+                .setPath("/" + path);
+        uri = builder.build();
+        uriCache.put(uriKey, uri);
+      }
+    } catch (URISyntaxException e) {
+      throw new APIException(
+          APIException.ApiExceptionType.ENGINE_INVALID_ENDPOINT_URL,
+          "Host: " + endpoint.getServiceHost() + " port:" + endpoint.getServicePort());
+    }
+
+    for (int i = 0; i < restRetries; i++) {
+      try {
+        HttpHeaders headers;
+        if (headersCache.containsKey(state.name)) headers = headersCache.get(state.name);
+        else {
+          headers = new HttpHeaders();
+          headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+          headers.add(MODEL_NAME_HEADER, state.name);
+          headers.add(MODEL_IMAGE_HEADER, state.imageName);
+          headers.add(MODEL_VERSION_HEADER, state.imageVersion);
+          headersCache.put(state.name, headers);
+        }
+
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
+        map.add("json", dataString);
+        map.add("isDefault", Boolean.toString(isDefault));
+
+        HttpEntity<MultiValueMap<String, String>> request =
+            new HttpEntity<MultiValueMap<String, String>>(map, headers);
+
+        if (logger.isDebugEnabled()) logger.debug("Requesting {}", uri.toString());
+        ResponseEntity<String> httpResponse =
+            restTemplate.postForEntity(uri, request, String.class);
+        try {
+          if (httpResponse.getStatusCode().is2xxSuccessful()) {
+            SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+            String response = httpResponse.getBody();
+            logger.debug(response);
+            JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+            return builder.build();
+          } else {
+            logger.error(
+                "Couldn't retrieve prediction from external prediction server -- bad http return code: "
+                    + httpResponse.getStatusCode());
+            throw new APIException(
+                APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,
+                String.format("Bad return code %d", httpResponse.getStatusCode()));
+          }
+        } finally {
+          if (logger.isDebugEnabled())
+            logger.debug(
+                "External prediction server took " + (System.currentTimeMillis() - timeNow) + "ms");
+        }
+      } catch (ResourceAccessException e) {
+        logger.warn("Caught resource access exception ", e);
+      } catch (IOException e) {
+        logger.error("Couldn't retrieve prediction from external prediction server - ", e);
+        throw new APIException(
+            APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, e.toString());
+      } catch (Exception e) {
+        logger.error("Couldn't retrieve prediction from external prediction server - ", e);
+        throw new APIException(
+            APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR, e.toString());
+      }
+    }
+    logger.error("Failed to retrueve predictions after {} attempts", restRetries);
+    throw new APIException(
+        APIException.ApiExceptionType.ENGINE_MICROSERVICE_ERROR,
+        String.format("Failed to retrieve predictions after %d attempts", restRetries));
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/service/PredictionService.java
+++ b/engine/src/main/java/io/seldon/engine/service/PredictionService.java
@@ -1,31 +1,37 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import io.seldon.engine.pb.ProtoBufUtils;
+import io.seldon.engine.predictors.EnginePredictor;
+import io.seldon.engine.predictors.PredictorBean;
+import io.seldon.engine.predictors.PredictorState;
+import io.seldon.protos.PredictionProtos.Feedback;
+import io.seldon.protos.PredictionProtos.Meta;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.time.ZonedDateTime;
 import java.util.concurrent.ExecutionException;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.protobuf.Message;
-import io.seldon.engine.pb.ProtoBufUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,178 +39,183 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Service;
-
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.seldon.engine.predictors.EnginePredictor;
-import io.seldon.engine.predictors.PredictorBean;
-import io.seldon.engine.predictors.PredictorState;
-import io.seldon.protos.PredictionProtos.Feedback;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-import io.seldon.protos.PredictionProtos.Meta;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Service
 public class PredictionService {
-	
-	private static Logger logger = LoggerFactory.getLogger(PredictionService.class.getName());
-	
-	@Autowired
-	PredictorBean predictorBean;
-	
-	@Autowired
-	EnginePredictor enginePredictor;
-	
-	PuidGenerator puidGenerator = new PuidGenerator();
 
-	@Value("${log.requests}")
-	private boolean logRequests;
+  private static Logger logger = LoggerFactory.getLogger(PredictionService.class.getName());
 
-	@Value("${log.responses}")
-	private boolean logResponses;
+  @Autowired PredictorBean predictorBean;
 
-	@Value("${log.feedback.requests}")
-	private boolean logFeedbackRequests;
+  @Autowired EnginePredictor enginePredictor;
 
-	@Value("${log.messages.externally}")
-	private boolean logMessagesExternally;
+  PuidGenerator puidGenerator = new PuidGenerator();
 
-	@Value("${message.logging.service}")
-	private String messageLoggingService;
+  @Value("${log.requests}")
+  private boolean logRequests;
 
-	public final class PuidGenerator {
-	    private SecureRandom random = new SecureRandom();
+  @Value("${log.responses}")
+  private boolean logResponses;
 
-	    public String nextPuidId() {
-	        return new BigInteger(130, random).toString(32);
-	    }
-	}
-	
-	public void sendFeedback(Feedback feedback) throws InterruptedException, ExecutionException, InvalidProtocolBufferException
-	{
-		PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(enginePredictor.getPredictorSpec());
+  @Value("${log.feedback.requests}")
+  private boolean logFeedbackRequests;
 
-		predictorBean.sendFeedback(feedback, predictorState);
+  @Value("${log.messages.externally}")
+  private boolean logMessagesExternally;
 
-		if(logFeedbackRequests) {
-			logMessageAsJson(feedback);
-		}
-		
-		return;
-	}
-	
-	public SeldonMessage predict(SeldonMessage request) throws InterruptedException, ExecutionException, InvalidProtocolBufferException
-	{
+  @Value("${message.logging.service}")
+  private String messageLoggingService;
 
-		ZonedDateTime requestTime = ZonedDateTime.now();
+  public final class PuidGenerator {
+    private SecureRandom random = new SecureRandom();
 
-		if (!request.hasMeta())
-		{
-			request = request.toBuilder().setMeta(Meta.newBuilder().setPuid(puidGenerator.nextPuidId()).build()).build();
-		}
-		else if (StringUtils.isEmpty(request.getMeta().getPuid()))
-		{
-			request = request.toBuilder().setMeta(request.getMeta().toBuilder().setPuid(puidGenerator.nextPuidId()).build()).build();
-		}
-		String puid = request.getMeta().getPuid();
-		
-        PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(enginePredictor.getPredictorSpec());
+    public String nextPuidId() {
+      return new BigInteger(130, random).toString(32);
+    }
+  }
 
-        SeldonMessage predictorReturn = predictorBean.predict(request,predictorState);
-			
-        SeldonMessage.Builder builder = SeldonMessage.newBuilder(predictorReturn).setMeta(Meta.newBuilder(predictorReturn.getMeta()).setPuid(puid));
+  public void sendFeedback(Feedback feedback)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    PredictorState predictorState =
+        predictorBean.predictorStateFromPredictorSpec(enginePredictor.getPredictorSpec());
 
-        SeldonMessage response = builder.build();
+    predictorBean.sendFeedback(feedback, predictorState);
 
-        //raw logging in engine, if enabled
-		if(logRequests){
-			//log json now we've added puid
-			logMessageAsJson(request);
-		}
-		if(logResponses){
-			logMessageAsJson(response);
-		}
+    if (logFeedbackRequests) {
+      logMessageAsJson(feedback);
+    }
 
-		//enriched logging outside engine, if enabled
-		if(logMessagesExternally){
-			ZonedDateTime responseTime = ZonedDateTime.now();
-			sendMessagePairAsJson(request,response,requestTime,responseTime);
-		}
+    return;
+  }
 
-        return response;
-		
-	}
+  public SeldonMessage predict(SeldonMessage request)
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
 
-	private JsonNode combineRequestResponse(String request, String response, ZonedDateTime requestTime, ZonedDateTime responseTime) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		JsonNode requestNode = mapper.readTree(request);
-		JsonNode responseNode = mapper.readTree(response);
-		ObjectNode combined = mapper.createObjectNode();
-		combined.set("request",requestNode);
-		combined.set("response",responseNode);
-		((ObjectNode)combined.get("request")).set("date",mapper.readTree(mapper.writeValueAsString(requestTime.toString())));
-		((ObjectNode)combined.get("response")).set("date",mapper.readTree(mapper.writeValueAsString(responseTime.toString())));
-		String depName = System.getenv().get("DEPLOYMENT_NAME");
-		if(depName!=null){
-			combined.set("sdepName",mapper.readTree(mapper.writeValueAsString(depName)));
-		}
+    ZonedDateTime requestTime = ZonedDateTime.now();
 
-		String depNamespace = System.getenv().get("DEPLOYMENT_NAMESPACE");
-		if(depNamespace!=null && depNamespace!=""){
-			combined.set("namespace",mapper.readTree(mapper.writeValueAsString(depNamespace)));
-		}
+    if (!request.hasMeta()) {
+      request =
+          request
+              .toBuilder()
+              .setMeta(Meta.newBuilder().setPuid(puidGenerator.nextPuidId()).build())
+              .build();
+    } else if (StringUtils.isEmpty(request.getMeta().getPuid())) {
+      request =
+          request
+              .toBuilder()
+              .setMeta(request.getMeta().toBuilder().setPuid(puidGenerator.nextPuidId()).build())
+              .build();
+    }
+    String puid = request.getMeta().getPuid();
 
-		return combined;
-	}
+    PredictorState predictorState =
+        predictorBean.predictorStateFromPredictorSpec(enginePredictor.getPredictorSpec());
 
-	private void sendMessagePairAsJson(SeldonMessage request, SeldonMessage response, ZonedDateTime requestTime, ZonedDateTime responseTime){
-		try {
-			String requestJson = ProtoBufUtils.toJson(request);
-			String responseJson = ProtoBufUtils.toJson(response);
-			JsonNode pair = combineRequestResponse(requestJson,responseJson,requestTime,responseTime);
+    SeldonMessage predictorReturn = predictorBean.predict(request, predictorState);
 
-			MultiValueMap<String, String> headers = new LinkedMultiValueMap<String, String>();
-			headers.add("Content-Type", "application/json");
-			headers.add("X-B3-Flags", "1");
-			headers.add("CE-SpecVersion", "0.2");
-			headers.add("CE-Type", "seldon.message.pair");
-			headers.add("CE-Time", requestTime.toString());
-			headers.add("CE-EventID", request.getMeta().getPuid());
+    SeldonMessage.Builder builder =
+        SeldonMessage.newBuilder(predictorReturn)
+            .setMeta(Meta.newBuilder(predictorReturn.getMeta()).setPuid(puid));
 
-			String depName = System.getenv().get("DEPLOYMENT_NAME");
-			if(depName!=null){
-				headers.add("CE-Source", "application/json");
-			} else{
-				headers.add("CE-Source", "seldon");
-			}
+    SeldonMessage response = builder.build();
 
-			HttpEntity<?> requestBody = new HttpEntity<Object>(pair.toString(), headers);
-			RestTemplate restTemplate = new RestTemplate();
+    // raw logging in engine, if enabled
+    if (logRequests) {
+      // log json now we've added puid
+      logMessageAsJson(request);
+    }
+    if (logResponses) {
+      logMessageAsJson(response);
+    }
 
-			restTemplate.postForEntity(messageLoggingService,requestBody,String.class);
+    // enriched logging outside engine, if enabled
+    if (logMessagesExternally) {
+      ZonedDateTime responseTime = ZonedDateTime.now();
+      sendMessagePairAsJson(request, response, requestTime, responseTime);
+    }
 
-		}catch (Exception ex){
-			logger.error("Unable to parse message",ex);
-		}
-	}
+    return response;
+  }
 
-	private void logMessageAsJson(Feedback message){
-		try {
-			String json = ProtoBufUtils.toJson(message);
-			System.out.println(json);
-		}catch (Exception ex){
-			logger.error("Unable to parse message",ex);
-		}
-	}
+  private JsonNode combineRequestResponse(
+      String request, String response, ZonedDateTime requestTime, ZonedDateTime responseTime)
+      throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode requestNode = mapper.readTree(request);
+    JsonNode responseNode = mapper.readTree(response);
+    ObjectNode combined = mapper.createObjectNode();
+    combined.set("request", requestNode);
+    combined.set("response", responseNode);
+    ((ObjectNode) combined.get("request"))
+        .set("date", mapper.readTree(mapper.writeValueAsString(requestTime.toString())));
+    ((ObjectNode) combined.get("response"))
+        .set("date", mapper.readTree(mapper.writeValueAsString(responseTime.toString())));
+    String depName = System.getenv().get("DEPLOYMENT_NAME");
+    if (depName != null) {
+      combined.set("sdepName", mapper.readTree(mapper.writeValueAsString(depName)));
+    }
 
-	private void logMessageAsJson(Message message){
-		try {
-			String json = ProtoBufUtils.toJson(message);
-			System.out.println(json);
-		}catch (Exception ex){
-			logger.error("Unable to parse message",ex);
-		}
-	}
+    String depNamespace = System.getenv().get("DEPLOYMENT_NAMESPACE");
+    if (depNamespace != null && depNamespace != "") {
+      combined.set("namespace", mapper.readTree(mapper.writeValueAsString(depNamespace)));
+    }
+
+    return combined;
+  }
+
+  private void sendMessagePairAsJson(
+      SeldonMessage request,
+      SeldonMessage response,
+      ZonedDateTime requestTime,
+      ZonedDateTime responseTime) {
+    try {
+      String requestJson = ProtoBufUtils.toJson(request);
+      String responseJson = ProtoBufUtils.toJson(response);
+      JsonNode pair = combineRequestResponse(requestJson, responseJson, requestTime, responseTime);
+
+      MultiValueMap<String, String> headers = new LinkedMultiValueMap<String, String>();
+      headers.add("Content-Type", "application/json");
+      headers.add("X-B3-Flags", "1");
+      headers.add("CE-SpecVersion", "0.2");
+      headers.add("CE-Type", "seldon.message.pair");
+      headers.add("CE-Time", requestTime.toString());
+      headers.add("CE-EventID", request.getMeta().getPuid());
+
+      String depName = System.getenv().get("DEPLOYMENT_NAME");
+      if (depName != null) {
+        headers.add("CE-Source", "application/json");
+      } else {
+        headers.add("CE-Source", "seldon");
+      }
+
+      HttpEntity<?> requestBody = new HttpEntity<Object>(pair.toString(), headers);
+      RestTemplate restTemplate = new RestTemplate();
+
+      restTemplate.postForEntity(messageLoggingService, requestBody, String.class);
+
+    } catch (Exception ex) {
+      logger.error("Unable to parse message", ex);
+    }
+  }
+
+  private void logMessageAsJson(Feedback message) {
+    try {
+      String json = ProtoBufUtils.toJson(message);
+      System.out.println(json);
+    } catch (Exception ex) {
+      logger.error("Unable to parse message", ex);
+    }
+  }
+
+  private void logMessageAsJson(Message message) {
+    try {
+      String json = ProtoBufUtils.toJson(message);
+      System.out.println(json);
+    } catch (Exception ex) {
+      logger.error("Unable to parse message", ex);
+    }
+  }
 }

--- a/engine/src/main/java/io/seldon/engine/tracing/TracingProvider.java
+++ b/engine/src/main/java/io/seldon/engine/tracing/TracingProvider.java
@@ -1,53 +1,37 @@
 package io.seldon.engine.tracing;
 
+import io.jaegertracing.Configuration;
+import io.opentracing.Tracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
-
-import io.jaegertracing.Configuration;
-import io.jaegertracing.internal.JaegerTracer;
-import io.jaegertracing.internal.reporters.InMemoryReporter;
-import io.jaegertracing.internal.samplers.ConstSampler;
-import io.jaegertracing.spi.Reporter;
-import io.jaegertracing.spi.Sampler;
-import io.opentracing.Tracer;
 
 @Component
 public class TracingProvider {
 
-	private final static Logger logger = LoggerFactory.getLogger(TracingProvider.class);
-	
-	private final Tracer tracer;
-	private final boolean active;
-	
-	
-	public TracingProvider()
-	{
-		String tracingEnv = System.getenv().get("TRACING");
-		if (tracingEnv != null && "1".equals(tracingEnv))
-		{
-			logger.info("Activating tracing");
-			active = true;
-			tracer = Configuration.fromEnv("seldon-svc-orch").getTracer();
-		}
-		else
-		{
-			logger.info("Not activating tracing");
-			active = false;
-			tracer = null;
-		}
-	}
-	
-	public boolean isActive() {
-		return active;
-	}
+  private static final Logger logger = LoggerFactory.getLogger(TracingProvider.class);
 
+  private final Tracer tracer;
+  private final boolean active;
 
+  public TracingProvider() {
+    String tracingEnv = System.getenv().get("TRACING");
+    if (tracingEnv != null && "1".equals(tracingEnv)) {
+      logger.info("Activating tracing");
+      active = true;
+      tracer = Configuration.fromEnv("seldon-svc-orch").getTracer();
+    } else {
+      logger.info("Not activating tracing");
+      active = false;
+      tracer = null;
+    }
+  }
 
-	public Tracer getTracer()
-	{
-		return this.tracer;
-	}
-	
+  public boolean isActive() {
+    return active;
+  }
+
+  public Tracer getTracer() {
+    return this.tracer;
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/api/rest/TestRandomABTest.java
+++ b/engine/src/test/java/io/seldon/engine/api/rest/TestRandomABTest.java
@@ -1,8 +1,15 @@
 package io.seldon.engine.api.rest;
 
+import static io.seldon.engine.util.TestUtils.readFile;
+
+import io.seldon.engine.filters.XSSFilter;
+import io.seldon.engine.pb.JsonFormat;
+import io.seldon.engine.predictors.EnginePredictor;
+import io.seldon.engine.service.InternalPredictionService;
+import io.seldon.protos.DeploymentProtos.PredictorSpec;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,11 +17,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -30,104 +37,84 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 
-import io.seldon.engine.filters.XSSFilter;
-import io.seldon.engine.pb.JsonFormat;
-import io.seldon.engine.predictors.EnginePredictor;
-import io.seldon.engine.service.InternalPredictionService;
-import io.seldon.protos.DeploymentProtos.PredictorSpec;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-
-import static io.seldon.engine.util.TestUtils.readFile;
-
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-	    "management.security.enabled=false",
-	})
+@TestPropertySource(
+    properties = {
+      "management.security.enabled=false",
+    })
 public class TestRandomABTest {
 
-	@Autowired
-	private WebApplicationContext context;
+  @Autowired private WebApplicationContext context;
 
-	@Autowired
-	private EnginePredictor enginePredictor;
+  @Autowired private EnginePredictor enginePredictor;
 
+  // @Autowired
+  private MockMvc mvc;
 
-    //@Autowired
-    private MockMvc mvc;
+  @Autowired private RestClientController restController;
 
-    @Autowired
-    private RestClientController restController;
+  @Before
+  public void setup() throws Exception {
+    mvc = MockMvcBuilders.webAppContextSetup(context).addFilters(new XSSFilter()).build();
+  }
 
-    @Before
-	public void setup() throws Exception {
-    	mvc = MockMvcBuilders
-				.webAppContextSetup(context)
-        .addFilters(new XSSFilter())
-				.build();
-	}
+  @LocalServerPort private int port;
 
-    @LocalServerPort
-    private int port;
+  @Autowired private TestRestTemplate testRestTemplate;
 
-    @Autowired
-    private TestRestTemplate testRestTemplate;
+  @Autowired private InternalPredictionService internalPredictionService;
 
-    @Autowired
-    private InternalPredictionService internalPredictionService;
+  @Test
+  public void testModelMetrics() throws Exception {
+    String jsonStr = readFile("src/test/resources/abtest.json", StandardCharsets.UTF_8);
+    String responseStr =
+        readFile("src/test/resources/response_with_metrics.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"request\": {" + "\"ndarray\": [[1.0]]}" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
 
+    ResponseEntity<String> httpResponse =
+        new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenReturn(httpResponse);
 
+    int routeACount = 0;
+    int routeBCount = 1;
 
-    @Test
-    public void testModelMetrics() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/abtest.json",StandardCharsets.UTF_8);
-    	String responseStr = readFile("src/test/resources/response_with_metrics.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"request\": {" +
-         	    "\"ndarray\": [[1.0]]}" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
+    for (int i = 0; i < 100; i++) {
+      MvcResult res =
+          mvc.perform(
+                  MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                      .accept(MediaType.APPLICATION_JSON_UTF8)
+                      .content(predictJson)
+                      .contentType(MediaType.APPLICATION_JSON_UTF8))
+              .andReturn();
+      String response = res.getResponse().getContentAsString();
+      System.out.println(response);
+      Assert.assertEquals(200, res.getResponse().getStatus());
 
-    	ResponseEntity<String> httpResponse = new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-    		.thenReturn(httpResponse);
+      SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+      JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+      SeldonMessage seldonMessage = builder.build();
 
-    	int routeACount = 0;
-    	int routeBCount = 1;
-
-    	for(int i=0;i<100;i++)
-    	{
-    		MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-        			.accept(MediaType.APPLICATION_JSON_UTF8)
-        			.content(predictJson)
-        			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-        	String response = res.getResponse().getContentAsString();
-        	System.out.println(response);
-        	Assert.assertEquals(200, res.getResponse().getStatus());
-
-        	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-    	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-    	    SeldonMessage seldonMessage = builder.build();
-
-    	    Assert.assertTrue(seldonMessage.getMeta().getRoutingMap().get("abtest") >= 0);
-    	    if (seldonMessage.getMeta().getRoutingMap().get("abtest") == 0)
-    	    	routeACount++;
-    	    else
-    	    	routeBCount++;
-    	}
-    	double split = routeACount /(double)(routeACount + routeBCount);
- 	    System.out.println(routeACount);
- 	    System.out.println(routeBCount);
- 	    Assert.assertEquals(0.5, split,0.2);
-
-
-
+      Assert.assertTrue(seldonMessage.getMeta().getRoutingMap().get("abtest") >= 0);
+      if (seldonMessage.getMeta().getRoutingMap().get("abtest") == 0) routeACount++;
+      else routeBCount++;
     }
-
+    double split = routeACount / (double) (routeACount + routeBCount);
+    System.out.println(routeACount);
+    System.out.println(routeBCount);
+    Assert.assertEquals(0.5, split, 0.2);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientController.java
+++ b/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientController.java
@@ -1,38 +1,37 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.api.rest;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.mockito.Mockito.when;
 
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
 import io.seldon.engine.filters.XSSFilter;
 import io.seldon.engine.pb.ProtoBufUtils;
 import io.seldon.engine.tracing.TracingProvider;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
-import io.opentracing.mock.MockTracer;
-import io.opentracing.mock.MockSpan;
+import java.util.*;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import java.util.*;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -47,281 +46,275 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.mockito.Mockito.when;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 // @AutoConfigureMockMvc
 public class TestRestClientController {
-	private final static Logger logger = LoggerFactory.getLogger(TestRestClientController.class);
-	
-	@Autowired
-	private WebApplicationContext context;
+  private static final Logger logger = LoggerFactory.getLogger(TestRestClientController.class);
 
-  @MockBean
-  private TracingProvider mockTracingProvider;
+  @Autowired private WebApplicationContext context;
+
+  @MockBean private TracingProvider mockTracingProvider;
 
   private MockTracer tracer;
-	
-    //@Autowired
-    private MockMvc mvc;
 
-    @Before
-	public void setup() {
+  // @Autowired
+  private MockMvc mvc;
+
+  @Before
+  public void setup() {
     tracer = new MockTracer();
     when(mockTracingProvider.getTracer()).thenReturn(tracer);
     when(mockTracingProvider.isActive()).thenReturn(true);
-		mvc = MockMvcBuilders
-				.webAppContextSetup(context)
-        .addFilters(new XSSFilter())
-				.build();
-	}
-    
-    @LocalServerPort
-    private int port;
+    mvc = MockMvcBuilders.webAppContextSetup(context).addFilters(new XSSFilter()).build();
+  }
 
+  @LocalServerPort private int port;
 
-    @Test
-    public void testPing() throws Exception
-    {
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.get("/ping")).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	Assert.assertEquals("pong", response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-    }
+  @Test
+  public void testPing() throws Exception {
+    MvcResult res = mvc.perform(MockMvcRequestBuilders.get("/ping")).andReturn();
+    String response = res.getResponse().getContentAsString();
+    Assert.assertEquals("pong", response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+  }
 
-    @Test
-    public void testSecurityHeaders() throws Exception
-    {
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.get("/ping")).andReturn();
-    	HttpServletResponse response = res.getResponse();
+  @Test
+  public void testSecurityHeaders() throws Exception {
+    MvcResult res = mvc.perform(MockMvcRequestBuilders.get("/ping")).andReturn();
+    HttpServletResponse response = res.getResponse();
 
-      final String noSniff = response.getHeader("X-Content-Type-Options");
-    	Assert.assertEquals("nosniff", noSniff);
-    	Assert.assertEquals(200, response.getStatus());
-    }
-    
-    @Test
-    public void testPredict_activateSpan() throws Exception
-    {
-        final String predictJson = "{" +
-        	    "\"request\": {" + 
-        	    "\"ndarray\": [[1.0]]}" +
-        		"}";
+    final String noSniff = response.getHeader("X-Content-Type-Options");
+    Assert.assertEquals("nosniff", noSniff);
+    Assert.assertEquals(200, response.getStatus());
+  }
 
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-      List<MockSpan> finishedSpans = tracer.finishedSpans();
+  @Test
+  public void testPredict_activateSpan() throws Exception {
+    final String predictJson = "{" + "\"request\": {" + "\"ndarray\": [[1.0]]}" + "}";
 
-      Assert.assertEquals(1, finishedSpans.size());
-    }
-    
-    @Test
-    public void testPredict_11dim_ndarry() throws Exception
-    {
-        final String predictJson = "{" +
-        	    "\"request\": {" + 
-        	    "\"ndarray\": [[1.0]]}" +
-        		"}";
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    List<MockSpan> finishedSpans = tracer.finishedSpans();
 
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-    }
-    	    
-    @Test
-    public void testPredict_21dim_ndarry() throws Exception
-    {
-        final String predictJson = "{" +
-        	    "\"request\": {" + 
-        	    "\"ndarray\": [[1.0],[2.0]]}" +
-        		"}";
+    Assert.assertEquals(1, finishedSpans.size());
+  }
 
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, response );
-		SeldonMessage seldonMessage = builder.build();
-		Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
-		Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
-		Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
-		Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
-    }
-    
-    @Test
-    public void testPredict_21dim_tensor() throws Exception
-    {
-        final String predictJson = "{" +
-        	    "\"request\": {" + 
-        	    "\"tensor\": {\"shape\":[2,1],\"values\":[1.0,2.0]}}" +
-        		"}";
+  @Test
+  public void testPredict_11dim_ndarry() throws Exception {
+    final String predictJson = "{" + "\"request\": {" + "\"ndarray\": [[1.0]]}" + "}";
 
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, response );
-		SeldonMessage seldonMessage = builder.build();
-		Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
-		Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
-		Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
-		Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
-    }
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+  }
 
-	@Test
-	public void testPredict_multiform_11dim_ndarry() throws Exception
-	{
-		final String predictJson = "{" +
-				"\"request\": {" +
-				"\"ndarray\": [[1.0]]}" +
-				"}";
-		final MultiValueMap<String,String> paramMap = new LinkedMultiValueMap<>();
-		paramMap.put("data", Arrays.asList(predictJson));
-		MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-				.accept(MediaType.APPLICATION_JSON_UTF8)
-				.params(paramMap)
-				.contentType(MediaType.MULTIPART_FORM_DATA)).andReturn();
-		String response = res.getResponse().getContentAsString();
-		System.out.println(response);
-		Assert.assertEquals(200, res.getResponse().getStatus());
-	}
+  @Test
+  public void testPredict_21dim_ndarry() throws Exception {
+    final String predictJson = "{" + "\"request\": {" + "\"ndarray\": [[1.0],[2.0]]}" + "}";
 
-	@Test
-	public void testPredict_multiform_21dim_ndarry() throws Exception
-	{
-		final String predictJson = "{" +
-				"\"request\": {" +
-				"\"ndarray\": [[1.0],[2.0]]}" +
-				"}";
-		final MultiValueMap<String,String> paramMap = new LinkedMultiValueMap<>();
-		paramMap.put("data", Arrays.asList(predictJson));
-		MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-				.accept(MediaType.APPLICATION_JSON_UTF8)
-				.params(paramMap)
-				.contentType(MediaType.MULTIPART_FORM_DATA)).andReturn();
-		String response = res.getResponse().getContentAsString();
-		System.out.println(response);
-		Assert.assertEquals(200, res.getResponse().getStatus());
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, response );
-		SeldonMessage seldonMessage = builder.build();
-		Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
-		Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
-		Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
-		Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
-	}
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, response);
+    SeldonMessage seldonMessage = builder.build();
+    Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+  }
 
-	@Test
-	public void testPredict_multiform_21dim_tensor() throws Exception
-	{
-		final String predictJson = "{" +
-				"\"request\": {" +
-				"\"tensor\": {\"shape\":[2,1],\"values\":[1.0,2.0]}}" +
-				"}";
-		final MultiValueMap<String,String> paramMap = new LinkedMultiValueMap<>();
-		paramMap.put("data", Arrays.asList(predictJson));
-		MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-				.accept(MediaType.APPLICATION_JSON_UTF8)
-				.params(paramMap)
-				.contentType(MediaType.MULTIPART_FORM_DATA)).andReturn();
-		String response = res.getResponse().getContentAsString();
-		System.out.println(response);
-		Assert.assertEquals(200, res.getResponse().getStatus());
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, response );
-		SeldonMessage seldonMessage = builder.build();
-		Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
-		Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
-		Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
-		Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
-	}
-	@Test
-	public void testPredict_multiform_binData() throws Exception
-	{
-		final String metaJson =  "{\"puid\":\"1234\"}" ;
-		final MultiValueMap<String,String> paramMap = new LinkedMultiValueMap<>();
-		paramMap.put("meta", Arrays.asList(metaJson));
-		byte[] fileData = "test data".getBytes();
-		MvcResult res = mvc.perform(MockMvcRequestBuilders.fileUpload("/api/v0.1/predictions").file("binData",fileData)
-				.accept(MediaType.APPLICATION_JSON_UTF8)
-				.params(paramMap)
-				.contentType(MediaType.MULTIPART_FORM_DATA)).andReturn();
-		String response = res.getResponse().getContentAsString();
-		System.out.println(response);
-		Assert.assertEquals(200, res.getResponse().getStatus());
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, response );
-		SeldonMessage seldonMessage = builder.build();
-		Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
-		Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
-		Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
-		Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
-		Assert.assertEquals(new String(fileData), seldonMessage.getBinData().toStringUtf8());
-		Assert.assertEquals("1234", seldonMessage.getMeta().getPuid());
-	}
-	@Test
-	public void testPredict_multiform_strData_as_file() throws Exception
-	{
-		final String metaJson =  "{\"puid\":\"1234\"}" ;
-		final MultiValueMap<String,String> paramMap = new LinkedMultiValueMap<>();
-		paramMap.put("meta", Arrays.asList(metaJson));
-		byte[] fileData = "test data".getBytes();
-		MvcResult res = mvc.perform(MockMvcRequestBuilders.fileUpload("/api/v0.1/predictions").file("strData",fileData)
-				.accept(MediaType.APPLICATION_JSON_UTF8)
-				.params(paramMap)
-				.contentType(MediaType.MULTIPART_FORM_DATA)).andReturn();
-		String response = res.getResponse().getContentAsString();
-		System.out.println(response);
-		Assert.assertEquals(200, res.getResponse().getStatus());
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, response );
-		SeldonMessage seldonMessage = builder.build();
-		Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
-		Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
-		Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
-		Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
-		Assert.assertEquals(new String(fileData), seldonMessage.getStrData());
-		Assert.assertEquals("1234", seldonMessage.getMeta().getPuid());
+  @Test
+  public void testPredict_21dim_tensor() throws Exception {
+    final String predictJson =
+        "{" + "\"request\": {" + "\"tensor\": {\"shape\":[2,1],\"values\":[1.0,2.0]}}" + "}";
 
-	}
-	@Test
-	public void testPredict_multiform_strData_as_text() throws Exception
-	{
-		final String metaJson =  "{\"puid\":\"1234\"}" ;
-		final MultiValueMap<String,String> paramMap = new LinkedMultiValueMap<>();
-		paramMap.put("meta", Arrays.asList(metaJson));
-		String strdata = "test data";
-		paramMap.put("strData",Arrays.asList(strdata));
-		MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-				.accept(MediaType.APPLICATION_JSON_UTF8)
-				.params(paramMap)
-				.contentType(MediaType.MULTIPART_FORM_DATA)).andReturn();
-		String response = res.getResponse().getContentAsString();
-		System.out.println(response);
-		Assert.assertEquals(200, res.getResponse().getStatus());
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, response );
-		SeldonMessage seldonMessage = builder.build();
-		Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
-		Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
-		Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
-		Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
-		Assert.assertEquals(strdata, seldonMessage.getStrData());
-		Assert.assertEquals("1234", seldonMessage.getMeta().getPuid());
-	}
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, response);
+    SeldonMessage seldonMessage = builder.build();
+    Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+  }
+
+  @Test
+  public void testPredict_multiform_11dim_ndarry() throws Exception {
+    final String predictJson = "{" + "\"request\": {" + "\"ndarray\": [[1.0]]}" + "}";
+    final MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
+    paramMap.put("data", Arrays.asList(predictJson));
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .params(paramMap)
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+  }
+
+  @Test
+  public void testPredict_multiform_21dim_ndarry() throws Exception {
+    final String predictJson = "{" + "\"request\": {" + "\"ndarray\": [[1.0],[2.0]]}" + "}";
+    final MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
+    paramMap.put("data", Arrays.asList(predictJson));
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .params(paramMap)
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, response);
+    SeldonMessage seldonMessage = builder.build();
+    Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+  }
+
+  @Test
+  public void testPredict_multiform_21dim_tensor() throws Exception {
+    final String predictJson =
+        "{" + "\"request\": {" + "\"tensor\": {\"shape\":[2,1],\"values\":[1.0,2.0]}}" + "}";
+    final MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
+    paramMap.put("data", Arrays.asList(predictJson));
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .params(paramMap)
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, response);
+    SeldonMessage seldonMessage = builder.build();
+    Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+  }
+
+  @Test
+  public void testPredict_multiform_binData() throws Exception {
+    final String metaJson = "{\"puid\":\"1234\"}";
+    final MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
+    paramMap.put("meta", Arrays.asList(metaJson));
+    byte[] fileData = "test data".getBytes();
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.fileUpload("/api/v0.1/predictions")
+                    .file("binData", fileData)
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .params(paramMap)
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, response);
+    SeldonMessage seldonMessage = builder.build();
+    Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(new String(fileData), seldonMessage.getBinData().toStringUtf8());
+    Assert.assertEquals("1234", seldonMessage.getMeta().getPuid());
+  }
+
+  @Test
+  public void testPredict_multiform_strData_as_file() throws Exception {
+    final String metaJson = "{\"puid\":\"1234\"}";
+    final MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
+    paramMap.put("meta", Arrays.asList(metaJson));
+    byte[] fileData = "test data".getBytes();
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.fileUpload("/api/v0.1/predictions")
+                    .file("strData", fileData)
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .params(paramMap)
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, response);
+    SeldonMessage seldonMessage = builder.build();
+    Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(new String(fileData), seldonMessage.getStrData());
+    Assert.assertEquals("1234", seldonMessage.getMeta().getPuid());
+  }
+
+  @Test
+  public void testPredict_multiform_strData_as_text() throws Exception {
+    final String metaJson = "{\"puid\":\"1234\"}";
+    final MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
+    paramMap.put("meta", Arrays.asList(metaJson));
+    String strdata = "test data";
+    paramMap.put("strData", Arrays.asList(strdata));
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .params(paramMap)
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, response);
+    SeldonMessage seldonMessage = builder.build();
+    Assert.assertEquals(3, seldonMessage.getMeta().getMetricsCount());
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(strdata, seldonMessage.getStrData());
+    Assert.assertEquals("1234", seldonMessage.getMeta().getPuid());
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientControllerExternalGraphs.java
+++ b/engine/src/test/java/io/seldon/engine/api/rest/TestRestClientControllerExternalGraphs.java
@@ -1,8 +1,15 @@
 package io.seldon.engine.api.rest;
 
+import static io.seldon.engine.util.TestUtils.readFile;
+
+import io.seldon.engine.filters.XSSFilter;
+import io.seldon.engine.pb.JsonFormat;
+import io.seldon.engine.predictors.EnginePredictor;
+import io.seldon.engine.service.InternalPredictionService;
+import io.seldon.protos.DeploymentProtos.PredictorSpec;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,11 +19,11 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -32,600 +39,721 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 
-import io.seldon.engine.filters.XSSFilter;
-import io.seldon.engine.pb.JsonFormat;
-import io.seldon.engine.predictors.EnginePredictor;
-import io.seldon.engine.service.InternalPredictionService;
-import io.seldon.protos.DeploymentProtos.PredictorSpec;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-
-import static io.seldon.engine.util.TestUtils.readFile;
-
 @RunWith(SpringRunner.class)
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@TestPropertySource(properties = {
-	    "management.security.enabled=false",
-	})
+@TestPropertySource(
+    properties = {
+      "management.security.enabled=false",
+    })
 public class TestRestClientControllerExternalGraphs {
 
-	@Autowired
-	private WebApplicationContext context;
-
-	@Autowired
-	private EnginePredictor enginePredictor;
-
-
-    //@Autowired
-    private MockMvc mvc;
-
-    @Autowired
-    private RestClientController restController;
-
-    @Before
-	public void setup() throws Exception {
-
-    	mvc = MockMvcBuilders
-				.webAppContextSetup(context)
-        .addFilters(new XSSFilter())
-				.build();
-	}
-
-    @LocalServerPort
-    private int port;
-
-    @Autowired
-    private TestRestTemplate testRestTemplate;
-
-    @Autowired
-    private InternalPredictionService internalPredictionService;
-
-
-
-
-    @Test
-    public void testModelMetrics() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/model_simple.json",StandardCharsets.UTF_8);
-    	String responseStr = readFile("src/test/resources/response_with_metrics.json",StandardCharsets.UTF_8);
-    	String responseStr2 = readFile("src/test/resources/response_with_metrics2.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"data\": {" +
-         	    "\"ndarray\": [[1.0]]}" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
-
-
-    	ResponseEntity<String> httpResponse1 = new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
-    	ResponseEntity<String> httpResponse2 = new ResponseEntity<String>(responseStr2, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-    		.thenAnswer(new Answer<ResponseEntity<String>>() {
-    		    private int count = 0;
-
-    		    public ResponseEntity<String> answer(InvocationOnMock invocation) {
-    		    	count++;
-    		        if (count == 1)
-    		            return httpResponse1;
-
-    		        return httpResponse2;
-    		    }});
-
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    SeldonMessage seldonMessage = builder.build();
-
-	    // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	    // Check prometheus endpoint for metric
-	    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    System.out.println("response is ["+response+"]");
-	    Assert.assertTrue(response.indexOf("mycounter_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mygauge{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 22.0")>-1);
-    	System.out.println(response);
-
-    	res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    seldonMessage = builder.build();
-
-    	 // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(100.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	 // Check prometheus endpoint for metric
-	    res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    Assert.assertTrue(response.indexOf("mycounter_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")>-1);
-	    Assert.assertTrue(response.indexOf("mygauge{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 100.0")>-1);
-    	System.out.println(response);
-    }
-
-
-    @Test
-    public void testInputTransformInputMetrics() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/transformer_simple.json",StandardCharsets.UTF_8);
-    	String responseStr = readFile("src/test/resources/response_with_metrics.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"data\": {" +
-         	    "\"ndarray\": [[1.0]]}" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
-
-
-    	ResponseEntity<String> httpResponse = new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-    		.thenReturn(httpResponse);
-
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    SeldonMessage seldonMessage = builder.build();
-
-	    // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	    // Check prometheus endpoint for metric
-	    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    Assert.assertTrue(response.indexOf("mycounter_total{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transformer\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transformer\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-    	System.out.println(response);
-    }
-
-
-    @Test
-    public void testTransformOutputMetrics() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/transform_output_simple.json",StandardCharsets.UTF_8);
-    	String responseStr = readFile("src/test/resources/response_with_metrics.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"data\": {" +
-         	    "\"ndarray\": [[1.0]]}" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
-
-
-    	ResponseEntity<String> httpResponse = new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-    		.thenReturn(httpResponse);
-
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    SeldonMessage seldonMessage = builder.build();
-
-	    // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	    // Check prometheus endpoint for metric
-	    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-    	System.out.println(response);
-	    Assert.assertTrue(response.indexOf("mycounter_total{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transform_output\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transform_output\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-
-    }
-
-
-    @Test
-    public void testRouterMetrics() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/router_simple.json",StandardCharsets.UTF_8);
-    	String responseStrRouter = readFile("src/test/resources/router_response.json",StandardCharsets.UTF_8);
-    	String responseStrModel = readFile("src/test/resources/router_model_response.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"data\": {" +
-         	    "\"ndarray\": [[1.0]]}" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
-
-
-    	ResponseEntity<String> httpResponse1 = new ResponseEntity<String>(responseStrRouter, null, HttpStatus.OK);
-    	ResponseEntity<String> httpResponse2 = new ResponseEntity<String>(responseStrModel, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-		.thenAnswer(new Answer<ResponseEntity<String>>() {
-		    private int count = 0;
-
-		    public ResponseEntity<String> answer(InvocationOnMock invocation) {
-		    	count++;
-		        if (count == 1)
-		            return httpResponse1;
-
-		        return httpResponse2;
-		    }});
-
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    SeldonMessage seldonMessage = builder.build();
-
-	    // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("myroutercounter",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("myroutergauge",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("myroutertimer",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(3).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(3).getValue(),0.0);
-	    Assert.assertEquals("myroutermodelcounter",seldonMessage.getMeta().getMetrics(3).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(4).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(4).getValue(),0.0);
-	    Assert.assertEquals("myroutermodelgauge",seldonMessage.getMeta().getMetrics(4).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(5).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(5).getValue(),0.0);
-	    Assert.assertEquals("myroutermodeltimer",seldonMessage.getMeta().getMetrics(5).getKey());
-
-	    // Check prometheus endpoint for metric
-	    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-    	System.out.println(response);
-	    Assert.assertTrue(response.indexOf("myroutercounter_total{deployment_name=\"None\",model_image=\"seldonio/router\",model_name=\"router\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("myroutertimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/router\",model_name=\"router\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("myroutermodelcounter_total{deployment_name=\"None\",model_image=\"seldonio/model\",model_name=\"model\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("myroutermodeltimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/model\",model_name=\"model\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-
-    }
-
-
-    @Test
-    public void testCombinerMetrics() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/combiner_simple.json",StandardCharsets.UTF_8);
-    	String responseStr = readFile("src/test/resources/response_with_metrics.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"data\": {" +
-         	    "\"ndarray\": [[1.0]]}" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
-
-
-    	ResponseEntity<String> httpResponse = new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-    		.thenReturn(httpResponse);
-
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    SeldonMessage seldonMessage = builder.build();
-
-	    // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	    // Check prometheus endpoint for metric
-	    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    System.out.println("----------------------------------------");
-	    System.out.println("----------------------------------------");
-	    System.out.println(response);
-	    Assert.assertTrue(response.indexOf("mycounter_total{deployment_name=\"None\",model_image=\"seldonio/combiner\",model_name=\"combiner\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/combiner\",model_name=\"combiner\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-
-    }
-
-
-    @Test
-    public void testModelStrData() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/model_simple.json",StandardCharsets.UTF_8);
-    	String responseStr = readFile("src/test/resources/response_strdata.json",StandardCharsets.UTF_8);
-    	String responseStr2 = readFile("src/test/resources/response_strdata2.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"strData\": \"my string data\"" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
-
-    	ResponseEntity<String> httpResponse1 = new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
-    	ResponseEntity<String> httpResponse2 = new ResponseEntity<String>(responseStr2, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-    		.thenAnswer(new Answer<ResponseEntity<String>>() {
-    		    private int count = 0;
-
-    		    public ResponseEntity<String> answer(InvocationOnMock invocation) {
-    		    	count++;
-    		        if (count == 1)
-    		            return httpResponse1;
-
-    		        return httpResponse2;
-    		    }});
-
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    SeldonMessage seldonMessage = builder.build();
-
-	    // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter1",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge1",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer1",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	    // Check prometheus endpoint for metric
-	    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    System.out.println("response is ["+response+"]");
-	    Assert.assertTrue(response.indexOf("mycounter1_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer1_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mygauge1{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 22.0")>-1);
-    	System.out.println(response);
-
-    	res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    seldonMessage = builder.build();
-
-    	 // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter1",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(100.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge1",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer1",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	 // Check prometheus endpoint for metric
-	    res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    Assert.assertTrue(response.indexOf("mycounter1_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer1_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")>-1);
-	    Assert.assertTrue(response.indexOf("mygauge1{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 100.0")>-1);
-    	System.out.println(response);
-    }
-
-
-    @Test
-    public void testModelBinData() throws Exception
-    {
-    	String jsonStr = readFile("src/test/resources/model_simple.json",StandardCharsets.UTF_8);
-    	String responseStr = readFile("src/test/resources/response_bindata.json",StandardCharsets.UTF_8);
-    	String responseStr2 = readFile("src/test/resources/response_bindata2.json",StandardCharsets.UTF_8);
-    	PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-    	EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
-    	PredictorSpec predictorSpec = PredictorSpecBuilder.build();
-    	final String predictJson = "{" +
-         	    "\"binData\": \"MTIz\"" +
-         		"}";
-    	ReflectionTestUtils.setField(enginePredictor,"predictorSpec",predictorSpec);
-
-    	ResponseEntity<String> httpResponse1 = new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
-    	ResponseEntity<String> httpResponse2 = new ResponseEntity<String>(responseStr2, null, HttpStatus.OK);
-    	Mockito.when(testRestTemplate.getRestTemplate().postForEntity(Matchers.<URI>any(), Matchers.<HttpEntity<MultiValueMap<String, String>>>any(), Matchers.<Class<String>>any()))
-    		.thenAnswer(new Answer<ResponseEntity<String>>() {
-    		    private int count = 0;
-
-    		    public ResponseEntity<String> answer(InvocationOnMock invocation) {
-    		    	count++;
-    		        if (count == 1)
-    		            return httpResponse1;
-
-    		        return httpResponse2;
-    		    }});
-
-    	MvcResult res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	String response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    SeldonMessage seldonMessage = builder.build();
-
-	    // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter2",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(22.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge2",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer2",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	    // Check prometheus endpoint for metric
-	    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    System.out.println("response is ["+response+"]");
-	    Assert.assertTrue(response.indexOf("mycounter2_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer2_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")>-1);
-	    Assert.assertTrue(response.indexOf("mygauge2{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 22.0")>-1);
-    	System.out.println(response);
-
-    	res = mvc.perform(MockMvcRequestBuilders.post("/api/v0.1/predictions")
-    			.accept(MediaType.APPLICATION_JSON_UTF8)
-    			.content(predictJson)
-    			.contentType(MediaType.APPLICATION_JSON_UTF8)).andReturn();
-    	response = res.getResponse().getContentAsString();
-    	System.out.println(response);
-    	Assert.assertEquals(200, res.getResponse().getStatus());
-
-    	builder = SeldonMessage.newBuilder();
-	    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
-	    seldonMessage = builder.build();
-
-    	 // Check for returned metrics
-	    Assert.assertEquals("COUNTER",seldonMessage.getMeta().getMetrics(0).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(0).getValue(),0.0);
-	    Assert.assertEquals("mycounter2",seldonMessage.getMeta().getMetrics(0).getKey());
-
-	    Assert.assertEquals("GAUGE",seldonMessage.getMeta().getMetrics(1).getType().toString());
-	    Assert.assertEquals(100.0F,seldonMessage.getMeta().getMetrics(1).getValue(),0.0);
-	    Assert.assertEquals("mygauge2",seldonMessage.getMeta().getMetrics(1).getKey());
-
-	    Assert.assertEquals("TIMER",seldonMessage.getMeta().getMetrics(2).getType().toString());
-	    Assert.assertEquals(1.0F,seldonMessage.getMeta().getMetrics(2).getValue(),0.0);
-	    Assert.assertEquals("mytimer2",seldonMessage.getMeta().getMetrics(2).getKey());
-
-	 // Check prometheus endpoint for metric
-	    res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
-	    Assert.assertEquals(200, res2.getResponse().getStatus());
-	    response = res2.getResponse().getContentAsString();
-	    Assert.assertTrue(response.indexOf("mycounter2_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")>-1);
-	    Assert.assertTrue(response.indexOf("mytimer2_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")>-1);
-	    Assert.assertTrue(response.indexOf("mygauge2{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 100.0")>-1);
-    	System.out.println(response);
-    }
-
+  @Autowired private WebApplicationContext context;
+
+  @Autowired private EnginePredictor enginePredictor;
+
+  // @Autowired
+  private MockMvc mvc;
+
+  @Autowired private RestClientController restController;
+
+  @Before
+  public void setup() throws Exception {
+
+    mvc = MockMvcBuilders.webAppContextSetup(context).addFilters(new XSSFilter()).build();
+  }
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate testRestTemplate;
+
+  @Autowired private InternalPredictionService internalPredictionService;
+
+  @Test
+  public void testModelMetrics() throws Exception {
+    String jsonStr = readFile("src/test/resources/model_simple.json", StandardCharsets.UTF_8);
+    String responseStr =
+        readFile("src/test/resources/response_with_metrics.json", StandardCharsets.UTF_8);
+    String responseStr2 =
+        readFile("src/test/resources/response_with_metrics2.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"data\": {" + "\"ndarray\": [[1.0]]}" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
+
+    ResponseEntity<String> httpResponse1 =
+        new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
+    ResponseEntity<String> httpResponse2 =
+        new ResponseEntity<String>(responseStr2, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenAnswer(
+            new Answer<ResponseEntity<String>>() {
+              private int count = 0;
+
+              public ResponseEntity<String> answer(InvocationOnMock invocation) {
+                count++;
+                if (count == 1) return httpResponse1;
+
+                return httpResponse2;
+              }
+            });
+
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    SeldonMessage seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    System.out.println("response is [" + response + "]");
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mygauge{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 22.0")
+            > -1);
+    System.out.println(response);
+
+    res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(100.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mygauge{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 100.0")
+            > -1);
+    System.out.println(response);
+  }
+
+  @Test
+  public void testInputTransformInputMetrics() throws Exception {
+    String jsonStr = readFile("src/test/resources/transformer_simple.json", StandardCharsets.UTF_8);
+    String responseStr =
+        readFile("src/test/resources/response_with_metrics.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"data\": {" + "\"ndarray\": [[1.0]]}" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
+
+    ResponseEntity<String> httpResponse =
+        new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenReturn(httpResponse);
+
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    SeldonMessage seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter_total{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transformer\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transformer\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    System.out.println(response);
+  }
+
+  @Test
+  public void testTransformOutputMetrics() throws Exception {
+    String jsonStr =
+        readFile("src/test/resources/transform_output_simple.json", StandardCharsets.UTF_8);
+    String responseStr =
+        readFile("src/test/resources/response_with_metrics.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"data\": {" + "\"ndarray\": [[1.0]]}" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
+
+    ResponseEntity<String> httpResponse =
+        new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenReturn(httpResponse);
+
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    SeldonMessage seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter_total{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transform_output\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/transformer\",model_name=\"transform_output\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+  }
+
+  @Test
+  public void testRouterMetrics() throws Exception {
+    String jsonStr = readFile("src/test/resources/router_simple.json", StandardCharsets.UTF_8);
+    String responseStrRouter =
+        readFile("src/test/resources/router_response.json", StandardCharsets.UTF_8);
+    String responseStrModel =
+        readFile("src/test/resources/router_model_response.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"data\": {" + "\"ndarray\": [[1.0]]}" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
+
+    ResponseEntity<String> httpResponse1 =
+        new ResponseEntity<String>(responseStrRouter, null, HttpStatus.OK);
+    ResponseEntity<String> httpResponse2 =
+        new ResponseEntity<String>(responseStrModel, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenAnswer(
+            new Answer<ResponseEntity<String>>() {
+              private int count = 0;
+
+              public ResponseEntity<String> answer(InvocationOnMock invocation) {
+                count++;
+                if (count == 1) return httpResponse1;
+
+                return httpResponse2;
+              }
+            });
+
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    SeldonMessage seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("myroutercounter", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("myroutergauge", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("myroutertimer", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(3).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(3).getValue(), 0.0);
+    Assert.assertEquals("myroutermodelcounter", seldonMessage.getMeta().getMetrics(3).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(4).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(4).getValue(), 0.0);
+    Assert.assertEquals("myroutermodelgauge", seldonMessage.getMeta().getMetrics(4).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(5).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(5).getValue(), 0.0);
+    Assert.assertEquals("myroutermodeltimer", seldonMessage.getMeta().getMetrics(5).getKey());
+
+    // Check prometheus endpoint for metric
+    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertTrue(
+        response.indexOf(
+                "myroutercounter_total{deployment_name=\"None\",model_image=\"seldonio/router\",model_name=\"router\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "myroutertimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/router\",model_name=\"router\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "myroutermodelcounter_total{deployment_name=\"None\",model_image=\"seldonio/model\",model_name=\"model\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "myroutermodeltimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/model\",model_name=\"model\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+  }
+
+  @Test
+  public void testCombinerMetrics() throws Exception {
+    String jsonStr = readFile("src/test/resources/combiner_simple.json", StandardCharsets.UTF_8);
+    String responseStr =
+        readFile("src/test/resources/response_with_metrics.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"data\": {" + "\"ndarray\": [[1.0]]}" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
+
+    ResponseEntity<String> httpResponse =
+        new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenReturn(httpResponse);
+
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    SeldonMessage seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    System.out.println("----------------------------------------");
+    System.out.println("----------------------------------------");
+    System.out.println(response);
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter_total{deployment_name=\"None\",model_image=\"seldonio/combiner\",model_name=\"combiner\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer_seconds_count{deployment_name=\"None\",model_image=\"seldonio/combiner\",model_name=\"combiner\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+  }
+
+  @Test
+  public void testModelStrData() throws Exception {
+    String jsonStr = readFile("src/test/resources/model_simple.json", StandardCharsets.UTF_8);
+    String responseStr =
+        readFile("src/test/resources/response_strdata.json", StandardCharsets.UTF_8);
+    String responseStr2 =
+        readFile("src/test/resources/response_strdata2.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"strData\": \"my string data\"" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
+
+    ResponseEntity<String> httpResponse1 =
+        new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
+    ResponseEntity<String> httpResponse2 =
+        new ResponseEntity<String>(responseStr2, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenAnswer(
+            new Answer<ResponseEntity<String>>() {
+              private int count = 0;
+
+              public ResponseEntity<String> answer(InvocationOnMock invocation) {
+                count++;
+                if (count == 1) return httpResponse1;
+
+                return httpResponse2;
+              }
+            });
+
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    SeldonMessage seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter1", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge1", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer1", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    System.out.println("response is [" + response + "]");
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter1_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer1_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mygauge1{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 22.0")
+            > -1);
+    System.out.println(response);
+
+    res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter1", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(100.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge1", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer1", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter1_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer1_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mygauge1{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 100.0")
+            > -1);
+    System.out.println(response);
+  }
+
+  @Test
+  public void testModelBinData() throws Exception {
+    String jsonStr = readFile("src/test/resources/model_simple.json", StandardCharsets.UTF_8);
+    String responseStr =
+        readFile("src/test/resources/response_bindata.json", StandardCharsets.UTF_8);
+    String responseStr2 =
+        readFile("src/test/resources/response_bindata2.json", StandardCharsets.UTF_8);
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    EnginePredictor.updateMessageBuilderFromJson(PredictorSpecBuilder, jsonStr);
+    PredictorSpec predictorSpec = PredictorSpecBuilder.build();
+    final String predictJson = "{" + "\"binData\": \"MTIz\"" + "}";
+    ReflectionTestUtils.setField(enginePredictor, "predictorSpec", predictorSpec);
+
+    ResponseEntity<String> httpResponse1 =
+        new ResponseEntity<String>(responseStr, null, HttpStatus.OK);
+    ResponseEntity<String> httpResponse2 =
+        new ResponseEntity<String>(responseStr2, null, HttpStatus.OK);
+    Mockito.when(
+            testRestTemplate
+                .getRestTemplate()
+                .postForEntity(
+                    Matchers.<URI>any(),
+                    Matchers.<HttpEntity<MultiValueMap<String, String>>>any(),
+                    Matchers.<Class<String>>any()))
+        .thenAnswer(
+            new Answer<ResponseEntity<String>>() {
+              private int count = 0;
+
+              public ResponseEntity<String> answer(InvocationOnMock invocation) {
+                count++;
+                if (count == 1) return httpResponse1;
+
+                return httpResponse2;
+              }
+            });
+
+    MvcResult res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    String response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    SeldonMessage seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter2", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(22.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge2", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer2", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    MvcResult res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    System.out.println("response is [" + response + "]");
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter2_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer2_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 1.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mygauge2{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 22.0")
+            > -1);
+    System.out.println(response);
+
+    res =
+        mvc.perform(
+                MockMvcRequestBuilders.post("/api/v0.1/predictions")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .content(predictJson)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8))
+            .andReturn();
+    response = res.getResponse().getContentAsString();
+    System.out.println(response);
+    Assert.assertEquals(200, res.getResponse().getStatus());
+
+    builder = SeldonMessage.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(response, builder);
+    seldonMessage = builder.build();
+
+    // Check for returned metrics
+    Assert.assertEquals("COUNTER", seldonMessage.getMeta().getMetrics(0).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(0).getValue(), 0.0);
+    Assert.assertEquals("mycounter2", seldonMessage.getMeta().getMetrics(0).getKey());
+
+    Assert.assertEquals("GAUGE", seldonMessage.getMeta().getMetrics(1).getType().toString());
+    Assert.assertEquals(100.0F, seldonMessage.getMeta().getMetrics(1).getValue(), 0.0);
+    Assert.assertEquals("mygauge2", seldonMessage.getMeta().getMetrics(1).getKey());
+
+    Assert.assertEquals("TIMER", seldonMessage.getMeta().getMetrics(2).getType().toString());
+    Assert.assertEquals(1.0F, seldonMessage.getMeta().getMetrics(2).getValue(), 0.0);
+    Assert.assertEquals("mytimer2", seldonMessage.getMeta().getMetrics(2).getKey());
+
+    // Check prometheus endpoint for metric
+    res2 = mvc.perform(MockMvcRequestBuilders.get("/prometheus")).andReturn();
+    Assert.assertEquals(200, res2.getResponse().getStatus());
+    response = res2.getResponse().getContentAsString();
+    Assert.assertTrue(
+        response.indexOf(
+                "mycounter2_total{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",mytag1=\"mytagval1\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mytimer2_seconds_count{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 2.0")
+            > -1);
+    Assert.assertTrue(
+        response.indexOf(
+                "mygauge2{deployment_name=\"None\",model_image=\"seldonio/mock_classifier\",model_name=\"mean-classifier\",model_version=\"0.6\",predictor_name=\"fx-market-predictor\",predictor_version=\"unknown\",} 100.0")
+            > -1);
+    System.out.println(response);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/config/TestConfig.java
+++ b/engine/src/test/java/io/seldon/engine/config/TestConfig.java
@@ -1,56 +1,51 @@
 package io.seldon.engine.config;
 
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import io.seldon.engine.grpc.GrpcChannelHandler;
 import io.seldon.engine.service.InternalPredictionService;
 import io.seldon.engine.tracing.TracingProvider;
+import java.io.IOException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.http.client.ClientHttpRequestFactory;
-
-import java.io.IOException;
-
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @Profile("test")
 public class TestConfig {
-    @Autowired
-    private AnnotationsConfig annotationsConfig;
+  @Autowired private AnnotationsConfig annotationsConfig;
 
-    @Autowired
-    private TracingProvider tracingProvider;
+  @Autowired private TracingProvider tracingProvider;
 
-    @Autowired
-    private GrpcChannelHandler grpcChannelHandler;
+  @Autowired private GrpcChannelHandler grpcChannelHandler;
 
-    @Bean
-    @Primary
-    public RestTemplateBuilder restTemplateBuilder() {
+  @Bean
+  @Primary
+  public RestTemplateBuilder restTemplateBuilder() {
 
-        RestTemplateBuilder rtb = mock(RestTemplateBuilder.class);
-        RestTemplate restTemplate = mock(RestTemplate.class);
-        ClientHttpRequestFactory requestFactory = mock(ClientHttpRequestFactory.class);
-        when(rtb.setConnectTimeout(anyInt())).thenReturn(rtb);
-        when(rtb.setReadTimeout(anyInt())).thenReturn(rtb);
-        when(rtb.build()).thenReturn(restTemplate);
-        when(restTemplate.getRequestFactory()).thenReturn(requestFactory);
+    RestTemplateBuilder rtb = mock(RestTemplateBuilder.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ClientHttpRequestFactory requestFactory = mock(ClientHttpRequestFactory.class);
+    when(rtb.setConnectTimeout(anyInt())).thenReturn(rtb);
+    when(rtb.setReadTimeout(anyInt())).thenReturn(rtb);
+    when(rtb.build()).thenReturn(restTemplate);
+    when(restTemplate.getRequestFactory()).thenReturn(requestFactory);
 
-        return rtb;
-    }
+    return rtb;
+  }
 
-    @Bean
-    @Primary
-    public InternalPredictionService service() throws IOException {
+  @Bean
+  @Primary
+  public InternalPredictionService service() throws IOException {
 
-        return new InternalPredictionService(restTemplateBuilder(), annotationsConfig, grpcChannelHandler, tracingProvider);
-
-    }
-
+    return new InternalPredictionService(
+        restTemplateBuilder(), annotationsConfig, grpcChannelHandler, tracingProvider);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/filters/TestXSSFilter.java
+++ b/engine/src/test/java/io/seldon/engine/filters/TestXSSFilter.java
@@ -1,17 +1,14 @@
 package io.seldon.engine.filters;
 
-import java.io.IOException;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
+import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.FilterChain;
+import org.junit.Test;
 
 public class TestXSSFilter {
   @Test

--- a/engine/src/test/java/io/seldon/engine/grpc/GrpcChannelHandlerTest.java
+++ b/engine/src/test/java/io/seldon/engine/grpc/GrpcChannelHandlerTest.java
@@ -1,60 +1,72 @@
 package io.seldon.engine.grpc;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import io.grpc.Channel;
 import io.seldon.protos.DeploymentProtos.Endpoint;
 import io.seldon.protos.DeploymentProtos.Endpoint.EndpointType;
-
-
-
+import org.junit.Assert;
+import org.junit.Test;
 
 public class GrpcChannelHandlerTest {
-	
-	@Test
-	public void testIdentity()
-	{
-		GrpcChannelHandler ch = new GrpcChannelHandler();
-		
-		Endpoint e1 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
-		Endpoint e2 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
-		
-		Channel mc1 = ch.get(e1);
-		Channel mc2 = ch.get(e2);
-		
-		Assert.assertEquals(mc1, mc2);
-		Assert.assertEquals(1, ch.size());
-	}
 
-	@Test
-	public void testDifferenceByType()
-	{
-		GrpcChannelHandler ch = new GrpcChannelHandler();
-		
-		Endpoint e1 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).setType(EndpointType.REST).build();
-		Endpoint e2 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).setType(EndpointType.GRPC).build();
-		
-		Channel mc1 = ch.get(e1);
-		Channel mc2 = ch.get(e2);
-		
-		Assert.assertNotEquals(mc1, mc2);
-		Assert.assertEquals(2, ch.size());
-	}
-	
-	@Test
-	public void testDifferenceByHost()
-	{
-		GrpcChannelHandler ch = new GrpcChannelHandler();
-		
-		Endpoint e1 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).setType(EndpointType.REST).build();
-		Endpoint e2 = Endpoint.newBuilder().setServiceHost("hostB").setServicePort(1000).setType(EndpointType.REST).build();
-		
-		Channel mc1 = ch.get(e1);
-		Channel mc2 = ch.get(e2);
-		
-		Assert.assertNotEquals(mc1, mc2);
-		Assert.assertEquals(2, ch.size());
-	}
+  @Test
+  public void testIdentity() {
+    GrpcChannelHandler ch = new GrpcChannelHandler();
 
+    Endpoint e1 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
+    Endpoint e2 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
+
+    Channel mc1 = ch.get(e1);
+    Channel mc2 = ch.get(e2);
+
+    Assert.assertEquals(mc1, mc2);
+    Assert.assertEquals(1, ch.size());
+  }
+
+  @Test
+  public void testDifferenceByType() {
+    GrpcChannelHandler ch = new GrpcChannelHandler();
+
+    Endpoint e1 =
+        Endpoint.newBuilder()
+            .setServiceHost("hostA")
+            .setServicePort(1000)
+            .setType(EndpointType.REST)
+            .build();
+    Endpoint e2 =
+        Endpoint.newBuilder()
+            .setServiceHost("hostA")
+            .setServicePort(1000)
+            .setType(EndpointType.GRPC)
+            .build();
+
+    Channel mc1 = ch.get(e1);
+    Channel mc2 = ch.get(e2);
+
+    Assert.assertNotEquals(mc1, mc2);
+    Assert.assertEquals(2, ch.size());
+  }
+
+  @Test
+  public void testDifferenceByHost() {
+    GrpcChannelHandler ch = new GrpcChannelHandler();
+
+    Endpoint e1 =
+        Endpoint.newBuilder()
+            .setServiceHost("hostA")
+            .setServicePort(1000)
+            .setType(EndpointType.REST)
+            .build();
+    Endpoint e2 =
+        Endpoint.newBuilder()
+            .setServiceHost("hostB")
+            .setServicePort(1000)
+            .setType(EndpointType.REST)
+            .build();
+
+    Channel mc1 = ch.get(e1);
+    Channel mc2 = ch.get(e2);
+
+    Assert.assertNotEquals(mc1, mc2);
+    Assert.assertEquals(2, ch.size());
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/grpc/SeldonClientExample.java
+++ b/engine/src/test/java/io/seldon/engine/grpc/SeldonClientExample.java
@@ -1,27 +1,21 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.grpc;
 
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.seldon.engine.pb.ProtoBufUtils;
@@ -29,52 +23,60 @@ import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Tensor;
 import io.seldon.protos.SeldonGrpc;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SeldonClientExample {
-	protected static Logger logger = LoggerFactory.getLogger(SeldonClientExample.class.getName());
-	
-	 private final ManagedChannel channel;
-	  private final SeldonGrpc.SeldonBlockingStub blockingStub;
-	  private final SeldonGrpc.SeldonStub asyncStub;
+  protected static Logger logger = LoggerFactory.getLogger(SeldonClientExample.class.getName());
 
-	  /** Construct client for accessing RouteGuide server at {@code host:port}. */
-	  public SeldonClientExample(String host, int port) {
-	    this(ManagedChannelBuilder.forAddress(host, port).usePlaintext(true));
-	  }
+  private final ManagedChannel channel;
+  private final SeldonGrpc.SeldonBlockingStub blockingStub;
+  private final SeldonGrpc.SeldonStub asyncStub;
 
-	  /** Construct client for accessing RouteGuide server using the existing channel. */
-	  public SeldonClientExample(ManagedChannelBuilder<?> channelBuilder) {
-	    channel = channelBuilder.build();
-	    blockingStub = SeldonGrpc.newBlockingStub(channel);
-	    asyncStub = SeldonGrpc.newStub(channel);
-	  }
+  /** Construct client for accessing RouteGuide server at {@code host:port}. */
+  public SeldonClientExample(String host, int port) {
+    this(ManagedChannelBuilder.forAddress(host, port).usePlaintext(true));
+  }
 
-	  public void shutdown() throws InterruptedException {
-		    channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
-		}
-	  
-	  public void predict() throws InvalidProtocolBufferException
-	  {
-		  SeldonMessage request = SeldonMessage.newBuilder().setData(DefaultData.newBuilder().setTensor(Tensor.newBuilder().addValues(1.0).addShape(1))).build();
-		  
-		  SeldonMessage response = blockingStub.predict(request);
-		  
-		  logger.info(ProtoBufUtils.toJson(response));
-	  }
-	  
-	  /** Issues several different requests and then exits. 
-	 * @throws InvalidProtocolBufferException */
-	  public static void main(String[] args) throws InterruptedException, InvalidProtocolBufferException {
+  /** Construct client for accessing RouteGuide server using the existing channel. */
+  public SeldonClientExample(ManagedChannelBuilder<?> channelBuilder) {
+    channel = channelBuilder.build();
+    blockingStub = SeldonGrpc.newBlockingStub(channel);
+    asyncStub = SeldonGrpc.newStub(channel);
+  }
 
-	    SeldonClientExample client = new SeldonClientExample("localhost", SeldonGrpcServer.SERVER_PORT);
-	    try {
-	    	
-	    	client.predict();
-	    
-	    } finally {
-	      client.shutdown();
-	    }
-	  }
-	  
-	
+  public void shutdown() throws InterruptedException {
+    channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+  }
+
+  public void predict() throws InvalidProtocolBufferException {
+    SeldonMessage request =
+        SeldonMessage.newBuilder()
+            .setData(
+                DefaultData.newBuilder().setTensor(Tensor.newBuilder().addValues(1.0).addShape(1)))
+            .build();
+
+    SeldonMessage response = blockingStub.predict(request);
+
+    logger.info(ProtoBufUtils.toJson(response));
+  }
+
+  /**
+   * Issues several different requests and then exits.
+   *
+   * @throws InvalidProtocolBufferException
+   */
+  public static void main(String[] args)
+      throws InterruptedException, InvalidProtocolBufferException {
+
+    SeldonClientExample client = new SeldonClientExample("localhost", SeldonGrpcServer.SERVER_PORT);
+    try {
+
+      client.predict();
+
+    } finally {
+      client.shutdown();
+    }
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/metrics/MetricsTest.java
+++ b/engine/src/test/java/io/seldon/engine/metrics/MetricsTest.java
@@ -1,16 +1,6 @@
 package io.seldon.engine.metrics;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import com.google.common.util.concurrent.AtomicDouble;
-
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -21,124 +11,123 @@ import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.seldon.protos.PredictionProtos.Metric;
 import io.seldon.protos.PredictionProtos.Metric.MetricType;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MetricsTest {
 
-	@Before
-	public void cleanMicrometer()
-	{
-		for(;;)
-		{
-			if (Metrics.globalRegistry.getRegistries().size() > 0)
-				Metrics.removeRegistry(Metrics.globalRegistry.getRegistries().iterator().next());
-			else
-				break;
-		}
-	}
-	
-	@After
-	public void cleanMicrometerAfter()
-	{
-		for(;;)
-		{
-			if (Metrics.globalRegistry.getRegistries().size() > 0)
-				Metrics.removeRegistry(Metrics.globalRegistry.getRegistries().iterator().next());
-			else
-				break;
-		}
-	}
-	
-	@Test
-	public synchronized void testGauge()
-	{
-		SimpleMeterRegistry reg = new SimpleMeterRegistry();
-		Metrics.addRegistry(reg);
-		CustomMetricsManager m = new CustomMetricsManager();
-		Iterable<Tag> tags = Arrays.asList(Tag.of("gtag1", "tag1value1"));
-		Metric metric1 = Metric.newBuilder().setKey("gkey1").setValue(1.0f).setType(MetricType.GAUGE).build();
-		AtomicDouble v1 = m.getGaugeValue(tags, metric1);
-		v1.set(metric1.getValue());
-		Metric metric2 = Metric.newBuilder().setKey("gkey1").setValue(2.0f).setType(MetricType.GAUGE).build();
-		AtomicDouble v2 = m.getGaugeValue(tags, metric2);
-		Assert.assertEquals(1.0D, v2.get(),0.01);
-		Assert.assertEquals(v1, v2);
-		Metric metric3 = Metric.newBuilder().setKey("gkey2").setValue(2.0f).setType(MetricType.GAUGE).build();
-		AtomicDouble v3 = m.getGaugeValue(tags, metric3);
-		Assert.assertNotEquals(v1, v3);
-		v2.set(metric2.getValue());
-		AtomicDouble v4 = m.getGaugeValue(tags, metric1);
-		Assert.assertEquals(2.0D, v4.get(),0.01);
-		Metrics.removeRegistry(reg);	
-	}
-	
-	@Test
-	public void testCounter()
-	{
-		SimpleMeterRegistry reg = new SimpleMeterRegistry();
-		Metrics.addRegistry(reg);
-		CustomMetricsManager m = new CustomMetricsManager();
-		Iterable<Tag> tags = Arrays.asList(Tag.of("tag1", "tag1value1"));
-		Metric metric1 = Metric.newBuilder().setKey("ckey3").setValue(1.0f).setType(MetricType.COUNTER).build();
-		Counter c1 = m.getCounter(tags, metric1);
-		c1.increment(1);
-		Metric metric2 = Metric.newBuilder().setKey("ckey3").setValue(2.0f).setType(MetricType.COUNTER).build();
-		Counter c2 = m.getCounter(tags, metric1);
-		Assert.assertEquals(c1, c2);
-		double d1 = c2.count();
-		Assert.assertEquals(1.0D, c2.count(),0.01);
-		Metric metric3 = Metric.newBuilder().setKey("ckey4").setValue(2.0f).setType(MetricType.COUNTER).build();
-		Counter c3 = m.getCounter(tags, metric3);
-		Assert.assertNotEquals(c1, c3);
-		c2.increment();
-		Counter c4 = m.getCounter(tags, metric1);
-		Assert.assertEquals(2.0D, c4.count(),0.01);
-		Metrics.removeRegistry(reg);
-	}
-	
-	@Test(expected = IllegalArgumentException.class)
-	public synchronized void testLabelsExceptionLowLevel()
-	{
-		PrometheusMeterRegistry reg = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-		Metrics.addRegistry(reg);
-		Iterable<Tag> tags1 = Arrays.asList(Tag.of("tag1", "tag1value1"));
-		Iterable<Tag> tags2 = Arrays.asList(Tag.of("tag2", "tag2value1"));
-		Metric metric1 = Metric.newBuilder().setKey("ckey1").setValue(1.0f).setType(MetricType.COUNTER).build();
-		Counter counter1 = Metrics.counter(metric1.getKey(), tags1);
-		try
-		{
-			//Exception throw here as Prometheus registry can't have same id with different length tags
-			Counter counter2 = Metrics.counter(metric1.getKey(), new ArrayList<>());
-		}
-		finally {
-			Metrics.removeRegistry(reg);
-			Meter m = Metrics.globalRegistry.remove(counter1); 
-		}
-	}
-	
-	@Test(expected = IllegalArgumentException.class)
-	public void testLabelsException()
-	{
-		for(MeterRegistry r : Metrics.globalRegistry.getRegistries())
-		{
-			Metrics.removeRegistry(r);
-		}
-		PrometheusMeterRegistry reg = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-		Metrics.addRegistry(reg);
-		
-		CustomMetricsManager m = new CustomMetricsManager();
-		
-		Iterable<Tag> tags1 = Arrays.asList(Tag.of("tag1", "tag1value1"));
-		Iterable<Tag> tags2 = Arrays.asList(Tag.of("tag2", "tag2value1"));
-		Metric metric1 = Metric.newBuilder().setKey("ckey2").setValue(1.0f).setType(MetricType.COUNTER).build();
-	
-		Counter counter1 = m.getCounter(tags1, metric1);
-		try
-		{
-			//Exception throw here as Prometheus registry can't have same id with different length tags
-			Counter counter2 = m.getCounter(new ArrayList<>(), metric1);
-		}finally {
-			Meter met = Metrics.globalRegistry.remove(counter1);
-		}
-	}
+  @Before
+  public void cleanMicrometer() {
+    for (; ; ) {
+      if (Metrics.globalRegistry.getRegistries().size() > 0)
+        Metrics.removeRegistry(Metrics.globalRegistry.getRegistries().iterator().next());
+      else break;
+    }
+  }
+
+  @After
+  public void cleanMicrometerAfter() {
+    for (; ; ) {
+      if (Metrics.globalRegistry.getRegistries().size() > 0)
+        Metrics.removeRegistry(Metrics.globalRegistry.getRegistries().iterator().next());
+      else break;
+    }
+  }
+
+  @Test
+  public synchronized void testGauge() {
+    SimpleMeterRegistry reg = new SimpleMeterRegistry();
+    Metrics.addRegistry(reg);
+    CustomMetricsManager m = new CustomMetricsManager();
+    Iterable<Tag> tags = Arrays.asList(Tag.of("gtag1", "tag1value1"));
+    Metric metric1 =
+        Metric.newBuilder().setKey("gkey1").setValue(1.0f).setType(MetricType.GAUGE).build();
+    AtomicDouble v1 = m.getGaugeValue(tags, metric1);
+    v1.set(metric1.getValue());
+    Metric metric2 =
+        Metric.newBuilder().setKey("gkey1").setValue(2.0f).setType(MetricType.GAUGE).build();
+    AtomicDouble v2 = m.getGaugeValue(tags, metric2);
+    Assert.assertEquals(1.0D, v2.get(), 0.01);
+    Assert.assertEquals(v1, v2);
+    Metric metric3 =
+        Metric.newBuilder().setKey("gkey2").setValue(2.0f).setType(MetricType.GAUGE).build();
+    AtomicDouble v3 = m.getGaugeValue(tags, metric3);
+    Assert.assertNotEquals(v1, v3);
+    v2.set(metric2.getValue());
+    AtomicDouble v4 = m.getGaugeValue(tags, metric1);
+    Assert.assertEquals(2.0D, v4.get(), 0.01);
+    Metrics.removeRegistry(reg);
+  }
+
+  @Test
+  public void testCounter() {
+    SimpleMeterRegistry reg = new SimpleMeterRegistry();
+    Metrics.addRegistry(reg);
+    CustomMetricsManager m = new CustomMetricsManager();
+    Iterable<Tag> tags = Arrays.asList(Tag.of("tag1", "tag1value1"));
+    Metric metric1 =
+        Metric.newBuilder().setKey("ckey3").setValue(1.0f).setType(MetricType.COUNTER).build();
+    Counter c1 = m.getCounter(tags, metric1);
+    c1.increment(1);
+    Metric metric2 =
+        Metric.newBuilder().setKey("ckey3").setValue(2.0f).setType(MetricType.COUNTER).build();
+    Counter c2 = m.getCounter(tags, metric1);
+    Assert.assertEquals(c1, c2);
+    double d1 = c2.count();
+    Assert.assertEquals(1.0D, c2.count(), 0.01);
+    Metric metric3 =
+        Metric.newBuilder().setKey("ckey4").setValue(2.0f).setType(MetricType.COUNTER).build();
+    Counter c3 = m.getCounter(tags, metric3);
+    Assert.assertNotEquals(c1, c3);
+    c2.increment();
+    Counter c4 = m.getCounter(tags, metric1);
+    Assert.assertEquals(2.0D, c4.count(), 0.01);
+    Metrics.removeRegistry(reg);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public synchronized void testLabelsExceptionLowLevel() {
+    PrometheusMeterRegistry reg = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    Metrics.addRegistry(reg);
+    Iterable<Tag> tags1 = Arrays.asList(Tag.of("tag1", "tag1value1"));
+    Iterable<Tag> tags2 = Arrays.asList(Tag.of("tag2", "tag2value1"));
+    Metric metric1 =
+        Metric.newBuilder().setKey("ckey1").setValue(1.0f).setType(MetricType.COUNTER).build();
+    Counter counter1 = Metrics.counter(metric1.getKey(), tags1);
+    try {
+      // Exception throw here as Prometheus registry can't have same id with different length tags
+      Counter counter2 = Metrics.counter(metric1.getKey(), new ArrayList<>());
+    } finally {
+      Metrics.removeRegistry(reg);
+      Meter m = Metrics.globalRegistry.remove(counter1);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testLabelsException() {
+    for (MeterRegistry r : Metrics.globalRegistry.getRegistries()) {
+      Metrics.removeRegistry(r);
+    }
+    PrometheusMeterRegistry reg = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    Metrics.addRegistry(reg);
+
+    CustomMetricsManager m = new CustomMetricsManager();
+
+    Iterable<Tag> tags1 = Arrays.asList(Tag.of("tag1", "tag1value1"));
+    Iterable<Tag> tags2 = Arrays.asList(Tag.of("tag2", "tag2value1"));
+    Metric metric1 =
+        Metric.newBuilder().setKey("ckey2").setValue(1.0f).setType(MetricType.COUNTER).build();
+
+    Counter counter1 = m.getCounter(tags1, metric1);
+    try {
+      // Exception throw here as Prometheus registry can't have same id with different length tags
+      Counter counter2 = m.getCounter(new ArrayList<>(), metric1);
+    } finally {
+      Meter met = Metrics.globalRegistry.remove(counter1);
+    }
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/pb/TestJsonFormat.java
+++ b/engine/src/test/java/io/seldon/engine/pb/TestJsonFormat.java
@@ -1,81 +1,79 @@
-/*******************************************************************************
- * Copyright 2019 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2019
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import io.kubernetes.client.proto.IntStr.IntOrString;
-
+import io.seldon.engine.pb.JsonFormat.Printer;
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.seldon.engine.pb.JsonFormat.Printer;
-
 public class TestJsonFormat {
-	private final static Logger logger = LoggerFactory.getLogger(TestJsonFormat.class);
-
-	@Test
-	public void testStrValCustomFormat() throws InvalidProtocolBufferException
-	{
-		final String val = "String Value";
-		IntOrString is = IntOrString.newBuilder().setStrVal(val).build();
-		Printer jf = JsonFormat.printer().usingTypeConverter(is.getDescriptorForType().getFullName(), new IntOrStringUtils.IntOrStringConverter());
-		Assert.assertEquals("\""+val+"\"", jf.print(is));
-	}
+  private static final Logger logger = LoggerFactory.getLogger(TestJsonFormat.class);
 
   @Test
-  public void testEscapeHTML()  throws InvalidProtocolBufferException
-  {
+  public void testStrValCustomFormat() throws InvalidProtocolBufferException {
+    final String val = "String Value";
+    IntOrString is = IntOrString.newBuilder().setStrVal(val).build();
+    Printer jf =
+        JsonFormat.printer()
+            .usingTypeConverter(
+                is.getDescriptorForType().getFullName(),
+                new IntOrStringUtils.IntOrStringConverter());
+    Assert.assertEquals("\"" + val + "\"", jf.print(is));
+  }
+
+  @Test
+  public void testEscapeHTML() throws InvalidProtocolBufferException {
     final String val = "<div class=\"div-class\"></div>";
     final String escaped = "\\u003cdiv class\\u003d\\\"div-class\\\"\\u003e\\u003c/div\\u003e";
     final String expected = String.format("{\"strVal\":\"%s\"}", escaped);
-		IntOrString is = IntOrString.newBuilder().setStrVal(val).build();
+    IntOrString is = IntOrString.newBuilder().setStrVal(val).build();
     Printer jf = JsonFormat.printer().omittingInsignificantWhitespace();
     final String json = jf.print(is);
     Assert.assertEquals(expected, json);
   }
-	
-	@Test
-	public void testIntValCustomFormat() throws InvalidProtocolBufferException
-	{
-		final int val = 1;
-		IntOrString is = IntOrString.newBuilder().setIntVal(val).build();
-		Printer jf = JsonFormat.printer().usingTypeConverter(is.getDescriptorForType().getFullName(), new IntOrStringUtils.IntOrStringConverter());
-		Assert.assertEquals(""+val, jf.print(is));
-	}
-	
-	@Test
-	public void testIntValDefaultFormat() throws InvalidProtocolBufferException
-	{
-		final int val = 1;
-		IntOrString is = IntOrString.newBuilder().setIntVal(val).build();
-		Printer jf = JsonFormat.printer().omittingInsignificantWhitespace();
-		Assert.assertEquals("{\"intVal\":"+val+"}", jf.print(is));
-	}
-	
-	@Test
-	public void testStrValDefaultFormat() throws InvalidProtocolBufferException
-	{
-		final String val = "String Value";
-		IntOrString is = IntOrString.newBuilder().setStrVal(val).build();
-		Printer jf = JsonFormat.printer().omittingInsignificantWhitespace();
-		Assert.assertEquals("{\"strVal\":\""+val+"\"}", jf.print(is));
-	}
-}
 
+  @Test
+  public void testIntValCustomFormat() throws InvalidProtocolBufferException {
+    final int val = 1;
+    IntOrString is = IntOrString.newBuilder().setIntVal(val).build();
+    Printer jf =
+        JsonFormat.printer()
+            .usingTypeConverter(
+                is.getDescriptorForType().getFullName(),
+                new IntOrStringUtils.IntOrStringConverter());
+    Assert.assertEquals("" + val, jf.print(is));
+  }
+
+  @Test
+  public void testIntValDefaultFormat() throws InvalidProtocolBufferException {
+    final int val = 1;
+    IntOrString is = IntOrString.newBuilder().setIntVal(val).build();
+    Printer jf = JsonFormat.printer().omittingInsignificantWhitespace();
+    Assert.assertEquals("{\"intVal\":" + val + "}", jf.print(is));
+  }
+
+  @Test
+  public void testStrValDefaultFormat() throws InvalidProtocolBufferException {
+    final String val = "String Value";
+    IntOrString is = IntOrString.newBuilder().setStrVal(val).build();
+    Printer jf = JsonFormat.printer().omittingInsignificantWhitespace();
+    Assert.assertEquals("{\"strVal\":\"" + val + "\"}", jf.print(is));
+  }
+}

--- a/engine/src/test/java/io/seldon/engine/pb/TestJsonParse.java
+++ b/engine/src/test/java/io/seldon/engine/pb/TestJsonParse.java
@@ -1,27 +1,21 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
 
-import java.io.IOException;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import org.junit.Assert;
-import org.junit.Test;
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -30,60 +24,65 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.primitives.Doubles;
-
-import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TestJsonParse {
 
-	String rawRequest = "{  \"meta\": {    \"puid\": \"avodt6jrk9nbgomnco7nhrvpo0\",    \"tags\": {    },    \"routing\": {    },    \"requestPath\": {    },    \"metrics\": []  },  \"data\": {    \"names\": [\"f0\", \"f1\"],    \"ndarray\": [[0.15, 0.74]]  }}";
-	String rawResponse = "{  \"meta\": {    \"puid\": \"avodt6jrk9nbgomnco7nhrvpo0\",    \"tags\": {    },    \"routing\": {    },    \"requestPath\": {      \"classifier\": \"seldonio/mock_classifier:1.0\"    },    \"metrics\": []  },  \"data\": {    \"names\": [\"proba\"],    \"ndarray\": [[0.07786847593954888]]  }}";
-	
-	@Test
-	public void multiDimTest() throws JsonProcessingException, IOException
-	{
-		String json = "{\"request\":{\"values\":[[1.0]]}}";
+  String rawRequest =
+      "{  \"meta\": {    \"puid\": \"avodt6jrk9nbgomnco7nhrvpo0\",    \"tags\": {    },    \"routing\": {    },    \"requestPath\": {    },    \"metrics\": []  },  \"data\": {    \"names\": [\"f0\", \"f1\"],    \"ndarray\": [[0.15, 0.74]]  }}";
+  String rawResponse =
+      "{  \"meta\": {    \"puid\": \"avodt6jrk9nbgomnco7nhrvpo0\",    \"tags\": {    },    \"routing\": {    },    \"requestPath\": {      \"classifier\": \"seldonio/mock_classifier:1.0\"    },    \"metrics\": []  },  \"data\": {    \"names\": [\"proba\"],    \"ndarray\": [[0.07786847593954888]]  }}";
 
-		System.out.println(json);
-		ObjectMapper mapper = new ObjectMapper();
-		JsonFactory factory = mapper.getFactory();
-		JsonParser parser = factory.createParser(json);
-		JsonNode j = mapper.readTree(parser);
-		JsonNode values = j.get("request").get("values");
-		
-		double[][] v = mapper.readValue(values.toString(),double[][].class);
-		double[] vs = Doubles.concat(v);
-		int[] shape = {v.length,v[0].length };
-		((ObjectNode) j.get("request")).replace("values",mapper.valueToTree(vs));
-		((ObjectNode) j.get("request")).set("shape",mapper.valueToTree(shape));
-		System.out.println(j.toString());
-	}
+  @Test
+  public void multiDimTest() throws JsonProcessingException, IOException {
+    String json = "{\"request\":{\"values\":[[1.0]]}}";
 
+    System.out.println(json);
+    ObjectMapper mapper = new ObjectMapper();
+    JsonFactory factory = mapper.getFactory();
+    JsonParser parser = factory.createParser(json);
+    JsonNode j = mapper.readTree(parser);
+    JsonNode values = j.get("request").get("values");
 
-	private JsonNode combineRequestResponse(String request, String response, ZonedDateTime requestTime, ZonedDateTime responseTime) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		JsonNode requestNode = mapper.readTree(request);
-		JsonNode responseNode = mapper.readTree(response);
-		ObjectNode combined = mapper.createObjectNode();
-		combined.set("request",requestNode);
-		combined.set("response",responseNode);
-		((ObjectNode)combined.get("request")).set("date",mapper.readTree(mapper.writeValueAsString(requestTime.toString())));
-		((ObjectNode)combined.get("response")).set("date",mapper.readTree(mapper.writeValueAsString(responseTime.toString())));
-		String depName = System.getenv().get("DEPLOYMENT_NAME");
-		if(depName!=null){
-			combined.set("sdepName",mapper.readTree(depName));
-		}
+    double[][] v = mapper.readValue(values.toString(), double[][].class);
+    double[] vs = Doubles.concat(v);
+    int[] shape = {v.length, v[0].length};
+    ((ObjectNode) j.get("request")).replace("values", mapper.valueToTree(vs));
+    ((ObjectNode) j.get("request")).set("shape", mapper.valueToTree(shape));
+    System.out.println(j.toString());
+  }
 
-		return combined;
-	}
+  private JsonNode combineRequestResponse(
+      String request, String response, ZonedDateTime requestTime, ZonedDateTime responseTime)
+      throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode requestNode = mapper.readTree(request);
+    JsonNode responseNode = mapper.readTree(response);
+    ObjectNode combined = mapper.createObjectNode();
+    combined.set("request", requestNode);
+    combined.set("response", responseNode);
+    ((ObjectNode) combined.get("request"))
+        .set("date", mapper.readTree(mapper.writeValueAsString(requestTime.toString())));
+    ((ObjectNode) combined.get("response"))
+        .set("date", mapper.readTree(mapper.writeValueAsString(responseTime.toString())));
+    String depName = System.getenv().get("DEPLOYMENT_NAME");
+    if (depName != null) {
+      combined.set("sdepName", mapper.readTree(depName));
+    }
 
+    return combined;
+  }
 
-	@Test
-	public void combineRequestResponse() throws JsonProcessingException, IOException
-	{
+  @Test
+  public void combineRequestResponse() throws JsonProcessingException, IOException {
 
-		ZonedDateTime time = ZonedDateTime.parse("2018-04-26T14:48:09.769Z", ISO_ZONED_DATE_TIME);
-		JsonNode j = combineRequestResponse(rawRequest,rawResponse,time,time);
-		Assert.assertEquals(j.toString(),"{\"request\":{\"meta\":{\"puid\":\"avodt6jrk9nbgomnco7nhrvpo0\",\"tags\":{},\"routing\":{},\"requestPath\":{},\"metrics\":[]},\"data\":{\"names\":[\"f0\",\"f1\"],\"ndarray\":[[0.15,0.74]]},\"date\":\"2018-04-26T14:48:09.769Z\"},\"response\":{\"meta\":{\"puid\":\"avodt6jrk9nbgomnco7nhrvpo0\",\"tags\":{},\"routing\":{},\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.0\"},\"metrics\":[]},\"data\":{\"names\":[\"proba\"],\"ndarray\":[[0.07786847593954888]]},\"date\":\"2018-04-26T14:48:09.769Z\"}}");
-	}
-
+    ZonedDateTime time = ZonedDateTime.parse("2018-04-26T14:48:09.769Z", ISO_ZONED_DATE_TIME);
+    JsonNode j = combineRequestResponse(rawRequest, rawResponse, time, time);
+    Assert.assertEquals(
+        j.toString(),
+        "{\"request\":{\"meta\":{\"puid\":\"avodt6jrk9nbgomnco7nhrvpo0\",\"tags\":{},\"routing\":{},\"requestPath\":{},\"metrics\":[]},\"data\":{\"names\":[\"f0\",\"f1\"],\"ndarray\":[[0.15,0.74]]},\"date\":\"2018-04-26T14:48:09.769Z\"},\"response\":{\"meta\":{\"puid\":\"avodt6jrk9nbgomnco7nhrvpo0\",\"tags\":{},\"routing\":{},\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.0\"},\"metrics\":[]},\"data\":{\"names\":[\"proba\"],\"ndarray\":[[0.07786847593954888]]},\"date\":\"2018-04-26T14:48:09.769Z\"}}");
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/pb/TestMatrixOps.java
+++ b/engine/src/test/java/io/seldon/engine/pb/TestMatrixOps.java
@@ -1,41 +1,41 @@
 package io.seldon.engine.pb;
 
-import java.util.Arrays;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.ojalgo.matrix.PrimitiveMatrix;
-
 import io.seldon.engine.predictors.PredictorUtils;
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Status;
 import io.seldon.protos.PredictionProtos.Tensor;
-
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+import org.ojalgo.matrix.PrimitiveMatrix;
 
 public class TestMatrixOps {
 
-	
-	@Test
-	public void testOj()
-	{
-		String[] names = {"c","d"};
-		Double[] values1 = {1.0,2.0,3.0,4.0};
-		SeldonMessage m = SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-					.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-							.setTensor(Tensor.newBuilder().addShape(2).addShape(2)
-							.addAllValues(Arrays.asList(values1)).build())
-							.build()).build();
-		PrimitiveMatrix p = PredictorUtils.getOJMatrix(m.getData());
-		Assert.assertEquals(values1[0], p.get(0,0));
-		Assert.assertEquals(values1[1], p.get(0,1));		
-		Assert.assertEquals(values1[2], p.get(1,0));		
-		Assert.assertEquals(values1[3], p.get(1,1));		
-		
-		Assert.assertEquals(values1[0], p.get(0));		
+  @Test
+  public void testOj() {
+    String[] names = {"c", "d"};
+    Double[] values1 = {1.0, 2.0, 3.0, 4.0};
+    SeldonMessage m =
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(2)
+                            .addShape(2)
+                            .addAllValues(Arrays.asList(values1))
+                            .build())
+                    .build())
+            .build();
+    PrimitiveMatrix p = PredictorUtils.getOJMatrix(m.getData());
+    Assert.assertEquals(values1[0], p.get(0, 0));
+    Assert.assertEquals(values1[1], p.get(0, 1));
+    Assert.assertEquals(values1[2], p.get(1, 0));
+    Assert.assertEquals(values1[3], p.get(1, 1));
 
-	}
-	
+    Assert.assertEquals(values1[0], p.get(0));
+  }
 }
-
-

--- a/engine/src/test/java/io/seldon/engine/pb/TestPredictionProto.java
+++ b/engine/src/test/java/io/seldon/engine/pb/TestPredictionProto.java
@@ -1,177 +1,167 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.pb;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Value;
-
 import io.seldon.protos.PredictionProtos.DefaultData;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Meta;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Tensor;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TestPredictionProto {
 
-	@Test
-	public void parse_json_extra_fields() throws InvalidProtocolBufferException
-	{
-		String json = "{\"x\":1.0,\"request\":{\"values\":[[1.0],[2.0]]}}";
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
-		SeldonMessage request = builder.build();
-		
-		String json2 = ProtoBufUtils.toJson(request);
-		
-		System.out.println(json2);
-	}
-	
-	
-	@Test
-	public void parse_custom_json() throws InvalidProtocolBufferException
-	{
-		String json = "{\"data\":{\"ndarray\":[[1.0,2.0],[3.0,4.0]]}}";
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
-		SeldonMessage request = builder.build();
-		
-		Assert.assertEquals(2, request.getData().getNdarray().getValuesCount());
-		
-		String json2 = ProtoBufUtils.toJson(request);
-		
-		System.out.println(json2);
-	}
-	
-	@Test
-	public void parse_tags_array() throws InvalidProtocolBufferException
-	{
-		String json = "{\"meta\":{\"tags\":{\"user\":[\"a\",\"b\"],\"gender\":\"female\"}},\"data\":{\"ndarray\":[[1.0,2.0],[3.0,4.0]]}}";
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
-		SeldonMessage request = builder.build();
-		
-		Assert.assertEquals(2, request.getData().getNdarray().getValuesCount());
-		
-		String json2 = ProtoBufUtils.toJson(request);
-		
-		System.out.println(json2);
-	}
+  @Test
+  public void parse_json_extra_fields() throws InvalidProtocolBufferException {
+    String json = "{\"x\":1.0,\"request\":{\"values\":[[1.0],[2.0]]}}";
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
+    SeldonMessage request = builder.build();
 
-	
-	
-	@Test
-	public void parse_json() throws InvalidProtocolBufferException
-	{
-		String json = "{\"request\":{\"values\":[[1.0],[2.0]]}}";
-		SeldonMessage.Builder builder = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
-		SeldonMessage request = builder.build();
-		
-		String json2 = ProtoBufUtils.toJson(request);
-		
-		System.out.println(json2);
-	}
-	
-	
-	@Test
-	public void defaultRequest() throws InvalidProtocolBufferException
-	{
-		String[] features = {"a","b"};
-		Double[] values = {1.0,2.0,1.5,2.2};
-		DefaultData.Builder defB = DefaultData.newBuilder();
-		defB.addAllNames( Arrays.asList(features) );
-		defB.setTensor(Tensor.newBuilder().addShape(1).addShape(values.length).addAllValues(Arrays.asList(values)).build());
-		SeldonMessage.Builder b = SeldonMessage.newBuilder();
-		Value v;
-		Value v1 = Value.newBuilder().setNumberValue(1.0).build();
-		
-		b.setData(defB.build()).setMeta(Meta.newBuilder().putTags("key", v1).build());
-		SeldonMessage request = b.build();
-		
-		String json = ProtoBufUtils.toJson(request);
-		
-		System.out.println(json);
-		
-		SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(b2, json);
-		
-		SeldonMessage request2 = b2.build();
-		
-		String json2 = ProtoBufUtils.toJson(request2);
-		
-		System.out.println(json2);
-		
-		Assert.assertEquals(json, json2);
-		
-	}
-	
-	@Test
-	public void customBytesRequest() throws InvalidProtocolBufferException
-	{
-		String customData = "{\"c\":1.0}";
-		SeldonMessage.Builder b = SeldonMessage.newBuilder();
-		b.setBinData(ByteString.copyFrom(customData.getBytes()));
-		SeldonMessage request = b.build();
-		
-		String json = ProtoBufUtils.toJson(request);
-		
-		System.out.println(json);
-		
-		SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(b2, json);
-		
-		SeldonMessage request2 = b2.build();
-		String custom = request2.getBinData().toString(StandardCharsets.UTF_8);
-		System.out.println(custom);
-		
-		String json2 = ProtoBufUtils.toJson(request2);
-		
-		System.out.println(json2);
-		
-		Assert.assertEquals(json, json2);
-	}
-	
-	@Test 
-	public void customStringRequest() throws InvalidProtocolBufferException
-	{
-		String customData = "{\"c\":1.0}";
-		SeldonMessage.Builder b = SeldonMessage.newBuilder();
-		b.setStrData(customData);
-		SeldonMessage request = b.build();
-		
-		String json = ProtoBufUtils.toJson(request);
-		
-		System.out.println(json);
-		
-		SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
-		ProtoBufUtils.updateMessageBuilderFromJson(b2, json);
-		
-		SeldonMessage request2 = b2.build();
-		
-		String json2 = ProtoBufUtils.toJson(request2);
-		
-		System.out.println(json2);
-		
-		Assert.assertEquals(json, json2);
-	}
-	
+    String json2 = ProtoBufUtils.toJson(request);
+
+    System.out.println(json2);
+  }
+
+  @Test
+  public void parse_custom_json() throws InvalidProtocolBufferException {
+    String json = "{\"data\":{\"ndarray\":[[1.0,2.0],[3.0,4.0]]}}";
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
+    SeldonMessage request = builder.build();
+
+    Assert.assertEquals(2, request.getData().getNdarray().getValuesCount());
+
+    String json2 = ProtoBufUtils.toJson(request);
+
+    System.out.println(json2);
+  }
+
+  @Test
+  public void parse_tags_array() throws InvalidProtocolBufferException {
+    String json =
+        "{\"meta\":{\"tags\":{\"user\":[\"a\",\"b\"],\"gender\":\"female\"}},\"data\":{\"ndarray\":[[1.0,2.0],[3.0,4.0]]}}";
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
+    SeldonMessage request = builder.build();
+
+    Assert.assertEquals(2, request.getData().getNdarray().getValuesCount());
+
+    String json2 = ProtoBufUtils.toJson(request);
+
+    System.out.println(json2);
+  }
+
+  @Test
+  public void parse_json() throws InvalidProtocolBufferException {
+    String json = "{\"request\":{\"values\":[[1.0],[2.0]]}}";
+    SeldonMessage.Builder builder = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(builder, json);
+    SeldonMessage request = builder.build();
+
+    String json2 = ProtoBufUtils.toJson(request);
+
+    System.out.println(json2);
+  }
+
+  @Test
+  public void defaultRequest() throws InvalidProtocolBufferException {
+    String[] features = {"a", "b"};
+    Double[] values = {1.0, 2.0, 1.5, 2.2};
+    DefaultData.Builder defB = DefaultData.newBuilder();
+    defB.addAllNames(Arrays.asList(features));
+    defB.setTensor(
+        Tensor.newBuilder()
+            .addShape(1)
+            .addShape(values.length)
+            .addAllValues(Arrays.asList(values))
+            .build());
+    SeldonMessage.Builder b = SeldonMessage.newBuilder();
+    Value v;
+    Value v1 = Value.newBuilder().setNumberValue(1.0).build();
+
+    b.setData(defB.build()).setMeta(Meta.newBuilder().putTags("key", v1).build());
+    SeldonMessage request = b.build();
+
+    String json = ProtoBufUtils.toJson(request);
+
+    System.out.println(json);
+
+    SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(b2, json);
+
+    SeldonMessage request2 = b2.build();
+
+    String json2 = ProtoBufUtils.toJson(request2);
+
+    System.out.println(json2);
+
+    Assert.assertEquals(json, json2);
+  }
+
+  @Test
+  public void customBytesRequest() throws InvalidProtocolBufferException {
+    String customData = "{\"c\":1.0}";
+    SeldonMessage.Builder b = SeldonMessage.newBuilder();
+    b.setBinData(ByteString.copyFrom(customData.getBytes()));
+    SeldonMessage request = b.build();
+
+    String json = ProtoBufUtils.toJson(request);
+
+    System.out.println(json);
+
+    SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(b2, json);
+
+    SeldonMessage request2 = b2.build();
+    String custom = request2.getBinData().toString(StandardCharsets.UTF_8);
+    System.out.println(custom);
+
+    String json2 = ProtoBufUtils.toJson(request2);
+
+    System.out.println(json2);
+
+    Assert.assertEquals(json, json2);
+  }
+
+  @Test
+  public void customStringRequest() throws InvalidProtocolBufferException {
+    String customData = "{\"c\":1.0}";
+    SeldonMessage.Builder b = SeldonMessage.newBuilder();
+    b.setStrData(customData);
+    SeldonMessage request = b.build();
+
+    String json = ProtoBufUtils.toJson(request);
+
+    System.out.println(json);
+
+    SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
+    ProtoBufUtils.updateMessageBuilderFromJson(b2, json);
+
+    SeldonMessage request2 = b2.build();
+
+    String json2 = ProtoBufUtils.toJson(request2);
+
+    System.out.println(json2);
+
+    Assert.assertEquals(json, json2);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/predictors/AverageCombinerTest.java
+++ b/engine/src/test/java/io/seldon/engine/predictors/AverageCombinerTest.java
@@ -1,253 +1,402 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
 import static org.hamcrest.CoreMatchers.is;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Value;
-
 import io.seldon.engine.exception.APIException;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitImplementation;
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Status;
 import io.seldon.protos.PredictionProtos.Tensor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class AverageCombinerTest {
-	
-	@Test
-	public void testSimpleTensorCase() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException {
-		List<SeldonMessage> predictorReturns = new ArrayList<>();
-		String[] names = {"c","d"};
-		
-		Double[] values1 = {1.0,1.0};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(2)
-						.addAllValues(Arrays.asList(values1)).build())
-						.build()).build());
-		
-		Double[] values2 = {1.0,0.5};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(2)
-								.addAllValues(Arrays.asList(values2)).build())
-						.build()).build());
-		
-		Double[] values3 = {2.2,0.9};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(2)
-								.addAllValues(Arrays.asList(values3)).build())
-						.build()).build());
-		
-		AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
 
-		SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns,null);
-		
-		Assert.assertThat(average.getData().getNamesList().get(0),is(names[0]));
-		
-		Double[][] expected_values = {{(1.0+1.0+2.2)/3,(1.0+0.5+0.9)/3}};
-		Assert.assertEquals(expected_values[0][0],average.getData().getTensor().getValuesList().get(0),1e-7);
-	}
-	
-	@Test
-	public void testSimpleNDArrayCase() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException {
-		List<SeldonMessage> predictorReturns = new ArrayList<>();
-		String[] names = {"c","d"};
-		
-		Double[] values1 = {1.0,1.0};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setNdarray(ListValue.newBuilder().addValues(Value.newBuilder().setListValue(ListValue.newBuilder()
-								.addValues(Value.newBuilder().setNumberValue(values1[0]))
-								.addValues(Value.newBuilder().setNumberValue(values1[1])).build())).build()).build()).build());
-		
-		Double[] values2 = {1.0,0.5};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setNdarray(ListValue.newBuilder().addValues(Value.newBuilder().setListValue(ListValue.newBuilder()
-								.addValues(Value.newBuilder().setNumberValue(values2[0]))
-								.addValues(Value.newBuilder().setNumberValue(values2[1])).build())).build()).build()).build());
-		
-		Double[] values3 = {2.2,0.9};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setNdarray(ListValue.newBuilder().addValues(Value.newBuilder().setListValue(ListValue.newBuilder()
-								.addValues(Value.newBuilder().setNumberValue(values3[0]))
-								.addValues(Value.newBuilder().setNumberValue(values3[1])).build())).build()).build()).build());
-		
-		AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+  @Test
+  public void testSimpleTensorCase()
+      throws NoSuchMethodException, SecurityException, IllegalAccessException,
+          IllegalArgumentException {
+    List<SeldonMessage> predictorReturns = new ArrayList<>();
+    String[] names = {"c", "d"};
 
-		SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns, null);
-		
-		Assert.assertThat(average.getData().getNamesList().get(0),is(names[0]));
-		
-		Double[][] expected_values = {{(1.0+1.0+2.2)/3,(1.0+0.5+0.9)/3}};
-		Assert.assertEquals(expected_values[0][0],average.getData().getNdarray().getValues(0).getListValue().getValues(0).getNumberValue(),1e-7);
-	}
-	
-	@Test
-	public void testUniqueValue() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException {
+    Double[] values1 = {1.0, 1.0};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(2)
+                            .addAllValues(Arrays.asList(values1))
+                            .build())
+                    .build())
+            .build());
 
-		List<SeldonMessage> predictorReturns = new ArrayList<>();
-		String[] names = {"c"};
-		
-		Double[] values1 = {1.0};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(1)
-								.addAllValues(Arrays.asList(values1)).build())
-						.build()).build());
-		
-		Double[] values2 = {1.0};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(1)
-								.addAllValues(Arrays.asList(values2)).build())
-						.build()).build());
-		
-		AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+    Double[] values2 = {1.0, 0.5};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(2)
+                            .addAllValues(Arrays.asList(values2))
+                            .build())
+                    .build())
+            .build());
 
-		SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns,null);
-		
-		Assert.assertThat(average.getData().getNamesList().get(0),is(names[0]));
+    Double[] values3 = {2.2, 0.9};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(2)
+                            .addAllValues(Arrays.asList(values3))
+                            .build())
+                    .build())
+            .build());
 
-		Double[][] expected_values = {{2.0/2}};
-		Assert.assertThat(average.getData().getTensor().getValuesList().get(0),is(expected_values[0][0]));
-	}
-	
-	@Test
-	public void testUniqueInput() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException {
+    AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
 
-		List<SeldonMessage> predictorReturns = new ArrayList<>();
-		String[] names = {"c"};
-		
-		Double[] values1 = {1.0,5.0,0.3};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(3)
-								.addAllValues(Arrays.asList(values1)).build())
-						.build()).build());
-		
-		
-		AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+    SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns, null);
 
-		SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns,null);
-		
-		Assert.assertThat(average.getData().getNamesList().get(0),is(names[0]));
+    Assert.assertThat(average.getData().getNamesList().get(0), is(names[0]));
 
-		Double[][] expected_values = {{1.0,5.0,0.3}};
-		Assert.assertThat(average.getData().getTensor().getValuesList().get(0),is(expected_values[0][0]));
-	}
-	
-	@Test(expected = APIException.class)
-	public void testNoInput() throws Throwable, NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException {
+    Double[][] expected_values = {{(1.0 + 1.0 + 2.2) / 3, (1.0 + 0.5 + 0.9) / 3}};
+    Assert.assertEquals(
+        expected_values[0][0], average.getData().getTensor().getValuesList().get(0), 1e-7);
+  }
 
-		List<SeldonMessage> predictorReturns = new ArrayList<>();
-		
-		AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
-		
-		averageCombinerUnit.aggregate(predictorReturns,null);
-	}
-	
-	@Test(expected = APIException.class)
-	public void testNoValues() throws Throwable, NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException {
+  @Test
+  public void testSimpleNDArrayCase()
+      throws NoSuchMethodException, SecurityException, IllegalAccessException,
+          IllegalArgumentException {
+    List<SeldonMessage> predictorReturns = new ArrayList<>();
+    String[] names = {"c", "d"};
 
-		List<SeldonMessage> predictorReturns = new ArrayList<>();
-		String[] names = {};
-		
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.build()).build());
-		
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.build()).build());
-		AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
-		
-		averageCombinerUnit.aggregate(predictorReturns, null);
-	}
+    Double[] values1 = {1.0, 1.0};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setNdarray(
+                        ListValue.newBuilder()
+                            .addValues(
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(
+                                                Value.newBuilder().setNumberValue(values1[0]))
+                                            .addValues(
+                                                Value.newBuilder().setNumberValue(values1[1]))
+                                            .build()))
+                            .build())
+                    .build())
+            .build());
 
-    @Test(expected = APIException.class)
-	public void testIncompatibleSizes() throws Throwable{
-		List<SeldonMessage> predictorReturns = new ArrayList<>();
-		String[] names = {"c","d"};
-		
-		Double[] values1 = {1.0,1.0};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(2)
-								.addAllValues(Arrays.asList(values1)).build())
-						.build()).build());
-		
-		Double[] values2 = {1.0,0.5};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(2)
-								.addAllValues(Arrays.asList(values2)).build())
-						.build()).build());
-		
-		Double[] values3 = {2.2,0.9,4.5};
-		predictorReturns.add(SeldonMessage.newBuilder().setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
-				.setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names))
-						.setTensor(Tensor.newBuilder().addShape(1).addShape(3)
-								.addAllValues(Arrays.asList(values3)).build())
-						.build()).build());
-		
-		AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
-		
-		averageCombinerUnit.aggregate(predictorReturns, null);
-			
-	}
-	
-    @Test
-	public void testGetOutputNoChildren() throws InterruptedException, ExecutionException, InvalidProtocolBufferException{
-    	
-    	SeldonMessage p = SeldonMessage.newBuilder().build();
-    	
-    	PredictiveUnitState state = new PredictiveUnitState("Cool_name",null,new ArrayList<PredictiveUnitState>(),null,null,null,null,PredictiveUnitImplementation.AVERAGE_COMBINER);
-    	
-    	PredictiveUnitBean predictiveUnit = new PredictiveUnitBean();
-    	PredictiveUnitBeanProxy proxy = new PredictiveUnitBeanProxy(predictiveUnit);
-    	predictiveUnit.setProxy(proxy);
-    	SimpleModelUnit simpleModel = new SimpleModelUnit();
-    	SimpleRouterUnit simpleRouterUnit = new SimpleRouterUnit();
-    	AverageCombinerUnit averageCombiner = new AverageCombinerUnit();
-    	RandomABTestUnit randomABTest = new RandomABTestUnit();
-    	
-    	PredictorConfigBean predictorConfig = new PredictorConfigBean(
-    			simpleModel,
-    			simpleRouterUnit,
-    			averageCombiner,
-    			randomABTest);
-    	
-    	predictiveUnit.predictorConfig = predictorConfig;
+    Double[] values2 = {1.0, 0.5};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setNdarray(
+                        ListValue.newBuilder()
+                            .addValues(
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(
+                                                Value.newBuilder().setNumberValue(values2[0]))
+                                            .addValues(
+                                                Value.newBuilder().setNumberValue(values2[1]))
+                                            .build()))
+                            .build())
+                    .build())
+            .build());
 
-    	predictiveUnit.getOutput(p, state);
-	}
-    
+    Double[] values3 = {2.2, 0.9};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setNdarray(
+                        ListValue.newBuilder()
+                            .addValues(
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(
+                                                Value.newBuilder().setNumberValue(values3[0]))
+                                            .addValues(
+                                                Value.newBuilder().setNumberValue(values3[1]))
+                                            .build()))
+                            .build())
+                    .build())
+            .build());
+
+    AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+
+    SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns, null);
+
+    Assert.assertThat(average.getData().getNamesList().get(0), is(names[0]));
+
+    Double[][] expected_values = {{(1.0 + 1.0 + 2.2) / 3, (1.0 + 0.5 + 0.9) / 3}};
+    Assert.assertEquals(
+        expected_values[0][0],
+        average.getData().getNdarray().getValues(0).getListValue().getValues(0).getNumberValue(),
+        1e-7);
+  }
+
+  @Test
+  public void testUniqueValue()
+      throws NoSuchMethodException, SecurityException, IllegalAccessException,
+          IllegalArgumentException {
+
+    List<SeldonMessage> predictorReturns = new ArrayList<>();
+    String[] names = {"c"};
+
+    Double[] values1 = {1.0};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(1)
+                            .addAllValues(Arrays.asList(values1))
+                            .build())
+                    .build())
+            .build());
+
+    Double[] values2 = {1.0};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(1)
+                            .addAllValues(Arrays.asList(values2))
+                            .build())
+                    .build())
+            .build());
+
+    AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+
+    SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns, null);
+
+    Assert.assertThat(average.getData().getNamesList().get(0), is(names[0]));
+
+    Double[][] expected_values = {{2.0 / 2}};
+    Assert.assertThat(
+        average.getData().getTensor().getValuesList().get(0), is(expected_values[0][0]));
+  }
+
+  @Test
+  public void testUniqueInput()
+      throws NoSuchMethodException, SecurityException, IllegalAccessException,
+          IllegalArgumentException {
+
+    List<SeldonMessage> predictorReturns = new ArrayList<>();
+    String[] names = {"c"};
+
+    Double[] values1 = {1.0, 5.0, 0.3};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(3)
+                            .addAllValues(Arrays.asList(values1))
+                            .build())
+                    .build())
+            .build());
+
+    AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+
+    SeldonMessage average = averageCombinerUnit.aggregate(predictorReturns, null);
+
+    Assert.assertThat(average.getData().getNamesList().get(0), is(names[0]));
+
+    Double[][] expected_values = {{1.0, 5.0, 0.3}};
+    Assert.assertThat(
+        average.getData().getTensor().getValuesList().get(0), is(expected_values[0][0]));
+  }
+
+  @Test(expected = APIException.class)
+  public void testNoInput()
+      throws Throwable, NoSuchMethodException, SecurityException, IllegalAccessException,
+          IllegalArgumentException {
+
+    List<SeldonMessage> predictorReturns = new ArrayList<>();
+
+    AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+
+    averageCombinerUnit.aggregate(predictorReturns, null);
+  }
+
+  @Test(expected = APIException.class)
+  public void testNoValues()
+      throws Throwable, NoSuchMethodException, SecurityException, IllegalAccessException,
+          IllegalArgumentException {
+
+    List<SeldonMessage> predictorReturns = new ArrayList<>();
+    String[] names = {};
+
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names)).build())
+            .build());
+
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(DefaultData.newBuilder().addAllNames(Arrays.asList(names)).build())
+            .build());
+    AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+
+    averageCombinerUnit.aggregate(predictorReturns, null);
+  }
+
+  @Test(expected = APIException.class)
+  public void testIncompatibleSizes() throws Throwable {
+    List<SeldonMessage> predictorReturns = new ArrayList<>();
+    String[] names = {"c", "d"};
+
+    Double[] values1 = {1.0, 1.0};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(2)
+                            .addAllValues(Arrays.asList(values1))
+                            .build())
+                    .build())
+            .build());
+
+    Double[] values2 = {1.0, 0.5};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(2)
+                            .addAllValues(Arrays.asList(values2))
+                            .build())
+                    .build())
+            .build());
+
+    Double[] values3 = {2.2, 0.9, 4.5};
+    predictorReturns.add(
+        SeldonMessage.newBuilder()
+            .setStatus(Status.newBuilder().setStatus(Status.StatusFlag.SUCCESS).build())
+            .setData(
+                DefaultData.newBuilder()
+                    .addAllNames(Arrays.asList(names))
+                    .setTensor(
+                        Tensor.newBuilder()
+                            .addShape(1)
+                            .addShape(3)
+                            .addAllValues(Arrays.asList(values3))
+                            .build())
+                    .build())
+            .build());
+
+    AverageCombinerUnit averageCombinerUnit = new AverageCombinerUnit();
+
+    averageCombinerUnit.aggregate(predictorReturns, null);
+  }
+
+  @Test
+  public void testGetOutputNoChildren()
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+
+    SeldonMessage p = SeldonMessage.newBuilder().build();
+
+    PredictiveUnitState state =
+        new PredictiveUnitState(
+            "Cool_name",
+            null,
+            new ArrayList<PredictiveUnitState>(),
+            null,
+            null,
+            null,
+            null,
+            PredictiveUnitImplementation.AVERAGE_COMBINER);
+
+    PredictiveUnitBean predictiveUnit = new PredictiveUnitBean();
+    PredictiveUnitBeanProxy proxy = new PredictiveUnitBeanProxy(predictiveUnit);
+    predictiveUnit.setProxy(proxy);
+    SimpleModelUnit simpleModel = new SimpleModelUnit();
+    SimpleRouterUnit simpleRouterUnit = new SimpleRouterUnit();
+    AverageCombinerUnit averageCombiner = new AverageCombinerUnit();
+    RandomABTestUnit randomABTest = new RandomABTestUnit();
+
+    PredictorConfigBean predictorConfig =
+        new PredictorConfigBean(simpleModel, simpleRouterUnit, averageCombiner, randomABTest);
+
+    predictiveUnit.predictorConfig = predictorConfig;
+
+    predictiveUnit.getOutput(p, state);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/predictors/PredictiveUnitBeanTest.java
+++ b/engine/src/test/java/io/seldon/engine/predictors/PredictiveUnitBeanTest.java
@@ -1,112 +1,106 @@
 package io.seldon.engine.predictors;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.lang.reflect.Method;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.NoSuchMethodException;
-import java.lang.IllegalAccessException;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.springframework.beans.factory.annotation.Autowired;
-
-import io.kubernetes.client.proto.V1.Container;
-import io.seldon.protos.PredictionProtos.DefaultData;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-import io.seldon.protos.PredictionProtos.Meta;
-import io.seldon.engine.pb.ProtoBufUtils;
-
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Value;
+import io.seldon.engine.pb.ProtoBufUtils;
+import io.seldon.protos.PredictionProtos.DefaultData;
+import io.seldon.protos.PredictionProtos.Meta;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class PredictiveUnitBeanTest {
-	
-	@Test
-	public void testMergeMetaList() throws InvalidProtocolBufferException, NoSuchMethodException, IllegalAccessException, InvocationTargetException
-	{
-		PredictiveUnitImpl pu = new PredictiveUnitBean();
-		Method mergeMeta = PredictiveUnitBean.class.getDeclaredMethod("mergeMeta", SeldonMessage.class, List.class, String.class);
-		mergeMeta.setAccessible(true);
 
-		final String puid = "puid";
+  @Test
+  public void testMergeMetaList()
+      throws InvalidProtocolBufferException, NoSuchMethodException, IllegalAccessException,
+          InvocationTargetException {
+    PredictiveUnitImpl pu = new PredictiveUnitBean();
+    Method mergeMeta =
+        PredictiveUnitBean.class.getDeclaredMethod(
+            "mergeMeta", SeldonMessage.class, List.class, String.class);
+    mergeMeta.setAccessible(true);
 
-		DefaultData.Builder d1 = DefaultData.newBuilder();
-		SeldonMessage.Builder b1 = SeldonMessage.newBuilder();
-		Value v1 = Value.newBuilder().setStringValue("one").build();
-		Meta m1 = Meta.newBuilder().putTags("key", v1).setPuid(puid).build();
-		b1.setData(d1.build()).setMeta(m1);
-		SeldonMessage s1 = b1.build();
+    final String puid = "puid";
 
-		DefaultData.Builder d2 = DefaultData.newBuilder();
-		SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
-		Value v2 = Value.newBuilder().setStringValue("two").build();
-		Meta m2 = Meta.newBuilder().putTags("key", v2).setPuid(puid).build();
-		b2.setData(d2.build()).setMeta(m2);
-		SeldonMessage s2 = b2.build();
+    DefaultData.Builder d1 = DefaultData.newBuilder();
+    SeldonMessage.Builder b1 = SeldonMessage.newBuilder();
+    Value v1 = Value.newBuilder().setStringValue("one").build();
+    Meta m1 = Meta.newBuilder().putTags("key", v1).setPuid(puid).build();
+    b1.setData(d1.build()).setMeta(m1);
+    SeldonMessage s1 = b1.build();
 
-		List<SeldonMessage> messages = new ArrayList<SeldonMessage>();
-		messages.add(s2);
+    DefaultData.Builder d2 = DefaultData.newBuilder();
+    SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
+    Value v2 = Value.newBuilder().setStringValue("two").build();
+    Meta m2 = Meta.newBuilder().putTags("key", v2).setPuid(puid).build();
+    b2.setData(d2.build()).setMeta(m2);
+    SeldonMessage s2 = b2.build();
 
-		SeldonMessage r1 = (SeldonMessage) mergeMeta.invoke(pu, s1, messages, puid);
+    List<SeldonMessage> messages = new ArrayList<SeldonMessage>();
+    messages.add(s2);
 
-		String r1str = ProtoBufUtils.toJson(r1.getMeta());
-		String j1 = ProtoBufUtils.toJson(s1.getMeta());
-		System.out.println(r1str);
-		System.out.println(j1);
-		Assert.assertEquals(r1str, j1);
+    SeldonMessage r1 = (SeldonMessage) mergeMeta.invoke(pu, s1, messages, puid);
 
+    String r1str = ProtoBufUtils.toJson(r1.getMeta());
+    String j1 = ProtoBufUtils.toJson(s1.getMeta());
+    System.out.println(r1str);
+    System.out.println(j1);
+    Assert.assertEquals(r1str, j1);
 
-		DefaultData.Builder d3 = DefaultData.newBuilder();
-		SeldonMessage.Builder b3 = SeldonMessage.newBuilder();
-		Value v3 = Value.newBuilder().setStringValue("three").build();
-		Meta m3 = Meta.newBuilder().putTags("key", v3).setPuid(puid).build();
-		b3.setData(d3.build()).setMeta(m3);
-		SeldonMessage s3 = b3.build();
+    DefaultData.Builder d3 = DefaultData.newBuilder();
+    SeldonMessage.Builder b3 = SeldonMessage.newBuilder();
+    Value v3 = Value.newBuilder().setStringValue("three").build();
+    Meta m3 = Meta.newBuilder().putTags("key", v3).setPuid(puid).build();
+    b3.setData(d3.build()).setMeta(m3);
+    SeldonMessage s3 = b3.build();
 
-		messages.add(s3);
+    messages.add(s3);
 
-		SeldonMessage r2 = (SeldonMessage) mergeMeta.invoke(pu, s1, messages, puid);
+    SeldonMessage r2 = (SeldonMessage) mergeMeta.invoke(pu, s1, messages, puid);
 
-		String r2str = ProtoBufUtils.toJson(r2.getMeta());
-		System.out.println(r2str);
-		System.out.println(j1);
-		Assert.assertEquals(r2str, j1);
-	}
+    String r2str = ProtoBufUtils.toJson(r2.getMeta());
+    System.out.println(r2str);
+    System.out.println(j1);
+    Assert.assertEquals(r2str, j1);
+  }
 
-	@Test
-	public void testMergeMeta() throws InvalidProtocolBufferException, NoSuchMethodException, IllegalAccessException, InvocationTargetException
-	{
-		PredictiveUnitImpl pu = new PredictiveUnitBean();
-		Method mergeMeta = PredictiveUnitBean.class.getDeclaredMethod("mergeMeta", SeldonMessage.class, SeldonMessage.class, String.class);
-		mergeMeta.setAccessible(true);
+  @Test
+  public void testMergeMeta()
+      throws InvalidProtocolBufferException, NoSuchMethodException, IllegalAccessException,
+          InvocationTargetException {
+    PredictiveUnitImpl pu = new PredictiveUnitBean();
+    Method mergeMeta =
+        PredictiveUnitBean.class.getDeclaredMethod(
+            "mergeMeta", SeldonMessage.class, SeldonMessage.class, String.class);
+    mergeMeta.setAccessible(true);
 
-		final String puid = "id";
+    final String puid = "id";
 
-		DefaultData.Builder d1 = DefaultData.newBuilder();
-		SeldonMessage.Builder b1 = SeldonMessage.newBuilder();
-		Value v1 = Value.newBuilder().setStringValue("one").build();
-		Meta m1 = Meta.newBuilder().putTags("key", v1).setPuid(puid).build();
-		b1.setData(d1.build()).setMeta(m1);
-		SeldonMessage s1 = b1.build();
+    DefaultData.Builder d1 = DefaultData.newBuilder();
+    SeldonMessage.Builder b1 = SeldonMessage.newBuilder();
+    Value v1 = Value.newBuilder().setStringValue("one").build();
+    Meta m1 = Meta.newBuilder().putTags("key", v1).setPuid(puid).build();
+    b1.setData(d1.build()).setMeta(m1);
+    SeldonMessage s1 = b1.build();
 
-		DefaultData.Builder d2 = DefaultData.newBuilder();
-		SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
-		Value v2 = Value.newBuilder().setStringValue("two").build();
-		Meta m2 = Meta.newBuilder().putTags("key", v2).setPuid(puid).build();
-		b2.setData(d2.build()).setMeta(m2);
-		SeldonMessage s2 = b2.build();
+    DefaultData.Builder d2 = DefaultData.newBuilder();
+    SeldonMessage.Builder b2 = SeldonMessage.newBuilder();
+    Value v2 = Value.newBuilder().setStringValue("two").build();
+    Meta m2 = Meta.newBuilder().putTags("key", v2).setPuid(puid).build();
+    b2.setData(d2.build()).setMeta(m2);
+    SeldonMessage s2 = b2.build();
 
-		SeldonMessage r1 = (SeldonMessage) mergeMeta.invoke(pu, s1, s2, puid);
+    SeldonMessage r1 = (SeldonMessage) mergeMeta.invoke(pu, s1, s2, puid);
 
-		String r1str = ProtoBufUtils.toJson(r1.getMeta());
-		String j1 = ProtoBufUtils.toJson(s1.getMeta());
-		System.out.println(r1str);
-		System.out.println(j1);
-		Assert.assertEquals(r1str, j1);
-	}
+    String r1str = ProtoBufUtils.toJson(r1.getMeta());
+    String j1 = ProtoBufUtils.toJson(s1.getMeta());
+    System.out.println(r1str);
+    System.out.println(j1);
+    Assert.assertEquals(r1str, j1);
+  }
 }
-
-

--- a/engine/src/test/java/io/seldon/engine/predictors/PredictiveUnitStateTest.java
+++ b/engine/src/test/java/io/seldon/engine/predictors/PredictiveUnitStateTest.java
@@ -1,39 +1,43 @@
 package io.seldon.engine.predictors;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import io.kubernetes.client.proto.V1.Container;
 import io.seldon.protos.DeploymentProtos.Endpoint;
 import io.seldon.protos.DeploymentProtos.PredictiveUnit;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class PredictiveUnitStateTest {
-	
-	@Test
-	public void testImageExtractionBasic()
-	{
-		final String name = "test";
-		PredictiveUnit pu = PredictiveUnit.newBuilder().setName(name).setEndpoint(Endpoint.newBuilder().setServiceHost("host")).build();
-		Map<String,Container> containersMap = new HashMap<String,Container>();
-		containersMap.put(name, Container.newBuilder().setImage("myimage:0.1").build());
-		PredictiveUnitState pus = new PredictiveUnitState(pu, containersMap);
-		Assert.assertEquals("myimage", pus.imageName);
-		Assert.assertEquals("0.1", pus.imageVersion);
-	}
-	
-	@Test
-	public void testImageExtractionWithPort()
-	{
-		final String name = "test";
-		PredictiveUnit pu = PredictiveUnit.newBuilder().setName(name).setEndpoint(Endpoint.newBuilder().setServiceHost("host")).build();
-		Map<String,Container> containersMap = new HashMap<String,Container>();
-		containersMap.put(name, Container.newBuilder().setImage("myrep:1234/someorg/myimage:0.1").build());
-		PredictiveUnitState pus = new PredictiveUnitState(pu, containersMap);
-		Assert.assertEquals("myrep:1234/someorg/myimage", pus.imageName);
-		Assert.assertEquals("0.1", pus.imageVersion);
-	}
 
+  @Test
+  public void testImageExtractionBasic() {
+    final String name = "test";
+    PredictiveUnit pu =
+        PredictiveUnit.newBuilder()
+            .setName(name)
+            .setEndpoint(Endpoint.newBuilder().setServiceHost("host"))
+            .build();
+    Map<String, Container> containersMap = new HashMap<String, Container>();
+    containersMap.put(name, Container.newBuilder().setImage("myimage:0.1").build());
+    PredictiveUnitState pus = new PredictiveUnitState(pu, containersMap);
+    Assert.assertEquals("myimage", pus.imageName);
+    Assert.assertEquals("0.1", pus.imageVersion);
+  }
+
+  @Test
+  public void testImageExtractionWithPort() {
+    final String name = "test";
+    PredictiveUnit pu =
+        PredictiveUnit.newBuilder()
+            .setName(name)
+            .setEndpoint(Endpoint.newBuilder().setServiceHost("host"))
+            .build();
+    Map<String, Container> containersMap = new HashMap<String, Container>();
+    containersMap.put(
+        name, Container.newBuilder().setImage("myrep:1234/someorg/myimage:0.1").build());
+    PredictiveUnitState pus = new PredictiveUnitState(pu, containersMap);
+    Assert.assertEquals("myrep:1234/someorg/myimage", pus.imageName);
+    Assert.assertEquals("0.1", pus.imageVersion);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/predictors/RandomABTestUnitInternalTest.java
+++ b/engine/src/test/java/io/seldon/engine/predictors/RandomABTestUnitInternalTest.java
@@ -1,95 +1,114 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.seldon.engine.exception.APIException;
+import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitImplementation;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.ojalgo.matrix.PrimitiveMatrix;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.seldon.engine.exception.APIException;
-import io.seldon.protos.DeploymentProtos.PredictiveUnit.PredictiveUnitImplementation;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-
 public class RandomABTestUnitInternalTest {
 
-	private int getBranchIndex(SeldonMessage routerReturn) {
-		PrimitiveMatrix dataArray = PredictorUtils.getOJMatrix(routerReturn.getData());
-		return dataArray.get(0).intValue();
-	}
-	
-	
-	@Test
-	public void simpleCase() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvalidProtocolBufferException {
-		
-		SeldonMessage request = SeldonMessage.newBuilder().build();
-		
-		PredictiveUnitParameter<Float> ratioParam = new PredictiveUnitParameter<Float>(0.5F);
-    	Map<String,PredictiveUnitParameterInterface> params = new HashMap<>();
-    	params.put("ratioA", ratioParam);
-		
-		PredictiveUnitState state = new PredictiveUnitState("Cool_name",null,new ArrayList<PredictiveUnitState>(), params,null,null, null, PredictiveUnitImplementation.RANDOM_ABTEST);
-		
-		PredictiveUnitState childA = new PredictiveUnitState("A",null,null, null, null, null, null, null);
-		PredictiveUnitState childB = new PredictiveUnitState("B",null,null, null, null, null, null, null);
-		
-		state.addChild(childA);
-		state.addChild(childB);
-		
-		PredictiveUnitImpl predictiveUnit = new RandomABTestUnit();
-		
-		// The following values are from random seed 1337
-		SeldonMessage msg1 = predictiveUnit.route(request, state);
-		int routing1 = getBranchIndex(msg1);
+  private int getBranchIndex(SeldonMessage routerReturn) {
+    PrimitiveMatrix dataArray = PredictorUtils.getOJMatrix(routerReturn.getData());
+    return dataArray.get(0).intValue();
+  }
 
-		Assert.assertEquals(1,routing1); 
-		
-		SeldonMessage msg2 = predictiveUnit.route(request, state);
-		int routing2 = (int) getBranchIndex(msg2);
+  @Test
+  public void simpleCase()
+      throws NoSuchMethodException, SecurityException, IllegalAccessException,
+          IllegalArgumentException, InvalidProtocolBufferException {
 
-		Assert.assertEquals(0,routing2);
-		
-		SeldonMessage msg3 = predictiveUnit.route(request,state);
-		int routing3 = (int) getBranchIndex(msg3);
+    SeldonMessage request = SeldonMessage.newBuilder().build();
 
-		Assert.assertEquals(1,routing3);
-	}
-	
-	@Test(expected=APIException.class)
-	public void failureOneChild() throws Throwable{
-		
-		SeldonMessage request = SeldonMessage.newBuilder().build();
-		
-		PredictiveUnitParameter<Float> ratioParam = new PredictiveUnitParameter<Float>(0.5F);
-    	Map<String,PredictiveUnitParameterInterface> params = new HashMap<>();
-    	params.put("ratioA", ratioParam);
-		
-		PredictiveUnitState state = new PredictiveUnitState("Cool_name",null,new ArrayList<PredictiveUnitState>(), params, null, null, null, PredictiveUnitImplementation.RANDOM_ABTEST);
-		
-		PredictiveUnitState childA = new PredictiveUnitState("A",null,null, null, null, null, null, null);
-		
-		state.addChild(childA);
-		
-		PredictiveUnitImpl predictiveUnit = new RandomABTestUnit();
+    PredictiveUnitParameter<Float> ratioParam = new PredictiveUnitParameter<Float>(0.5F);
+    Map<String, PredictiveUnitParameterInterface> params = new HashMap<>();
+    params.put("ratioA", ratioParam);
 
-		predictiveUnit.route(request,state);
-	}
+    PredictiveUnitState state =
+        new PredictiveUnitState(
+            "Cool_name",
+            null,
+            new ArrayList<PredictiveUnitState>(),
+            params,
+            null,
+            null,
+            null,
+            PredictiveUnitImplementation.RANDOM_ABTEST);
+
+    PredictiveUnitState childA =
+        new PredictiveUnitState("A", null, null, null, null, null, null, null);
+    PredictiveUnitState childB =
+        new PredictiveUnitState("B", null, null, null, null, null, null, null);
+
+    state.addChild(childA);
+    state.addChild(childB);
+
+    PredictiveUnitImpl predictiveUnit = new RandomABTestUnit();
+
+    // The following values are from random seed 1337
+    SeldonMessage msg1 = predictiveUnit.route(request, state);
+    int routing1 = getBranchIndex(msg1);
+
+    Assert.assertEquals(1, routing1);
+
+    SeldonMessage msg2 = predictiveUnit.route(request, state);
+    int routing2 = (int) getBranchIndex(msg2);
+
+    Assert.assertEquals(0, routing2);
+
+    SeldonMessage msg3 = predictiveUnit.route(request, state);
+    int routing3 = (int) getBranchIndex(msg3);
+
+    Assert.assertEquals(1, routing3);
+  }
+
+  @Test(expected = APIException.class)
+  public void failureOneChild() throws Throwable {
+
+    SeldonMessage request = SeldonMessage.newBuilder().build();
+
+    PredictiveUnitParameter<Float> ratioParam = new PredictiveUnitParameter<Float>(0.5F);
+    Map<String, PredictiveUnitParameterInterface> params = new HashMap<>();
+    params.put("ratioA", ratioParam);
+
+    PredictiveUnitState state =
+        new PredictiveUnitState(
+            "Cool_name",
+            null,
+            new ArrayList<PredictiveUnitState>(),
+            params,
+            null,
+            null,
+            null,
+            PredictiveUnitImplementation.RANDOM_ABTEST);
+
+    PredictiveUnitState childA =
+        new PredictiveUnitState("A", null, null, null, null, null, null, null);
+
+    state.addChild(childA);
+
+    PredictiveUnitImpl predictiveUnit = new RandomABTestUnit();
+
+    predictiveUnit.route(request, state);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/predictors/RandomABTestUnitTest.java
+++ b/engine/src/test/java/io/seldon/engine/predictors/RandomABTestUnitTest.java
@@ -1,22 +1,28 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.seldon.protos.DeploymentProtos.Parameter;
+import io.seldon.protos.DeploymentProtos.Parameter.ParameterType;
+import io.seldon.protos.DeploymentProtos.PredictiveUnit;
+import io.seldon.protos.DeploymentProtos.PredictorSpec;
+import io.seldon.protos.DeploymentProtos.SeldonPodSpec;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.util.concurrent.ExecutionException;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,68 +30,61 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.seldon.protos.DeploymentProtos.PredictiveUnit;
-import io.kubernetes.client.proto.V1.PodTemplateSpec;
-import io.seldon.protos.DeploymentProtos.Parameter;
-import io.seldon.protos.DeploymentProtos.Parameter.ParameterType;
-import io.seldon.protos.DeploymentProtos.PredictorSpec;
-import io.seldon.protos.DeploymentProtos.SeldonPodSpec;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class RandomABTestUnitTest {
-	@Autowired
-	PredictorBean predictorBean;
-	
-	@Test
-	public void simpleTest() throws InterruptedException, ExecutionException, InvalidProtocolBufferException
-	{
-		PredictorSpec.Builder predictorSpecBuilder = PredictorSpec.newBuilder();
-		
-		predictorSpecBuilder.setName("p1");
-		predictorSpecBuilder.setReplicas(1);
-		predictorSpecBuilder.addComponentSpecs(SeldonPodSpec.newBuilder());
+  @Autowired PredictorBean predictorBean;
 
-		PredictiveUnit.Builder predictiveUnitBuilder = PredictiveUnit.newBuilder();
-		predictiveUnitBuilder.setName("1");
-		predictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
-		predictiveUnitBuilder.setImplementation(PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
-		PredictiveUnit pu1 = predictiveUnitBuilder.build();
-		
-		predictiveUnitBuilder = PredictiveUnit.newBuilder();
-		predictiveUnitBuilder.setName("2");
-		predictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
-		predictiveUnitBuilder.setImplementation(PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
-		PredictiveUnit pu2 = predictiveUnitBuilder.build();
-		
-		
-		predictiveUnitBuilder = PredictiveUnit.newBuilder();
-		predictiveUnitBuilder.setName("3");
-		predictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.ROUTER);
-		predictiveUnitBuilder.setImplementation(PredictiveUnit.PredictiveUnitImplementation.RANDOM_ABTEST);
-		predictiveUnitBuilder.addChildren(pu1);
-		predictiveUnitBuilder.addChildren(pu2);
-		Parameter.Builder pBuilder = Parameter.newBuilder().setName("ratioA").setValue("0.5").setType(ParameterType.FLOAT);
-		predictiveUnitBuilder.addParameters(pBuilder.build());
-		PredictiveUnit pu3 = predictiveUnitBuilder.build();
+  @Test
+  public void simpleTest()
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    PredictorSpec.Builder predictorSpecBuilder = PredictorSpec.newBuilder();
 
-		predictorSpecBuilder.setGraph(pu3);
+    predictorSpecBuilder.setName("p1");
+    predictorSpecBuilder.setReplicas(1);
+    predictorSpecBuilder.addComponentSpecs(SeldonPodSpec.newBuilder());
 
-		PredictorSpec predictor = predictorSpecBuilder.build();
+    PredictiveUnit.Builder predictiveUnitBuilder = PredictiveUnit.newBuilder();
+    predictiveUnitBuilder.setName("1");
+    predictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
+    predictiveUnitBuilder.setImplementation(
+        PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
+    PredictiveUnit pu1 = predictiveUnitBuilder.build();
 
-		PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
+    predictiveUnitBuilder = PredictiveUnit.newBuilder();
+    predictiveUnitBuilder.setName("2");
+    predictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
+    predictiveUnitBuilder.setImplementation(
+        PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
+    PredictiveUnit pu2 = predictiveUnitBuilder.build();
 
-		
-		SeldonMessage p = SeldonMessage.newBuilder().build();
-			
-        SeldonMessage predictorReturn = predictorBean.predict(p,predictorState);
-		
-        Assert.assertEquals((double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2),0);        
-	
-	}
+    predictiveUnitBuilder = PredictiveUnit.newBuilder();
+    predictiveUnitBuilder.setName("3");
+    predictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.ROUTER);
+    predictiveUnitBuilder.setImplementation(
+        PredictiveUnit.PredictiveUnitImplementation.RANDOM_ABTEST);
+    predictiveUnitBuilder.addChildren(pu1);
+    predictiveUnitBuilder.addChildren(pu2);
+    Parameter.Builder pBuilder =
+        Parameter.newBuilder().setName("ratioA").setValue("0.5").setType(ParameterType.FLOAT);
+    predictiveUnitBuilder.addParameters(pBuilder.build());
+    PredictiveUnit pu3 = predictiveUnitBuilder.build();
+
+    predictorSpecBuilder.setGraph(pu3);
+
+    PredictorSpec predictor = predictorSpecBuilder.build();
+
+    PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
+
+    SeldonMessage p = SeldonMessage.newBuilder().build();
+
+    SeldonMessage predictorReturn = predictorBean.predict(p, predictorState);
+
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2), 0);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/predictors/SimpleModelUnitTest.java
+++ b/engine/src/test/java/io/seldon/engine/predictors/SimpleModelUnitTest.java
@@ -1,22 +1,28 @@
-/*******************************************************************************
- * Copyright 2017 Seldon Technologies Ltd (http://www.seldon.io/)
+/**
+ * ***************************************************************************** Copyright 2017
+ * Seldon Technologies Ltd (http://www.seldon.io/)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ * *****************************************************************************
+ */
 package io.seldon.engine.predictors;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.kubernetes.client.proto.V1.Container;
+import io.kubernetes.client.proto.V1.PodSpec;
+import io.seldon.protos.DeploymentProtos.PredictiveUnit;
+import io.seldon.protos.DeploymentProtos.PredictorSpec;
+import io.seldon.protos.DeploymentProtos.SeldonPodSpec;
+import io.seldon.protos.PredictionProtos.SeldonMessage;
 import java.util.concurrent.ExecutionException;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,137 +30,137 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-import io.kubernetes.client.proto.V1.Container;
-import io.kubernetes.client.proto.V1.PodSpec;
-import io.kubernetes.client.proto.V1.PodTemplateSpec;
-import io.seldon.protos.DeploymentProtos.PredictiveUnit;
-import io.seldon.protos.DeploymentProtos.PredictorSpec;
-import io.seldon.protos.DeploymentProtos.SeldonPodSpec;
-import io.seldon.protos.PredictionProtos.SeldonMessage;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class SimpleModelUnitTest {
 
-	@Autowired
-	PredictorBean predictorBean;
-	
-	@Test
-	public void simpleTest() throws InterruptedException, ExecutionException, InvalidProtocolBufferException
-	{
-		PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-		// PredictorSpecBuilder.setEnabled(true);
-		
-		PredictorSpecBuilder.setName("p1");
-		// PredictorSpecBuilder.setRoot("1");
-		PredictorSpecBuilder.setReplicas(1);
-		PredictorSpecBuilder.addComponentSpecs(SeldonPodSpec.newBuilder());
-		
-		PredictiveUnit.Builder PredictiveUnitBuilder = PredictiveUnit.newBuilder();
-		PredictiveUnitBuilder.setName("1");
-		PredictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
-		PredictiveUnitBuilder.setImplementation(PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
-		
-		PredictorSpecBuilder.setGraph(PredictiveUnitBuilder.build());
-		PredictorSpec predictor = PredictorSpecBuilder.build();
+  @Autowired PredictorBean predictorBean;
 
-		PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
+  @Test
+  public void simpleTest()
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    // PredictorSpecBuilder.setEnabled(true);
 
-		
-		SeldonMessage p = SeldonMessage.newBuilder().build();
+    PredictorSpecBuilder.setName("p1");
+    // PredictorSpecBuilder.setRoot("1");
+    PredictorSpecBuilder.setReplicas(1);
+    PredictorSpecBuilder.addComponentSpecs(SeldonPodSpec.newBuilder());
 
-		
-        SeldonMessage predictorReturn = predictorBean.predict(p,predictorState);
-        
-        Assert.assertEquals((double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2),0);   
-		
-        
-	}
-	
-	
-	@Test
-	public void simpleTestWithImageNoVersion() throws InterruptedException, ExecutionException, InvalidProtocolBufferException
-	{
-		PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-		// PredictorSpecBuilder.setEnabled(true);
-		
-		PredictorSpecBuilder.setName("p1");
-		// PredictorSpecBuilder.setRoot("1");
-		PredictorSpecBuilder.setReplicas(1);
-		
-		final String imageName = "myimage";
-		SeldonPodSpec.Builder ptsBuilder = SeldonPodSpec.newBuilder().setSpec(PodSpec.newBuilder().addContainers(Container.newBuilder().setImage(imageName).setName("1")));
-		
-		PredictorSpecBuilder.addComponentSpecs(ptsBuilder);
-		
-		PredictiveUnit.Builder PredictiveUnitBuilder = PredictiveUnit.newBuilder();
-		PredictiveUnitBuilder.setName("1");
-		PredictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
-		PredictiveUnitBuilder.setImplementation(PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
-		
-		PredictorSpecBuilder.setGraph(PredictiveUnitBuilder.build());
-		PredictorSpec predictor = PredictorSpecBuilder.build();
+    PredictiveUnit.Builder PredictiveUnitBuilder = PredictiveUnit.newBuilder();
+    PredictiveUnitBuilder.setName("1");
+    PredictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
+    PredictiveUnitBuilder.setImplementation(
+        PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
 
-		PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
+    PredictorSpecBuilder.setGraph(PredictiveUnitBuilder.build());
+    PredictorSpec predictor = PredictorSpecBuilder.build();
 
-		Assert.assertEquals(imageName, predictorState.getRootState().imageName);
-		Assert.assertEquals("", predictorState.getRootState().imageVersion);
-		
-		SeldonMessage p = SeldonMessage.newBuilder().build();
+    PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
 
-		
-        SeldonMessage predictorReturn = predictorBean.predict(p,predictorState);
-        
-        Assert.assertEquals((double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2),0);   
-		
-        
-	}
-	
-	@Test
-	public void simpleTestWithImageVersion() throws InterruptedException, ExecutionException, InvalidProtocolBufferException
-	{
-		PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
-		// PredictorSpecBuilder.setEnabled(true);
-		
-		PredictorSpecBuilder.setName("p1");
-		// PredictorSpecBuilder.setRoot("1");
-		PredictorSpecBuilder.setReplicas(1);
-		
-		final String imageName = "myimage";
-		final String imageVersion = "0.1";
-		SeldonPodSpec.Builder ptsBuilder = SeldonPodSpec.newBuilder().setSpec(PodSpec.newBuilder().addContainers(Container.newBuilder().setImage(imageName+":"+imageVersion).setName("1")));
-		
-		PredictorSpecBuilder.addComponentSpecs(ptsBuilder);
-		
-		PredictiveUnit.Builder PredictiveUnitBuilder = PredictiveUnit.newBuilder();
-		PredictiveUnitBuilder.setName("1");
-		PredictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
-		PredictiveUnitBuilder.setImplementation(PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
-		
-		PredictorSpecBuilder.setGraph(PredictiveUnitBuilder.build());
-		PredictorSpec predictor = PredictorSpecBuilder.build();
+    SeldonMessage p = SeldonMessage.newBuilder().build();
 
-		PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
+    SeldonMessage predictorReturn = predictorBean.predict(p, predictorState);
 
-		Assert.assertEquals(imageName, predictorState.getRootState().imageName);
-		Assert.assertEquals(imageVersion, predictorState.getRootState().imageVersion);
-		
-		SeldonMessage p = SeldonMessage.newBuilder().build();
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2), 0);
+  }
 
-		
-        SeldonMessage predictorReturn = predictorBean.predict(p,predictorState);
-        
-        Assert.assertEquals((double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1),0);
-        Assert.assertEquals((double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2),0);   
-		
-        
-	}
-	
+  @Test
+  public void simpleTestWithImageNoVersion()
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    // PredictorSpecBuilder.setEnabled(true);
+
+    PredictorSpecBuilder.setName("p1");
+    // PredictorSpecBuilder.setRoot("1");
+    PredictorSpecBuilder.setReplicas(1);
+
+    final String imageName = "myimage";
+    SeldonPodSpec.Builder ptsBuilder =
+        SeldonPodSpec.newBuilder()
+            .setSpec(
+                PodSpec.newBuilder()
+                    .addContainers(Container.newBuilder().setImage(imageName).setName("1")));
+
+    PredictorSpecBuilder.addComponentSpecs(ptsBuilder);
+
+    PredictiveUnit.Builder PredictiveUnitBuilder = PredictiveUnit.newBuilder();
+    PredictiveUnitBuilder.setName("1");
+    PredictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
+    PredictiveUnitBuilder.setImplementation(
+        PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
+
+    PredictorSpecBuilder.setGraph(PredictiveUnitBuilder.build());
+    PredictorSpec predictor = PredictorSpecBuilder.build();
+
+    PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
+
+    Assert.assertEquals(imageName, predictorState.getRootState().imageName);
+    Assert.assertEquals("", predictorState.getRootState().imageVersion);
+
+    SeldonMessage p = SeldonMessage.newBuilder().build();
+
+    SeldonMessage predictorReturn = predictorBean.predict(p, predictorState);
+
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2), 0);
+  }
+
+  @Test
+  public void simpleTestWithImageVersion()
+      throws InterruptedException, ExecutionException, InvalidProtocolBufferException {
+    PredictorSpec.Builder PredictorSpecBuilder = PredictorSpec.newBuilder();
+    // PredictorSpecBuilder.setEnabled(true);
+
+    PredictorSpecBuilder.setName("p1");
+    // PredictorSpecBuilder.setRoot("1");
+    PredictorSpecBuilder.setReplicas(1);
+
+    final String imageName = "myimage";
+    final String imageVersion = "0.1";
+    SeldonPodSpec.Builder ptsBuilder =
+        SeldonPodSpec.newBuilder()
+            .setSpec(
+                PodSpec.newBuilder()
+                    .addContainers(
+                        Container.newBuilder()
+                            .setImage(imageName + ":" + imageVersion)
+                            .setName("1")));
+
+    PredictorSpecBuilder.addComponentSpecs(ptsBuilder);
+
+    PredictiveUnit.Builder PredictiveUnitBuilder = PredictiveUnit.newBuilder();
+    PredictiveUnitBuilder.setName("1");
+    PredictiveUnitBuilder.setType(PredictiveUnit.PredictiveUnitType.MODEL);
+    PredictiveUnitBuilder.setImplementation(
+        PredictiveUnit.PredictiveUnitImplementation.SIMPLE_MODEL);
+
+    PredictorSpecBuilder.setGraph(PredictiveUnitBuilder.build());
+    PredictorSpec predictor = PredictorSpecBuilder.build();
+
+    PredictorState predictorState = predictorBean.predictorStateFromPredictorSpec(predictor);
+
+    Assert.assertEquals(imageName, predictorState.getRootState().imageName);
+    Assert.assertEquals(imageVersion, predictorState.getRootState().imageVersion);
+
+    SeldonMessage p = SeldonMessage.newBuilder().build();
+
+    SeldonMessage predictorReturn = predictorBean.predict(p, predictorState);
+
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[0], predictorReturn.getData().getTensor().getValues(0), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[1], predictorReturn.getData().getTensor().getValues(1), 0);
+    Assert.assertEquals(
+        (double) SimpleModelUnit.values[2], predictorReturn.getData().getTensor().getValues(2), 0);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/service/UriCacheTest.java
+++ b/engine/src/test/java/io/seldon/engine/service/UriCacheTest.java
@@ -1,36 +1,34 @@
 package io.seldon.engine.service;
 
-import org.junit.Test;
-import org.junit.Assert;
 import io.seldon.protos.DeploymentProtos.Endpoint;
-
+import org.junit.Assert;
+import org.junit.Test;
 
 public class UriCacheTest {
 
-	@Test
-	public void testUri()
-	{
-		Endpoint endpointA = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
-		Endpoint endpointA2 = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
-		Endpoint endpointB = Endpoint.newBuilder().setServiceHost("hostB").setServicePort(1000).build();
-		final String predictPath = "/predict";
-		final String predictPath2 = "/predict";
-		final String feedbackPath = "/feedback";
-		
-		final String key1 = InternalPredictionService.getUriKey(endpointA, predictPath);
-		final String key2 = InternalPredictionService.getUriKey(endpointB, predictPath);
-		final String key3 = InternalPredictionService.getUriKey(endpointA, feedbackPath);
-		
-		Assert.assertNotEquals(key1, key2);
-		Assert.assertNotEquals(key1, key3);
-		
-		final String key4 = InternalPredictionService.getUriKey(endpointA2, predictPath);
-		
-		Assert.assertEquals(key1, key4);
+  @Test
+  public void testUri() {
+    Endpoint endpointA = Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
+    Endpoint endpointA2 =
+        Endpoint.newBuilder().setServiceHost("hostA").setServicePort(1000).build();
+    Endpoint endpointB = Endpoint.newBuilder().setServiceHost("hostB").setServicePort(1000).build();
+    final String predictPath = "/predict";
+    final String predictPath2 = "/predict";
+    final String feedbackPath = "/feedback";
 
-		final String key5 = InternalPredictionService.getUriKey(endpointA, predictPath2);
-		
-		Assert.assertEquals(key1, key5);
-	}
-	
+    final String key1 = InternalPredictionService.getUriKey(endpointA, predictPath);
+    final String key2 = InternalPredictionService.getUriKey(endpointB, predictPath);
+    final String key3 = InternalPredictionService.getUriKey(endpointA, feedbackPath);
+
+    Assert.assertNotEquals(key1, key2);
+    Assert.assertNotEquals(key1, key3);
+
+    final String key4 = InternalPredictionService.getUriKey(endpointA2, predictPath);
+
+    Assert.assertEquals(key1, key4);
+
+    final String key5 = InternalPredictionService.getUriKey(endpointA, predictPath2);
+
+    Assert.assertEquals(key1, key5);
+  }
 }

--- a/engine/src/test/java/io/seldon/engine/util/TestUtils.java
+++ b/engine/src/test/java/io/seldon/engine/util/TestUtils.java
@@ -7,10 +7,8 @@ import java.nio.file.Paths;
 
 public class TestUtils {
 
-    public static String readFile(String path, Charset encoding)
-            throws IOException
-    {
-        byte[] encoded = Files.readAllBytes(Paths.get(path));
-        return new String(encoded, encoding);
-    }
+  public static String readFile(String path, Charset encoding) throws IOException {
+    byte[] encoded = Files.readAllBytes(Paths.get(path));
+    return new String(encoded, encoding);
+  }
 }


### PR DESCRIPTION
Fixes #937.

## Changes

- Run [`tidy`](https://github.com/htacg/tidy-html5) on `pom.xml`.
- Add `checkstyle` linter to `mvn validate` which will flag violations of [Google's Java style guide](https://google.github.io/styleguide/javaguide.html).
- Add `-Xlint:all` flag to `mvn compile`, which will flag usage of features marked as deprecated. 
- Remove some dependencies which were flagged as unused by `mvn dependency:analyze`.
- Add [`pre-commit`](https://pre-commit.com/) config to manage local Git hooks. There is currently a single hook configured which will run [`google-java-format`](https://github.com/google/google-java-format) on modified `*.java` files on each commit.
- Run [`google-java-format`](https://github.com/google/google-java-format) across all `*.java` files to make style consistent.
- Add note to `CONTRIBUTING.md` about [`pre-commit`](https://pre-commit.com/) and  [Google's Java style guide](https://google.github.io/styleguide/javaguide.html).

## Notes

[`pre-commit`](https://pre-commit.com/) is a cross-language tool to handle Git hooks. We can also use it to handle `python` or `go` formatters. For `python`, `black` already offers integration [out of the box](https://github.com/psf/black#version-control-integration) and therefore could also be interesting for #947. 
