### PR TITLE
Add tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,5 +187,6 @@ testing/scripts/go
 
 # pyenv
 .python-version
+.tox
 
 operator/operator.tar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,48 @@ heavily opinionated formatter.
 
 To integrate it on your local editor, you can follow the official instructions
 to [set-up black](https://github.com/psf/black#editor-integration).
+
+## Tests
+
+Regardless of the package you are working on, we abstract the main tasks to a
+`Makefile`.
+Therefore, in order to run the tests, you should be able to just do:
+
+```bash
+$ make test
+```
+
+### Python
+
+We use [`pytest`](https://docs.pytest.org/en/latest/) as our main test runner.
+However, to ensure that tests run on the same version of the package that final
+users will download from `pip` and pypi.org, we use
+[`tox`](https://tox.readthedocs.io/en/latest/) on top of it.
+To install both (plus other required plugins), just run:
+
+```bash
+$ make install_dev
+```
+
+Using `tox` we can run the entire test suite over different environments,
+isolated between them.
+You can see the different ones we currently use on the
+[`setup.cfg`](https://github.com/SeldonIO/seldon-core/blob/master/python/setup.cfg)
+file.
+You can run your tests across all these environments using the standard `make test` [mentioned above](#Tests).
+Alternatively, if you want to pass any extra parameters, you can also run `tox`
+directly as:
+
+```bash
+$ tox
+```
+
+One of the caveats of `tox` is that, as the number of environments grows, so
+does the time it takes to finish running the tests.
+As a solution, during local development it may be recommended to run `pytest` directly
+on your own environment.
+You can do so as:
+
+```bash
+$ pytest
+```

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -15,31 +15,10 @@ pipelineConfig:
             - args:
               - -C python
               - update_package
-              - install
+              - install_dev
               - test
               command: make
               name: test-python
-            - args:
-              - -C python
-              - update_package
-              - install-tf
-              - test
-              command: make
-              name: test-python-tf
-            - args:
-              - -C python
-              - update_package
-              - install-gcs
-              - test
-              command: make
-              name: test-python-gcs
-            - args:
-              - -C python
-              - update_package
-              - install-all
-              - test
-              command: make
-              name: test-python-all
           - agent:
               image: seldonio/core-builder:0.4
             name: seldon-engine

--- a/python/Makefile
+++ b/python/Makefile
@@ -94,12 +94,12 @@ setup_linter:
 run_linter:
 	black \
 		./ ../testing \
-		--exclude "(testing/scripts/proto|seldon_core/proto/|.eggs)"
+		--exclude "(testing/scripts/proto|seldon_core/proto/|.eggs|.tox)"
 
 run_linter_check:
 	black \
 		--check ./ ../testing \
-		--exclude "(testing/scripts/proto|seldon_core/proto/|.eggs)"
+		--exclude "(testing/scripts/proto|seldon_core/proto/|.eggs|.tox)"
 
 .PHONY: clean
 clean:

--- a/python/Makefile
+++ b/python/Makefile
@@ -49,21 +49,9 @@ update_package: get_apis build_apis update_version
 install:
 	pip install -e .
 
-.PHONY: install-tf
-install-tf:
-	pip install -e .[tensorflow]
-
-.PHONY: install-gcs
-install-gcs:
-	pip install -e .[gcs]
-
-.PHONY: install-all
-install-all:
-	pip install -e .[all]
-
 .PHONY: install-dev
 install-dev:
-	pip install -e . -r requirements.txt
+	pip install -e . -r requirements-dev.txt
 
 .PHONY: uninstall
 uninstall:
@@ -71,7 +59,7 @@ uninstall:
 
 .PHONY: test
 test:
-	python setup.py test
+	tox
 
 .PHONY: type_check
 type_check:

--- a/python/Makefile
+++ b/python/Makefile
@@ -49,8 +49,8 @@ update_package: get_apis build_apis update_version
 install:
 	pip install -e .
 
-.PHONY: install-dev
-install-dev:
+.PHONY: install_dev
+install_dev:
 	pip install -e . -r requirements-dev.txt
 
 .PHONY: uninstall

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+mypy
+pytest
+pytest-cov
+Pillow==6.2.0
+tox

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-mypy
-pytest
-pytest-cov
+mypy<=0.740
+pytest<6.0.0
+pytest-cov<3.0.0
 Pillow==6.2.0
-tox
+tox<4.0.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,6 +18,5 @@ setuptools >= 41.0.0
 pandas==0.25.3
 futures<4.0.0
 tornado==4.5.3
-Pillow==6.2.0
 google-cloud-storage >= 1.16.0
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -15,11 +15,9 @@ gunicorn >= 19.9.0, < 19.10.0
 minio >= 4.0.9, < 6.0.0
 azure-storage-blob >= 2.0.1, < 3.0.0
 setuptools >= 41.0.0
-
 pandas==0.25.3
 futures<4.0.0
 tornado==4.5.3
 Pillow==6.2.0
-minio >= 4.0.9
 google-cloud-storage >= 1.16.0
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -16,7 +16,5 @@ minio >= 4.0.9, < 6.0.0
 azure-storage-blob >= 2.0.1, < 3.0.0
 setuptools >= 41.0.0
 pandas==0.25.3
-futures<4.0.0
-tornado==4.5.3
 google-cloud-storage >= 1.16.0
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,8 +1,32 @@
 [aliases]
 test=pytest
 
+[tox:tox]
+envlist =
+  py37
+  tensorflow
+  gcs
+  all
+
+[testenv]
+deps =
+  pytest
+  pytest-cov
+  Pillow
+commands = pytest {posargs}
+
+[testenv:tensorflow]
+extras = tensorflow
+
+[testenv:gcs]
+extras = gcs
+
+[testenv:all]
+extras = all
+
 [tool:pytest]
 addopts =
     --tb native
     -W ignore
     --cov=seldon_core
+

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,7 +43,7 @@ setup(
         "azure-storage-blob >= 2.0.1, < 3.0.0",
         "setuptools >= 41.0.0",
     ],
-    tests_require=["pytest", "pytest-cov", "Pillow"],
+    tests_require=["pytest<6.0.0", "pytest-cov<3.0.0", "Pillow==6.2.0"],
     extras_require=extras,
     test_suite="tests",
     entry_points={

--- a/testing/scripts/kind_test_all.sh
+++ b/testing/scripts/kind_test_all.sh
@@ -47,7 +47,7 @@ if [[ ${KIND_EXIT_VALUE} -eq 0 ]]; then
     SETUP_EXIT_VALUE=$?
 
     ## INSTALL ALL REQUIRED DEPENDENCIES
-    make -C ../../python install-dev
+    make -C ../../python install_dev
     INSTALL_EXIT_VALUE=$?
 
     ## RUNNING TESTS AND CAPTURING ERROR


### PR DESCRIPTION
Resolves #1042. However, before making any changes we should discuss on #1042 if we want to introduce `tox` or not.

## Changelog
- Add `requirements-dev.txt` with `pytest`, `tox` and `mypy`
- Add `tox` config to `setup.cfg`
- Remove all `install-*` targets in `Makefile` and the different steps in `jenkins-x.yaml` since the diff environments are now hanled by `tox`