### PR TITLE
WIP: Extracted templates from helm charts for offline deployments

### DIFF
--- a/examples/centralised-logging/full-setup-existing-kubeflow.sh
+++ b/examples/centralised-logging/full-setup-existing-kubeflow.sh
@@ -33,11 +33,14 @@ sleep 5
 
 helm upgrade --install seldon-core-analytics ../../helm-charts/seldon-core-analytics/ --namespace default -f ./kubeflow/seldon-analytics-kubeflow.yaml
 
-helm upgrade --install elasticsearch elasticsearch --version 7.1.1 --namespace=logs --set service.type=ClusterIP --set antiAffinity="soft" --repo https://helm.elastic.co
+#helm upgrade --install elasticsearch elasticsearch --version 7.1.1 --namespace=logs --set service.type=ClusterIP --set antiAffinity="soft" --repo https://helm.elastic.co
+kubectl apply -f generated-charts/elasticsearch.yaml --namespace logs 
 kubectl rollout status statefulset/elasticsearch-master -n logs
 
-helm upgrade --install fluentd fluentd-elasticsearch --namespace=logs -f fluentd-values.yaml --repo https://kiwigrid.github.io
-helm upgrade --install kibana kibana --version 7.1.1 --namespace=logs --set service.type=ClusterIP -f ./kubeflow/kibana-values.yaml --repo https://helm.elastic.co
+#helm upgrade --install fluentd fluentd-elasticsearch --namespace=logs -f fluentd-values.yaml --repo https://kiwigrid.github.io
+kubectl apply -f generated-charts/fluentd.yaml --namespace logs
+#helm upgrade --install kibana kibana --version 7.1.1 --namespace=logs --set service.type=ClusterIP -f ./kubeflow/kibana-values.yaml --repo https://helm.elastic.co
+kubectl apply -f generated-charts/kibana.yaml --namespace logs
 
 kubectl apply -f ./kubeflow/virtualservice-kibana.yaml
 kubectl apply -f ./kubeflow/virtualservice-elasticsearch.yaml

