### PR TITLE
Update transitive dependencies

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -320,6 +320,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
       <version>${grpc.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>proto-google-common-protos</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <!-- Outdated transitive dependency through grpc-protobuf -->
+      <!-- Waiting on https://github.com/grpc/grpc-java/pull/6336 -->
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-common-protos</artifactId>
+      <version>1.17.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -340,6 +340,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>28.1-jre</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <!-- Outdated transitive dependency through guava -->
+      <!-- Waiting on https://github.com/google/guava/pull/3671 -->
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+      <version>2.11.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -391,6 +391,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
       <version>${jaeger.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <!-- Outdated transitive dependency through jaeger-client > jaeger-thrift -->
+      <!-- Waiting on https://github.com/jaegertracing/jaeger-client-java/issues/666 -->
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>4.2.2</version>
     </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -332,7 +332,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <!-- Waiting on https://github.com/grpc/grpc-java/pull/6336 -->
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
-      <version>1.17.0</version>
+      <version>1.16.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>


### PR DESCRIPTION
Fixes #1002.

## Changelog

- Update `checker-qual` to `v2.11.1`. There is an open PR to change it in `guava` here https://github.com/google/guava/pull/3671.
- Update `proto-google-common-protos` to `v1.16.0`. There is an open PR to change it in `grpc-protobuf` here https://github.com/grpc/grpc-java/pull/6336.
- Update `okhttp` to `v4.2.2`. There is an open issue to change it in `jaeger-client` here https://github.com/jaegertracing/jaeger-client-java/issues/666.  

## Notes

The latest version of `proto-google-common-protos` seems to be `v1.17.0` according to [Maven Repository](https://mvnrepository.com/artifact/com.google.api.grpc/proto-google-common-protos/1.17.0). However, as it's pointed out in this issue https://github.com/grpc/grpc-java/pull/6336, the https://github.com/googleapis/common-protos-java repo seems to be still pointing to `v1.16.0`. Therefore, it seems sensible to update to `v1.16.0` until it's confirmed which one is the latest version. 