### PR TITLE
Fixed test by moving bytes conversion to utils

### DIFF
--- a/python/seldon_core/flask_utils.py
+++ b/python/seldon_core/flask_utils.py
@@ -66,9 +66,6 @@ def get_request() -> Dict:
                 raise SeldonMicroserviceException("Can't find JSON in data")
     if message is None:
         raise SeldonMicroserviceException("Invalid Data Format - empty JSON")
-    if 'binData' in message and message['binData'] is not None:
-        binData = message['binData']
-        message['binData'] = base64.b64decode(binData)
     return message
 
 

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -549,7 +549,7 @@ def extract_request_parts_json(
         features = request["strData"]
     elif "binData" in request:
         data_type = "binData"
-        features = bytes(request["binData"])
+        features = base64.b64decode(request["binData"])
     else:
         raise SeldonMicroserviceException(f"Invalid request data type: {request}")
 

--- a/python/tests/test_combiner_microservice.py
+++ b/python/tests/test_combiner_microservice.py
@@ -171,7 +171,6 @@ def test_aggreate_ok_bindata():
         + bdata_base64
         + '"}]}'
     )
-    bdata_base64_result = base64.b64encode(base64.b64encode(bdata)).decode("utf-8")
     print(rv)
     j = json.loads(rv.data)
     print(j)
@@ -179,7 +178,7 @@ def test_aggreate_ok_bindata():
     assert j["meta"]["tags"] == {"mytag": 1}
     assert j["meta"]["metrics"][0]["key"] == user_object.metrics()[0]["key"]
     assert j["meta"]["metrics"][0]["value"] == user_object.metrics()[0]["value"]
-    assert j["binData"] == bdata_base64_result
+    assert j["binData"] == bdata_base64
 
 
 def test_aggreate_ok_strdata():


### PR DESCRIPTION
Currently the aggregate (combiner) test fails in master due to the code change only addressing single seldon messages, but not multiple seldon messages. It could be possible to address both cases in the `get_requests`, but it would be quite fiddly given that we would have to check and iterate across all messages. Instead the conversion is moved to the test_utils, which means that the `predict_raw` function will have the raw data, and the predict function will have the bytes object.