--- a/examples/centralised-logging/generated-charts/elasticsearch.yaml
+++ b/examples/centralised-logging/generated-charts/elasticsearch.yaml
@@ -1,0 +1,247 @@
+---
+# Source: elasticsearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "elasticsearch-master-pdb"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: "elasticsearch-master"
+---
+# Source: elasticsearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: elasticsearch-master
+spec:
+  selector:
+    heritage: "Tiller"
+    release: "elasticsearch"
+    chart: "elasticsearch-7.1.1"
+    app: "elasticsearch-master"
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: elasticsearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: elasticsearch-master-headless
+  labels:
+    heritage: "Tiller"
+    release: "elasticsearch"
+    chart: "elasticsearch-7.1.1"
+    app: "elasticsearch-master"
+  annotations:
+    # Create endpoints also if the related pod isn't ready
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like elasticsearch-0 to resolve
+  selector:
+    app: "elasticsearch-master"
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+---
+# Source: elasticsearch/templates/statefulset.yaml
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: elasticsearch-master
+  labels:
+    heritage: "Tiller"
+    release: "elasticsearch"
+    chart: "elasticsearch-7.1.1"
+    app: "elasticsearch-master"
+spec:
+  serviceName: elasticsearch-master-headless
+  selector:
+    matchLabels:
+      app: "elasticsearch-master"
+  replicas: 3
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-master
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 30Gi
+
+  template:
+    metadata:
+      name: "elasticsearch-master"
+      labels:
+        heritage: "Tiller"
+        release: "elasticsearch"
+        chart: "elasticsearch-7.1.1"
+        app: "elasticsearch-master"
+      annotations:
+
+    spec:
+      securityContext:
+        fsGroup: 1000
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - "elasticsearch-master"
+      terminationGracePeriodSeconds: 120
+      volumes:
+      initContainers:
+      - name: configure-sysctl
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        image: "docker.elastic.co/elasticsearch/elasticsearch:7.1.1"
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        resources:
+          {}
+
+      containers:
+      - name: "elasticsearch"
+        image: "docker.elastic.co/elasticsearch/elasticsearch:7.1.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 3
+          timeoutSeconds: 5
+
+          exec:
+            command:
+              - sh
+              - -c
+              - |
+                #!/usr/bin/env bash -e
+                # If the node is starting up wait for the cluster to be ready (request params: 'wait_for_status=green&timeout=1s' )
+                # Once it has started only check that the node itself is responding
+                START_FILE=/tmp/.es_start_file
+
+                http () {
+                    local path="${1}"
+                    if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
+                      BASIC_AUTH="-u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
+                    else
+                      BASIC_AUTH=''
+                    fi
+                    curl -XGET -s -k --fail ${BASIC_AUTH} http://127.0.0.1:9200${path}
+                }
+
+                if [ -f "${START_FILE}" ]; then
+                    echo 'Elasticsearch is already running, lets check the node is healthy'
+                    http "/"
+                else
+                    echo 'Waiting for elasticsearch cluster to become cluster to be ready (request params: "wait_for_status=green&timeout=1s" )'
+                    if http "/_cluster/health?wait_for_status=green&timeout=1s" ; then
+                        touch ${START_FILE}
+                        exit 0
+                    else
+                        echo 'Cluster is not yet ready (request params: "wait_for_status=green&timeout=1s" )'
+                        exit 1
+                    fi
+                fi
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 2Gi
+
+        env:
+          - name: node.name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: cluster.initial_master_nodes
+            value: "elasticsearch-master-0,elasticsearch-master-1,elasticsearch-master-2,"
+          - name: discovery.seed_hosts
+            value: "elasticsearch-master-headless"
+          - name: cluster.name
+            value: "elasticsearch"
+          - name: network.host
+            value: "0.0.0.0"
+          - name: ES_JAVA_OPTS
+            value: "-Xmx1g -Xms1g"
+          - name: node.data
+            value: "true"
+          - name: node.ingest
+            value: "true"
+          - name: node.master
+            value: "true"
+        volumeMounts:
+          - name: "elasticsearch-master"
+            mountPath: /usr/share/elasticsearch/data
+      # This sidecar will prevent slow master re-election
+      # https://github.com/elastic/helm-charts/issues/63
+      - name: elasticsearch-master-graceful-termination-handler
+        image: "docker.elastic.co/elasticsearch/elasticsearch:7.1.1"
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - "sh"
+        - -c
+        - |
+          #!/usr/bin/env bash
+          set -eo pipefail
+
+          http () {
+              local path="${1}"
+              if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
+                BASIC_AUTH="-u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
+              else
+                BASIC_AUTH=''
+              fi
+              curl -XGET -s -k --fail ${BASIC_AUTH} http://elasticsearch-master:9200${path}
+          }
+
+          cleanup () {
+            while true ; do
+              local master="$(http "/_cat/master?h=node")"
+              if [[ $master == "elasticsearch-master"* && $master != "${NODE_NAME}" ]]; then
+                echo "This node is not master."
+                break
+              fi
+              echo "This node is still master, waiting gracefully for it to step down"
+              sleep 1
+            done
+
+            exit 0
+          }
+
+          trap cleanup SIGTERM
+
+          sleep infinity &
+          wait $!
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+

