### PR TITLE
WIP: webhook service issue but then cert issue

### DIFF
--- a/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-css-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-css-rolebinding.yaml
@@ -16,6 +16,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: seldon-manager
-  namespace: seldon-system
+  namespace: '{{ .Release.Namespace }}'
 {{- end }}
 {{- end }}

--- a/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-rolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: '{{ .Values.serviceAccount.name }}'
-  namespace: seldon-system
+  namespace: '{{ .Release.Namespace }}'
 {{- end }}

--- a/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-sas-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-sas-rolebinding.yaml
@@ -16,6 +16,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: seldon-manager
-  namespace: seldon-system
+  namespace: '{{ .Release.Namespace }}'
 {{- end }}
 {{- end }}

--- a/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-proxy-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-proxy-rolebinding.yaml
@@ -14,4 +14,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: seldon-system
+  namespace: '{{ .Release.Namespace }}'

--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: seldon-system/seldon-serving-cert
+    certmanager.k8s.io/inject-ca-from: '{{ .Release.Namespace }}/seldon-serving-cert'
   creationTimestamp: null
   labels:
     app: seldon

--- a/helm-charts/seldon-core-operator/templates/mutatingwebhookconfiguration_seldon-mutating-webhook-configuration.yaml
+++ b/helm-charts/seldon-core-operator/templates/mutatingwebhookconfiguration_seldon-mutating-webhook-configuration.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: seldon-system/seldon-serving-cert
+    certmanager.k8s.io/inject-ca-from: '{{ .Release.Namespace }}/seldon-serving-cert'
   creationTimestamp: null
   labels:
     app: seldon
@@ -15,7 +15,7 @@ webhooks:
     caBundle: '{{ .Values.webhook.ca.crt }}'
     service:
       name: seldon-webhook-service
-      namespace: seldon-system
+      namespace: '{{ .Release.Namespace }}'
       path: /mutate-machinelearning-seldon-io-v1alpha2-seldondeployment
   failurePolicy: Fail
   name: mseldondeployment.kb.io

--- a/helm-charts/seldon-core-operator/templates/rolebinding_seldon-leader-election-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/rolebinding_seldon-leader-election-rolebinding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: seldon-manager
-  namespace: seldon-system
+  namespace: '{{ .Release.Namespace }}'

--- a/helm-charts/seldon-core-operator/templates/rolebinding_seldon-manager-cm-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/rolebinding_seldon-manager-cm-rolebinding.yaml
@@ -17,6 +17,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: seldon-manager
-  namespace: seldon-system
+  namespace: '{{ .Release.Namespace }}'
 {{- end }}
 {{- end }}

--- a/helm-charts/seldon-core-operator/templates/validatingwebhookconfiguration_seldon-validating-webhook-configuration.yaml
+++ b/helm-charts/seldon-core-operator/templates/validatingwebhookconfiguration_seldon-validating-webhook-configuration.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: seldon-system/seldon-serving-cert
+    certmanager.k8s.io/inject-ca-from: '{{ .Release.Namespace }}/seldon-serving-cert'
   creationTimestamp: null
   labels:
     app: seldon
@@ -15,7 +15,7 @@ webhooks:
     caBundle: '{{ .Values.webhook.ca.crt }}'
     service:
       name: seldon-webhook-service
-      namespace: seldon-system
+      namespace: '{{ .Release.Namespace }}'
       path: /validate-machinelearning-seldon-io-v1alpha2-seldondeployment
   failurePolicy: Fail
   name: vseldondeployment.kb.io


### PR DESCRIPTION
Prompted by https://github.com/SeldonIO/seldon-core/issues/952. Not intended for merging. Just to illustrate a path.

Without this change then if the operator is installed in a namespace other than seldon-system (in that issue in the namespace 'seldon') you get:
```
Error from server (InternalError): error when creating "mnistpolyaxon.yaml": Internal error occurred: failed calling webhook "mseldondeployment.kb.io": Post https://seldon-webhook-service.seldon-system.svc:443/mutate-machinelearning-seldon-io-v1alpha2-seldondeployment?timeout=30s: service "seldon-webhook-service" not found
```
However even with the changes we then get:
```
Error from server (InternalError): error when creating "mnistpolyaxon.yaml": Internal error occurred: failed calling webhook "mseldondeployment.kb.io": Post https://seldon-webhook-service.seldon.svc:443/mutate-machinelearning-seldon-io-v1alpha2-seldondeployment?timeout=30s: x509: certificate is valid for seldon-webhook-service.seldon-system.svc, not seldon-webhook-service.seldon.svc
```
I guess this is because it's being installed with a pre-prepared cert that [references the namespace](https://github.com/SeldonIO/seldon-core/blob/master/operator/generate-keys.sh#L37) as by default certManager is not enabled.

So this PR does not fix the issue.

Also we'd really need to fix the generation process for the helm chart rather than patching the chart directly. So this isn't intended for merging.