### PR TITLE
Decode binData before sending it to Predict function

### DIFF
--- a/python/seldon_core/flask_utils.py
+++ b/python/seldon_core/flask_utils.py
@@ -66,6 +66,9 @@ def get_request() -> Dict:
                 raise SeldonMicroserviceException("Can't find JSON in data")
     if message is None:
         raise SeldonMicroserviceException("Invalid Data Format - empty JSON")
+    if 'binData' in message and message['binData'] is not None:
+        binData = message['binData']
+        message['binData'] = base64.b64decode(binData).decode("utf-8")
     return message
 
 

--- a/python/seldon_core/flask_utils.py
+++ b/python/seldon_core/flask_utils.py
@@ -68,7 +68,7 @@ def get_request() -> Dict:
         raise SeldonMicroserviceException("Invalid Data Format - empty JSON")
     if 'binData' in message and message['binData'] is not None:
         binData = message['binData']
-        message['binData'] = base64.b64decode(binData).decode("utf-8")
+        message['binData'] = base64.b64decode(binData)
     return message
 
 

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -549,7 +549,7 @@ def extract_request_parts_json(
         features = request["strData"]
     elif "binData" in request:
         data_type = "binData"
-        features = bytes(request["binData"], "utf8")
+        features = bytes(request["binData"])
     else:
         raise SeldonMicroserviceException(f"Invalid request data type: {request}")
 

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -16,7 +16,6 @@ from seldon_core.flask_utils import (
     ANNOTATION_GRPC_MAX_MSG_SIZE,
 )
 from seldon_core.proto import prediction_pb2_grpc
-import base64
 import os
 
 logger = logging.getLogger(__name__)

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -114,10 +114,6 @@ class SeldonModelGRPC(object):
         self.user_model = user_model
 
     def Predict(self, request_grpc, context):
-        data_type = request_grpc.WhichOneof("data_oneof")
-        if data_type == "binData":
-            binData = request_grpc.binData
-            request_grpc.binData = base64.b64decode(binData)
         return seldon_core.seldon_methods.predict(self.user_model, request_grpc)
 
     def SendFeedback(self, feedback_grpc, context):

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -16,6 +16,7 @@ from seldon_core.flask_utils import (
     ANNOTATION_GRPC_MAX_MSG_SIZE,
 )
 from seldon_core.proto import prediction_pb2_grpc
+import base64
 import os
 
 logger = logging.getLogger(__name__)
@@ -113,6 +114,10 @@ class SeldonModelGRPC(object):
         self.user_model = user_model
 
     def Predict(self, request_grpc, context):
+        data_type = request_grpc.WhichOneof("data_oneof")
+        if data_type == "binData":
+            binData = request_grpc.binData
+            request_grpc.binData = base64.b64decode(binData)
         return seldon_core.seldon_methods.predict(self.user_model, request_grpc)
 
     def SendFeedback(self, feedback_grpc, context):

--- a/python/tests/test_model_microservice.py
+++ b/python/tests/test_model_microservice.py
@@ -609,7 +609,7 @@ def test_proto_bin_data():
     bdata_base64 = base64.b64encode(bdata)
     request = prediction_pb2.SeldonMessage(binData=bdata_base64)
     resp = app.Predict(request, None)
-    assert resp.binData == bdata
+    assert resp.binData == bdata_base64
 
 
 def test_proto_bin_data_nparray():

--- a/python/tests/test_model_microservice.py
+++ b/python/tests/test_model_microservice.py
@@ -609,7 +609,7 @@ def test_proto_bin_data():
     bdata_base64 = base64.b64encode(bdata)
     request = prediction_pb2.SeldonMessage(binData=bdata_base64)
     resp = app.Predict(request, None)
-    assert resp.binData == bdata_base64
+    assert resp.binData == bdata
 
 
 def test_proto_bin_data_nparray():

--- a/python/tests/test_model_microservice.py
+++ b/python/tests/test_model_microservice.py
@@ -418,9 +418,8 @@ def test_model_bin_data():
     bdata_base64 = base64.b64encode(bdata).decode("utf-8")
     rv = client.get('/predict?json={"binData":"' + bdata_base64 + '"}')
     j = json.loads(rv.data)
-    return_data = base64.b64encode(base64.b64encode(bdata)).decode("utf-8")
     assert rv.status_code == 200
-    assert j["binData"] == return_data
+    assert j["binData"] == bdata_base64
     assert j["meta"]["tags"] == {"mytag": 1}
     assert j["meta"]["metrics"][0]["key"] == user_object.metrics()[0]["key"]
     assert j["meta"]["metrics"][0]["value"] == user_object.metrics()[0]["value"]
@@ -430,8 +429,8 @@ def test_model_bin_data_nparray():
     user_object = UserObject(ret_nparray=True)
     app = get_rest_microservice(user_object)
     client = app.test_client()
-    encoded = base64.b64encode(b"1234")
-    rv = client.get('/predict?json={"binData":"' + str(encoded) + '"}')
+    encoded = base64.b64encode(b"1234").decode("utf-8")
+    rv = client.get('/predict?json={"binData":"' + encoded + '"}')
     j = json.loads(rv.data)
     print(j)
     assert rv.status_code == 200


### PR DESCRIPTION
So the client won't need to implement decode in `predict_raw` by themselves.

Unit tests all passed.

Fixes #909 