--- a/examples/centralised-logging/generated-charts/fluentd.yaml
+++ b/examples/centralised-logging/generated-charts/fluentd.yaml
@@ -1,0 +1,356 @@
+# Source: fluentd-elasticsearch/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-fluentd-elasticsearch
+  labels:
+    app.kubernetes.io/name: fluentd-elasticsearch
+    helm.sh/chart: fluentd-elasticsearch-5.0.0
+    app.kubernetes.io/instance: fluentd
+    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/managed-by: Tiller
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  system.conf: |-
+    <system>
+      root_dir /tmp/fluentd-buffers/
+    </system>
+  forward.input.conf: |-
+    # Takes the messages sent over TCP
+    <source>
+      @id forward
+      @type forward
+    </source>
+  monitoring.conf: |-
+    # Prometheus Exporter Plugin
+    # input plugin that exports metrics
+    <source>
+      @id prometheus
+      @type prometheus
+    </source>
+
+    <source>
+      @id monitor_agent
+      @type monitor_agent
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @id prometheus_monitor
+      @type prometheus_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for output plugin
+    <source>
+      @id prometheus_output_monitor
+      @type prometheus_output_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for in_tail plugin
+    <source>
+      @id prometheus_tail_monitor
+      @type prometheus_tail_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+  output.conf: |-
+    <match **>
+      @id elasticsearch
+      @type elasticsearch
+      @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
+      include_tag_key true
+      host "#{ENV['OUTPUT_HOST']}"
+      port "#{ENV['OUTPUT_PORT']}"
+      path "#{ENV['OUTPUT_PATH']}"
+      scheme "#{ENV['OUTPUT_SCHEME']}"
+      ssl_verify "#{ENV['OUTPUT_SSL_VERIFY']}"
+      ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
+      type_name "#{ENV['OUTPUT_TYPE_NAME']}"
+      logstash_format true
+      logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
+      reconnect_on_error true
+      <buffer>
+        @type file
+        path /var/log/fluentd-buffers/kubernetes.system.buffer
+        flush_mode interval
+        retry_type exponential_backoff
+        flush_thread_count 2
+        flush_interval 5s
+        retry_forever
+        retry_max_interval 30
+        chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
+        queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
+        overflow_action block
+      </buffer>
+    </match>
+  containers.input.conf: |-
+    <source>
+    @id fluentd-containers.log
+    @type tail
+    path /var/log/containers/*.log
+    pos_file /var/log/containers.log.pos
+    tag raw.kubernetes.*
+    read_from_head true
+    <parse>
+    @type multi_format
+    <pattern>
+    format json
+    time_key time
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+    </pattern>
+    <pattern>
+    format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+    time_format %Y-%m-%dT%H:%M:%S.%N%:z
+    </pattern>
+    </parse>
+    </source>
+
+    # Detect exceptions in the log output and forward them as one log entry.
+    <match raw.kubernetes.**>
+    @id raw.kubernetes
+    @type detect_exceptions
+    remove_tag_prefix raw
+    message log
+    stream stream
+    multiline_flush_interval 5
+    max_bytes 500000
+    max_lines 1000
+    </match>
+
+    # Concatenate multi-line logs
+    <filter **>
+    @id filter_concat
+    @type concat
+    key message
+    multiline_end_regexp /\n$/
+    separator ""
+    </filter>
+
+    # Enriches records with Kubernetes metadata
+    <filter kubernetes.**>
+    @id filter_kubernetes_metadata
+    @type kubernetes_metadata
+    </filter>
+
+    # Fixes json fields in Elasticsearch
+    <filter kubernetes.**>
+    @id filter_parser
+    @type parser
+    key_name log
+    reserve_data true
+    remove_key_name_field true
+    <parse>
+    @type multi_format
+    <pattern>
+    format json
+    </pattern>
+    <pattern>
+    format none
+    </pattern>
+    </parse>
+    </filter>
+
+    #exclude kube-system
+    <match kubernetes.var.log.containers.**kube-system**.log>
+    @type null
+    </match>
+
+    # Filter to only records with label fluentd=true
+    <filter kubernetes.**>
+    @type grep
+    <regexp>
+    key $.kubernetes.labels.fluentd
+    pattern true
+    </regexp>
+    </filter>
+
+    <filter kubernetes.**>
+    @type grep
+    <exclude>
+    key $.kubernetes.container_name
+    pattern istio-proxy
+    </exclude>
+    </filter>
+---
+# Source: fluentd-elasticsearch/templates/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd-fluentd-elasticsearch
+  labels:
+    app.kubernetes.io/name: fluentd-elasticsearch
+    helm.sh/chart: fluentd-elasticsearch-5.0.0
+    app.kubernetes.io/instance: fluentd
+    app.kubernetes.io/managed-by: Tiller
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+# Source: fluentd-elasticsearch/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluentd-fluentd-elasticsearch
+  labels:
+    app.kubernetes.io/name: fluentd-elasticsearch
+    helm.sh/chart: fluentd-elasticsearch-5.0.0
+    app.kubernetes.io/instance: fluentd
+    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/managed-by: Tiller
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  - "pods"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+---
+# Source: fluentd-elasticsearch/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluentd-fluentd-elasticsearch
+  labels:
+    app.kubernetes.io/name: fluentd-elasticsearch
+    helm.sh/chart: fluentd-elasticsearch-5.0.0
+    app.kubernetes.io/instance: fluentd
+    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/managed-by: Tiller
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+- kind: ServiceAccount
+  name: fluentd-fluentd-elasticsearch
+  namespace: logs
+roleRef:
+  kind: ClusterRole
+  name: fluentd-fluentd-elasticsearch
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: fluentd-elasticsearch/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd-fluentd-elasticsearch
+  labels:
+    app.kubernetes.io/name: fluentd-elasticsearch
+    helm.sh/chart: fluentd-elasticsearch-5.0.0
+    app.kubernetes.io/instance: fluentd
+    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/managed-by: Tiller
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  updateStrategy:
+    type: RollingUpdate
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluentd-elasticsearch
+      app.kubernetes.io/instance: fluentd
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fluentd-elasticsearch
+        helm.sh/chart: fluentd-elasticsearch-5.0.0
+        app.kubernetes.io/instance: fluentd
+        app.kubernetes.io/version: "2.7.0"
+        app.kubernetes.io/managed-by: Tiller
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        checksum/config: dc41741a3a79bcf90817f6e4cad1db9f8686db6a98698992468bb3f5930c0c86
+    spec:
+      serviceAccountName: fluentd-fluentd-elasticsearch
+      containers:
+      - name: fluentd-fluentd-elasticsearch
+        image:  "quay.io/fluentd_elasticsearch/fluentd:v2.7.0"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: FLUENTD_ARGS
+          value: "--no-supervisor -q"
+        - name: OUTPUT_HOST
+          value: "elasticsearch-master"
+        - name: OUTPUT_PORT
+          value: "9200"
+        - name: OUTPUT_PATH
+          value: ""
+        - name: LOGSTASH_PREFIX
+          value: "logstash"
+        - name: OUTPUT_SCHEME
+          value: "http"
+        - name: OUTPUT_SSL_VERIFY
+          value: "true"
+        - name: OUTPUT_SSL_VERSION
+          value: "TLSv1_2"
+        - name: OUTPUT_TYPE_NAME
+          value: "_doc"
+        - name: OUTPUT_BUFFER_CHUNK_LIMIT
+          value: "2M"
+        - name: OUTPUT_BUFFER_QUEUE_LIMIT
+          value: "8"
+        - name: OUTPUT_LOG_LEVEL
+          value: "info"
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          {}
+
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: libsystemddir
+          mountPath: /usr/lib64
+          readOnly: true
+        - name: config-volume
+          mountPath: /etc/fluent/config.d  #pointing to fluentd Dockerfile
+        livenessProbe:
+          initialDelaySeconds: 600
+          periodSeconds: 60
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then
+                exit 1;
+              fi; touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck; if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ]; then
+                rm -rf /var/log/fluentd-buffers;
+                exit 1;
+              fi; touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness; if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-liveness -print -quit)" ]; then
+                exit 1;
+              fi;
+
+        ports:
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      # It is needed to copy systemd library to decompress journals
+      - name: libsystemddir
+        hostPath:
+          path: /usr/lib64
+      - name: config-volume
+        configMap:
+          name: fluentd-fluentd-elasticsearch
+

--- a/examples/centralised-logging/generated-charts/kibana.yaml
+++ b/examples/centralised-logging/generated-charts/kibana.yaml
@@ -1,0 +1,93 @@
+---
+# Source: kibana/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana-kibana
+  labels:
+    app: kibana
+    release: "kibana"
+    heritage: Tiller
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5601
+      protocol: TCP
+      name: http
+      targetPort: 5601
+  selector:
+    app: kibana
+    release: "kibana"
+---
+# Source: kibana/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana-kibana
+  labels:
+    app: kibana
+    release: "kibana"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+
+  selector:
+    matchLabels:
+      app: kibana
+      release: "kibana"
+  template:
+    metadata:
+      labels:
+        app: kibana
+        release: "kibana"
+      annotations:
+
+    spec:
+      volumes:
+      containers:
+      - name: kibana
+        image: "docker.elastic.co/kibana/kibana:7.1.1"
+        env:
+          - name: ELASTICSEARCH_HOSTS
+            value: "http://elasticsearch-master:9200"
+          - name: SERVER_BASEPATH
+            value: /kibana
+
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 3
+          timeoutSeconds: 5
+
+          exec:
+            command:
+              - sh
+              - -c
+              - |
+                #!/usr/bin/env bash -e
+                http () {
+                    local path="${1}"
+                    set -- -XGET -s --fail
+
+                    if [ -n "${ELASTIC_USERNAME}" ] && [ -n "${ELASTIC_PASSWORD}" ]; then
+                      set -- "$@" -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
+                    fi
+
+                    curl -k "$@" "http://localhost:5601${path}"
+                }
+
+                http "/app/kibana"
+        ports:
+        - containerPort: 5601
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 500m
+
+        volumeMounts:
+


### PR DESCRIPTION
This PR contains the extracted manifests from the helm chart commands that would enable for offline installations. This was tested to work. It could be possible to pass a flag to select that we'd want to use the manifests instead of helm.