### PR TITLE
Move from logback to log4j2

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -254,7 +254,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <groupId>org.json</groupId>
           <artifactId>json</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- Excluded to use Log4J2 -->
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opentracing</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -246,8 +246,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
+      <artifactId>spring-boot-starter</artifactId>
       <exclusions>
         <exclusion>
           <!-- Excluded due to nn standard license -->
@@ -260,6 +259,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <artifactId>spring-boot-starter-logging</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -300,10 +304,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Fixes #1007.

## Changelog

- Add explicitly the `spring-boot-starter` package to handle excludes more cleanly
- Remove `org.springframework:spring-web`, which is already being added by `spring-boot-starter-web`
- Exclude `spring-boot-starter-logging` and add dependency on `spring-boot-starter-log4j2`

## Notes

The only reason to add `spring-boot-starter` explicitly is that currently all the `spring-boot-starter-*` excludes are handled on `spring-boot-starter-test`, because it's the first one that appears. Since this one is also including `spring-boot-starter`, it makes sense to add it explicitly and specify the excludes there.

This is also the recommended way to do when the project combines multiple `spring-boot-starter-*` projects (e.g. [here](https://docs.spring.io/spring-boot/docs/2.2.0.RELEASE/reference/htmlsingle/#howto-configure-log4j-for-logging)). 