### PR TITLE
Updated GPU wrapper to uninstall TF without GPU

### DIFF
--- a/wrappers/s2i/python-gpu/python-gpu/Dockerfile
+++ b/wrappers/s2i/python-gpu/python-gpu/Dockerfile
@@ -18,7 +18,6 @@ COPY ./s2i/bin/ /s2i/bin
 
 # keep install of seldon-core after the COPY to force re-build of layer
 RUN pip3 install seldon-core
-# RUN pip3 uninstall tensorflow -y
 RUN pip3 install tensorflow-gpu
 
 # Numpy version 1.16.1 required for tf-gpu

--- a/wrappers/s2i/python-gpu/python-gpu/Dockerfile
+++ b/wrappers/s2i/python-gpu/python-gpu/Dockerfile
@@ -17,7 +17,12 @@ WORKDIR /microservice
 COPY ./s2i/bin/ /s2i/bin
 
 # keep install of seldon-core after the COPY to force re-build of layer
-RUN pip3 install tensorflow-gpu==1.14.0
 RUN pip3 install seldon-core
+RUN pip3 uninstall tensorflow -y
+RUN pip3 install tensorflow-gpu
+
+# Numpy version 1.16.1 required for tf-gpu
+RUN pip3 install numpy==1.16.1
+
 
 EXPOSE 5000

--- a/wrappers/s2i/python-gpu/python-gpu/Dockerfile
+++ b/wrappers/s2i/python-gpu/python-gpu/Dockerfile
@@ -18,7 +18,7 @@ COPY ./s2i/bin/ /s2i/bin
 
 # keep install of seldon-core after the COPY to force re-build of layer
 RUN pip3 install seldon-core
-RUN pip3 uninstall tensorflow -y
+# RUN pip3 uninstall tensorflow -y
 RUN pip3 install tensorflow-gpu
 
 # Numpy version 1.16.1 required for tf-gpu


### PR DESCRIPTION
Updated the Python TF-GPU wrapper to uninstall Tensorflow (without GPU) after the Seldon-core install and only install Tensorflow-GPU. An install of Numpy=1.16.1 was also added to clear Warnings due to version 1.17 of Numpy with TF-GPU.