### PR TITLE
Update watch-rollout-status for Argo CICD demo

### DIFF
--- a/examples/cicd-argocd/watch-rollout-status
+++ b/examples/cicd-argocd/watch-rollout-status
@@ -17,10 +17,10 @@ ${KUBECTL} rollout status deployment.apps/docker-private-registry-deployment -n 
 ${KUBECTL} rollout status deployment.apps/seldon-core-seldon-apiserver -n default -w
 ${KUBECTL} rollout status deployment.apps/seldon-core-seldon-cluster-manager -n default -w
 
-${KUBECTL} rollout status deployment.apps/application-controller -n argocd -w
+${KUBECTL} rollout status deployment.apps/argocd-application-controller -n argocd -w
 ${KUBECTL} rollout status deployment.apps/argocd-repo-server -n argocd -w
 ${KUBECTL} rollout status deployment.apps/argocd-server -n argocd -w
-${KUBECTL} rollout status deployment.apps/dex-server -n argocd -w
+${KUBECTL} rollout status deployment.apps/argocd-dex-server -n argocd -w
 
 ${KUBECTL} rollout status deployment.apps/jenkins -n jenkins -w
 


### PR DESCRIPTION
updated the deployment name of argocd-application-controller and argocd-dex-server

