### PR TITLE
Update to explainers for Seldon Core

### DIFF
--- a/examples/explainers/imagenet/imagenet_explainer.yaml
+++ b/examples/explainers/imagenet/imagenet_explainer.yaml
@@ -43,7 +43,9 @@ spec:
       - name: SELDON_LOG_LEVEL
         value: DEBUG
     explainer:
-      type: anchor_images
+      type: AnchorImages
       modelUri: gs://seldon-models/tfserving/imagenet/explainer
+      endpoint:
+        type: GRPC
     name: default
     replicas: 1

--- a/notebooks/explainer_examples.ipynb
+++ b/notebooks/explainer_examples.ipynb
@@ -39,51 +39,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "namespace/seldon created\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl create namespace seldon"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Context \"kubernetes-admin@kind\" modified.\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl config set-context $(kubectl config current-context) --namespace=seldon"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "clusterrolebinding.rbac.authorization.k8s.io/kube-system-cluster-admin created\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl create clusterrolebinding kube-system-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default"
    ]
@@ -97,26 +73,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "serviceaccount/tiller created\n",
-      "clusterrolebinding.rbac.authorization.k8s.io/tiller created\n",
-      "$HELM_HOME has been configured at /home/clive/.helm.\n",
-      "\n",
-      "Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.\n",
-      "\n",
-      "Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy.\n",
-      "To prevent this, run `helm init` with the --tiller-tls-verify flag.\n",
-      "For more information on securing your installation see: https://docs.helm.sh/using_helm/#securing-your-helm-installation\n",
-      "Happy Helming!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl -n kube-system create sa tiller\n",
     "!kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller\n",
@@ -125,18 +84,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for deployment \"tiller-deploy\" rollout to finish: 0 of 1 updated replicas are available...\n",
-      "deployment \"tiller-deploy\" successfully rolled out\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl rollout status deploy/tiller-deploy -n kube-system"
    ]
@@ -150,118 +100,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NAME:   seldon-core\n",
-      "LAST DEPLOYED: Tue Oct 22 09:18:10 2019\n",
-      "NAMESPACE: seldon-system\n",
-      "STATUS: DEPLOYED\n",
-      "\n",
-      "RESOURCES:\n",
-      "==> v1/ClusterRole\n",
-      "NAME                     AGE\n",
-      "seldon-manager-css-role  1s\n",
-      "seldon-manager-role      1s\n",
-      "seldon-manager-sas-role  1s\n",
-      "seldon-proxy-role        1s\n",
-      "\n",
-      "==> v1/ClusterRoleBinding\n",
-      "NAME                            AGE\n",
-      "seldon-manager-css-rolebinding  1s\n",
-      "seldon-manager-rolebinding      1s\n",
-      "seldon-manager-sas-rolebinding  1s\n",
-      "seldon-proxy-rolebinding        1s\n",
-      "\n",
-      "==> v1/ConfigMap\n",
-      "NAME                     DATA  AGE\n",
-      "seldon-config            1     1s\n",
-      "seldon-spartakus-config  1     1s\n",
-      "\n",
-      "==> v1/Deployment\n",
-      "NAME                       READY  UP-TO-DATE  AVAILABLE  AGE\n",
-      "seldon-controller-manager  0/1    1           0          0s\n",
-      "\n",
-      "==> v1/Pod(related)\n",
-      "NAME                                         READY  STATUS             RESTARTS  AGE\n",
-      "seldon-controller-manager-864f5f6cb6-f8zl9   0/1    ContainerCreating  0         0s\n",
-      "seldon-spartakus-volunteer-7d6dd98f89-9sfwv  0/1    ContainerCreating  0         0s\n",
-      "\n",
-      "==> v1/Role\n",
-      "NAME                         AGE\n",
-      "seldon-leader-election-role  1s\n",
-      "seldon-manager-cm-role       1s\n",
-      "\n",
-      "==> v1/RoleBinding\n",
-      "NAME                                AGE\n",
-      "seldon-leader-election-rolebinding  1s\n",
-      "seldon-manager-cm-rolebinding       1s\n",
-      "\n",
-      "==> v1/Secret\n",
-      "NAME                        TYPE               DATA  AGE\n",
-      "seldon-webhook-server-cert  kubernetes.io/tls  3     1s\n",
-      "\n",
-      "==> v1/Service\n",
-      "NAME                                       TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)   AGE\n",
-      "seldon-controller-manager-metrics-service  ClusterIP  10.96.103.140   <none>       8443/TCP  1s\n",
-      "seldon-webhook-service                     ClusterIP  10.108.245.187  <none>       443/TCP   0s\n",
-      "\n",
-      "==> v1/ServiceAccount\n",
-      "NAME                        SECRETS  AGE\n",
-      "seldon-manager              1        1s\n",
-      "seldon-spartakus-volunteer  1        1s\n",
-      "\n",
-      "==> v1beta1/ClusterRole\n",
-      "NAME                        AGE\n",
-      "seldon-spartakus-volunteer  1s\n",
-      "\n",
-      "==> v1beta1/ClusterRoleBinding\n",
-      "NAME                        AGE\n",
-      "seldon-spartakus-volunteer  1s\n",
-      "\n",
-      "==> v1beta1/CustomResourceDefinition\n",
-      "NAME                                         AGE\n",
-      "seldondeployments.machinelearning.seldon.io  1s\n",
-      "\n",
-      "==> v1beta1/Deployment\n",
-      "NAME                        READY  UP-TO-DATE  AVAILABLE  AGE\n",
-      "seldon-spartakus-volunteer  0/1    1           0          0s\n",
-      "\n",
-      "==> v1beta1/MutatingWebhookConfiguration\n",
-      "NAME                                   AGE\n",
-      "seldon-mutating-webhook-configuration  0s\n",
-      "\n",
-      "==> v1beta1/ValidatingWebhookConfiguration\n",
-      "NAME                                     AGE\n",
-      "seldon-validating-webhook-configuration  0s\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!helm install ../helm-charts/seldon-core-operator --name seldon-core --set usageMetrics.enabled=true --namespace seldon-system"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deployment \"seldon-controller-manager\" successfully rolled out\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl rollout status deployment/seldon-controller-manager -n seldon-system"
    ]
@@ -276,102 +128,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NAME:   ambassador\n",
-      "LAST DEPLOYED: Tue Oct 22 09:18:26 2019\n",
-      "NAMESPACE: seldon\n",
-      "STATUS: DEPLOYED\n",
-      "\n",
-      "RESOURCES:\n",
-      "==> v1/Deployment\n",
-      "NAME        READY  UP-TO-DATE  AVAILABLE  AGE\n",
-      "ambassador  0/3    3           0          0s\n",
-      "\n",
-      "==> v1/Pod(related)\n",
-      "NAME                         READY  STATUS             RESTARTS  AGE\n",
-      "ambassador-5784b5cb9d-cqtfv  0/1    ContainerCreating  0         0s\n",
-      "ambassador-5784b5cb9d-mp2pt  0/1    ContainerCreating  0         0s\n",
-      "ambassador-5784b5cb9d-z7sr7  0/1    ContainerCreating  0         0s\n",
-      "\n",
-      "==> v1/Service\n",
-      "NAME              TYPE          CLUSTER-IP      EXTERNAL-IP  PORT(S)                     AGE\n",
-      "ambassador        LoadBalancer  10.111.184.152  <pending>    80:31322/TCP,443:30535/TCP  0s\n",
-      "ambassador-admin  ClusterIP     10.111.194.82   <none>       8877/TCP                    0s\n",
-      "\n",
-      "==> v1/ServiceAccount\n",
-      "NAME        SECRETS  AGE\n",
-      "ambassador  1        0s\n",
-      "\n",
-      "==> v1beta1/ClusterRole\n",
-      "NAME             AGE\n",
-      "ambassador       0s\n",
-      "ambassador-crds  0s\n",
-      "\n",
-      "==> v1beta1/ClusterRoleBinding\n",
-      "NAME             AGE\n",
-      "ambassador       0s\n",
-      "ambassador-crds  0s\n",
-      "\n",
-      "==> v1beta1/CustomResourceDefinition\n",
-      "NAME                                          AGE\n",
-      "authservices.getambassador.io                 0s\n",
-      "consulresolvers.getambassador.io              0s\n",
-      "kubernetesendpointresolvers.getambassador.io  0s\n",
-      "kubernetesserviceresolvers.getambassador.io   0s\n",
-      "mappings.getambassador.io                     0s\n",
-      "modules.getambassador.io                      0s\n",
-      "ratelimitservices.getambassador.io            0s\n",
-      "tcpmappings.getambassador.io                  0s\n",
-      "tlscontexts.getambassador.io                  0s\n",
-      "tracingservices.getambassador.io              0s\n",
-      "\n",
-      "\n",
-      "NOTES:\n",
-      "Congratuations! You've successfully installed Ambassador.\n",
-      "\n",
-      "For help, visit our Slack at https://d6e.co/slack or view the documentation online at https://www.getambassador.io.\n",
-      "\n",
-      "To get the IP address of Ambassador, run the following commands:\n",
-      "NOTE: It may take a few minutes for the LoadBalancer IP to be available.\n",
-      "     You can watch the status of by running 'kubectl get svc -w  --namespace seldon ambassador'\n",
-      "\n",
-      "  On GKE/Azure:\n",
-      "  export SERVICE_IP=$(kubectl get svc --namespace seldon ambassador -o jsonpath='{.status.loadBalancer.ingress[0].ip}')\n",
-      "\n",
-      "  On AWS:\n",
-      "  export SERVICE_IP=$(kubectl get svc --namespace seldon ambassador -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')\n",
-      "\n",
-      "  echo http://$SERVICE_IP:\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!helm install stable/ambassador --name ambassador --set crds.keep=false"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for deployment \"ambassador\" rollout to finish: 0 of 3 updated replicas are available...\n",
-      "Waiting for deployment \"ambassador\" rollout to finish: 1 of 3 updated replicas are available...\n",
-      "Waiting for deployment \"ambassador\" rollout to finish: 2 of 3 updated replicas are available...\n",
-      "deployment \"ambassador\" successfully rolled out\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl rollout status deployment.apps/ambassador"
    ]
@@ -396,77 +164,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[34;01mapiVersion\u001b[39;49;00m: machinelearning.seldon.io/v1alpha2\r\n",
-      "\u001b[34;01mkind\u001b[39;49;00m: SeldonDeployment\r\n",
-      "\u001b[34;01mmetadata\u001b[39;49;00m:\r\n",
-      "  \u001b[34;01mname\u001b[39;49;00m: income\r\n",
-      "\u001b[34;01mspec\u001b[39;49;00m:\r\n",
-      "  \u001b[34;01mname\u001b[39;49;00m: income\r\n",
-      "  \u001b[34;01mpredictors\u001b[39;49;00m:\r\n",
-      "  - \u001b[34;01mgraph\u001b[39;49;00m:\r\n",
-      "      \u001b[34;01mchildren\u001b[39;49;00m: []\r\n",
-      "      \u001b[34;01mimplementation\u001b[39;49;00m: SKLEARN_SERVER\r\n",
-      "      \u001b[34;01mmodelUri\u001b[39;49;00m: gs://seldon-models/sklearn/income/model\r\n",
-      "      \u001b[34;01mname\u001b[39;49;00m: classifier\r\n",
-      "    \u001b[34;01mexplainer\u001b[39;49;00m:\r\n",
-      "      \u001b[34;01mtype\u001b[39;49;00m: anchor_tabular\r\n",
-      "      \u001b[34;01mmodelUri\u001b[39;49;00m: gs://seldon-models/sklearn/income/explainer\r\n",
-      "    \u001b[34;01mname\u001b[39;49;00m: default\r\n",
-      "    \u001b[34;01mreplicas\u001b[39;49;00m: 1\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pygmentize resources/income_explainer.yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "seldondeployment.machinelearning.seldon.io/income created\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl apply -f resources/income_explainer.yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for deployment \"income-default-4903e3c\" rollout to finish: 0 of 1 updated replicas are available...\n",
-      "deployment \"income-default-4903e3c\" successfully rolled out\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl rollout status deploy/income-default-4903e3c"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,58 +204,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Success:True message:\n",
-      "Request:\n",
-      "data {\n",
-      "  tensor {\n",
-      "    shape: 1\n",
-      "    shape: 12\n",
-      "    values: 39.0\n",
-      "    values: 7.0\n",
-      "    values: 1.0\n",
-      "    values: 1.0\n",
-      "    values: 1.0\n",
-      "    values: 1.0\n",
-      "    values: 4.0\n",
-      "    values: 1.0\n",
-      "    values: 2174.0\n",
-      "    values: 0.0\n",
-      "    values: 40.0\n",
-      "    values: 9.0\n",
-      "  }\n",
-      "}\n",
-      "\n",
-      "Response:\n",
-      "meta {\n",
-      "  puid: \"8qs8ieo9jp79i5bjs63nc1n6bk\"\n",
-      "  requestPath {\n",
-      "    key: \"classifier\"\n",
-      "    value: \"seldonio/sklearnserver_rest:0.2\"\n",
-      "  }\n",
-      "}\n",
-      "data {\n",
-      "  names: \"t:0\"\n",
-      "  names: \"t:1\"\n",
-      "  tensor {\n",
-      "    shape: 1\n",
-      "    shape: 2\n",
-      "    values: 1.0\n",
-      "    values: 0.0\n",
-      "  }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = np.array([[39, 7, 1, 1, 1, 1, 4, 1, 2174, 0, 40, 9]])\n",
     "r = sc.predict(gateway=\"ambassador\",transport=\"rest\",data=data)\n",
@@ -537,17 +217,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['Marital Status = Never-Married', 'Hours per week <= 40.00']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = np.array([[39, 7, 1, 1, 1, 1, 4, 1, 2174, 0, 40, 9]])\n",
     "explanation = sc.explain(deployment_name=\"income\",gateway=\"ambassador\",transport=\"rest\",data=data)\n",
@@ -556,17 +228,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "seldondeployment.machinelearning.seldon.io \"income\" deleted\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl delete -f resources/income_explainer.yaml"
    ]
@@ -581,76 +245,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[34;01mapiVersion\u001b[39;49;00m: machinelearning.seldon.io/v1alpha2\r\n",
-      "\u001b[34;01mkind\u001b[39;49;00m: SeldonDeployment\r\n",
-      "\u001b[34;01mmetadata\u001b[39;49;00m:\r\n",
-      "  \u001b[34;01mname\u001b[39;49;00m: movie\r\n",
-      "\u001b[34;01mspec\u001b[39;49;00m:\r\n",
-      "  \u001b[34;01mname\u001b[39;49;00m: movie\r\n",
-      "  \u001b[34;01mpredictors\u001b[39;49;00m:\r\n",
-      "  - \u001b[34;01mgraph\u001b[39;49;00m:\r\n",
-      "      \u001b[34;01mchildren\u001b[39;49;00m: []\r\n",
-      "      \u001b[34;01mimplementation\u001b[39;49;00m: SKLEARN_SERVER\r\n",
-      "      \u001b[34;01mmodelUri\u001b[39;49;00m: gs://seldon-models/sklearn/moviesentiment\r\n",
-      "      \u001b[34;01mname\u001b[39;49;00m: classifier\r\n",
-      "    \u001b[34;01mexplainer\u001b[39;49;00m:\r\n",
-      "      \u001b[34;01mtype\u001b[39;49;00m: anchor_text\r\n",
-      "    \u001b[34;01mname\u001b[39;49;00m: default\r\n",
-      "    \u001b[34;01mreplicas\u001b[39;49;00m: 1\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pygmentize resources/moviesentiment_explainer.yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "seldondeployment.machinelearning.seldon.io/movie created\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl apply -f resources/moviesentiment_explainer.yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for deployment \"movie-default-4903e3c\" rollout to finish: 0 of 1 updated replicas are available...\n",
-      "deployment \"movie-default-4903e3c\" successfully rolled out\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl rollout status deploy/movie-default-4903e3c"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -661,53 +285,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Success:True message:\n",
-      "Request:\n",
-      "data {\n",
-      "  ndarray {\n",
-      "    values {\n",
-      "      string_value: \"this film has great actors\"\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      "\n",
-      "Response:\n",
-      "meta {\n",
-      "  puid: \"re1drvdqoppisg1cl42aib3abc\"\n",
-      "  requestPath {\n",
-      "    key: \"classifier\"\n",
-      "    value: \"seldonio/sklearnserver_rest:0.2\"\n",
-      "  }\n",
-      "}\n",
-      "data {\n",
-      "  names: \"t:0\"\n",
-      "  names: \"t:1\"\n",
-      "  ndarray {\n",
-      "    values {\n",
-      "      list_value {\n",
-      "        values {\n",
-      "          number_value: 0.21266916924914636\n",
-      "        }\n",
-      "        values {\n",
-      "          number_value: 0.7873308307508536\n",
-      "        }\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = np.array(['this film has great actors'])\n",
     "r = sc.predict(gateway=\"ambassador\",transport=\"rest\",data=data,payload_type='ndarray')\n",
@@ -716,17 +298,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'names': ['great'], 'precision': 1.0, 'coverage': 0.5007, 'raw': {'feature': [3], 'mean': [1.0], 'precision': [1.0], 'coverage': [0.5007], 'examples': [{'covered': [['this film UNK great UNK'], ['UNK film has great actors'], ['UNK film UNK great actors'], ['this UNK has great UNK'], ['this film UNK great UNK'], ['this UNK has great UNK'], ['UNK UNK UNK great actors'], ['UNK film has great actors'], ['UNK film UNK great UNK'], ['UNK UNK UNK great actors']], 'covered_true': [['UNK film UNK great UNK'], ['UNK UNK has great UNK'], ['UNK UNK UNK great actors'], ['UNK UNK has great UNK'], ['this UNK UNK great UNK'], ['UNK film UNK great actors'], ['this UNK has great UNK'], ['this UNK UNK great UNK'], ['UNK film has great actors'], ['this film UNK great UNK']], 'covered_false': [], 'uncovered_true': [], 'uncovered_false': []}], 'all_precision': 0, 'num_preds': 1000101, 'names': ['great'], 'positions': [14], 'instance': 'this film has great actors', 'prediction': 1}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = np.array(['this film has great actors'])\n",
     "explanation = sc.explain(deployment_name=\"movie\",gateway=\"ambassador\",transport=\"rest\",data=data,payload_type='ndarray')\n",
@@ -735,17 +309,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "seldondeployment.machinelearning.seldon.io \"movie\" deleted\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl delete -f resources/moviesentiment_explainer.yaml"
    ]
@@ -760,135 +326,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[34;01mapiVersion\u001b[39;49;00m: machinelearning.seldon.io/v1alpha2\r\n",
-      "\u001b[34;01mkind\u001b[39;49;00m: SeldonDeployment\r\n",
-      "\u001b[34;01mmetadata\u001b[39;49;00m:\r\n",
-      "  \u001b[34;01mname\u001b[39;49;00m: image\r\n",
-      "\u001b[34;01mspec\u001b[39;49;00m:\r\n",
-      "  \u001b[34;01mannotations\u001b[39;49;00m:\r\n",
-      "    \u001b[34;01mseldon.io/rest-read-timeout\u001b[39;49;00m: \u001b[33m\"\u001b[39;49;00m\u001b[33m10000000\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m\r\n",
-      "    \u001b[34;01mseldon.io/grpc-read-timeout\u001b[39;49;00m: \u001b[33m\"\u001b[39;49;00m\u001b[33m10000000\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m\r\n",
-      "    \u001b[34;01mseldon.io/grpc-max-message-size\u001b[39;49;00m: \u001b[33m\"\u001b[39;49;00m\u001b[33m1000000000\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m\r\n",
-      "    \u001b[34;01mseldon.io/engine-java-opts\u001b[39;49;00m: \u001b[33m\"\u001b[39;49;00m\u001b[33m-Xmx10G\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m    \r\n",
-      "  \u001b[34;01mname\u001b[39;49;00m: image\r\n",
-      "  \u001b[34;01mpredictors\u001b[39;49;00m:\r\n",
-      "  - \u001b[34;01mcomponentSpecs\u001b[39;49;00m:\r\n",
-      "    - \u001b[34;01mspec\u001b[39;49;00m:\r\n",
-      "        \u001b[34;01mcontainers\u001b[39;49;00m:\r\n",
-      "        - \u001b[34;01mimage\u001b[39;49;00m: docker.io/seldonio/imagenet-transformer:0.1\r\n",
-      "          \u001b[34;01mname\u001b[39;49;00m: transformer\r\n",
-      "    \u001b[34;01mgraph\u001b[39;49;00m:\r\n",
-      "      \u001b[34;01mname\u001b[39;49;00m: transformer\r\n",
-      "      \u001b[34;01mtype\u001b[39;49;00m: TRANSFORMER\r\n",
-      "      \u001b[34;01mendpoint\u001b[39;49;00m:\r\n",
-      "        \u001b[34;01mtype\u001b[39;49;00m: GRPC\r\n",
-      "      \u001b[34;01mchildren\u001b[39;49;00m: \r\n",
-      "      - \u001b[34;01mimplementation\u001b[39;49;00m: TENSORFLOW_SERVER\r\n",
-      "        \u001b[34;01mmodelUri\u001b[39;49;00m: gs://seldon-models/tfserving/imagenet/model\r\n",
-      "        \u001b[34;01mname\u001b[39;49;00m: classifier\r\n",
-      "        \u001b[34;01mendpoint\u001b[39;49;00m:\r\n",
-      "          \u001b[34;01mtype\u001b[39;49;00m: GRPC\r\n",
-      "        \u001b[34;01mparameters\u001b[39;49;00m:\r\n",
-      "          - \u001b[34;01mname\u001b[39;49;00m: model_name\r\n",
-      "            \u001b[34;01mtype\u001b[39;49;00m: STRING\r\n",
-      "            \u001b[34;01mvalue\u001b[39;49;00m: classifier\r\n",
-      "          - \u001b[34;01mname\u001b[39;49;00m: model_input\r\n",
-      "            \u001b[34;01mtype\u001b[39;49;00m: STRING\r\n",
-      "            \u001b[34;01mvalue\u001b[39;49;00m: input_image\r\n",
-      "          - \u001b[34;01mname\u001b[39;49;00m: model_output\r\n",
-      "            \u001b[34;01mtype\u001b[39;49;00m: STRING\r\n",
-      "            \u001b[34;01mvalue\u001b[39;49;00m: predictions/Softmax:0\r\n",
-      "    \u001b[34;01msvcOrchSpec\u001b[39;49;00m:\r\n",
-      "      \u001b[34;01mresources\u001b[39;49;00m:\r\n",
-      "        \u001b[34;01mrequests\u001b[39;49;00m:\r\n",
-      "          \u001b[34;01mmemory\u001b[39;49;00m: 10Gi\r\n",
-      "        \u001b[34;01mlimits\u001b[39;49;00m:\r\n",
-      "          \u001b[34;01mmemory\u001b[39;49;00m: 10Gi          \r\n",
-      "      \u001b[34;01menv\u001b[39;49;00m:\r\n",
-      "      - \u001b[34;01mname\u001b[39;49;00m: SELDON_LOG_LEVEL\r\n",
-      "        \u001b[34;01mvalue\u001b[39;49;00m: DEBUG\r\n",
-      "    \u001b[34;01mexplainer\u001b[39;49;00m:\r\n",
-      "      \u001b[34;01mtype\u001b[39;49;00m: anchor_images\r\n",
-      "      \u001b[34;01mmodelUri\u001b[39;49;00m: gs://seldon-models/tfserving/imagenet/explainer\r\n",
-      "      \u001b[34;01mconfig\u001b[39;49;00m:\r\n",
-      "        \u001b[34;01mbatch_size\u001b[39;49;00m: \u001b[33m\"\u001b[39;49;00m\u001b[33m100\u001b[39;49;00m\u001b[33m\"\u001b[39;49;00m\r\n",
-      "    \u001b[34;01mname\u001b[39;49;00m: default\r\n",
-      "    \u001b[34;01mreplicas\u001b[39;49;00m: 1\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pygmentize resources/imagenet_explainer_grpc.yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "seldondeployment.machinelearning.seldon.io/image created\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl apply -f resources/imagenet_explainer_grpc.yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for deployment \"image-default-5d14729\" rollout to finish: 0 of 1 updated replicas are available...\n",
-      "deployment \"image-default-5d14729\" successfully rolled out\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl rollout status deploy/image-default-5d14729"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/clive/anaconda3/envs/seldon-core/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:526: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
-      "/home/clive/anaconda3/envs/seldon-core/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:527: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
-      "/home/clive/anaconda3/envs/seldon-core/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:528: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
-      "/home/clive/anaconda3/envs/seldon-core/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:529: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
-      "/home/clive/anaconda3/envs/seldon-core/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:530: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
-      "/home/clive/anaconda3/envs/seldon-core/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:535: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from PIL import Image\n",
     "import matplotlib\n",
@@ -914,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,34 +394,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f761186f0f0>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAREAAAEICAYAAAB4TcDdAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsvXu0bUte1/f5Vc3Heu29z/Oe231vd1+lEVoMiDzUiNoOBSXiKwZESWwcKNFIjGJMMAOVqGh8DEmMQSCJCmpERyJDA6IM0UZEM0SjA+UhYNPQr9u3z3PvvV5zzqrKH7+qWrXmXvvcc++5xz6dPjXG2nutOWvWrOevfr/v71ESQuBZepaepWfp9Sbz0a7As/QsPUsf2+kZEXmWnqVn6bHSMyLyLD1Lz9JjpWdE5Fl6lp6lx0rPiMiz9Cw9S4+VnhGRZ+lZepYeKz0jIs/Ss/QsPVZ6w4iIiAQRWYrI146uf5+IfPob9Z5n6aOXROQHReSdH+16PEtvbBKRTxWRfzK69t/H9RxEpHpoASGEN+QDBODto2u/Cvi7xe+vAb7mEcsT4E8Ad+LnTwAS7/0M4G8BHwHuAn8P+KTi2Z8Vr93WJu6V2wL/O/CTwBnwr4DPL+7/TOCfA/fi5+8DP7O4/3uA9wCnwAeBrwOq4v5/CPyzWPYPAJ9zSfv+wrjPgPcCLz1qfxff3w1sgPPY5r8JvOmNGtun/QN8KfCPR9f+EvClj/h8G8fjFHgZ+MpXyf/TgW+PY3wb+JOj+18M/DCwBP4d8AuLezPg6+NzD4B/VNz7zjiG6dMB/zree+vo3nmcP7833n8n4Ef331WU/VeAD8U2/ijwW0d1/jvArxpdeym+o3pof7yBA3mIiHwH8CXF76/h0YnIfw78W+BF4AXgh4DfHu99NvBlwDWgBv4I8CPFs58U7/8aLhKReazHSygn9gVxMrwU71+J9wSwwO8CfqB4/hOAK/H7NeAfpEkXf98BvjA++5+ihOjqqA6fA3zPuM94PCLyW0d1+tbXMYYPnSxP64fHJyJ/HPhe4CrwDpSQ/IpL8jYoYfjKOJcmwKcW9z8X3aB+XpxfLwAvFPf/CvCtwM04Rz7jIfV6N/AHL7n30wBXzNt3Au9/SFmfArTx+yfHNn5Gcf9LgG8fPfMSH00iEjt7DbxYXPsaIhFJjQZ+L/AKSiV/S5H3nwBfXvz+MuD/ueTd1+L7r4+uv50REbnk+R8Afv2B6xXwO4HVJc9dRzmVr4+/vwD4wVGeHwW+bFTmvwQ+9UCfvZfHJCLx9+8E/k383gJ/Gvgp4MPANwDT0Rj8t3FS/WXgBrrL3ke5vO8FTFG/Xxa/fzbwT2O+DwF/DmhG8+G3Az8W8/wvRE7yVdr129Bd/AzdOH5OvP5V6OJN139dvP4OlAtz6O57P17/Szw6Efkg8HnF7z/CJUQY+HLgex9S1j8px3t075NRTuD4Eer0EgWROHD/DwH/sPj9Th5CREbPflIcsy8qrr2Artd2VIePKhH5FGD5kPzvBAbgD6PcxH8ErIi7Nsrq/dwi/2cCZ5eU9WuBDx24/qpEBLgVJ+Enj67fj/XzwFeP7v2mOBkCKlJ9Wrz+BcAPjfL+GPB1xe/fB/xPh/rsMfr+3ew4kRsoJ/KX4++vA/42SmiPgP8b+OOjMfgTKLGZorvyN8QxqYFfyE6MfC87IvIZ6G5bxcn2w8DvHs2Hb0c5u7fGfjq4uxfPfCHwAeCzUE7w7cDbintvRnf334CKCm+K976UESfyGvruaqzrreLaf0IUIw7k/wsosf1OVCR5N/AfxHsWFUG+CvhxlED/OXZE+zcD/zqOye34/cLmFfP+QeDdl9wTlKB+6Wg9dehG8RPxHfPRc1+PrrEA/L/AYnT/lH2u6iU+ykTkFwAvPyT/O1HKV+IJrwA/L353FAsb+MT4DhmV82KceL/xwDseSkTiIvn7wDdecn8O/BfAr7zk/ieiu9bz8fd1lPj8xlj2u1Ai9I3x/lvi5Do51GeP0ffvjpPjfuyLv4qyy4Iutk8o8v584CdGE29S3P/DKN50oV4UROTAvd8NfNtoPnxO8ftvAF/1Ku34e8B/9Yht/lfAr4nfv5TXT0TeEuta9sHnAu+9JP93AT3w+Si3/ftQjKxBiVxAMbU3oQT9+4Cvjc/+d/H+18T8vxjlnt5x4D0/ziWcFErYzymIAPA8iucZVNT5R4fmNUroPgf4aqAe3fsA8IuK3y/xCETkSap476E738PSnRDCUPxeAYv4/Rw4Lu4dA+chtg5ARG6ig/r1IYS/9loqJyIG3VE64CsO5QkhLNFd+VtE5LkD938M+EGUwhNCuIPiMF+J7gi/AiVS74+P/I/AHw4hPHgtdX3E9LtCCFdCCC+EEL4khPARlJDMgH8hIvdF5D7wd+P1lD4SQtgUv/8UOoG/S0TeIyJfdehlIvIzROTbReRlETkF/hi6aMr0cvG9HNvL0lvQHfbQ+36ziPyroh0/68D7Xk86j//Hc+3skvxrlGB9ZwihQ0XF66hYtY55/ucQwodCCLeBP4Ny2enZHvijIYQuhPA9wD8EPq98gYh8DkoU/s9L6vAu4P8KIaS6E0J4OYTwQyEEH0L4CeC/AX79+MEQggsh/GN08/0do9tH6Eb0mtKTJCI/DoiIvPA6n/9B4NOK358Wr4EWfBUlIH87hPC1vIYkIoJqaG6h7GT/kOwGXYiXtaNCwVYAQgjfE0L4rBDCNeA/Q+XgfxZv/1LgT8WFlxbYPxWR3/Ra6v8a0m104n5KJDBXQggnIYRyMYfygRDCWQjh94YQfjrwq4GvFJFfeqDsPw/8CPCJIYRjdJeVx6zv+yj6MiUReRvwv6LE/noI4Qrwb4r3hfEzj5pCCPdQfODSuTZKP3DZ+2JZ7x/dL7//wKHHDlx7F/A3SyKRkohMUdHumy+pX1nuw9b33ryN67RBlRmvKT0xIhKp9N9HWbbXk74FncAviMibUQD2LwGIyDHK+n5fCOHCTimaJminICITEWmLLH8e3Tl+VQhhPXr2c0Xk00XExvf8GZSr+uF4/7cmrkREfibw+4HvLp7/dBGp47N/GnhfCOHvxds/A52gPzt+QNXg33agDV8qIu99tK46nEIIHl18X1fU+QUR+eWXPSMiXyAib4+E9gEqVvoDWY9QGfpcRD6Zi7va60n/G/Bfi8hnxDF8eyQgc3b4EyLyW1BOJKUPAy+KSHNJm16K9g4vXfLebwG+WkSuxrb8NuJcO5D+CvDzROSXiYhFxbjbxPkB/EXgvxSR5+JG93tQbAhUxPgp4PeLSCUivwD4JehcTnWdAl/0kPf/OnQ+/sNRG3+JiLwt9ttbgP8BFUuJdfliEVnEef3LUZH7u4sifjHwD0II20vee3l6PXLkJXLaBfke+JXAd16S/52M0GT2gTsB/iSqIbgbvyeA713xfUv29eJvHcly5ee98d7b4u/N6Nkvife/EN1hz9FJ+x3sg01/EZ20y1jfP8W+PP3X0MX3APjrwHOvpc+Ke38A+KuP2PfvZqT3L+5NUFEj2bb8MCr6XDYGvye2a4nuqn/gkvH5RUU/fS+Kpfzjy9qGLoo/+ght+e3obniOchufHq9/bZwHSUT4HnZgchPH6S5w+0CZvzDWvb7knaWdyIcp7ETY2We8tbj2H6Oc9mns+08p7tWoeHsfFef+7Gh+fAqq1VpSaJmK+78RVREf1GShBOePHLj+lSimsUI5uj8LHMV7N2N/3Y91/tfAbxs9/x3Arx5de4lHwETSonzsJCIbYAv82RDCHyiufx/wFSGEf/mGvOjjJInId6Eg4w+/auZn6aFJRL4axX6+8aNdl6cxicinoiDszy+u/SGUMLWolsdd+vwbRUSepWfpWfr4TE8MExGRXyEi/1ZEfvwyhP9Z+vhLIvINInJ+4PMNH+26PUuvLz0RTiQCTj+K6tvfD3w/asfxQ2/4y56lZ+lZ+qimh3vnvf702cCPhxDeAyAi34raTxwkIvP5NFy9UqrpH4OwhUd5OuWQ/D3R0lD+AIJXXDZauWGMYGX3nkDI+cPoPyIQ9J8IeL8rV0RyPhH9o6Yr6b5BRPDe5/yqMAlabwmEUF6n+G/wBLz3+nxgdD8WETWkCcd2ftAbIRT1C/k5Y0x+364HZU+xm5ruvSOEwHbbs+06vPN0/ZDr0tQV3nuMMTRtHfvHkwsLATH6Lud2yqG+HxARmqbGmN29vh/w3mOtxRiDc45hcLk/Ur5dnwsi2qZhGBBjMCI47xUsLBrlw64PQvmdlK+YdHJIyx3gUbXfKWv5f3zjsqIOvSbE8QmBoKDzzQNPPlZ6UkTkBRQhTun9wM8tM4jIl6N+CFw5OeJ3/Y7fUN67sCAP4zq7RTfOXw58ef3Q9/RxzuE98b/mcX1PCLogq6FjOrFcmze4fmDYBrb9BuccYgJBtLyu6yJqDcMwYIzBWst0OtU6GWF5viaEwHSiWknnHD4IxhiwBmtrLEI9aWnbNrfHx3eYympfxaZMJhO6rsNai1jDZHHEZujp+55hGPC9Y7PpMMbg/UBVa9/UdQvBQjBswwa8Ltztak0IDmsEa4W6bWjblqqqELFgDCZ+QJ/xkeB471lvNvR9z+n9JXfvPeCn3v8h3vOen8J1jsrWXL06Zzpt8d7z1re9QNNUGGNYLpfUdcswdNR1rcTABYwxhBBYrbZ477l27YR2UrNer1meb3nlw3dYr7fcfO4KVdNy+/ZdttseIxXnqxX37i7zGIsIx8eL3TiJZb1ec3R0RNd1eKed2sex7/2uXVVVYauK7XbLMAw6FlgkzTsgxM3AyGEscsz9l/NUfAB8HueUXwm39kHqC2Oq3RweahAwNiAS0GEZqGJd6spy53T1kwcr9JjpSRGRV00hhG8CvgngxRduPZZMdUgkk9GOMCZM5c5SqLQYm0Tk+ziC0TIG75WyJxWXCJLzjSZI/OmcwzmnO6UY6rrGe6+74IiTCIMjBPDG4DroJIAR6rrGWksIMMQd2VqbOQ4RJUJucHg/ICFQ1zVVVeGrge22z+0rCacgBB/w3kXuoIrP60YGsseFHOprEdnj4KwxeGvz+29ev8bLH/wg9WJOZWpOrsxpmpphGJhMmkicJBPaum7jmFjEhsxdzGZTnHPUjaWqKqqqom1hNp8A0DQV0+mE06aiaRqMqdhsNlgb2S8i99NUhJDaa3GuiovPUNdKoH3cuMQ5+r6naVqapiEEoUvtBkziSkMgYHTjf51mdyIXWBAtKzEhsa8VMQDdSEPcHDxVZZR4mEDTVNSNxYphPp1w53T1+ir1KulJEZEPoCbMKSX/lkdKbxROUxKLy+6VhGX83kPXEE/A450jBJ1EaZfaiTYhE5X0+rQI0i4ynU6V3V9vMqfTtjWg3EtwnhAgWOVsQJd/EydREnOapsE5l7mQ3GanbLmJ7P2QJ5/WxzmX32VECF7wIRIj3+v7Qdn8goBon426JBOR3dhVlU6t2WzC3bueo6M5165dZTaZ4ZxjOot2YaILp6rSeyZxYSsnAMq5JAJpjWEYukhAlBj0nWM6nWCMYTJtaJqKtq5oJkqQ7t2DSatlbDbKTUzaGiOBYRiwVZN3eGt9XMipx8EY5YSP5hMwFdtthzFQYbUfw35fvFp6aJ747ritKHdHIt5ps4kExEsUvUDMgDWeSVthraFtLCfHDW2rRLyyVi2FnkB6UkTk+4FPFJGfhhKPL0Y9X9+QtFvYFxd9+h8u5N2Xh4G8e/soB6fFHAL4YdjhJFE0CeJxPiibOzjcEDEHdGL6+NaqqcHH8gYHcRFuNhs2mw1iDUeLE4ZhoGpqFQl84PzsQRZ/JpMJRix+cAQBU1f4YeB0s1GCU0119/bCpJ6w6TusNXgPoe/potgUAtSzKRIC87k+s96sWK1W+KHH+57KKp7QR+KhnI1yOtNqiglkLkgXukUiB7SHyQSySKO4RUNlG9761hdZr1bYd3wCLgys12tOTk5YrXRnvHrlKlVV5f4fhgFjQWRG1ynBkLhg+94hMmM6bbM4OJtMWcynrNdr5otWxSx7g8lkppjKsOL6FeX+7tz5CFVV8eKLL7JarTg/P2e17Tg5mTIMA8MwsFwuAXjrW5/T8fKO4+M3RxFD+Mgrd7l6fI3bdx4wDIHtZqCqGnycUyEEJczF3EwbVklAUv+l+wkTUg6zYug9VZX6OTD0gclkQmX092a7ggBHRzWf9PbrXDk+Zj5vOTle0FgbCWd0kqtqvu/7n4g082SISAhhEJGvQK3rLPAXQgiX+SIA+9T5AkB5IO8bqVUav08CmWMIHojkoeRM0kKx1pLYfVBcxIiAheA8+EAfxZiS+9FdFtbrNXVdK9tft4gIwzCobO7JnIRnoI27bd/3uH7AIFnGr82ufOccdUDfWynHYYzJ7H/iLFIyBELwkfvZB38rUTznMlEm9mB8h2gZ3oMoJ2Gkpqktvq2ZTlugxVrLZNKioK2haZVIhBCw1mIrIQSPiMnXxmx8xgUs1LXEsXFMJirWTFtP3Shhms1mVEbrPp0prtO0FYOzTFyNxIUagqOqGhIH0rY1IThmkznz+Yyqqjg9PePoeMZ6tcUKtNMJ3m3xiLYbCDgeBUgd96cxRkF7DEiFiEOCiZxRoDaW2gaM6LMni4qmqXju1g1efP4q0+mUo/mU2WQauTbBpOGsnhxy8cRKDiH8HTTk2hNJh9jq15MuEKOgMmmapHvQmA8kTjKx1xK1KqYyBO8uamqEYgePGEbUnNR1zXK53OEqItiqQeei0Pc91nuaVonLdr2hapQ93fYd/eCZMsE5T9M09H4ADMbohGRwKtY4jxHZ4yastfjBAi5jKknECcFhApmApEWshLLAbmIbDTskKfXb4HfEK4kLs9kMsYY6stip7yrb7DAdCyHUJFVD7hcxeAPOx/rFuthKMMZj4rg0TRNFw1aB2aCi1LZWsXA+n1HXNU1jca4mhJa6VrFGgkMEmkoXYdu2tLXh5HhB27ZMJg1dt8EYQ7deMZ+2iK1ZrbvMgSA+ih+BEPaxrkOp3BB14WtDhgLMVT3QwKSZUFloa0NVGW7evMJsPuHWreu8cOMEay2z2QyDVZwmzSuA+qBb0RuSPmrA6jgdwiPG6RAH8ihcySEx5lAeZacHFQmivFlVhhCEEBy1aWhrz6S2OLwSGPFgDE7ZBgiB3g34QYFUA3mHb1sF5jCCdzpp5gslAl2/obINwQeqVnfT4Du8d5ye3aeuayazKdv1UrUTV29Q1zXnyzPatmW17pjMZnjvGPoezzl11VJZy/r8TAHIxQJrLf0wwfUD+IAl4IaBvtsSnO7miKeZquhT1TstTMkV+JGYaI1hKAhoU9VQ1WBrgvM0jXB0pACx8zMIgdlMJ3llG8WBcBizk/9VS+Z1UcT394PP45QInLHK9VTVhmmzoOs3zKYmcolQGUvXDaxWK27eOKauVYRczFX0WS2XDMMAXGEy0brM53NEhMViEbU0HsRjbM9m0/GWF29y+5U1P/GTP4UYJdR1YxkG1a5YCbi4vDJXO5qnJUcYMgiuv7uzJXVVIQSaChZHc164teCFF97E8fExTV1x/coJxmo5vmPHpeIwogB8CNpf9TDwpNJTQ0TK9DCisG9f8bie5/vlpo8xQjLpMCYRHg2+IhLyrhwMBBNtQJxBjAGjaD2VAQxhcMRNk2EYlMWvLG0zBWA2m0XNjad3ATGWEFW9jbGaP9k9dH3elTcbDQGSFrUbnIKE6bdzNLUoNjPiNBInYq0FZ/CiWgsVH1K72eM8HgZSlykBlOnZQVRTMwDG1gRUtPNRxBNsbkcIBmNDrMvuurL0+m7nh7ggLcZUiIC1JveviGCkwhqLrXTxJvC5bessOgZcLMPE/hmy3cp0OslaomSPovkdi/k0ltHykVfOaZpKxce6iW3wgEGCI4SdSjb1/WXJWkvbtiA93numswn9tqNpa2aTihdfeJ63vDDj5vVrTCYTHT+VoPGDU42hB+eTbcyw447wGB7+/sdJTyUROZREbEFcdmximty+AFMRgVBqXvSySbiBUUOoaNihIFhQIhBMBMdsZKfRBWgEgjEMRuilwhiLNw4XejweW0dMIATaWll1fNo1VXQxUu0W1xDl56bBhEAVAmazVU1K19P1G4bKsnaO6WSKdL0Cl87j3AB+yWp5xo2bt8AHZpMpq9VWJ+OiYegcp8tTrrU3sKYmuAC9x/WeCkNja7ZugzE1YsCHCotDUCOvuq52BFQMNvRqQ2It4KP8ohyDresMSjaTXcQFEaEG3Rmtikd97xBU7AAyoJoWWVWpEZp3QCR25f1Aj/MOY1WV2bSTTPxnsxnBCxK1OWK17LrVReecy+/NRMk58JKJy3J5xmKx0LrXVSYCiTAfLQxHUdRcXDlivjyn/chdZosW5wYqawhecK6CrcFYbb/OP4PzUMuOe/N+YDqbqKgngpWK5eqMxazGLAI3b1zlTbeu84lv/2m0rcUmbMoraK/gvWJoqZ6K5e1EGe89G+kefxFekp5qIvKou9+hNJbbS7Woc4m4+ALDiO8ziXWOFD0YxCTA1WFNiNiFYEyNqRrEhGyYFELA9QPeq0VpJRbv4yBLUhkajFGQs0cReGsts1Z3TNfW1F0FNu7QzjOYgasnV3jw4IEalvUbBGG5XDIEz/HxMf2wBalxg2G77bAikZPRxbDZrDMX5b3K/yoyqIq0W68iZuNGnJnu1oM4TNjJ6rZusn3CMAxqrDX0I85F9sakVE2na+UYZ+wlQClGlaBxYv1LjsdaS9M0dNsh4ytBTCbgCTxNRKmcF4vFIr9nsVgop1LMvVLblLA4Yww3bl7nPe95L7PZlPmsZT6/xunZGc4Fzs/WSDIOCxLng1AZS5BkmatY1vPPP8d2u6brOiZtTVPP8K7nsz/rs7lyPOPKyYKqghDFOz/s/kvcpEpRPWsTs7bxgKnCG5ieSiIytt94nHLKdKhM5Uh2E9XHgUq/bWHnQTCAw0abCDVMqlRWjiyr9z6rSZ1z9BLoXYhm4H3BYqratJlNmUwm9P2gkzQEmqpSoNAYhlhu27Zgo4alrtn2HWJ27dtut1lbMwxDtuUNg4OmwojQRfVxaltagOWCMZVFCqMmX4yHSf+NwQNRfM+Le6yyPJTKnb0cp/GGMV7A5TMJoE4ELN1LYlpql0cXrsTx2lNHF+8Mxe+6rnd9EfuqTMopKTZkAuAH5tOWo6N5FE17hsHTbTq8U0jUObAIwVqCF+WUnaeeRI5VBlbLM65cOcH3S46PFty4+Waunsw5Op5RVbqBBR8yviaBbIs07u9k5jI2XXhS6SkhIocNvf59pORbUi7uIdp/hBDYDF2efJVAWwUGqfFDwATDtgt432HrRnX4VUXbtkgg75rW1pEl7+m6Lqpw1d7jI3duM51OuXJ8wnK5zKbY165doxsczWTGdrsF5xFTsbhyldVyyeLkCtZaVqtzptMpq9Uqm3IvT5cczfV7Z7a0YqnaBte5LBqUC0VE2G63VFZxBDWnlmhvYREJeMi7ePkcBLbbLYvFQolIQdjKHTBNZCW8dS4j3SsJhTEGF59L3ENKk8kkihr1jiMqtF9VrcTeGEPvBmBgGPbFppKQiQhtq1xNstHZ1V3fmZ5N34dB++/87H0cLxZUV2qu3bhGXVsWs5q+dzQVfOT2OSEYNltHXbdYWyuHYgJVUzOd1kxnLffufohr16/x1hdvMa0cb3vb25hMWyojSOgxIeI93kbVfpq8amhGADGS+1uKvs++V/7jjBN5PQRkbN+QfF/G18v8KjvqQsi/g4KoqfNVM6MOZS54TAj4RrAYAp5KBKqKTefwbhNBziGz2t4rom+MYXE0w0TRpap0KlzvfF5cw+CZTtUozTmh7xw9TlWztaHrOqbTKcfthNXqnO22AyPZ1sT1PZUxTBrVOoQhMNgB06nZtxs6pKqw1jIMPQSH4Jm0Nd12zWQ2j9agCs4Gs1PrAmq3YqBzA9YoIUhiRLbGHY+J150xOI81BqlqjOyIRZroaUEnApeIkXdOd25RWx01ZS80L1WVF38mRlbUUC+Oq7Xp5A9VwRJxHwAhUFV1fm9VVRnMTnVSsJSsloaoWZtNePGFW4hY5kczmqZiNrN02wEjAbGWruvo+4CRiu1WNWKTqYKxN5+7ggmen/2zfg7HxwsCjpdu3VICOGwRB8E7vAhu0yluB3uWwRblpIbEdTgPsR+jPjxyYk8unPJTQkQu93MZX4ddB5Ys2lgEMlEeLWd1yW0cEpmSp6dOcEXaM1AVklesDtTgB3AW70FMoKmbnLf3Q8Zd+r6nqtXA6fzcZyeuySRhAnWWs+toT3FyfCU6otXZga4PgTruiCEEjo+vcHb2ANMZBunYbrfU9Yy+65R7WSlhEaPEx1bVzjAtyvw2TvKkwTARVDamBVECm3GMgktAdnhFIh65TwsnPFXPmjxOKV9d1wTZt9hM45BFp4IolGOVfI7KMktCl665weVF3/c9FLhKOZe0LxSX2myG3J5xmaWYtMNhhKPjOcFbFvMJQTxVfcS27rl37wHHiymbjVXNnjQ8cOfYxQypPOt1r4ZjxvCm529grWVxNKVCgevaVqqGx6pIimCI/VoQkL2+i9O9XBepruqh/WTSU0JE9lO5uC/DNQ49s09ECvbugHyuHEbp6CSjcgpVbn6n2ic4P0Dv8UMPogZSw2qb2XTvHF5QsUbUXX2zXrPdJHFJd8amaWjaI5qmYRgcIao1J5OJgqHimM1medGcn59jo1PbanWuYKrdslx6JjNL204j8TKsu56jWRNNxXtsVVHXVhVXweGcevhOJpOoGlacYbFY0A09ddXm3d5UQlU1SKXeu6ohCGopY8j5rLUQCW8SG3TyBqw1iEBdq1rWlIBqJDqhIPLhwCJO/5PoMZ4r5UdM2CNu2/U2E06BPD8kKCFRbmbnW5QJpvbAiDPRq9evXyMEWC07ZrNJ7JOAtRuef/55tn2XiXS/8XTbJcdH11iu7vP8zWNuPXeNo+M5z127hpoOBMLWxTkU8L3P/UiwBPbdDMLgctuNhEjA49wNHofbhUB4cpDI00dEHqaReZiYc+GZ8DBgVUaTrpyEPrt4A4RIwUUEgwWi3GwCQbxy2kGaZjsJAAAgAElEQVSojRCiDYN3KvqcbVYKhDYTptM2s8vJrH273bLZ3MF7JTjzxTFd11FbidzHjogAzOfzPKk2mw3DMNC2LUdXTghRTl+ttzRODduWmzXT6ZR+GLBdx3y2yN7ESTsSQsh1cs5xdHIM6zVVtG7VRWEvgI0SF/J0Oi20XurnU+ZNcUXS7j7m7Eq5PalxD3GJh0DOVF4iKMmjOXFCw9AB+97HJTeRiYpRopM4P8VbdpxSHVX25aZkjGE2n7DdDCwWDVVjVeTyQvCWW7eOWW/P8a7HOced2/d4y1ufp7YNN0PNfD7nhTe/STlAr2MX3IAfdqEnnFfnSB983ON2ddAGmzSx1agx4V0h5NARqd7+krAEb0R6qojIa8FCHpZ3DC6NJ2X58f4i+JcGA1FNS0qN1BgE8QEjhmgnpZNRUDAwqCbGiKLw/XZL1yk4W1dt1iwsFscspguWKz0r6PT8jOm0ZTZt2GyWrFYr2tmU1fKM6XSq7ux1RT/06lp/87rmadvIoahcPz8+wXXb6LK+s51x7IOXSawpvX/rumaz2SixigsMEzUhBRia+ieJFpWpd6EOap1SOTxBfH+5s5fEIv0vwxkkm44S5BwTnPGC3pWVRDITtS5Ji3ZYbauGZ2ljAOd2ZZU+O+U8yhyaMVSVhbqJHIDFA9Npg5hK1bI4Nps1z928FttnuLJQm5C2UvP+4IPaFPmdmO5cr22J/ar9vlO7lxuk5t8X7bMYSuS6zOGN+Y1ITwkReW2amYeJNK/2/bLn9yg8inMkDgV2Ez1ki1VBvC5OUOBVigVaRiQbonVm2jFXqxVNEx3Fojfq0dER2xidq+s3LI5mYKrMDicRLdmj2MU8+4csFgtefvkVptMpi8WCtXcMbsfqlm1Mi66MP5I+VVWx6bbZolRByv2FBAowum4XNCjbJoywLAX0dv1XYlqJOzmURAQfF86hDaBsV1lOKYpaa7PqNhGmMZe7q9OufQm0Hfdbule2Q0UgC6JOcsqJSQSOtT8RQ993TGct3XZgNptRWy2zH7ZYMRC0vVpmV2j19tuQIt+NxfSyX4w2bEf4Ahfa/Uanp4SIaBqDbK8lXeA4JDlE7RZMEI14Vna6R1nFQACjsmMQwJvEQepiEqHzuoCdqNozWLCmiurEHhu9TqcmhecbsHEydV2HWJ0os2mDd1sVP4Y6P1PVKhpMJ3MWiwXn6xVN07Barbh69Srn5+fMJlPu37+vzmFty/lqqT45k5rJrMWFgSF4Hjx4wHPPPYdzjqqNXEkoFkpV4fueurF4gXlUCdsaNt3A/EhFnwROBhRoNlKpX4brNKKXMfgwZIM8ggZUkqQNMWBE3YqUMGuAJwRsjM42bAeV503AuQFxASHgBofE3X030DGIUxjUdN7U2pZEtLOBmt/9twFEuZsEPFbJqFAChhqP4L2jqtTnRMQUhGcH4KYNQgQqOyXFPglRfDYhYEQtmXWCCU3VEAbH7GhOXVm879KEV7sP14OA6weCQ8VmAT9EE/qEw5i4LiTZN0VuOqRAUj6Ho0hOihrnJtPyJ5KeKiJSppIgXKatSWl8b5/9vKjVOfR/rLmRQgZPYkHTNNSyj1ANw6Cu5U2rkyAEXEg2BokoKu7gnOItZ2fqHFfXNbOTE/quQ5zn/oMHOOd4/vnnFQyNk7iqKu7evZutKefzOavNmvV6zTAM3Llzh5deeon1WkMuTiYTmqbh3r17XL16laOjI5bLZRZFjDF5sdV1zWq7yR7FyQ5D1dBK/JqmQexOu5NCPSbtTCkelmMA5Imc8IpyVy/zpwWaRL8d6OouqCcVhI1GW6bcaVU1XHJaY44nhKCOh4VtSYhEQcHf3Vzz2RO58HwuuK4UTClhaQQljs4n50slOI2tME1NWzdsNhtC7Mehi1bOg3Kg+F2EsnI+5nk5sv7Nc1UkP5vyu2CQEbfypNKTPIv3NaTDrNZY9nvdpY/KGLO0cBErOVSHbcQ3xrJ1acCUxAIbwbgUMLiqFFOo65pJO8t4wmI6YTGd0Pdb6spgK+He/Tv4MOQJBSpC1HXNdrvdwwZms1mOfZqC/Eyn07zIU3jC+Xy+185U5tjgq+yPMRiZfpcGXun62Aq1FJPKMstFWOIgh0SVQ6lU7+7et2P1y3eWn3FIg0PYQonbHNqY9uOayMH8CS8qnR3rpqKplONMEedKQjFuexZNDtRz/P58z1xs14U8Tyg9tZzIo6aHcyGHJ+WYYBwaRH8gQE9bN4R+w7bvsU2NNer1aq0lDFDXDVKp8RdB42iIqRhcB8HQ1JMoR0PfKzB5/+49jQAmhunJibr1b5SjCNGmJMUB6bpOgzbHmJqJCNy4cYPbt29nmxI7nXH79m1u3brFcrlkOp0ym83Y9l2e5KbQuEwmGpIwOYGlfhDZ+Yt4HLYyKm4EBZYH5xnc7iz0DGgW/Z+Ia+lFDOrpnHdb7zOAWKk3oMblKTCLPDY++a6kRbPjrmAXlrEkinsYhw9Q7exAkm1FSRATkUpEo4oGeolopLIaq/2/Ltql5ugafmA2UTW5QeOV9JstyScrYUnJy7qceyXBKuemu0RPuwcDOL83DiV3/aTSU8KJ7KdD2Mi4E8Ycwzj/ZSKLTlwgeqCm76UbfFl28k5Nn2SjkNSZwfkYJ1XYbjXWRFU1MVye4FHXdA1qM6FpJhwdnWRRodtuWa9W4AMvv/wy9+7dAx9YrVaID6zXa+7du6ehFbstvRuyPUqqhzEaTvHFF19ku93igufWm57n9PyMbugJAoN32cbEWg0xkLiqdG02mwE7K9BERMpFGoKauYMa0iWupFSvlmORrqXduezX8nsiMjt7kN0ubyvJUdnGO3jyNE5jUwK9ad4YY/LCzn0ghtpWFwDmVO+xJimVmxZoVVXUTYWxEs3TPYZAU1mmbcN8OmHaNgQ3gPN0640CEyEwdH32wt0zmLQGsQoiBVGi4WO0vCA7zrHkgvY1U4LYHQdoqgpTVYi1hI83TuSQbD2eoK+Gk4w5kjFLV3Ig++rDiyJNCEE1LAQNU1hVGlgo7qCqkuzVSQ6dDLogoqYmSIFX6G5//fp1NpsNp6f38UH1+pO64fZt9aW5fv26enXWDZ0ZmEwmuBhgZrVa7cnowzBkTOO5557jwekpVVVx9do1VqsV264DEZoo2qxWK6oi2vw8RlBPWIdqocghHEVkh/L7gEXD7hlVhOyJXBfGzmkM2jBotDTxIYfsS0RlvPNaa6Ovh8OaCismxwzxQc/GSfhFKdpIYaOyN95hZ0Oy4ygOi7ipvFJkK0XVNE9S/49tbtoigljfd1Qx9kvwGvEMLxmA39Vvn+CNCeF4vqY0dqrLedjfQJ8kFwJPKScyTnsd/hrSZdzLZYNTEpTyvWU53vu8uJLmIqluh2FgiKBaEkPSolBP3Z579+4wDBpOr2mazAXYuqKdKfEo2doEZi6XS6y1bLfbDH5ut9uRxkAyd5B8QFLe0ts17fal6JIIQI5cVvRDaZtx2fhchiel5w8R7HJnT/UqN4sEXpa77gWTdPF77Ri3a1fOvjfw3iYkPn8CLn+MJYddHM8lLUfPd7FWMHoqDFVl4uYR8FFln9TVFC4Ah3C3cf+OcaZD7Tk0Bv++01PCiTxcLBnvEo9cati39Rh39BjY2rs/GjAjggkeTIVzHev1GhsXaGMrXCzfDTubkHY2xbiBYbPWIDaLRT7eIQGdi6tHesjT6SlNaJjP5xgD5+en1M2M4+NjnNdnqu2Wru/58CuvcPPGDY21GkWL2WyWRYTj4+M9cSHZc4QQsjbJRWKo79sZkCWWuYvWrgkAPkR8U/8kfCUR13KsdhwemdiOZfUSZxhzm2NQMXF3fd/viEvkCAbnaevZ3jgmTMPFc3oqY/cIWOJKykV86L2pTSUBSwTN9UlD16jHrRvwvbbVDQNGKtyg5v8mCH2KPpb6oXhficdkFW3RlovzOxLnWF6ua2G+P+7XNzo9JURkPx3azQ5NsodR3V0HH94pX00USgqjbF1ZvlN2rHiIloaDhKgliVHfgdXqXHGGpub8/Jyz8wd4p2JCEn2o1Wry6tWr+UiJaYxvulwqp1EZDZwzmU2z6jnFGEmL5OzsLOMaSR2diMZ0OuX8/DxzJpvNhmnEP0rtSCJ+Sauz3W6zl656wepRBWrK7uLvXRmJCI0xpcQVjcev5KJS3yZgNHkSl+DijjPZjVNpy5LakxZ73skLcDX4/Q2lqaoceWwsWiWxYhLtbBL3mPAiWxC/+XyO9571+XInEiUcyCVRkAysg0bjT2JROSdTW8YHm5XEdkyIhQgQk8Dhi5zLk0pPJREZo9Kwz5HkjnxoKSZONvWA1Gf3UfAxy67fJROH8l0iagBlK0MVDXtCiI5Ow4AXi6cHa2jaKU1dwaRi1W0xRji5eROqmtXZObaucvliGupWXfd9jFTWRCc6i/DBD7yPF198szpzbaCtGpzbLaq+73M8jyRaBXaiVpp4R0dHUV6Gqq7phy2TacMqEq6dI56Ni6tmYGeCLtWurLTQk/hhPITgkWHA5VP0djv2drvNY5qwhkSQoCQKuxCTpWm5/tePdXqCoI9R1Stboebgyfzb5XaXcUh8JHjBRC7TezVuO0BAyoVqjNG86EYydB11MkKLkzBhOCECpXnjCR4r0EWfKpe5QBVn6zqdG5xCGfgce+YQpmewOYaqWpAVFtJEzsd7xKuRWrKhKfvzSaSPCUzkjUiXiTTltZwKsUlFm93kKHfNHPtCBIlYiO+HrG0QCSymM6xojJCrV69ycnLCbDaj6/tMBFOgojTxT8/PaCZtxj3STp8WYDrmUSOc7zQpCeQrtSCJ0CQtTpqUpbhzSINSsvQiggnquwEm+unoGbZpxxuLL6l/9o2z9o9HKFPaIHZE46LNw9jmZMzml46C5Zin8g+JSuM0fk/qnzHnOn5PwsrG9cqEPfZH2e7LcJryf1nPcR1Ksaysy5ijeZJcCDylnMghUeMQ8PQo5Vwm0qSyxguuJCCAuljH1+p5roFh8AiOdbelnSoHYLzay4cQWJ6fYrcV7WSGFzg6OspYyNGVEwDu3bunkzMGkWkmCrCenJxw//SUTddxfPUKQxj4sX/3Ht7xjnfkwDOJoCQiNp/Ps7VpIixpF00EInEZZb98+MMf5tqNGwDZQvYQYFfaSJRYQlocQ9QaBdHI44TA4BSz8OGiCKOq2h0+kspN9U62KcmrNuE0Y+5iLOoYswuKVHIkCTcB9oha2cZywY6tcF0Rc7YUdZLGSMe2z/2RRasQskiYvIOTZ3EiJt4rMWZU7z3Vb6qXd3uEYUzoAKzsn7yXQh64RzhM6/Wmp5KIvFq6jDKP0yHuY8yBlKBiCGE/zoW+LP92rkNDdXmNXN4NmEU8TsJAcGq30FY1bnBs1mro9eDuPepJy8nJCb3TidZMWoIIfTyLt+s6pkcLNtstk5keJ3F25wGbbc/x8THvf//7uX7zZgbc0vGSpW1HZltld8reZDLJO6X3Pv+ujc1n/CbMYjqd5oVQhh+EHdCX+slLYZsRQUTvnYp23hcEa9f/pbpUOZndgiitZ9u2zc8kbCcRjEMaplTfJI4emgfWFpHPCkOsh3EYJZFKfVv2JdZkexuf+2C3+FVTlsS0nUo+1anEb9L11Mfl/NS5p9jK2Hq4nN8pHEC6lgzpxkTzjU4fU+LMkwCIxjtZek/5zjJf+pQ7MtZcmJhVVSEBzs/PdLfeqkbHGKOalBH4V57Bm46CvPX887zwwgv0fc+DBw+y+jaBlcYYzs/P8yLU6Gb7Lvul6FIuigTM5rNazP5xmWO2uDTyKrnCcZ+kstM97VIFZdP3EPZ39vTukutJCy61ZzwHxqx+FmnEaLiGgFqnevV+Lp8/JCqN06E5sLOwjR92RmiHynUuZExpR+R28y6Vd5mYVmpmSu6onHu5H0fPp2DN+Z3//w+PqOmyXaGcsA979hB1Lp8td4HxIJX5jDE53ksGMb3D1Ja+14OVvOtwEth0W47mi2jR6vEugBclEgK1rbKjVbJS3TQbPe7QGPq1cgM+BFarTT4iM2tvgBdfeCvn61U86e6cqqqYzo7p+54rV65wdnaWF+L9+/eZR5A14SNHR0dq8BQCZ2dnXL9+nfPlqdYpTu4QQgxRsDsGojQht2KyuX3qozIWiba/y2bXIQSCc9i6RoIeYBWc1wXtw17ZyRJ1LDJl4LawJC2Ny1Iq3fwTgUtlJu3NzpkuiRE7nKkc93Q9cWeaR8fHhB1RSDY7mUCP5mfqmxSvFZQz0UOw9h0Q9zjifsgkL1nU+qBex+lYzrK9480tEbnEgezWxVMa7V1E3gucoSqQIYTwmSJyDfjrwEvAe4EvCiHce7xqPlJd8qDoTlgcA+EPizNlyh0OCLuJuzsWoYagth7b9YqhD1gcm+2W4+MFlanpVr1aq3p17+59j5fAdLpAjOHs7Ewd4oYGW+vkunb9Ot57PT/Ge1arFdO5WrW+EiPBb7cbmqZhvV7TtBXWGtq2pqoMy+UZ87lambZty2q1yvK3Mcpuz2azGNdVD3FKp96nRbPdbrOKsgw/uB8cyGDQwEvD4HVKBj2MyRFyGMa21rNwfTTJt1EsSos59bWNu29aqOWCTqLaeGySiFYapSW8I9dd9nfc3XgnVXYiQglbChwK9nMI+A3e5wWa2jsOsDS260ihF5WooMGaizalVIqNpRhTfpdR20rOMBEhEUHMziZHRGIw56dbnPklIYSfHUL4zPj7q4DvDiF8IvDd8ffrTmVHP4z9fNjzj0I80vcStCwHAtRoKwX+mU6nez4oTdPsokcZQWyFMao52Ww2CLqzrFYrNssVIur2Hoxg6oqqbbJh1+p8SVs3+VAl2GEgq9Uqa3/SxFmtVllLU/q6jEWl1WqVWeM0wdOuXe6G4/5KYtSFZPa1LSVLn/ptzCGWizQ9m3bzsdHZeJxLbqMUP8v8Y+51HIyobFv5vrKMEsQtRZTyfUkTU7ap7LvSsrYEhIdofCZYrKmpbKOqWixGqgttL7mrUqQc1zm/pwhcBOpmoN+fHCfyJASlXwN8c/z+zcCvfZSHHiaqHMo7zl/q58s8484v1WLjAQkhMPTbrEnp+571es1ms8lYxN27d/M1EeHatWsADM5R1XpKfGUbKtvQNA3TqXIV9+/fJ4TAYjZn0rSsT88xLrDarDmNuImIGpUdHx/zkY98hK7rOD6+ktu3Wq04OlLR6eWXX2a5XBJCYDqdcvfu3YyTTKfTXN7x8THn5+d7kztEtjyJL8mIKhHFMuRBCBrPte/7TEwSDlCC0rZRApswncQZjIlIKZ6kPOPFWv5O+Uv1c/lceYREalfmIgvOp6zzGLuAi0SwrEtZ97wp+LDXltQ/+5osfbf2pXIuJycnGqC7afZseUo8KomKJXFK9U6hHUpiXc7t0lHUFoeZhWJtvNHpcYlIAL5LRP6FiHx5vHYrhPCh+P1l4NahB0Xky0Xkn4vIP18u1wcLH4Nm6bzdoBdj9VPsST3geRfFfQcIjstK7toSFIgjHgOhaLay6CF6QwwBOufZxIBDk6ahMhXHixNELHcfnHJ2rtzF7GhKPa0ZrKc3jq1TkaASo4500dfFe48jsO62hPMVUwQ7DNgY5KZ3HbbWSXPv3h2OjqbMZhPaSc1qtQaEvt9q3NVMDCaEINTxeArvPWerJZ1T8/sh+BxTtWkaXBBM1WBMlcMMrM+Xuc+SU6EfeprKUjUWFwb04OsB/IC4ARs8xjkm1mLF7DQ+TZNPzysJQdaqBIMfAkOnZ+HiRY8sDYbaNhdY/Zhlj/CLWLyYrEmy1uJ8D+L1DNz4XU8orPI8UVuXHXEYcyRleel+JjhGP6EyYGyMiAZeDA7BIXp2sa1x3ZZp0+rRDg4wFQOCVJYh7B+ynkTpKhoTVlWDGkxajK3xQVW3yVnTFgZ/eV6L7Hn+DhJwRv+zj0+/oelxicjnhBB+DvD5wO8UkV9U3gw6MgdZjBDCN4UQPjOE8Jnz+fSRXvZ6xJjyuQsAVJF3/FzJrST5t+u6PTPrNlqadl3HcrksjMHq7FhX2qEYY9hutxmzCCHQDbrz22bn34IPGoszLvqkpUiL0VrLtWtq35E4iclkkiOdbTYb9c+ZTLMYVAKiVVWx2WwKE/P4v20ym55O40uLfyzrp766dLGN+rYURYALxH1slFZyHofY90Ni6Fhs2hNtwjgOK7nOKX9Z3nhepDwJiynbXhropT5Ohn+pjNIwMWnExmbt5bWs9i3qVXI5Zf1KTKkcj1SXJ2mtCo9JREIIH4j/XwG+Dfhs4MMi8iaA+P+Vxyj/NecviUA+++SSCZnYv3KgYf94xzIoEKgJ9/n5GcOgCyyJH82kVRFo2OaJMJnNmUzn1NMJ9XSC834nHvUD06ZlvV5z+/Zt3ve+93HlypVMFJSdVRVpUg3PZ0c09YTNusum6tvtlqtXr3L/fowaf3qa65rEikQYEjHYbrecnJwwnSrxTn4tJfipgO42q4KXZ+cE53H9oNomlw6UjoGbYx+Xokj2VynGJP3v+y3gsVYIQX1xkgp4GDr84LLLfLIETsdiZNU6OzF2jF2MRRMdUF1Q2kbd5VPdx5zJ3rORs0l1Tf9T36VYJwm4TotXKpvDNjTTSQ76lIzp9HyhHRFLfVZqpdL/yWSSOaRhGDIgnZ5NczcRrjSW2f4mPIVm7yIyF5Gj9B34PODfAH8beFfM9i7gbz1uJYt3vmqeVwNSy3yXpbF+fhxQB3am6imlAU6TPHEvfe/wqHGZravdDuNVnZfM4Ou65vT0dE9GXm+WOTTA2dkZAIvFMW073TvdbbPZsFgs8uRLC//8/DwTtJJzSh6/qT8TIS05r5SyTB327RqAvCBLXGE8TmORtORmynxp0aY+Lwl5+RmXN8ZbxgDomNNJZe7eb/aITnlvPN/Ksve4hZjGfeNcIBgbRcYaEYuwO3XwEEZT1rMrwNuy/8f9V3Ik6X4ZC2WMS73R6XFUvLeAb4uVq4D/I4Twd0Xk+4G/ISJfBvwk8EWv9wUPW+jaYY/2/Ji9vqzckqVNv8vDl5zTc2H1u2cYPM4ZTAxQJMYDgonRvzPhiQGak9dt2kkS4WmaBkvNBz/4QRaLBVeu6RklnQj9oGfI3L17l6ZRzmI6nWKq3YTZbDYcHZ1k7+AErt69e3cP5ExxTWCnRi0XQRKfyt2+327xwwCl02G8XxKQcmKP+/cQ0SitN2E/Nkvqq5KwjcfykIiaOIpS3NgtonTQk4HCjD1zDQWxKTmocSqJnZqs7wjomIilssRfNPRLfX9INClxkhSaUftg3zkxvaMkEqnMcmy1rU+hsVkI4T3Apx24fgf4pY9TqctSycZqp5eRuXes8nj3Sod7H7pX1Hvve95xjHaRMYZKBCvRn8Z5+t6z9Bqxq7FgrdpmNO0slmEZBs8ggU08UqJpGtq2ZbveYIzh9r27eeK9+c1vZrPZ8KM/8iN80jvewXQ2ox8G6rbhyrWr+KDGbZPJhNVqlbUpzjmNPxJtEgDqqmKxWKjdiZ0yayeZO0rvS6JT2rXOludMGjVyMwGIoK2yxTt/mN6plma7VoJWNQ3b7XYPe9nhBeqlK8mEUjzeO4xp81gmFXMSt9IiSXiQ917V5rKzZNXFVTOEfS1QWqwlLiAiBF8EWqZS0BUyEd8DOAsiVIoZvh/2CIRzkThLaZOkc6zr9fzjvu9pp5MsMibgue97JrW+d7PZAGqQl0BUFZXVpcHpgRoaFc4kNbBuHiEe+K5GkLIn8owNBp9U+pgwe38Y5/CwZ0pCcdnOcpHg+IO/0/v0nT5GvNphKSredDjX08UjLpuq3rMVMMawHeIB3W5g023zdWNMdqJ77rnnsizt3M5E3cXFu16vMzCbJk2ykNRFptajk7ambiyD61itz/cmcNqpkliTyomKrT1T7UQYSkKdFvNl1pOZRfeBSvT8XisaVjEdRF2KEKWYkAhAAiNLPOuQirZc9CV3sy+W6KfER8pxSZxEGeJxjK2MOYdEfMfiSM5nJLcjPVOKi9vtNuNOpco8jQeQtThlncr2lc6J+SzoOK5lvZ4kEXmqzN4flh5GAMrvaaDSNR3UUZ6CUIzLT5NsF4yoPL/EIdZQWYGg9hluGMBCi2OzUnuPo6OrGGlYr87oXMBOGvWw3XbZo9c2umhPT09xzjGfz7OPzNHRkZrHbwauXr3CvXv3uHfvHrdu3SLZG6SJowdJSyYQ3g9YW2fbDrEK/vZ9j7ALCyCVzQAf6ISezWa6Y0anub7vaZqGfttlC1gfD5HGqyn8dr3BNMoBJeAwsdPOOUyoEFG1pC4Sl1WxOsn1DBzne4xVEdX5nrZqqa3FxedqW13gDHQR79j2RAB24kZp0l7vLSblTtQKdBj6XF4a+xKfqWwT/ZWaSAQC1u6OIC3nTVrYOE/fDzSTCW7b432ITo4zTAzpeP7gNONKaT7WzY6TwBrSmdJq92HouhSbRbDVvhl8STxSvcY41pNIHxOcyGXpkOz9ahT3UbiXy8ovr5U7l57nqtG+JXhWq3O6TsUVCbBdb3YHFcWJOXj9JHYzaVlOTk545ZVXWK/XUYvhshFXCgadUP0QQsYwSvf5FLjZGDVfT6JGKYuXLC+wF2zYVDbvapWxRXwU2dtJx6rDEmNIiyO1ryQAY63JGMgc93GZZzyOY+1GyRmUeXc78mE/q5LglAZrSYVbtj+1r1T3jvsghIAtnCFTWalNadzS71IEK43qyraOueJkbLfDTMKeSHlZ373R6WOaiMCja2Mue/Zh18oJkRaPDswuKDKwi69pdv4gy/NzVqsVk6kuzhRcqHcDtlYX/vl8nq0XRTSqWQqPmCKRJQA0TZRhGDJYCjvtif7v9ohSCIHKWNq2zc8n7iLZvCScoDx5rnT7T3YvacGUu/xY1Zj6r1zM2ZArGIxJC+kiIbmgVi36fzweh8b/MgIyFrUuA2pLjdRYTWx/V5gAACAASURBVJ1xmeJ+erbUgIw54bEHcikWlQGMEndYEqwM5LMjcsluJ7WnFGVLDhAu+tU8yfRUijOvhoHsRBg9ZX0fv9D4HnqNvPPs7zZpEpWDr4Cf9wGPst9Adl0yMYJlCKgDmgTauLsP244heK5euQF+4PTuHbpuxTB0dJtzbDujaizBD+BFQbe6ou8d16/dVDuM5VKd8MKAYOk7RzOtWS7PGIY2mjs3nJ0t2Ww6Tk5OlCU+V6xjOp1ydnbGZDLLMUNEBFOpt+l6vebk6nVAF8zEmqymTn43xqv17tCp2lhMBVWNNxYGBQCNMcUpfIM67g1dPos376bBEwiEKhAPQd4RIecheMTEeLQxqnAKbmRtzRAXblVVmHhmbwoIbYwBa/D4aM4dqI0heBf9ly6qZsuNIIscsS8Ihsra6HvURpW+njscfADxzOYT1udLjKlyf7XRlmY+nbJarXD9gI1nGPngwTudo1Zo6zaq/Lt4NlGFtMotzudHQMSqxGU8bLFY6EFoKRmL2LihBMc2emaLif5PzuO3PZUxKnoJGef6uAdWUxrvCOUO81rSq3EgJc6S/o93rjEbmixG+77naHHCbLrI7GUIYU8kCEGDOqfDum/fvs18Pt/bOZIqVkRDK7Ztm43eQgicn5/jvVqyJgOjzWaTnewSh5MCNR8fH2fuI+1yqS2bzSbvaqV1atnXpVHePtGOqtUDXqKXiStlP4/7ugS2Uz+X5RwarzHAOr6e8o+5qfI9afcvgdzE2SRRr8yTnkvR15LXcz4AvRDr0jlE6X3p6NOEwyRuUkTPJ7LWcnR0lGPFlB/vPa7vsqaoruscbmLsKCki+XjNZ5hITOOFnjp1zE6m+4+Kcew/c9FL0lAO5OH6ZHTd6y53fHycLUpD4fORzOO9V9f9Tb8BC6fLU+pJjVRCM23onHIJx8fHeWJvt9t87u56vVbOJXruDsPAjRs3+MAHPsAmaofSRC4tUhMRqaoqanxc9p1JbUraoHTURKklKUHH8e5e9qeEw569QNZajAlz+f0QfnKwrEvmSUkESsJY4gsl6Jg0TaVYkwFNazMhT8+m/mzbNt8bE7xMRGLdk1g6Xyxo2pYqukc4NFLcdlAisFjsNqDS1L0yQnAD6/Wa9XqJkRDDd4Zs0Vu26xD+9CTSUynOXJbGHaHy+EVz3ocRjxJAO/QRUbVkEDLBEAkYVHSCOBkMmDRQMfq4j7vxKsbb3Gx7rt28AVY5Dh9PiV+tVohVL892OmW9XuOC5+joKE+As+U58+ksE47JZMIHP/hBrl27lkMizmazfD7ver3O1q/DMKh9yHRK1dS57xK2kfogHR+R7qcJvNls9ojFbDZjeXoGwp4/TQgahmAy07CKjfdIAfKFwSFG9DBrGxhcV7im71uAWmsh7EcCS4TQmp1hWlrIQ9jnKlLKolkknmlcrdnhEyXRS7/LObDDvtiLpt9tNjRNnQnOarWiiebuwzDgncOLhnYYgtfzZVwEN62KitZaVpu1hnXYqKp+vdbfR0dHrK2wHWIQq3hUhUmhHZ0ezDqdVIRgcV3PQLQojsbT1loN/BS5EBf7xj45aeZjixMpWbq0g8BhIjG+Pt71DoF3uzyQbEDy8ZGyzxZ6v3+OajoacvAOY3RitW2bQa90WJWI+kyslysMev3q1at74RGDwMnJSV6wSdNy48YNVqsVy+UyE4tkX5JUxG9/+9sz17BerzPuUbLoe4sggrrpECwgczvlrj0WJbJ4E/ZDGqaUT+IzuyMY9vtvfNLdbhySJqnEMtI7Su1QCQKn8svTCMvNJAHA6X4qowQsS61TMkBLNjWp/DIWbVJpJ04ucQ5pzEII1JN2tznZXQxZ732OSXN0dMR8Po8iL3TdgDEVXTegp+YRsRhD0+xU3WUaz/sSPH7S6engRMKjAT8lO5p+h1DagxwOd1hyH+N04ZlR/mD2nb3EVnjfY406ZoUAPqgoM5su8N5zev8BxsLi5AqbzYpNr7FJjo800nvaebqu4/xcD7iaT2c769CmzlqasYx+9erVjHukyZvOdUls961btzg9Pc3q3cRy27rN+RIrvn9AFZydne0HfUYXa9u2ON+zGQY9J9cHtaO0Fj84TBV9NZzDGoNnR2xS/NeqNoR4+NXYvmIvTIDsvFkTIUmxOrKTpN0Bo2W+1F+J4KQ0mUz3DLqSqjv1a3q+tJpNmjBrd273TdNw586dTHwTZnV0dES/3VfbJi6jsbtl5gkZLM0aoAJfS5q+JO6GELJYmUJcpk2hkvR8jW122E5S5QcfSNbuzn1sBSV6ommMV5TpEGj2sPypvP18Fy0eTSg1Q7tQAGPU3wUfT2E3dL3jzr27zBZz2rZlOp3m3TAZnJ2dndFtVmzXS+pGLU3X6yXb7ZqmqTJgB/DgwYPMOdy4cWMvaFDauTebDefn52w2m6w+9t5z9+7dXMekTiyxjxJ0a5omG7OlhRtCoJlO9lTNKeXAOtGQrZTBE9A45iRSv6c6ldzDIWCzrF/aLEq8oByHkuPcGaSZDGyPN5iED5U4SlLXJ+5E3QrOmU5mPHjwIKvYK2Nx/UBbNxo/trIax8M7PaAsBObzOVLt1MQlp5Ji2qiGSA+3ShxcCidRqoPrtsljNJ/PaWfT7I/lgh7CnoiQtVY1RQENVv3xKs68Gnfyeu8fwkLKdEGbIHHHshdjYZSA4jDogpjMZmrN6lRdlyZPwkP+P/LeLda2JMsOGjMea62993nccx+ZWZldVVmVVU03VbLbTRtkZASSjWgsS/4z8AUIqT/AQkJ8AD9gwQ8fWAgJ0VIjWcY/GBASIAFW2y3Z/nBbYLfa/XRX1yOrKqsy8+bNe177sR4RMfmYMWPF2ufcrKzquuoreqVOnnPX3nvt9YiYMeeYY445TRMePnyIR48elYyOpk+JSFKF1mKz2ZTVV1e4b33rW7i8vFzE6joZldMRY8RuJ+0qdJJoWlaNR80F0cyCTs7T09NF2KHXp+Bgfe06kev3iFGZWzrWq/2L7vMxS/RFz7H2Go7xrfq9x8/2ODQ7BlDrTTkwwKzmrsa19pbUK6jHQR1u6fkeh5LOHNXb5LKJGCO6riv3WBeKuqiwXXXwvoVIbyYMISLwktuyAKKrMoOXtb0a4cw926cNb+pwZt73g3/u+w4iAic55rxzBgDlN4EoyW8k6JuVfp1SyhKBLZrWoe/3ZQBpaDEMAy4vL8FMePDgDP2YQ4pVB9u2xVtIeSXbbrdocpHbkydP0Pd9kQ/Q8EPTvNfX13jw4AGYGR9//DHWJ5sCljLJyqy1N1pJ3HUddrtdcc0BlBT04XAobnWfq4SHQw9DEs4550Rtq/I2NMwiIphsHEIIIFOJCoc5fGGePYdhGLBarcoEyg9mMZHq513Cm/zWOeyZs0bee2hjMTUg6kHVhYNEVIr+9LO1sb29vYXzswCTGvHD4SAeoZ9p92pwy31oPFJu/K2K+HXKWT1CNV4azuh9cM7BkWjs1tel3l1KoXgeGrIRUHR/X2aK95UzIvXKwTyTvkTyUME3LVSyBeAkWubihVcqP0yztBwDQCbfJKgS/GyQkn4PcUntGkNCNmNZX1NKmYSWe8EaBiGUVanvI5xrsN6cwvkWTAa3N6L03vcjxjDh8ePHEuvHiG59AhBhHEJ2wT3GXgC8w+FQJpXyRJxz2O7F0+hW88o1DAPWJxtJCJDFan0CTsDz58/FS2lXZbUTanyLlIBpillmQNLF6hXpxNI2FuvVCQ4567Pf7+Gdh+StEqzJQsQpK8Ebg5ASLBFSnrSzLgngXbN41kTC2D05OZGaFEfg3FfYwoMJsK7qfpfroXym5SOPFwsLSqLqXoPhmsImQwXPCjHCWMCZqn8MSxMolV1wzuHm9hree5ycboqRBQCmhJAifJMxJ66Vz2aBK6MLHSAtIWwWG6qalhORGGOXgW+i0mqVWZjLYRIimc1gdZoqFTR2YCNFf4EZZI44OubV1Vh9KduLQoz7XNUXhiTMix91r48v+L7vqX/rqnSfW6y/CUs+xDTF0pNE1cO0uE3rSY4zHgBKLA6gAHsaZqgHcn19XfgHh8MBl5eXuLq6KgP+5OQEAMr31tT2Y96C6KXercStC7pqrEDP9zjUKd4FL7uwHa9+x662fqdOdA0j9PuPn/V9Y6TeX/+7fj76d30+x++twxxjDMjMhW3e+9Loq76WmihWG131Xo7ra/Q1BUbr9+m5UUhwTKUdaRonhGEEj+Hea9LNeSOV5VlTlgzDWMBYyN9/lDwR4G7KD8Cdm3a83WdQ6kn6IsNzbJxedOwYIwyAAEbbWBAIMAYxRHlwmNXNtMVD3d+FmfHgwQMchhHtqithyCY3llLtD+9l1VV5QkCMiwJ6q5WomvXjgLOzMzx9+rSUlAMoHoZmerz3SByyO34N79vCco2ZMq5ktPV6VWQXVQRalePrZzMMPQ6HA05PT/PD4bl0PWibUGHc6rHVEB0L7qSUSjm8As7ee4xTXEw8FX2uw4X7DMsi7W7mFpSactXXFWitMacYZxxkGAZ4JyS+pvWLYsU6LOq6FoYkDCuAKRFinJDizDXRsCNk8e5idDj3iMnhh42MFCYgRoxDDumkoTHYoYRf9djW4xJRAVV1f7kf9/CpflzbK2lEgPs4HncNwidlW4ghKS79DUHCwUuw8L6NiMCYDZEhA4L02QXk885mFmGb3XRY9EW0JqJdSaXtGAOsyVRoQinz1/J8qZ2QhtwKirrGL7ggKqx8enqK6+trMDPefOuz6A89pjGia9d49PAJ3n33XTjnsF7Pq+E0TQW7WFntVjdWkzjAmGbOQGRAWK+zvieKFzBzaQ2hYVbjfA4P5/SoMbI6ipfkMU15UpCEp7X2q3IvNFRiCJW+5oDUz+U4tXvf2Kk9nGOvpfbMUprTpm0O+VYrMajW2UWRYZ1lEm5HwhSmogpn3dySY1QinxNBozptSyQ1RIm1Nktwo931TbkGyliRjFtJqTtnwRwXXqBgKk2+LxPGcQ65FO+xzcuTe39lwxn9/SKvov79omPc5wZ/0uv3GaXj11ShS+NUtf71gNWUrjEGh8Oh8DgAFFCz6Tq0Oe0LoNDkFfDUcn8dtJrG7ToR/P3Od75T5AOcc/jOd76DJ0+eIKWEq6urspoqvd1ai9PNBpvVCqu2FRc5RHCIaKyBozmlWWdg6nS2TkZr58rgOnMEzNkPSwRvbRElosSgxLAguJyZKJXGOV3LzItVW8+hfkYL15+OqPYV8Fr/reelv18UBkvrzKGs5HUauT6ufq/qiWgqtg4D9d+KBenx9P7V4S8y0KoZmnLNuTlYBIPNUdEgUMaCYlx1vyBgBsePPZcf9/bKeSLHD3/+vQxnCoBaSGb31cG8CEMBkKstQbH6nrsGh/MKwJCVzTsL7y2cpezaB3hrYZ2Hy4PfWIf9QRperTcniDFizHUR2hPHZ0OjjaXU4yAiXFxcZJHllJmvK1xdXeHi4lEBbx9cPCqfOz09xZMnT3BzcyPK801T1N/btsXNzU0xTDqYHj66wNDPBC4BAk3hJeiAV4KWEsRS5qNo3U3XdWiaBtvtVkBhPxOzaoxBPRMA+TtmbZM6farYjvMG46HP7rnDlIFPb+YOf2rwauxhNuZzHUndTLsmmelYU8aqYjKy/0icipZeUV26H0N1PMxGqx8HeOtKlfb5+TmG/VyVq1jb5c21GFvnsDqV8UI8GzAAMsaaWYhbPz+OMq6azqMxc72Tgs0qK2nsy/NEXjkjAtyvG6Hbi4yDqpfpfm3gwxCWIPTvF4B0d/59j+FOcUIghrWMlNOl6/VaBmsIOf27dH91EGvWox8D+nGEyYNZ3ds6tEnMmfYeCtek6zp89NFHODs7g3MOt7e3JRTQ79NQhIjw+PHjMuidl1j9448/LpNN23Eamj2VRDN+U2c1pB5jprorTqGr6uLZ8bIVhwpd673QtKoxM7W9sDWrdCpXYso1s1THx/Gzq/GO2kjUYKca3ToUFkNk8muxTEJ5/zJcIpqFpNXopAQYzRABYHAxxHpfx148xsPhgG6zRr+TtP8wjZiGESenp2hyrVCMEa2VzynxzBiDCCBm4+6z51v3qJmSkOL2vWShrHUitWAMQCRz4CVtr6QRqbcXAZ93w5D7XdR6wByDs58U7tTHJgKsNXCuEqlRt9bKxGvaNcZJmKI3N1cLXMBaWzAO3wpQqalCrZ/QFOR+v8cUpS5DurZx0QN5+PAhDocDiAjrXIsTM1HJWltKx/XalNL+8NEDSF+UBnPPlXmCKsVeJ6Lec53kwzCUug+9j7UXgHTk6vMMXOoEVeNUA61F15XnamOtHg6REbOX0DRzaKfH0ed2XGPD2YgxLQH6+prKxMxsVG+oeCPHHtPxZ5WPU99nvWfihc4cEeeaQlVXwHq/38Nnw6thr27eWbQ8h8pqLMoiY1vYHB5NIYr3nRLSFAAjBt1WqV1TEdDiS0QuXlkj8kneyPF2XwiToF4ISq49/gCcZD5WHngZ2LMG8N7BmqUCeO0iMxO69RpMBNd0SBzg2qa41GdnZ9jtdnCNCAat1+uyMjZNU7AQQPgQyjTVlUbDB8VGLi8vC95xOBxKgZ9mVRRTGYYBH330EQDg/FzV0kKJo621CLriVTyMOlxkZnCO8acMpOq5SL1MgsGc5pUHeJfRq5P2mF0JZANfeQ51qpeIhDh1NHlxtE/HjTybZWq1fr0GWzXk0m0O3xJEqOquBOPcc3fpYdUhD9GMF/m2wartihC34WVaWY1oSglTP5TFzhqDEGepROcapMgAE4QTnJX0jQFloH8eQ64A+kSEKb48nsgrY0SomtcEIesQgIh5UIi3UQ8iJaDdBWFNzHUUVek5F8Hmufo3VgaFARjK381JQMBMTjKW4EyC9w4hzDqcUxhAhsFw6Pwaw3AoymLjlMV+YDFMEeuTMwBLKT5dEduaqRoiri+vYIzD+fn54jPTNMmgARBDwCHjEkNmsXJKQPZ81J32RqqAP/zwIyFNnZzg5uYGgOARTWsQ0wCTtP/rLBsgavMME476pUCyC9MwIplcmSqVlMUbsdbCEBeDMPSH4vE4YxE0m2XUg2G03kvKd5ywOj+TboFAKfCrJ71iEokAWIN+6NE6j7b14Nx0m7MoD0gIh2qYdII7MhjHAJtVzAwIcdLJDYAZxpky6VNkOKsYi2TtiJYpbjDBmgbMUwHdQ5KsGxHB55BXvTVtXGaMwWa1LuFQnyU1dbHQoaoFgbX2TYoTCEDXtqBszLV+J6UEvMROmq+OEbkT56r7VXsOZvHvmvzzIkC13nfXC1m2AFDwVgZXzooYAmVGY+RYsjG6Gutkc1ZK8q2dCVkFnIxLYd7a2OlEuL6+xvn5efE0xHV2wu1om+o8RRLQ+6a4vbe3t8UwKEahBXnDeMDZ2RkYjLYRwWfR1hhyE3DGOMrK6kzK508VdiATpN/t9UFl7ZJT6eIXo7BP46z6RcosTowpysq43W4L/qOhXqGeT1JGrxT/umhO75Wyh5EriGthI61QVRxHjTIzIWV2cq3wr2BuHCfh0xh7ND5mQeY6xFGNk7p3jx5LP6sGLoQA6+aQqYy4lLDtD4vsU4yxkATHYSxG4zi0NGZJCqzHLjg3io8TTM4K1fdQGawvY3s1jAih9DsBcvihf6e6VmIpiltncu77Ae7HPSQ5I1ATh1T2lv5KGQcBJeH5JII388NUjQ4VyDHGoPMNBhpm6j0BxnoYA8RpHsA1iSvGucVmZEHznXOw3sGDcbsVunUDV7Icug1DxkYyQWy3u80VnTJhNmsxEF3rsdveZm7KGcbhgMN+C2s9drfSAOvk5ERWxfwDAI3vBOj0oqIW41TSlZvTdQFPpSReuCcKMusKKQDp3P2vTN4yqaSdh/cWq1WHEEa0razWh0NaVE/L2xkhKaYxix8RM4YwYb1eY9gfqslFRWfUZO8tKDdlnOYaGl6WWyAbrCKK5F0xHs7Ozdp1EUgpFaIgsNQqUdxHOTHTNKHJ3pyGRZqdSilhtVkXrydyAuVzsd4BackODlm8iIiK2BNn7VpdjGpj9bK2V8OIfKptSVkGfjjcpP4cIwJ3Bg6KS01ZGEqEhOeHUNOUAZTVdL1eg2NE4xwmlsyQDkwZBliAgrrCOOeEnQgslLz0vLQwbpomNBlwnPu/BMQQ0LNok2gPGCICk0FKTV4hYxnI25tbqbfJRYDOGMQw4ZCzBWy5lJYP4wHW+OJ1EVGpaWnbDsNhJjQtgc0jY465grlmjRqaORVt22WOxlTo5TU/I3GADtUXLRBqcAopjXMq/yjDo+9XY39cEFfjG7V3wSwemXdzc3fgbqMondRN0yCmpcSBjqExZ1BKZiWHsYpTlXtklurtZObmWGqoC0DOUu7PxtwZZ2pIX9b2ahiRakLLv3MzWwDSMV4xkSXwqQOjZqB+2p/5WMsBKasYFxe4K0pS8l6NUeuHstvtYJNBuxLORB9yc6msI9E0M2haTyR17Wv2pSiCzyniAsDmGFqL41rfLQxTAUlDAJCwvRmEG7JqyjUSJ0zDHjdXH2d+R4u2aXBxcSoENQBjf8iD3YMRMGZ8oFs1uLm5QZoo96IZ8wQY0LayAtfNnDQVSmbuVA/MtTyc5uyHVgvX92CVGb8u5EwJhwx02xIqGWMQ8nG99xgPfcV70ZBY7mPf9wvjUJPbOKaj5780Om0WINLP3UdcUwOg3pikzy04MWKYDWmYInzblIrlKYmH2a5XOPQ9GrtULqvnhXgWSwkDhmRpEoe8MMliM41BvHtrQDzzV17G9gONCBH9VQB/HsBTZv5q3vcQwP8E4G0A7wL4i8x8SXLl/w2APwdgD+DfYuZf+2FPSm+ccD9Msbq6uty3Gt3xSIyU9Sdkzkj+LTD/4vrmz+uql6IoQvFMcffOw5q5SEsHRakzMU0ZVOotMM/ArcbXNV8BAMZhKt7MdrudPxcjKM7Ao9KqkV/v93uZ3KrvmdJicN/e3mK97hDHuUfJG2++jqurKzAa9P0+YzgWl5fPAQBPnryGwHJN4zQVBTY9p9Y3SCmAaDZ+9aTSFVVxIr1uTY3q/YkxlsyBik4DKGQ4fSZieLm46upR1OxQbx1CincmnqzyEo7VYklpkjoVTVOrF3LseQAoXpm2qgghlFRwPVb137Ux9Bkg1jGm92K1WiFk+r++D0C5R6XiNxui+v47Z6GRIBFJ18CM3RFLaGxsBp4Ng6yTLA4BgWf88Me9fZrk8V8D8PNH+/5jAL/CzF8G8Cv53wDwrwL4cv75BQC/+GlOgnOfl8SMmJAnvvxeehD3exvAXcNyn2utr8UyuauMDtTrqUBPMmjUfc0iu9qKAUApQOu6DjBS1h9Sgrcz29AZX9TXNQ6uvSdtDXF1dVWqRfV7FJiVlowyEVKc+40YY3B7e7swItM0IU4jzk5OgUR4/uwSh12P/faAd7/1Pbz33Q/x4QfPsepO0OTm3X3fo+97vP/976Hf7XD18cdovMd6Jf1/p2nAdNiDpxEEIMUIThGNd+AUkWJADBOmcQCBkWIAWOQSgGVGpOh/WIJvHJy3IJIUunMi7bDd3iKGAEOzTKIjAwtCCgFULRhqUPTZqsen/y64hrWLHsBhnJBCvDM+1DDWYcQ0TUVDtWby1oYrhFDaPWi5Q71w1NwT5dfo7xqorzflEKnB0YWnkAizgVGDaEm76/UL71ywlT9Enggz/z0ievto918A8C/lv/8HAH8HwH+U9/91lifyD4joARF9hpnf/xTfk//KqbUqzDje7sNCPils+TQbUU5N5uyCMUbaYio3BFWZeP7+euVhQzk9rKEDYGBhvQFxKvUzOrA0PhbQMmK9WmHMPW+9FSAvsTBgmbmaUBbeOYRpQAhjdv+Hxb2KIeBwGApw2Pcjbm8/hrE+g5weH7z/DCena6HwO+Dm5hpd22J7e4umbXF5eYmzszPBXYYBLVnEHFKenGyQqjoRDR+Oa0f0WdWrfI0nHE+GOsbXe11jFXVNT70o1Ary+vrM98jfGQVI19fuG0/199f3U7+XWTJtemzdCuNW09/GFA1W/ffy2MtqY91fBJ6YJWU9jeW6x3FEQ3P4qt+r979xcj7TNInGidEmV9KV4IeZCz/s9qNiIq9XhuEDAK/nv98C8N3qfe/lfXeMCBH9AsRbwfn5SfXgKgA01dmX+bP3YSD1QLgX4Ks9lqKjmlcmw6BMcQbRjNEoYYoB68StVQ9gtVoJRpAzDuL2AgRbAYMWxOIWqxq7fr7GVHS11OyHTn5VtirMyhwmhBBKSnWsVNrrcGEYJIX7wQdPYUhCh+++90FuByHehW8sHjw4xxe+8Hk8fPQAcThgJBEHOjs/L+Habr/HGCaElEAG2FGF7UwBva70maoNLCeeelGa1ag1ThRw1ePVPyklWGMQc/m8GitjDIh5IQ/AMcH5uV3E/Kzv3hv1IvQ9+rtO2wJz/Y8uACJ+PO+vwVJ9jkoKVLZw7eFUY78cH5hbnioeVHsvuq/rOphYNUEzszfkvYdJku6PU4Bt2orZe/9C/OPc/sDAKjMzEf3QZ8nMvwTglwDgrTdfY42s5P5mIyBrRx4oyw5sgKhoISUhlKUsVZhmTyAXy4j7m38MUKpI5Y2pGBDmCA+CMQxvBED01qD1HkACLGWSUIK1Bj7H2ylFONsCbEQ5y8uk9VmHgokwpoCmE4WyBOBwkIEZpkNZdTenJ/CQQXY4HDCEAHIWTdugAdDvD+W8fVbHGicZgKumAyaD3e0tkg2wzQNcbwd8vN3i/e8/xWE3oj0lONdg1bQ4PzmDM4w47fC7v/kbWK02+OxbP4HzBxsYSrj68HvwvsXj117Hg26Nbb/HuO/hncP29hana6lSDsMeHhtM4wSoMTUiAcDMIAukMNfizHE+ME0DYmS03QoiZ8jwbQvfnsA5+bzzc0rYe4/IEiQtSIJ5AiJLP8RJWi6AGSZlL07x24O3GAAAIABJREFUohDnNHz2YgiAIcWwZpnHkkI1Xrgvee1Rg6R9jXUzxhSau4Lv+rz0+pkZiaPgdZVHoxmdOq1tyIK8yZKaO2CKmdqOrGUjoZ43AI8jHBPYrQDTwJoWnAhG9AQQX6Id+VGNyIcaphDRZwA8zfu/B+Cz1ft+Iu/7obZ6lXiRFV0YlE9pacsqV/eUqb5TVlOCt9JtzNK8ohEBwyCpOe0RAjBMbpgNnt3bQmGuVhXnHAi2sFljfqqbdVPSfLvDvpTZbzYbTMO4KBjT8xequXyXanrEKD1lrbVgihiHgP4w4unTjzCNA05ONiA3wFupRG6bFkgTQA62IUQmfPTxMzAmtN5jtfaYcre1EIEQwyJ0qT1A3UdYPjP1EIhmcSDFMNQLsXaZ6Zqv967Cu/5dbzoJj/EEBXT1PGrvdUHCqo6pBrCMK9xNjdYgrP6u99Wfqb9XzzFGAe3rz6uQUF0ZzMzwvsE0jUgk96WxDpQzcDErn+n3RE5IiWCcgXHztJ6fBV7a9qMakf8DwL8J4L/Mv//3av9fIqK/AeCfA3D9afAQYOlyHYckuu/474JhGLoziOpjHA+E8lV5EJEhUIqyCrCUXYuuah2fY9EqUQ2Dll0725RMCjDH+d16VbIWbaZAp5RwcSE9ZW5vnsvnG49H60dlwgzTJBqcFQ5zenqKw0HYjonz+/YHWCIMhxEmCZdj8gG31zt87/1n8NTi4WdOwRzxYLMCMyFMhBQT+jghgRHJYRjH0gfHe4t3vvh5dF2Hq+tbXFw4ABGWE9IUi4sNiGH13VyK3+SMxiwwLMWLes+apkEMUpNirS8rtiqyTZkvYRCKh1bT3WvM5Pi3hgcyces+wqPk56oJn1LKnQ6pGDZmRt/P2i/6vI2bs23DEMr4mUOGeezWAKqOw/q8jDFgHGEqcVaXt5gxmSLaNAV0ziMlxng4IOTm6N7NlcUxisdBTuQYmGxJTABQ8b2Xsn2aFO//CAFRHxPRewD+M4jx+J+J6N8B8G0AfzG//f+CpHe/Dknx/ts/zMkcx6d57x1vpMTM2QvhtIylj43N8ecNas0SEcohI53hnREld29d1qbU9ybpXk8G05hrSCLgbMUh8HP/EpUmPOz2cM08WeY4Wq7v4uICgGSiSm8UIpC1InKcU7jTkEG2RrCDwxAQOaFtVzAM9LsB0xAANtgPwPtPn2IYJrz++im870WQOE0AC7ciUQOyBoYIFADfWqRxxH4M4MOId7/9AVarFq+9/hD7/RZd68EpT2w3Gw0ARSmN2SJFUVLTVV3i+XXBicAE5yzGaSi6s4CW5CvfxUgtC8+yA2qYyPrF861/66IBzLKMRHOZvm7FgFSLkWriatGkGqYYI1on36mhWDlOrOQb03zNaqxqD6VOeRtrF68nnsM9AOAhM00TYAxh3Xbo+21OMQckiGHyzoJDRAwTQmI4b+EbL4YRjMBCSgMAwy+PEvZpsjP/xgte+jP3vJcB/Ht/0JOqjnfHTTz2WBTreNFWhwHL/VLoh8hgEzOvVLAOay3IzANTzLgM4gcPHmC/3y8GC7PQ3B38YvIo+agf8wBdzTUW6lYP0wyMagoxaNqyIqQRUY718/e2ESFYHKZtXo2tpFtTwhTkXM9PV9isPZwNYIwI+whygHMenAiBhKHrrJGVzBpQTEgw2B16jCGgWTXwnUPn51aSpqotIRL1MuVqpJRAkUrhGzHAMRWCmfFyfxuSitRZa2rGBqy1sDQzReuJytW4qFd7/V2/Jl5fKMddjJtqU8q5Gnhl6KrBqNs46HFkXC09jhqU1fNYvl/H4VFvmJobRHNdDDNLJW8ImIYBY5A2m00nimVIEci6K1ZV2IwryYH75szL2F4NxiogoFj+s9QyJC4iQvcbAuWnz3Hzi1apxYRPCUQMbyyMJzjD8NaiaTysQWEFEpGQdrJnsPFdYT6O41g4HgAwBmkmlVLC+fl54XkAmJXCSeoaGq+gW1oobflci+Og2MA8eVYdFxZoCAGr7hRhmuCvW2xvbuE6wuHA6Kcez58znjxucXrS4/R0gPctgAY3XeYpJIIZRzSccenokKLF85vrDGwCYYwIacB3vvs9XF9f46e++AWcnG8wjr242TBo2xXGscdms0K/7ctKPY5SRxPGCb4VseOu6/K4zo3Mmy5nUhwOh6GEhjrpUhIvwloBK6WthRxLeSIGM6W8yfyNUE3eguEggjhzSaKQzWIKxfNrm1nTg5xdGCHBT7IoEoTAWDRlsjej2FftTUi2TtqNANLGUi5t5rIU3gfmsKxotOTXVcn/7KTDpu2KR5RSEvlJMghgjGMEYOGsMG6NIXie8ZX0Eu3Iq2NE8vYiq1mvPPpv9UCOMY/Fe+7ZjAGIDIwRIRhvDbx1RfKwcEbkjBbnVqcQtYBKH7z+aFe71gtgtj47KZySmulapzULCSvH/03T5IbOeTUxDIe5Ovj68qa837ctxjGCnEfgHn2/x8MLC98krFcrON8iJQMbovRGCQEcIqZpBLFFiAn73YTWW7k5UKBSPInb7R7Pr65wcp6bktu68nleQdMUMFZuewkjonYQVHareD7MMtj5HrASRyGA3od6Ra891IKPsGRjJq1DShJGqZ6GVvMW0SSz5F4oIKvHk2tYfr9OcutsSb3XYKoagxBnD+eYnKbfJdeKRVp3GhVvGuCbBm3ToGkM+lw0mCLAiJmcJ7R6ojklLEzvl1crc7y9MkbkxWHHPSHM0Xb8el0ncPx5IsrYpzQ7XrUdLFE2IBpmVE2STN34KiKxSAoKkSeAYwQZQdLVNdUsROENBM41LLPi1/PnzyAtK8/LCjZVpC2yRvCP3Mmt8EPUvfdSX7Q+PQGRwc31Hq5b4fD8CjEMaBqg6wzazoPIIUaCczmbwgAcI0VZoS5venz8fIcvvf0I4xgwRUGYiQgWMlHe+977ePzaYzSNB4nKS/HuihHJgG8tRxBCQOM7wUZyaUCZhMq34OXiEHMxoxrWeoLqv489Tz2POqRIaS5oLPhNxRPxdia5FYOlY6R6jjOvR/dPefKbBShbA70ywo7rtJYesS4ozs5aqiFjX8YYkDXY5BYhh/4WIczeCpFHihImU0rwTbvAa+qwKe+5M29+XNsrY0ReBIhqDFyn4UqaUd68SHUdH6/+KaudYTgCnDEIYQAIMBnwI/2PpPpRwyl1t7XWQVdgBUwTJDwCUFinOvj6vs8rh8siNUDXNWVV4wyuac0N2dktTkQga0DTjLUwMx4+fCg6JJe3iGRAbYtnHz3Dh5dbvPEG4+GDBuvWg6IDvAd54Gw1glNE2xLMSYMhdrjuO/ytX/sG2tPXcdI6TI1FQsR2PyFFYBoBYzfYj1t849vfxU+89QacA1onRLi2bWEsi2J5LpJLibHdisiOmQxSm8BDRHQdGr+arzNnFvQeNk2DPsssdJl/UTI6eUIfLzR12FI/dyHUKbgKxLAcBxIqZzCUZlX7WHm7dQal9oLmkCuVcaHntMjEVL2b6/2LylyaJQd0Mem6rhDMQooYpwhYg5VrwKmi2scAZ6SmJrlWxIqIxNATISUgIt83+0egA96nBX/q1eiT3nOfV6ObPiznpZpCmjuFxWA4jm8l9EjlJ6WY411G30udhGqi1NiFMlrHnEKthX6JllW7tVuu7+HKiOl5CL4Qi3yAZD0MIov4UdMSmlJ9bOf2m9bAEtC4nImOAcZZjAEA+aINInVCpqiJab3I97///Zy6nolUGsLpZnNWCZhbJIggk7kzEetJrat/vel7agOyIG2lWcqw9n6Ov6euLdLvtNaWMKT+0XutY+C46jrGWJ5ZDcjeJ/monzsOxRV0r9nJNZtXw0DvPWDntiH1Z+pQrw6l55DmLq3+ZW2vlCdS/61q7ZQEaFUGKuUuuMzCRlRwa4GKV+8N2uiHEmwWdZHGx1nIJQY4S7BkQZHBOStgrUVjZ5da1biJpLesPhPtpRIPB7jVBkSErlshcUDihH7aY2UdGpcrQiGl2Uja20SOY7M3QkTwRrwYJKlSlQFMsLYiW5kGiQir0zOk3QHkbhHGCdYYNI1ka1zbYiJCYomlJ5dgLQMpwHED7nboR4YJHmd2C29eh+0mtF2H8WYLPkR0xsDsenDb4IMP9+C0Rkx7mEZqo7umxRQDyLZIAIYg6vLWOsBYxCAeViKGb7VZFpBAwnVBREpUwOcUAlZZwEi5Noo9HXsglgxSiKJMFpP87QRTiBFo/RpEjH48wJAHg0unuJgkfU9kkIxUJ1sieONBicRQGvE6LUtoNMUJsBGJJQ1vIsAp40M6buMyiyOpWAeyplQA11kn5lwglw0RZZ1bq4zUxIgxgJhgWbJeemzTiFJcIIJtveBZLAQ/aRAWAQigq72BX8b2ahiRymE4jiHr1aNeDY7fvzgcL1PDEmUYEMvkt2TgTPY2yAmNmGZNTa0BGccRxssqsd/vpQF0WTFVXEdXCmB/2Obv3WTAU+pf+l7o6sJW1QK+DKRidnO79Vr2VYSl2hNJiUpJvXos3nucnjp4f4m+36PrGmw6YNU2YIqQ1pAiNs3jCEZAgoNtCePU4Dd/+wN03uFznz0F+2f473/xf8G+J7z5pZ/Fv/bnfx7T7nvgzVPQ9ACPHz/GL//y38Y//6f/BFzToPMdxjAh8szSNcbAmhkwJiLc3Nzg4vFjeQYkeqmhGEMDJsI2NwqHMUJpZy5lDSa/RyDZeYVPnArjVJ/1brfLgK0YLCJJjbPL4yfNgtDMjDhFOMO4ub6GJaBtpJMfJ6DNeqcGEq7GGMGB4H0LhvTr1boafSa11ozuH4YBIWf86tdr4qLeL6XRq3eqoV8IAcYe9fThqgao8uwYkK6PlXf1MrdXJpwB7k/L3ueGHe+77ybVVOn6oYo3kAcwCyhalJ/M7Naqi6lutjEGTXY51XVW7QdmRkwTfDY46vL2/Zh7rABN4zLQF5FSQIxT4TDUBvLYVdfX1SVXF1t/6qI0/V0GTuIM2mXNC44gFm7HyBFDJFxdT4hpQuMDyMUsUbjCeLPD2194B91mjSkNAFLx0G5vdhB/rgKgIcrken/0GpqmQbdZL55NPWn0XNUIFeC4Al/rzEUxIJXhUFLYcoWPi++IYQKnCOuy0QdgMpA+9gcMhz2mUVL0jfPwziKFCRzlmTkj3hIlaWyVpjmc0HGmeiOSkp4W11yHqrU0wPGYrq/DVOTFIsloJWxOqIyEuavcpuOGmYvO7MvaXg1P5AjFZuaSoapvzp33fNKWRYm0Ipc4lRSuEbUhJEj9ARHAOlAZi4nZZBV2jY2NEbeU0pJNiYxRWGsRAwpAOo6hTGI1SNbaRb8RnXhazWmMye79mFXBlEPBEPfUoM3Znhikm9xms8rgrZHVG0BIAdaLJ5RAEpqwAdhhtHtc7T0+fJrwxTdWePtNgwfNQ/wXf/k/wBQYX3/3Izx++AgGjHX7BoYxwFrCanOO3/it38Mbn3mE1coiThHJGCSWfrtqeL1tyyDXrEJKCTAEQw5dN19vXflax/M66VQJv2iqHBnbGjOR1PFUjGjx2BoxXPvtHpwk62SMwXa7FbmDvscuJXzn5r3yPE5OTiSDdnaWJ7U80yn3ujX5GrWPcBZBXfA8Cm6DijQY59ajukDouIiZPNa1DaZhBKzJYZd4Ys7NwP4Ug2B02nOaJJtoczOtCAGPxSv5I9TQ+xiUOjYW94Gm94U+9evCBzjSiSBxhdWpmQFbQEIVkaKzScRy1NDVIJ5+bnZbDzDGYdWdlONpxaoS03QVnhXExbgMw4Am94pRl9c1vqQBYSq6NTOQDV29+rbOY7c7YBwTpsmiaS2mIM2pERP6/RaOGnAakTwAcvDW4ic+8xArL/ICnHYgIjx51CGlAwiu3K+UGNMUMYYZ9GyaBh9dXuK1114rFax6f8ZRJoH3DcgY7Pd7PHr8mjwPP5OqNBRYraSeSEWPVfpAjYoS8zSLUjwNa8AZkJyp6Qnb3Q4hSJvRkMWyx8MIazw+ePoBpklCjO3VNa6vrzEOE4bc7tR7j8++9WZp+eEaj7if0KwaOG8AAxh4EBmMY5+vZS4SlEXDzV5HRSysCxDV69XP1RT/KUxFFKuUG+TYX2unyritkgApJfGuKxGmPwIp3iUPQP8+9jw+yfs4NiCzRyO4BZEO/FiqkQTTmF1NIirEn9q9nLMHcxhDlcseQ4Aa+jrroJxubWSknooet3bf6+bROrgUL6ld/eqKBcPJSuu+sdhsNlmMSGpkmGVlpMSISZofUdKsisdhN8KAcXpqEYYtrAGcM/DGwpoAioBlhncQ7ghksHICpkmKvhxxYanqNdZGXdiqqxzDx1xo5wu7N6W5lajeZ/G+JEUJCEjLLFXTeXSAScoCJMkURRGPafbq+gFX18/x2muvYdW2uL3Z5TBGyIDPnn4MZsbNzQ0+fvosA+Jr+E5S1/2ux3e+/V2sVitMMWG16vDg4gwpBPRRPD5CA9hZVU2flY4DXTBk390MSS2jqZ7JmNO9yBgaIBiejqn6+Pr7OCMEruQEKnztZW2viBFZGoyUUiGM1S6r/vvY89DBeCcuzCGNxMcAUYIlgm00rHCwRkWYdaLerXsAqoeVeGHTjVin3LIwU6+jKI5xLooSNqHLrysG4CT0oGXVb+2ma/WveicxzhiR1YbiBwezsnjrjQ2+/9ab+P3f/328drICEsHbBiFO6IdRvAzJDWHdMOLE8JPD6arHO59lrPgEk2VMEYiJcb7pRJuFGYMfwORAlMBs4JsWN9s9Lh6cg4jw4OFjhDii9SsQ59ocTliv14C1ICMUeesk3duuV5gmERIWkFUMqms8pjDBNx4xznodUwiIaVlXomBryPIMNW3eZND8/Pwc/W6Pftfj3W9+GyklfO1r/0S8nnaewJtTqXptGiMhYQNY73Gy8gACfuPX/h+cnJzgnS//JNbrDt1mjfW6A3hEdMJjMYoF4a4BEQ0Q2dd13WJBqD3u2itRL9PlUMhX3RT1s95W5LLKPqkYYi3b8DK3V8SIyHbfxd4XtrzovS/aNF3qTI4vrRDKQBK2ADKXc83d4sabCuHmEMFQTwUAcxk8kcMizFHDGMKIZrUq3kTdGhNAoYLHGEH588VgWRTim/BBZsxhShOIUTgohub2AiFkCT9qkOII6RpoctoPYA5o7ArrxuG1Rw7rjoAdwbQOBkCiCAdbVkTszSJtCaAYNKJMlHMtxqmHy+63YEEiDaD381glv36Wtrp2+a5ZAqAGL2svEQAieDFhU5RGYN45cBBZgX/0//469vstbm5uijJ904jQlHNeFOmsh/Mtdn2PdSf3uPEWHCecPzhB3w94/3vv4QvvfAnTFNH3ASsvYyfaCCp0eVsZ+gp4pqX2CLD0Dsq12ln9X7EivIhkxzOVnrQv0rE3nmP2H1427NNvr5QRAV5sKOpU1X1hzh0cBCIRUIYbScMjAamA47tKieVmEy1WBs3b10CY5PqDIPx5pUkV3bnNHetSBlvrxtVawKcDzJMApCqNWJOGQFxSdboyqUfmWpc/Z8DswZPgLo8fPsLQXyKl2VsrKWlBmUXPggjDocfnPvsGmAe07kSqek0QETcntS3EFmwMGBOYrYRQMMINMXKufQzYNGv0w1y0RmQyriRRfAgBbafiO7MBUg5IXbMi935ZLzXvX5LSjDFwxhbSViLxYL71zW/gqz/9FWy3W/R9j+fPn+Hk5ETEoZ2DpZifHWEIA7xnGBvRrTIJLTGcZRjT4GTfom0ctrsbhJDgAiO5WQe2HosWc5hrTJVlxOw51yRCNa5lzCv/6MgTPr4PaoxKhqaaM+pNSzifP/P/d0xEiTrzDYBod7CByiK+yFjMgOgcm6ZIAIVsGDgLLpOwMI2BxZS/FCDOWIdmg6KsKmWgxoSUy9r7INkDWzW0IpKqX2Ij7QgA7KuKTG9dab1AlNPIxqDppGJX22uK5zGvQs45hCmAKMv9OeGi6ESKo1asGkSeYLzF5975LAJF/Mrf+bt47fk1Hpx6eL8Cc14dD89grAHZBo4HfOWLg2AYyeM27RB6KUp0htH4FUJI2N4OsOzB/R4DJ9yMDOdXmHpCChHtSQuiNYwxWHUbMBFgHMZwEFDQeLgmt7sgi3a9Qhp7bDan0rKCGjRNmyeJ1KcwEQyLaNG8eOjEE29Q2iGglBokJqC1CDcDrFvDGIv/83/7m9he7vCFn1zjc1/5IiINiH4AIuHMOSQeEZoWv/+1CePEeOtzTwA7IsQB3jewsUXrGzw584iT3Iuvfev38MV3fhpnrkXoB/n+xHDkwACarC+DXKSoWToFTRNmA1GH6PqbpyV1HhAOCChBkolzpk8qlDPIWtmI2gDFGDMI+weaop+4vRJGBDg2Igxg6XncF9stDcu8n0z+t8lhC9fd5O8y91KKoEoKETzzC6y1YLNUMqu3shJwpU7VzFWd0xQzkU1jJRkc2uipplXr8dTrWACqaY6z65hbV2uX202cnm7w5bffwe7570ibg1WD/WFA264wJIbJBC6ESYSG4DBFwBgvgtTWwDmDEBhhSrldRQSMRcqAatetkBBzkWCDxLkgMcTCMK1FizftiVwn5vAEmFPbMcaj9pp3PU/FA6ylRUig94iI0BiLkQ2GPuDm6mMc9pc4PV/j8cNTrLo1+gkIjuHIwmNCohZkW7z34R6bjcVPmATLA9ZdA2s9+okx8oCzpgF5COv1+5cYxh60OZMJnNnEMcYi5H0MyteD8/i6eDE2l562AsmUcTfGXZHvY29dvJyl51If62VsrwzZTA3HvH2y6byLidxtA6D3T9TcURiL+llbKZwxJ6BmAFaAl/5o3YquFMziOivfoR4UJe+fszDHNRZaI1GDb8orqOsngJmhqNcFyORpmgZt67HZSIn+at3i/Pwcb3/mbUwR2O72WHkDkybEcUDbrOF8A2c7MCzGCIAcYjJgOFnNs95HGEbp8ULS9jHBIrKU2KsR0DqaudBtXmFVYEnZlqqvovdAjYziPcCLM2wvWkSKMc3lDBIWWDx/do13v/kNvP76GT7/ucdYrV1V5OfQtk0eLwywwcdbxn4ihNDj4XmH067Fyju0awvbMCJEk6RbeTx4cIbb2+sc+lroFEqVAYhY1gTp8zq+Rl2YjjMt9fgrXirmWh8dI5+EIR7fs/uwqB/X9gp5IoCCkfPNuZ/38aLBNXsZUgMDjvAEWEidROcdiBiW0t2by5zp0ABZKkVt8jA13qUS3xZ5vXw+0aWSQgRm5qH3HuBZWm8Rx/JM4ddqVQBlNV8UnTm7MCbec+k7k1JC00rrxAcXJ3j402f4tX/8AN94fwubPsBnP/MEQ0z4/o2EDNQYWL9GskC0HXb7g+i/UpBsVkogNojThMN2RJgSbvsVLq+eY7M5hXPSRnN9dop9GNE0XdF+dSxEunItLvNisnKaEPeWWrWtkbSq99Ju9DAMOD89LdkZXdGl4tnAeg/nuNxnxWHGccTv/s438Du/+TW88/k38PhBxGY1gq1Hu/JIrsVEPaapx9olNE2L697h2e4Cu3CLLx8In+9WaG2HGBiuCejHCBodaIpoLfCVf+pNfO2bH+Fqu8MbqwfFUHqfCxgbtxhXCpbqePPeg3hO185Acu7TG5RSgAIu15OkzuAVwaFM5Z81aeaWFjP+8vLimVfDEznKiiwNw3KF1331a/ceUl/jnPaDGJlj6yzpN8ECVPe0GBZaGjGd2PUKUdPgY4yIaSoixbr61o249Uf7ymg4M47jfIzM0qx5I7VOhTFG+rjm81HPplsJzgIf8dWf/Tk8u+yx245Y+QYUA1IKSJluX6qAUxQVsuyF6XlM04QwRcTISAkYpoRhyueFmWjm2wYXFxdlEhlnF7wPWT1tMRLWekntZu9LW2jqylyukazonUSW1gkwMDSDziZPXvDcxHuapCXpfr/HqvEwYPTDAcwWu/0WbevhG8GpGFHkAnKfXIbF85uAj65G7KcA9haODNY+F046QtMYWEp48toFEmLORN3tiKcLRO1l1LR9JsF9phhL18TIUiuUUiwTXo+jPzNofZdXpVttOOp58CN0dfnU2yvkiSyNxXGsVyP1x68tPyduqqiTAY0xktolhjY/NlXYxGnZkiGlAFSaDcjexuwuL6UYC35h5/NsGjUqeeU3lceRtUqLSrybXW3Kk0iNCjNjtVrJd/BsLKSl49xhTSdgCCPazsGdAl/66a9g2E+4+eY/wAcf3IBMwPnpRlp6Dnucn19UbFeLxhlQCnAGSHESTgsx9mPCbZ+wHRhn5w9Fyi/0eOutL8s5+QY321tsTk8w9tJ17/0PP8D56Vmm7ies1t0iK6NFabURVYxHjXItiqypcQBFwZzIYAxSEAlIP5lvfeNdXN7e4uzsBMZO4JTQNh3IrGGIEdOIECOctdh0ayTj0KYOrYuwboP/9D//RZyf3+JnvvoZ/If//r+LC+dhjREB7ilJRooITy4e4mvfvpFzMgZdu0LTtSA7F+AxJXDM13VPJFHjWnU2UK9X8bIZ2zBZU/UHZzCPsaWXGcoAr4gnwlh6IOp+1S6Y7q8NyX3vX3ggkApMU8kd1vezxiOIGByn/L453FEhoS5T0mtPouZ8MM/p3FonE8BCM2Qcx/J3XYhVext1EdvNzQ2GQTRIt9ttmWjTNGAYDuUzolUyio5I63Dx8AQ/8yf/GXw8OHz74wEHXqNh4MGqw+sPH8KkCG8JngAOEWGcgBBhYJGiwcdXB1zeDOiDx+3ocHm5z6lRxqr1eOeLb2dMgIpLD0hV6+uvv46Hjx9hDFOh7Zc+tU4IVwTxIrwTwWbvGgz9mBuc+3Lva8Oin08ZYFSBqMa1GEehvO/6gJEPIBNhXQPnNoB1gA2IcQAlC0KbjfiIwAneJFgO+Ft/8//Gr/7qrwJuBecz5uQaWONgXIuQxbwJIyhOmcU7twkxOdUc0lx7Vadz75vQujjp9WlfXg3PBFPLwDK4mS6sAAAgAElEQVRQPJaQUs6ECemuLn/Q49Y/L3N7ZTyReqtdsWOXrn79PqS73qSHh/xNHJHHrf4vr2JHHo9FBs1y+jSKe5lSgq8aKtXSfd45KX6qPCYlpEkR36pMBuPm4ixgSUiqsxX6twKPGg5oNqKWJNTXUkoYxgNM6iTTQgF/8k//C/iVX/5fcXPY4qc+9xAhjnj05CFCCtJjBT53BCQ4IgyD1L9MgRGjxZQ8rm5uYJTOTqJ1UfriwhYB5ZQSTk9P0fdVQ+l8XYoPaT9flVuoBa0BFCaq/n2fyFB5VgV0JHz00UcAgClKzxkx7sIWZpfQWieK9BPAnIWKjEHkiP2uh/MJf//v/2387PYJ/ru/8m3EYYJZnWDI4R2IYF0DSqN00QtjOWfnHHwrGBA5A5i5wVidjTLGLDr3HY/3edzQwgARzYV6usjUY1A/W49/Da+O58zL2F5RI7L0No7pvveBrCVOhGiGGAIspK+KYeGJJPVIZC7kY4twiwFyZzL5/kWNwpE1r4vw1BiENCElGSitb2GMLXhISql0OdPeNMc1DSnHxTqI6onjveAIWunqnCtZor6fhW6MTdhsNnj+fMKDdQ9zyvjSz30VDz/7OvbbS9z+1t8FJsbT976P04szqTtJESGKorlvPOLI2PcH9L3Ffkh4drXHPnQ4OVkDiYDYo2tapCmA2rkrPQDASCGhrqDaoxgAVicClJLNAs48F9TpZGlb0Qnd9YeSTldvRJ+5tS7X7cRSGmBg8fz5c3mvaWFawra/wsnqEYyzcKsICgxLhGm0IHJIYg1lUjanaPw1zrobnFuDp9/8CKfWYjtuwZZBYwuGBZyBJ2DYJSBNAFR2Yc5IiYi1AuLqab5Y06MeV4LNyPid3z+/3maxpjr8qT0efQ41daAOuV/W9soYkaWB0Fgf0h6QU1nBgLpOgNWpgHxcUmGGcqd4YqSs7EQkaV6hM9UxY+amEInaVmJYqw89CuOPCUgJEXN9CwBwmKSaNhEsDJxlIEXEYY9EFhMMaL0GnJXvbFqoUI5opzo0uTFSLvgAEWGYRtFZDYTAM1VeSlkoYwuqLWLLCsWJsL3d4/S8xX6IcK6BnSLeePIE/PgxrjcbvPfee/id3/xNvLm+wP72CifrFrvdLVarFt96+gwJLUJc4f2rhO1uxG5PuLh4HXz4ADEecLZZ4+JBB3J5RQwRuyELCmXGk+I41lo0rcMwDDjJAKUlKUFgA9hcnt8fBsnCgEGQfsERggN5IyxZ47NRiQ6dWQEUMGVG7O32AN+cYHtzC08G09DhZHUGRxGGR1zdNmjjLVbdCSIb9P0WpyctQgBW1iLRiEN/wMMHG0xhD+tsLsxkWDI4NLkROzG6RIjG4TAOCKGH9Ws0nYNrGzBJI68yqSFerIyxBM5lF1o/VbIwQKkXExkJgqmqztX7EIGpF80dArMuTHl/qkOplycF8EpgIsfbD8y4VH8feyL62nE8+EnHrN+7rH9ZbhJiLK1+narU75jp6am4+YqF6GspJZH0yyuLxrTWSjWuZjZK3F+5/Vodq/obXdeBaNm7RFci1eQkIpw/vMBXv/pV/Jk/+y+jHwM+fPoMTbdBPwUMISIEETQOU8Jut0Pf73F2vsY09UgccXJygrPzEzx+/HjhMdVpWN10Ih2T5tR7WLVduR9N0xStEF1Z65WzxhWMMQsQu+s6XF5eIoUouiXZu2Caa5IsGaxXm+L5eD+nYZkjnCV0HnA241tppuMLoDnzZ/aHQdjLfT8LTjtbMk41PlSnWXV/7TnUWx3C3OeN6v05fl+Nq+kh1fM49uBf1vZKeSI1Ul2yH/fI7s+FSyyrWjEi4pKIbB6XxskMXgCqtWHRz5YHD80C5fjfzQ80xlBpaGYvSBsYhSE/WMD6FhKXy+1V5W5DS7eWmQtRjTJI1veiTTFMI0wn/WrGGIpWR1Eoz1wAlXFsW+mKNgwDdjc7IcY1jfSXGQawcxijrOynF4/xL/7Zn0cMI/7Jb/82Bv4Iv/9730UYIg6DeHqffftLODk9x/r0DOMwoUmvYxx2oCw90HUdnJPzFSnCVDwiYE5pEqNoXRy2O7jczMpaW8KXmDKPhgz6Sk+14C7VwwsIUp0d5D6GkHD58RW224OUSgAYQ8DQB4xIoHTAyekDUIrYDz2QjBRgcoR3LVJMeHTu0Lo1WmvQNSvExEhsMfSMGEfY5hwREVNIwCThyhtvvAHXzICoXqOeuywIsyehNUS1gawNiY55kZuYWdh16vg4OzljJvViGTKvabmIvkxw9dUwIow7k6v8ZjEU5QcoHfIyvDHfYNZGzqkU2BEZWCv4CLK7fAymAnPatrb+atHnFUVVwOW0YoygxNWKgNxmIoBYOBBjmGC98ibMncFWRIcAbFYrjBlEXbUdhvEARhQEPoc1q0zUAgSP2e1FRAhVod5msym9ZWu5RjIWY+ZFdN0KGEZ88ad/Bl/6ys+CrIGHwxQG9OMI30rLz9vtDZ5fXSHcTLi6/AjjdACssIC17sdUxq/2DnUh6FbtrEofZw/ucDiIIQzCP5EMji9eWD1xjrVJQ2X8hyEArHycCU3XIsSQZR4IjiMSi+FpWw9jCGnaAqGHNS0uNgOeXJzibONwOOzhm5UYxpjQeI/9YZTQBhbWNvhHv/67+Kk/8aeEcdqIp6hKdCXjRwaRZ/lLYwxA6klUQ78a9+oF6VbT+2tguTYIddZRFz/5O0K67ul7X17Q8WoYkaOtBlP138AyG6OeR7m5Yk0AiIK3o4Su8XCUYLP8OxdjVT+M2Ss5Dmn04c/79UHO+p8hBBFwBmOsMiaMNLcCqMISVx2bc6MnXXGnSbgN3orJIwUXqwFUN7ACgAcPHpRaFQ0N+r4v7qz3rZDJsurXGCOMCuSQwWpzArIeh8MBgRhDFAlDZJ7NarXCm12DbbPHxcMTvPutb+D0VIyUAs6cZRAOh0Nhqqohcc4hhgBnxQO5vb0tRk568Bhs1id4+uwjtG0LHexsuDBY63alginNDbFTBFbdBjH0sKZB1zVYbdZgMmCexCOdJoxTQONaTABiCLAwOdQJ+MqXLrBuAW+DVBzHCA49OFn0hwO8a0TWER7Pnu1x8eQttM0pVpt19iCpsIfr8wTVrUckW1dn9e4Lafj439VipiGRfk9NfTdWPL7EATHkBZZFjU7mxB8iY5WI/ioRPSWi36r2/WUi+h4R/Xr++XPVa/8JEX2diH6PiP6VT3si9cpVHeteD0W3BekreyDM0qVueYxlzxLDQlunJIi9AUAsf6sRUANWYxg6WcdxLCu9Tt4xu/JEBN80WK1W2GxOJSuDOS4+roPR443jWFYejeX1PZLx8SV1WvNIpmkqYQHRzENRo6XiRW3bwluDOI3oGl/Ov21bTP2Ak9UaiRKMN+g269noOYem6WCsGCw9nnoWXdcVw1bYpBUmoJ6cekP1JNBr2263eO2117Df78s9VwNdK6XV/BtdsBX3AUQPxjmH9XoNhscUAN+usN/ewhtbjBJIdF6dFS2W1x53ePCgg6W5p0zghJQnbtNa9Ic9xnHE17/5bbz99k8WerrJpRT14mbMXO90PGZ1//E4q8fFIpw/Drfz5xRrA5YaK5qZWe7/w8dE/hqA/xbAXz/a/18z839V7yCifxrAvw7gKwDeBPC3iegn+VM0vahB0xdt9UNZgKmV2pgOJEcMQgJxKlgEYTYmM74yT1aiufeLPoAaLHXZ5FLGAAAsADOdYAruhSAYiqiEc+lep8c15GD97OmkMJVjDtMIZyS1q+xObVqtbFbdtttt8Wacc1h3YlRub28XYsiOEh5fnGEYpbiu8S0O/Rab9Qr7/RbkI7qmQYoR/W4sQkjbm5vcmU5aHzx79gwXFxdgJkyTTKa+77Fer0sfYs3QSJwvZfuN87Deoe97dF2H7XaLlBJONqfY3tyi9TKpRfhYG1NxWclTYhiXRYoOUo3cD3s0rQMlC2MsfDI4OTnBt772bXSfX4Ovdzg/93DGglIsoOo4Shak61YYx1sgEhK1WK1Pcb3bgwNjZUUKYL+7ARJweX2DNz//ZQxs8ejJE/jOizodcvY7RVjouCQwRYAVA2HpGQO7AMiBZXGetUvV+3pu1OF1baSOKfeoXpf3vFyeyA/0RJj57wF4/imP9xcA/A1mHpj5WwC+DuCf/YHfcQ9jNX/3nfcuASKq8JE84Uk8EnkuynoVILS6pvK7jjFTDiUsEYhZvJPcHMFVRLO6x2tkoUPHyOUnJUnFGnJoGqlnCSGgsXMBnq7MNa9C608AoPXSUCmFKadxx0zJDyAz4zDqiSiNvu97hHHC2A9ofQPKNP/Dbo9xmLDdyWqfwJjiCKKIEAe0ncNms0EMoRilk5MTxEm8FeMN3n//ffyxP/Yz+PKXv5yVyyxCmAFV9RxWq1U5N2fsQnio73uM44jr62s4Eq9QPbppmrDZbHB7e1syOnpcbcNQwpgUETjm75F7c3V1icYZWOsxxRbXtwE3uxHWNeAUgKyva4yBazZgajHEBELAqusQg8F+n7BaXWDVnYEDYTxMePLobUyDxXe/8xSvv/kFnF08xvpsg9VqJdiRmb2AeuJrJkknunq1fd+XzNpxFS9DzpFz5bD+kJk9HR3rC51ebeHBM7FNeCpL7/BlbH+QI/8lIvqNHO5c5H1vAfhu9Z738r47GxH9AhH9QyL6h4fDsJjYtSHR7nf1D7JEfgFa8011VGUFChiab2oOYepeMfp9egxg1oBQWrvS2OWYtdGZSWK1EWMCvGvhbCNIu5kRfOlF0+NwOCw/kwfEdrvFdrvF4XCQZll5UjZVK4ZpmhCGUWDiGHF+egpLhMa5YvwuLy8xDEPJgDRNg6Z12I8C8u4GacoFa7AferStR9M49LsJXbvG6699Bs5bhDjBeUI/7MAJ+Mxn3sKzZ8/g206yE7aRwUuVlF++hycnJyCS9K8BLUSHu64TBfZcH/P8uaxR6/Uau9tt9nJmglTpuUJzScC8j9E4aVy+2ayAJCHI6fljfHy1x+1hxPXtHmO/RxgHlKZhtoV1LZxfgUjafFi3Qkwdrq4HXN/2IDQYe8Zv/eN38c2vf4g//sf/FDZnj3B68RBsZAFRspyke/Mkz+vVbPBqxTe5V23b3kn56nitf+pxWpdbaGh3/H65Pw5Ey+O9zO1HPfovAngHwM8AeB/AX/lhD8DMv8TMP8fMP7fK1aefJqS55zjl79pwaGHWj/L5Gveo+Ruq39F1naxC2cCUB2rnFg8pJQROC48jpQRHM6/kmBeg56OeitLFdbIp/gLM0gFaW6P8kvPzc1xcXBSgk4hgrLz//PwC1no41+BwkP7BXdcVIt8qa8EqtiJG1OLs7ARdJwLF5+f/H3nvFnNZkuV3/SJi3871u+W1MuvaV7tnPDbIGHGRjI2M4MVCQhY8IIyQzIN5QOIBixeeLPnJkp+QjPyAhQ1YBmksZBhZlkBCMNjGM+72uKe6q7urqqsqKzO/+7ntawQPKyJ2nJNfzfRYnePUeEuZ3/eds88++xKxYq3/+q//Oornt16v9zCcsMpuNptoIJWSVhC73S5O/HB+ICvmgwcP4vWXZcn5i5fxeaT3JM36pNwarbVU6PqeO0op5osjmr6jbhu6YexrbK3FaRXPdyz4E/Uva+VelcWEdif9ZX7f7/sO3/zG76fIp5wcn/nCwXGxkuP2++MveaYpnhE8rGBYDuUhDsdk2CeA0On1px50eoy7/r3OcOafKjvjnHsefldK/bfA/+r//Bx4O9n1qX/tZznm3u/RoPg0rgs//WofwFSlvQtoW3Aa46BwGq0HXzujACNAnJcC0BGptr52SlTMFUb0R1MQywmuMViF6kevJYB5Efwyk9iQylmLzjJs32My4usDTqjW1rLdbjHGxBUbf8zwwPOyiO47gNqI0TA6A2s8P0MznYtqWHCRU/JbWZbCqXAi0lz5tK0xijKXkvmyLHGDJZ+U2GFUCptOpYVkrzRXVzcczWdyPnIDcMqC6kUnBBIhooLpdE7TdBwdnbDZ1iwWE6ztGJyjqCpub1dMZjOqqWRpjHNkhVzD4CzHp0e0dePTopaBJBXvpFgvy0r63rHbrDlazNlutxwdlWRr6FdXlBMoj97j/OaGd2vLVbfDup7TB8eobkc+mYIquLpekQGzaUVdb7HtwKSYQe94cb1is9lgqyeUJ/dZnJ2B3mG7hrzKMbmXPVRKKsM9NhfqqLBatFn8GFMWlLIMblysUmMbQFmlRuKi8iCwYG37dWQRUE5Cv0CoC6le2efuTpI/r+2fyogopR475575P/9dIGRu/hbw15VSfxEBVr8B/L3f9oB38EQOQ467MBPw4JTvMKfBK7prjOeDhF0lbnzVGo8P69UU2+E5BHc1TbOOpd+aptlFD6NrWo/sV1HnQpuxX21o1BS4FqhR+FcpRabyuK+47WaP0FVOpKq4reso/hyaYgfvIHyvYDYDzU72C0po0+k0XmPbtqisRPmV/daT23abbWTEKiX8jc1mQ8OYfjfGRG8oDObwewgFJYszrvyTyYTb21smkwmr1Yr5csF0OqXrOm5ubpjNFuMx8tDUXPCmkCUTD01TTSdhXFJUhvlJDp9fo7nHKs/58vJzTs4ANJOuJ7Mdygk4fX9WMbQz2l1HrgouXzxH5z1976jm93jvrW/w4K3HYiDzEp1nlKUA3mOZ/qsTNM2qhOcRtwTTACIOFrvocdCIyvWxhigds2GxO5wn6XelHtzr2n5bI6KU+h+APwrcU0p9BvzXwB9VSv1BxDn4GPhPAZxzv6GU+hvAPwF64M/+LJmZsB3iE4dG45A3In8MwgVwol4m7w+RbBaP+dXXR0DT79rSB+UckQ0YGlkJM1DcTGm6FEDPbHSZfXd5meBiSAKwFs4hy3Pp0wIx5ZubbG8QpinOMIki7dmvRkVR4IaBzA/Muq4pJ5V4JdbF8CotCoxuvhvDA6WkG32WaU5OjhjaLhLKwuQI7SoA5vO5GLW2j03Hq6pC5aI5G8SH2t2Osixjl7vUGwsTT/giI6ciGCrnhHAYMmrWCqelKDLyfEnbtlTzKbZvmS1Oub6uublZ8X//nx+x6TRFKdXWZWGYZQPKWWzeYfIKRUZvNc++vGF2XHB8co+n739bUvXzGSozkurODEoUrkh1eb9qYqehRDCu6fANz3bf4IzSECmmkYZI4f6kRiMNX9IyhDRUeh3bb2tEnHP/wR0v/5XfYv8/D/z53+mJ3OWJ3PX+4etyc7yiu1Iexd6/Yd4R/tnOQe2nj++qPUite/hdZ4qmEQyiqiqcE+WsPDeRhRg8j4BnOJdQu7WOq7lkD3IJM/KcPC/jQAvfq7N9rdZQATwMAxro/ACrqorcZFjE2wiejXOO7VY0QiaTCWVZ0nQjv2a320Xh5dvbW0pfKBjCqDQOB5Jj5zHTZK3FZBJ6TSaT+H2pwQgGtahKJpMJwzCw3W7jsZumERA42dKshDEGcgeD9R6CJ/llBUU5Y7mc8/S99/nhb34XgOX8A6pyQtftZL0vpzx7/pLPnz1nV/cs7z3knfe+xmR2xGxx5NtQgHbONyYSYWarIE+Az7vG6OF1hveC8TnEfOTf6BWHzw922Dvm4fcdjuFXUr5fse/Pa3sjGKuB5ZF6Hunk/apCIglRRDekyDIyrTHa1734TQGS3n0VXEofbng2dz2sFClPQc/0nNq2jaXv1lqUGVfqIhdmY1kUVNXkFeRdQrL9hy0eQeh61++tLlpr0bRwPYOvpZmUpeAwHh3MfWvL4CmkXkxZlnvnGwzLUDeRy/Lg3n36vuf6+lpSvW0X99tut6CJ/YSD97Ber5lMZvGe7nY7tCe2BS8mKzO6vgUKZrMZNzc3LJdLdGYiH0ZWXmFbZpmm6xpgzNBoJXXYUldUS/m9kibd+bTC1Ts0CsvA0fGUf+NP/DH+xB//t6jrHf/4e7/GzWZN34q+3ZaSt7/zR/jgDxWYTAx25o12XkorDJ2PoKjKxsK+XI/d6g5DiVTCIDUIXdeh8yKOseDBBsMs3uAYEsoX3N0KM/3eFLA9xFmisX1N2xthRA63u6x7+nck6SgxIMLStiJ1qCQbgQvd60ZcxKhDnGXUsrA29Ow9SA0n6eLUxUxdUIBpNd2rqAyNl/vegpNVuuk78rzw2QRx2eNDZ7/v7zAMWD/AAhYCNmmtIOed5aM8Qecn4eAci8UCpUTHMxwvXE8gdG2323hN8/k8Dsah67m4uohG4+byKl5bSD9PJ2XEN7TW3NzcMJlMuLm5YbFY8PLlSx48eMBgLWWW+0zSmrPjE25ubihnZQSC27bFuCyqt81ms+jx5Hkem2wHTCRcj0xIUZVTRvuJYlAqZ7AtptAMrqUoFdnQkRWGP/gv/YJMNkYd1EFLMVSWZbhhwGSaTCmMcmgGTF4xMGCxOO+dFUWBHQ6Z0SORMSw06VgJ74/jb3/yB9wt3PfoUTA2gb/bE9/HYO4qF8n0Gwas/m5th4DRXe8rrSDRBxFRF+PrQ746JJLfxweplKHvbCRypRma8Jk0FDj0jLbb7d5EVOzXR2RZhsqE/JN6QHFyJANQDNrYazWsSsNgk6xQQs3XY8FaADFvb28l/PCp2vB6OL+2bZnNZuR5zvPnkmzT2UgxD+0cNptN9BgigexglQ2ZmVDnEmj38Vq0kMzm8zk7j4mkK61SKpLmwrnleT6mqBOeQ3rPs8xPGO+JYDRDP4gYlTb0rsfhKEyG0RICaWvBOIzxYK2yGBXaZuYS4li5x3lmyLRmUKFwk0gpV0pHZf9wL9J+wHfhenHcqXGSH4oFyT77Sm7hWCHz8lXhfoqBfNWceR3bG2NE7rzZB+8fbuGmRW9EpZJwY8Gdc55kdgi2Jh4GiGpW0KrYCzXCOdhx9crMCKJqrTG5UMBhEL5FiGd7R5b5AdP3lOVYbHcX4BWJaV4UOExaUbXSSUiTjZMvK2J4ArBdbzC5hC/HVYVJiWpJb5vZbMZ6vSbPpUNd7sZsUVBQW0xnhHqdpmli/UmY3AHgDQV1YVUNmRaAumlYrVYopbh39gCAwcm1TqcSMgR6fzBGZVlGGn3psy/pcw8AZXge4lUqprOSdtOwqS2mkgJM3StaNYjoT+hf66Rosior8O1ArbXkOkdr3+x7CPv2ZChMJvibyEH0cZFKw4aAcaXGIa3/6fseewemNhpLEeP6KkwERu/4cK6khuRwjtjXaFDeeCOSuuGHOgzKK0eFaknj62UG24v8nd8Ea91vniybTR6gAadIpRFhXwMVN9bEhDjTWhEcwmQRY1BKxUbdYygi9RV9P5LXAk4hHtXYGtFa60vMJUuyWq24vr5mOq2SEnn2zsGpsYamyPIYDoBXGlMjLR18fY4HckchHReV0rSGItPsdhtfHLivAXt9fcVyuYyrbyDehftZlhKuNLstXSdC0E+ePKGuGyG4ee8lnFPts1V5njOfz2maJnp3XT82S8+1Fq9Aj+ny0MEwLwu6dovOSyo1w+oeawdc12O9stq0mqI0aMRLypWiKEQrxmQ5g4OyKHEKOsRgFyFEsZ1fNMYJD/up3jTMTcdwunClGbcQpoTXYy2OtYmxIH720Gik4f3h4piGNq9ze2OMSLqFjIvcAIl5pTmbjys93mCcFaq7FvDUIih6rjNssPTaMShQTo8rB+GBpIxDadHo7Kjp4AhGK2iniquucpngbWCPZiXK9UynlRiNQbI8xaQStmTvH/IwYG0feSJZltGFAQjgHMYPvr5pcX7QlnmBqaR3i/YDtyhDb2GkHYZzLKYT7y6DHhRD14tH0LQMQ0c3WNZ9z3K5xLrQ58RGLQ/LaChefvmSlV1JiIGhnBTU2wY3AFYzny9xzrHZbDieHbFarXDORK8Fp/2KTfQsJEwx1PWWe0eP6TwWUw8dhlGXo21bmr5jupjTeG8mUx78ZUARQOYRENda07cdWhcMDBQV9L2XyJwqjDfkwVibLPMaM9C7DJMbCSmVohv6SKkPRC3xfoS6PyBGoevGxSSdwGELNTVO3ki8DsHjPH2StNnUMOxzoLTWknH03nVMGvg5okSJQIyXduDuLt4jWRh/3tubYUTc3Z6Ic+NNiw9JfD10QiKz1jEM/j4FEDG5iUbpMEvlGEnsCGPhlLUW411ZaVw1alZK1mPntSNsBM4wGusGMu1iatLiMF6OQMKQsXVCys0IqdkwEA8zPtYNaJWhjQFlmc0nMRzph4Fca6w3PHhvJixb1kqbhqZpIlYznU4jk/Xi4oKjoyPOz8+5vb1lPp9ze3sbryt4FQHnqOuasqx8KUCPwzKtSozSvLy8YD6ZUlUVm82GzhKp78YY3nrrreglBRA3KL3f3NxwdHLMqpaygPPVmnunZyMAGRT3tYv4xyiTICt3+jzjP8aVPHg94VmnP0NoNmJj+0Q9Oe4BoJ/gZSm29Wookf6+j1eETb5zn1uSjpXD0D6t3g0eTng/BXUPjZr+PW9EeJUdmv6e7PXKZ1Cj53LXdgjM+Q/GX2M2JcU+nKwUh2BV041KXtWkEC1OKzhI14nQjVKK2ULIU3aQldp1YxgRdEWVXxmLQJV3I/oezikMpjS1O04UaQY1n8+iRqlzUJaVNLEqS46Pj7m5ufHZhIrW4xfpIDw6OgKItS2xONCqWKuTnlP4XOal/7quYzqdkvteMRjNfDbHeOXzvtN0g5c0VNJWs5pOQImRyvM8kuYki2A8vd5FjOdwHBzG/qmi2ohF2L3neIg/HGIRweCloUAMNdV+Q7V9DIOvPK9gfML4OjQgYTtkmH7VdtccSY1Fep1fNR9ex/ZGGZH0Z/g9/h1IYHuf2qcIH944AcXuzuqMnxn/PmQE3vWZlMjj1BgL50WBVt4ziQNGifiR1nEypj1WwioZcJYwkFP3OAyKYExCe81dLSJGtae9A1HYaDIpmU7nbDabiCUp5WJJ/mazYTqdcn19vVcIGKpL+75nPr/0/2EAACAASURBVJnH4223270YX4xSHq8lz420gvSKasPQYQohnU0nc16+fCmsVDTL5ZLNekOeF9I1zrlIwMvzHNtLYd9kNt27/vQ5hJBpXGXV3uorkzJ4dOPqfte4CteeGoWvAifDsdPJmnoj+0Ze0Q79wcQej7dvzL76u8L5pjyldL/De3O4/VZG6ee1vTFG5NDSh39CGnJ4JFE0VZ2wMBTCiDRKAb2nuu8PhkAzByKeEJSonNvnZoDoox6CYGHgBvcygKlKKdwwoLSmHRzONQA0jexXeIWzpukiDhKrcz0eYb1HEsDNAIYFNzvs75yU+FeVUNgd0hz79vY2HrttW46Pj2M1rdbaYxVC2loen0TK+83NTTzHtIDPDUNsOA37eMbt7lqu2bbcXq/iPWmco61rlotjmtWOxWLBdrPi5OSE3XbH2dlZvM9BVHoYLLYXr6FPugMaWb6lI591sdlXuAfD4MiygrSawrn9Z5XnOW7o/P6d79w3TkLnfPsQJeUOTSOU/OB9hOMY4/VY7T4ofzhZw7ML7OEIeKpxbB8aDhiTBsbkcb/R+xmboKXh9njN+1hMCugGEmB4PRz7dW1vhBFx3O2J7O/xah2CliIGb8ldNDIkDyoaIwfKqHi8NA6O3+LG+pv0YQNold2Z0w8/U4S9zPL42ZvLK6rZHGCPMu7AE6nkgR/G5qEp9kiysrFgbrvdkhcFeZ5x//5be1KKwzCwWm2YzeQYQb6w6xoBTyOpSSZDUCIzxkR1skBC03mGGnoGa1HKxOyBmc1ovMG7vb1ld33N+++/z9XFpXgvXc/yaCmeyHQaJ1cIXZRS3Fzd8PSdt0UiQRGNYFUJON35jI8bbDQkcr/D8zF7RiHLAi9lzH71SVYnXSzChAyfDRmvcA/DdpjZOJzIh2MhNWTpuD0MO1KjknoXaTgWiHYpRpae912LbsgGpud76C29ju2NMCLAnpJ7AFp9jmYPw0i3+CAAcDHrcviQtNv/TCyjcURlNPnTRS5JfLBWViutNV4JIHo0MNKbAxdAa03dbMHp6CEEI5liG8YTh2bVJK5AgXPRdz2DB9sMCqMN27qBLKcqS6zJyCphvAYA8Pr6msViQZ7nvPXWWwShp81m489TtEzLsowTNsuyqBgWJl4AIXftmP4NRma7aWmagSITrshyvuDk6Fg0RFZruq7j7PQUrTXXnuWaZYWIInkuSqjgnU6nvn9wTzmbRmmEpmni+cWJ7yUGrbVkZZVMChVxhzSdKSv46IkOgzT+DhM8ZYkC0UilIGQ6Ke+ajEpJYzGllIyjMF7UGFQ7+6oRCed3aKxSLyhdOMLnw3YXBnIY5oQQKTVqv+c9kbClFtXhXrl5jsFHLNLPxCd10QYynYOSBt4hPayUiMYpHYrpPE050VV91dL3e+4ljIMnIDLOJV7OEMBH6TgnnAUV08JD39O5fi+O11qj/YQNeEYglEUKe9cR2om2rVTU9n1H58HdvBfPZXV1FZmMylcBX1xcMJtJT9zj42MviNRzcnYP56RJeCCeBVGlMIjDdc/nM3/PfB1Ms8O5gbat2W5WVCbn4uKCYXCcLY8Z2o6z5TG9Hbg+f8m6lsbeDks7NB6rmeAGh/Yd4NpaaPpbb9z6vsdZJ3qrk4qh6zCJ6HA4x3S1luOK9xJIZ1mW0fkQJe7Xj+JOAT8JzzU1KIG7EhaGQ+OUGhrpzrc/2VOvIvVKwuROiWLj2N7nf4QFKb3O1Fik53uXcdNa+26J43f83jciiUU9dLv2QDBUzMYo1N5k3U8FJ9ba3mHFD77+EPRKQbbwHMbwCbRLiEYDGIPHXqSmJQx0SWNWaDNO0jC4QuYlENHCwFFKRW9BKSJwGijn0YXHywAuZ9KqoZSeMat1zWx5IoYmz1kul9E4fvypKFem2hRAbIwF46o4Tkq3t4JrLULIm+tbQDRSr64vOJofs91uWa1WWBzvvf/BHtU9CEaH8GY2mdD4TJUxJjJu23pkvqbPLc0OpZP1kFB1GKYGQDm8lxqCMVy0e8cK15nek3ScxIl74GEcMkkPS/XD8dPj3OVFpEYhNSCHRuHw7xQHCUM6NWKva3szjAivpqzukvfYu9movdfkYXz1seMx3P4NTWPlNMV313fHyTdYhsEmk2vMDKVGSOQUJ3T+O9O8fzAeQdQ4AGLpYAi9V9PBFt5rmibiGWFgbrciILTb7aiqaQRExbNpeOutt2JFbVhpy7Lk+vpajuEg931rsmKss4ncjnaLHQZ2fqW2dqCrO/JCKoa32y2PHz9mcJLRaZqG7e5LplPhkLRtG/kjIGZ4vV5j/ULQ9z25kRCrqAQT0gf8Dps8c2ttxFkO0+KhaZdz3gPxhK4AiIdnMQxCZEyLJ8Pxw70NmEkKZB6OjbsMVGoUDp9j+FuM1r5HE67t0Gu5y5Ck+6fj/VBu4HVub4gRcREM0Ub4FbI4yOQcVxYFWIy2BBJfOqCU9LWUm+9ZhQoIlHcdST1Jn9ckHtaZwSkjHef8oDO+FabTmszH15YeY6Q5d1aEassM51qRU2y9MTCWuunoetGg6IuCIq/8ceVzm83an5NjMpnEwROMW3CpQwo0DuR6wKJo6waUiaSwpu4YaNjtNjFU2W63IxkNcD6MarVmsxJD1nUd+EZb0yzzyTAZ2CcnJ1xf3+LIwGXcXJ5zNJtye33JdDqlQNPutkyzitvza5TRZKWIXM9nU99yM+O6rtmu1wKaziaYzLDZ3Ao+pBQ2Lxj8tXaNwpgc21lMmaGUQasMSy/ku2RiZUrLs3WMYKqT52ytxWQK7a8nD2QzJaUJRZaxbZuIz4zGZ98DC2MsNVh7q7xSklmSOEKU9YIBSIxGPwjBUP6Wy3BuxMpSD8b54yjA+RA/fh/7nk9Y4MK4sfa3rkX7eW5vhhE5cM1efXvf25CbguirOsXg+dXCNB0/55wTgtNXHC/9O7wW6l/wRsTZ4FmMoUgozQaNsuIVyUAwKGUxPq3cd5Z+aCnKSTQEIx/Er1JubCew84zXCNIaI3IGPlvTNJJCTnuPaCMr8aNHj1gul+RVyWClx+/5+XlceUNNSjohyrKMq62WuDAeH8Y6oaZpmE6nrG9ux2Zdjfwcup5N06ExFHmO0TlKjatu27bUdc1isWDwILBSKgoVTYqS3llQ5oCFbHGuRScMTUtPlstk6btQxyKQehoKWmt9z2Khrku17f4KHlTnhC6uooEORiQNa1KVsL0S/cQ4xPF2AHymY/FwS0OzuyZ6MEDREBxopaaf2cMT/dg8DLVe1/ZmGBGxCOPNUi5a3RT5lp8jx8P20PfSPiHPiB4HaohjRlaJTEhfSX/e8F5KNR+GAdtIgVhwf7vkvejuaoNyFqVyMFakGV3O0As5a7cTUZyyzFlMlxiv+SGSgCXGaIpCJmmOQnkhXmkzoaM6fJVL4VxQ+7IKsOKeP7x/RlEUPHv+kpN7Z1igd47MwWq14vLyEmMMpz5bopTowGotuqwmL+gGi8kLdk3rV+8uyjYWhdSJLBaL2CyrqirKScWyP+bZJ59g2w47GVjOCozqydUghl0ZyqzEKcMQOCDbHX0rWZ4cYbFuVmusRfRilZTvd22PNY4sL8QgYBmcpdAZTqtoPEJtSwCs216OrfwEz0xGD+hhbB6VTvbUMGC9j9sPWCVguIyNoNmSR4Ny6K2E44Wf0eAdMFRD6CKGwX9tgj+l5wb79PZD43JXyH0I4IbFLw2rXtf2ZhiRZLvLGqcPB6yvowgFdsGtGwFV2QT8jDdVc6dQc3iwIU5Gj13mAFRs4r1fRZzyLUBITaHqdrlc4gbrPY824gOh2lXrsdpV5WPrhKDFGiQLNxsJSYI8YMA4pGVBzma9i/vN53MuLi7AD9blchnvXdt3fmATyWV5nsc2FmHQV1UVB68x+d5EyDITGa226RgGx84zWZkVMRWcaxPFnhWarqt96nZH5osFm3ZHMRHOS1aUVFMRMzJOnuvRYsGua3FFIUC6C+pvo5hT0+yicRS8xOt5OEthAiBsPYZiOJT6TUOBfhh7DYWJnU7ewxDmMGuSGoDwWsC80vfCvR0SPO/QswjbaAzupsQfejqHAGyKx/zzEc6wf3MO065hGx9kj/MhQFGGMnYPkMoeUq2JDh56vLECQI0rRyqGOwwDzgaQbWxLKfuOrEkZgDk6WVGM0THL1DQ7yc5sNj5dOMTeIWEFC2GT82FNURRRo6RpGm5vb8lzmTC5l+RbrVYREFzdioEJDb2NyeQcPfdjt9sxm82iLol8Rx7vQdDuCFT6PM/Z7HbM5/N4TSFLIhoiPRjNdDaja1qm8xnb9YamCW0tRp4DLhS9Kd98K4scEAnhRlAUO7Bdb+JrBiGwFdMJyu2LNSuIKXGl0pTrmEXJchFjtsN+eX6YjCGFm4YkgdgXxtdhJqht2kj+CsdMDcXhOA3HOAxvIlnxAGhNQ429602OGbReU68n/dzhnHGpJ87d4dTPa3sjjIjjDiX3EJq4/bSZcxaNlGznhZHMiAoDAsa8jQix2AHpyasUvZVVyfh7L2nMtKZCYYeeLGUdetAqzwp65Zmp1kWXtt6KwXAEsHfAOQXKkJcVlh1lObZmqMpqdKcZCUnbTY3WfczqTCYF692GaTWPhqfM8thdLQzSixcvUUrjvMaF6XsyndP3lqbpMHnG4GRSmaGNLMiQ1QgeV2h0HdTEjMlj7YxzjpPlCe3Qe+NnaHdtJJm1ncINlrre8u67p54wt8MOmpyM3jo613q1OQ9iO4ttG6l4NjlFJniRZSAzOcY5lLMMXU9bbyVLo1U0bLoIQj/yTESFfZz8ymhsJ4S0vJzE8RRSzSMtwEW2cApqh/EBkIXFI+j0+n9Kqz38JM3Q3OUZhHPrh7FOam/MM6Zqw+KlE7q+1q+GR+mWejaO/QX597wRUXgOCIkC01dcs7h4HlhN8BEH4AyokN4aY8vwIMIDbtsmEnZSyjMw1scMQS1dCFx1XdM68VqqvIhpUpkEhrbrJauDZuiaOBhMVkgVK748v5GVNHg/0dOximGQeH+3q8VwVaMifOYHXdd12MHSBG6H0vR9F41B7yx5VtLbgdPTU5bLJTerlQCJaJQB6RksadpBSmtj6BUGWwBAQ4o4qK4PzmKKXKQeswKd5by8uMT2js8+/pzVasvTp084OZ1KF8KwJjiwXvApU9pT6SU9YVWPckPMCA102J0Y6rauyYocw+gVwihT2HVtvJdhC15CGFNZloEdSWTpBHTO0dsRg1BKRaOSku+C4U/rWBz7XsthaPJVXsBhWHJIFEtDrRQPdHd8Nh3Xh9tvdQ4/z+2NMCKy6Ri37gNVrxKMwiZ/iyt9102MTEOErRpCiNxI46fZbBbl+cLxIm/Ed82LTaO6gdyP075p4/7WStxdlCX4geZymYCG/TLz9EGGbMBkWkYNkywrUEpHt9+UOdvtNgoXh8/5mwPApJrSdIKTXF1dRU8jyzJJ+TZNdN9DTUzQF9ntdvG80lVN67FYMJxL3/dkXgx5vlyQ5Tln9+/RNA3r9Zp60+Gc4jf+8Yd89tln/LF/819mPp9jG4cjUSC3DrSUDjjvPUbsBSde3GCxSDWvU4r1eo1pMrKi4LiQ6wtgrw4SAzqtnvaZCj9mjDEof53h/qSFcsr5am8ncH4gE4QK8PAMxzG5PzFTYlq6z35C4HDcjvuGf2nmLISGBzLBe55IioscEu6Cx3fXvPl5b2+EEXE4rOvGh+LCKgHSnMoDUyrk+jM/4XdkuUHjmEwr1je36LLg9OSUwuTc3t6w2d7IIAaGzsekPoTY7aRU3qIj9du6/R6raeVu7vcR/EKyKEUuuIKxjVSYKuEo2KFjYARf+y6otHmQ2Eq7h+1GHrBQ3jO019mw1tIMA0VVRhnD3lmslcGfeTf+yxfPaJqG2XTB2dk9FsdHtJ0wQ0WesIV+IMNxcrTwq3JPkefYCOpCWeYMnVzzpKzYrm99CrfDGoM2oHURDejZo3ssjxfoKmN3c49uXfPTn3ws59l2ZG5GfT1gTIMz0lDL0EOe0+oSO2QMtXiCroU8y5BWug1oxQ9/8oxqPuPxu29z9uAM7Y2588JTSo1VtwoJpxSjQQpi0MHj7B04bRicVIWnk7zrhj3SYerZBA9kH0gfF5DgsdlB2oTAPj5x6CUEbEf+8JR7fy0iPD16RdG7Ctid1RHrcTj62NBeo3RPoM9ba8GlmEzSfuI1bG+EEYG73a3U0gquYZIbE+jblizPWa1WnJ2ecnJyzIvnz2l3DUpBUeY+czJafX0A5EY41o0KY2F1SXVDjX+oIZRJ97feBd77Hm3Q2o2Aohp5KDYJt5xzvpBOSWuCQY6xPD72bTB9gRzSy9YYw24lEgBlWVIW0gf46PSE3W5H28lACjT5oshQymGSVTj3HffCqt73PdZPlt1uJxhDgvCDKNqbTMSV6614Me+99x4ffu/7KA3Hx0J933Vbzp+/4OHD+56HERTsx1U3yAAWRcVf++v/PUdHR/xr//q/QjkpmFUTFosF9x49jFW9KiFiHRaqpRN6cPv4RHjGe8Qxm+HUftV0qqsSPhOwjv4AIwmfSUMoY0wMbcN7IcRM6QGHHt/hHDAm2xv36XiX2q+7w5k0i/PqfPrnABMhuWHp3+Nm/UPthZCkPXZieyaTCYvZnNXacnt7w263RStFWcpk7YexLkQmhCF9dgK07veWSTu1j6f46ooU9u/7nlxr6TGD9bUznWd7HrFrar+fRRsPCFowWtMjRjAF2dpemkiZWpS9lssl8/mUbhgL5hofbvSd9dWkclGz2Qy1a2jbEYcRozfQdLcxvbtarSLLtaoqttstbrDRoJWTKl575dPCm90OLHzx2U+ZTCb0tufm+hJTGEyeUUwqdrst5aTk8vKc4+UCdANOY/serR0DBsdAVR3zy7/8y+I1TCZY4J98/0Oevv82n335jLPHj4VfkxlpBFYVaKfp1VjImBLD4oqvR/wiPHMY64W6zKAG5Ys3R65GUJwLamrpyh10WYPh2huZSeiRiiOlZLU40YNXepDVSY1BICGGv/eyLoBwY7xxSY4RjEu43lAyloZ3r2t7M4wIBzjI3msWlPVkJIldM59uWx5NefHiBRqJ2Yuom9mQFROGoTu4eSFMsfFviyPXGu3BRW3GCZ3GtMFoBEwiuL9d1wltu22YziY4p2jbmpyKfmi5uLr0A0lR5JU/tqZtO9q2Q2WyIi2XS2Yz0VBdr9cSimy90nrXcnsNt+t1nCzFdEFRFLz//gc8f/6calJwcXkdK4FD1z+lFJvNFrDce/BQrtqvkn3fc3NzE8vu59PZHi4UrnW9XtPsaqbzGV3TcHp8DEA9WJ48ecK9ew/40fc/5GixpK53ZLlmuZjRtzXa9PT02L6XamrlQGt+8IMf8/TpexRFwWazwuSaR08ek08KHj55xGS5ZLpcoLIcp7VQxX2GZey9MyrFBTYwWvgeAfsIzNTMEFOrFmnfEe5FwICC8QnAbFoUmXoTd4GpzjkP+O+HPKkcZfhsWqWrtY5ZpXBtMURKPB9rrSdMykJ4l7eSeo5a7Rurf6aMVaXU28BfBR4iWPtfds79JaXUKfA/Ae8hTb3/lHPuSsld/UvAvwNsgT/tnPuHP8vJHIJTcgJhwlvcIGm1spKJ/vLlSyE/uV5ISH5VKorC38D9cuzxuP7BK/EGQul/eD8dMIHclMoWpiK+YZBkRYG1UjQX3FhZ1TKavhOg1lq2W/GMFosli8WCciopy5ubG54/fxY1ReaLKWVecP/BY1arlQgl5zmdv8ZwTl9++SXT2cxrpErWyNqevrdYK7iPtGmE58++pCgKlsslfddxtFjGlS6rJtGrSlODAYCczSYonLA4B7nfNZbtdg1ojo6PabcNRydLLs8vyJKMGMOAs2PXOZzj+PjYa8M2vPfB72dT74SprKyk0oeBtvfs1DBplLTQhLGRU6r8prX0rwnPZW8193MoksG0SFfKPvu8IWDPkzF3eCLpmAqG3eTZK++nMo7heNaKPRsGAZK1Ghctg4iQCw4YBiUH2iR9DO2/ah69Xih1f/tZPJEe+C+cc/9QKbUA/j+l1N8B/jTwd51zf0Ep9eeAPwf8l8C/DXzD//sjwH/jf/6WWwpEaZW6ZV4i0VmOlwus7SNbMVh0h6QsRTvEGwHuWi3894RBoRR5Xr7yMFKLntKbQ+WuCN1YTyATzdOubdBOoYYB1TQMQ+ebWVl2O6mc/YXf9wtMJjOapuGLz74Q2rcbadyFNuS5pldgrGh4hCbYvZXJcnt9DcC33v2AsqxAjV3v2jYYAMOjR2coJbyPYRAdkPV6u7c6rtfrmOWYTCaUk4rWp4tnzKRd5nRK3/fMJvM4KTebDev1Oma4blZrKi8sdHz/TBTYLm5o64ZqqnC9pW078qrCOtAmQ/UNJycLBjfjs+ef8e777zCZTyiqgnboycrSizmNIWSabQgtOFMFs2EYGNyIgwTDb4zB2ZFBmmUZfZsxMMDQE1TbUpZpzIIxGpQQuoR9wrgI55IdUOs7T9E/DH9F3nEMcdL3ZewLfyVo08hiGBRCQyZtkPR8vCY53wC8WudpBgasFcrC69p+WyPinHsGPPO/r5RS3weeAH8S+KN+t/8O+D8QI/Ingb/q5A7/qlLqWCn12B/nK7c0dLB29ATcYFFZxmwigxQsRW7wReHxp3x+5B6kPXjjg7VeskhL20VFcBm1D00GtBnBzjAQx+ZOI04SqmsjBdq3ZcQpdJ75OpeWt99+m97Cy+fPefHihfAirKVvZXJURYYdevqE2FWUGbvVGjLDbie1PE/feZvpdMpbb73Fzc1N0s0u8FTGsvWyKnjx4kvvGYWqzp4sGxtMaa158OABV1dXKKU4PT0lK3LOz8/p+55JWVEsxKObn92T8vyiZLNac//sAS8vzinLirpuWcyWMAPQdHWDOrO8WG2lURdF9A4sDoMsDE45OtugjOHJe29BDqbKad1AXsoky/Mcq6DMTQQ3D5XkglEIv5d+guYJhb3rOrTxC0qWw5BkVawsN4chQZpVyVJSWJqlUSPjNXhFqUEIjODw2WB4QlFk5L2YccE7DJXCeY0GJ9G6wRFcrLAwxH/87hDN4HeIiSil3gP+EPD/Ag8Tw/AlEu6AGJifJh/7zL+2Z0SUUn8G+DMA81mVvh7jVIkPC6bTirbxrQwi9dcRevCOsNO4iYcSCvH2axVciA99fJmCXoG/ccgNkH2I4Fv6YJVS5FXJdrVlGOTv2WzGo/vv8uEPfoO2kcEcBrZzjiLLyVRG44lpWZHj+t43T7KgM+p6x6NHj7n/8AHn5+d897vfBadZnhzzrXuP6PuebVPTdQNtI+xPlKNbtzR1y2Qy2wOKQw3IdDqNmZmQCt1ut+yuapRSURogJWfNFnPq7Y6qqnj27BmzxVyATd+Soa5rJtOpUPvrFoXxE1dhHfTOYwROus5JTZAW8lqeSfrat4mwzpEZP1l8+lNDlG5Mw4rDCtuAKaRCRDBmRcSTUHTJeDDJsw6ZtPDc03ETvm8cX+Nkt1a0YNMy/nRLM0WHczoFV+Ox7/g9/WxYLMM+h0mA9LNvjBFRSs2B/xn4z51ztwcn7dRh9+zfZnPO/WXgLwPcPztyB+9FYEsrx2q1oSpSd8+X30MMS/w5+p8OhYQdQdkdEiZgGDQ+l14UUkBmh1cfRvA2tNZgDEUxFqlZK82UlJZub4ujI3Jj+MmPPqJtW36y23hN0RI7DGgtnhXOMXQi39f7Sdj2TfQclssl3/zmN/nNH3zIrqk5Pz9Hq4z3Pvg6R0dHKKW4ubkZB7cL/VtauqZmtpizXBx5wzGJ5xo0Tq21QuBKpAYXiwU6M1EaYLVacXR0FElsddOR+7qTxeKI69sbprMZ5XTCUPfMZ0t2TcNyNqcpd9JFTmlh6KggKCSFfE1Xo6uK49MTlscL1kMtgHBmyEwhIZjrsa6nyERouigKMBnO36MQbgTMA0YtkdBQPFy3tZZyUqAIvXCJmZ0gdRCetSjKjWFsmNyH6V0gKptFb6HfV2AP4UwaGsv74/iKQGjA7iLo/6pxCN52DMuR7gQAdpD9IoCq7jZir2P7mYyIUipHDMhfc879L/7l5yFMUUo9Bl741z8H3k4+/tS/9jNtARQKLmIAMZVykcGnfP/dEXyN/+0fR6WriI7ouQmZGJWR+YnUdzIwlVHJZ8YUoLjWMqDSitzlcim8jbrl+vo64gQOIYYpl4E1dNbSNY1ogtiexWxKnuecnh6htfTFraopdV3z8uVLfvTjj+N1dF3H4HqqquLq6iaGWFlu2DU7MYJKobOMwbvLWmcoNE3TRXc/ds87yDyUZclqtSKfjAZyMpnEVhJlWUpLSKVi57qze/e4vr5m1zYsyhnWCq/FDQOb8y2YjNzkBI6CFVqp8FCGhulkSjWZUrc9j58+4Uc//jH379/351uitIlC0tVMao/oBxGNYr+/baoMF0Kduq7jc5xMJsJ90ZrMYyQto+fZe1woSFoGTCTco1BDFMLb2P7C34toYOyY3Um5RuE+j/jIyBIOr8X2EXpfnCg1YqNRkUVRkaSitVQyH/JQ5Lhjmvh1bD9LdkYBfwX4vnPuLyZv/S3gPwL+gv/5y8nr/5lS6n9EANWb3w4PiSC0k5RulmUMfQuDJTfifRglwj9p6KIxsY2iskl1rkIalIaVEG9Msn3j4FRH3zUoZTAohs5hlBHeRu77nDjHgKXrdhSZuP5FUfDgwQNWq5V0jLMKoxwai+07UWezIphkycizHJMV3H/nPZ598ZmEIXVNs1nzrUdPaduW1e0uydwswPMhYtPrsqTrGn+fLLt1w0bB2VtP4mTTQw/DQNt1NHXrQUV/35yTGhRvJLbbrRDV8gqQ3rpNV0dDU1RSf1N6EWTnHP3QkpcZaGlunRei3L7brDGl4vL8OfPJnOV8TrFY0nQdZhgoBkeBRuUlq7ammk6oninMPwAAIABJREFUzpb0uWI6nbHe7Hj69B12bUMxkwzT8eJEQotC0/YDk1wm66DCxEr4OkbT+BqfwvNwjMmit7JrGsIE65PV3Snoux6T5wxtKwGyExCy7XsK7zmkIUwYS8E7HYaBTI/tOiUV7cdzkNAMmFDizQSDdIjFjKR7h9ZBtHyQmjBCOCyzJjBFghRCmBrOOZT32LAWhSJT/2xFif5V4D8EvqeU+nX/2n+FGI+/oZT6T4BPgD/l3/vbSHr3IyTF+x//LCeSotTW9uBcEqaMadl0C9b91dfNXvuIQwQ8/T48vuLMvoqVC7UHIFmcssT2coyjoyM+/vjjCK6KcpaN4NrUE8FEFlBzfXGNc47vfe8fMamq2BDq7OyMzz//nL6XxttKj4Bhnue0jbSPyPPCI/MhLg4rrNTGBG3Vtunl2FUV+RFaSYYGYL5YSOMvqyjzgtxkaD263Tc3N1EWIKRQg5JZel6h0jfU84QQbzqdcnN9w2I6JysKBudQVoSQQ+jQdR0zM2c2m0UDWeZVnKClFyMaet/r2I3en9aarBrL9tPnCrLybn2BYxpWyL5BEEgmb+Gbc3dK0w8t1oXnSDSkwfsImFI67pRSdMOwB8rG93SyUDkX6fBhLKa9d1MsJB3LAf9QSklCQAXj8eoWzjM9Rxjxm3C817X9LNmZ/4u7ZrBsf/yO/R3wZ38nJ6EYST/ODTAI81PqNbSvwrVRHk4bMRQpB0Qo6b6DOsR+MvuAlvdU7PjAM68dYozBAcYrmoUH0Hss4fj4mLOzM66urri+vqbyxmA+n9M2fSRqOWe5OD9P0H2LdkLumkwmZMZwfHzManXD7e010/kMbTJMpuLgCryR2XQhsoS77SuD+fjePVlpMynp3+02UulaFNRdQ7Ormc1m9E3L1HNdNr6pdlkKRnO72YreR1GQacVsMo2Fd7vNNlL0M23oGiGntXUzPjjrGLqebd3SdQNKZ1STCXlZUs2nhObnvetQWtH2HdV0Ql5OxjBtGMh8UV2Y+KvrW2azmUhCdm0MDbbbLQUVOkgUohisZbveUHnDafxi0A09mfHl9FaBNxCE0MCOEyx4LH3fx+MEw9X3Fp2NuEZqLGQB2fcwbBzRjKLgVmQ6UxA2PZ5WSUYoKdpMjdPQi5e+9/1qxEFSQNd5b2rECF8va+SNYayGmzgMPUZJxazWoTmRuHRiaPZvSngYoeIysFGd3VdHTz8jaL9KDNeBbql3QY0xPDo7o/Yq5be3t9KIqRC8JqiK5VnJ+fm50Mt9ejrKLvYDZSWizvfvv8XF+Tmr1SrG4yoQiayj7prYfOrZs2dstzXTxZzZbBHPNUj1DTj6toFO4nWjFbvVhvl8ikayQ812R9e23PiYfr5Y0HYd9WbDdDpjvph6rKTl8rIhL4s9ryM0vppOp+w20mc3NJYKKcWXl+f+pioePnhMNZtLE/E8o1eOvCq5ujhHa3jy5BHPLs+596gSo68U9+/f5/r2hslkQjWbslqtOD09pa7ryNsIuMx8Pme93e4JVgdyYUibhmLF6Xw2Zt0y4zVWeoSopbxn59mpbYPzCv7O9ZJZ0prpVBqz922dpMpt/Km1FnA/JYXhYPDtP11Spq/H8WftfpvMkDXLsgxcWrQnYlthzMLd7TFSqn00UOx7NqlX8vPe3hAjoiIAZJBqXWN8GbRSOBduciirV3FllsEjRwn08lC2nnoqewi4dbGSE4gU6ZDyXK1WvP/++yijubi4kJWtaXBOgMW27fZSjbe3t1RFxrSaoLQM+szTjk0xhgHPnz9HIYZSwlVL00jbh4cPHzKfywT8yU9+wqSaMVvMo1GrqgqTZx7kcwwOTKZYraQRle168kxze9UyOz3lyaPHrNdrbq6vadtWOstVojRfNw2bzUZWWifckqj4jqQ5N5sNoVXE9fU1i9kyZni6ruPdd9/l8vIyNsg6Pz/npz/9Ke+++x7z5YLPP/2c+WKBXe/Yti2nx0c0fcfjJ28xOMuLFy94+PAh11dXzOZzdk3NarVieXIcQ7FhEExmMplQ1zVbL2QdwM4AKgawN2Rn8jyPHfXCZO2tsIidc5jMUeQ54KnxtiX37UZdT/xulQCfwTsI3QCFIZxHsD+l34cJnStNFwBTDOiRlxTOxVpLlheJl3O4QGZ7HsneZkaOSDBIsQarH0l6h1men/f2hhgRF8v/92I7ZYWS7IQ8NrIF5W1hW1qcE5HfsAURX9iPO9PQJnVNQwaorCpevHjBL/3SL3F7eyvaqJ1v9ej5FM65vbBCa5EGMAqcdgy2x3Y9tTdIgXEZ0oibzZr5fB5Xn0k54+zsjOl8xg9/+COKqow9dJtuiJM7Lwtubm7iYLUK+sZ6GcWctx49YrlYsF2tUXnGhx9+yNXVFRPf7yUYybquOTs7oyhKzwURILtteopqQpblBLV3Y6So8OzsjHorRYFB3+Tzz5/x6NEjmqZjtVpx7/5Duq5jMpnwySefMD8SjdfF0ZFMtMxwcXXJWZGRG8VkMo0hynyxYLFYxP43gWUacJmQdg7328Z7O7KcU3WyvhdMzRQmTvy+lTqq+VwMs00qu/t+YOwjNK7gXd/QD/vPW6Qiuyi1AJDpESCN+IY3BrkxtIFvY0dhpjBOw/WM6fp9rlQ4ZlgwQ6bNORePCyMJL3pfB2P8dW5viBHx3A6lRHhZaTEUVqPNgFHG5/2DYQj5erHUaaWjHEvQ7bvqHML7wbg0TUOWl7RdR5bnvP/++/zar/0aZ2dntG0rgKeDoevJMJRFISpdw8BgLRrQxlBvN/H8J5MJgG8UtR3PgyHyEEKG56Mffp/Lq3OWi2Op0/HnNJ3MOT07EaZomdM0NW3bSIFblvH46VOUgvXtFV3X8oMf/ibHyxO0MjgfO5+ensYV2lqLUQZnRchocJaimtJdX1N5UlpwsxeLBc652AB8vV6DlVRwMOSz2YyXL19ijOHk9B4XFxfM5wueP/uStx495uOPP0ZrTb1uKaqSoiwpJhnz5YLf+PAH/MF/8V8QjKMoIjC8WCwYhoGVV2KbTCbkZRGBaKWUgLVK7RmNwAyVJlWIslxmqHcSjpVlifYEwcjx8AuRyTLKYsLt7a2/Rz4UdX30fDuvQ9P3ffS8QsrY9gODGTkqSuHFlkaZAaXUfshykAw4rO8K25gGlj5AIQsXxlPmK9XTZAF4QNfuyzT+cxDOhPSUlLSrAEIxeg02qX0Iuh6H6bG9m3lAeU/fV9YxkHRRVz3f/va3+d73vsftzRWz2YzNZuMrTDcRYBxd1RG0CqtgWZaStXCw3e7ig07z+xL/yir27NnnvHjxJcfzGVQ6Ao1KKRZHSy4uLrBKcJOX5+ecnp7y6NEjPvvsM27WK7Ivv4yxcFVVKAxvv/Mum82O3UYA1LwswGhcXcMwMC0qaaTdD3zx5Zd88MEHVNMJi8URt6sV89mEi4sLmkDL9tjDfLGg3jbsPPdiNptxeXUlLSu++IKn77zN8fEJH330EY8fPqJpGpbLJZ9++ikPl/f57IvPyTLDw7MnXK9u+aVf+iXOz8+5d0/o9F3fs9vtODk7FUzGjG1IdWYoioLb21uUGinms9mMwMfYbrfR4xIOkaPvxlW6do7lTNqJtv4eKz2OnaysOD4raLZy7wbbUZiMYej3vAHnpMboiy++8NhYEXv8hl5Dyob2HCr2OyqKgtZP5OBdwch1ybKxKteYgIWETUd1OqVclIIAMVZxvDOOd7m+sQn66/ZG3ggjooC8MHGi9m2DHQaM0ihGkZn0YaZunPQb2ddsCOFNGg9G19AYcq3BaN5++22evzjn+9//vlS7Jr1MUsMRmJBCLhrFimD0bPI8x/ZdRPgF8Mxp2pa62fL06VOeP/uS29tbjo6OJJvg0586IzI71+s1T5++w6eff8Ev/OIvRmZk0DktFaw3twB8/YP3KYqKL5+/5Pxces3kxmCT/bM8x2QZg/VMTY9pWCvp2do3pwJZtW9vb1kul/G+39zcMClndF3ve+vWbDZbzs8vOD09pe8HPv/8cx49esTQD/zoRz/i6OgIYwzn5+d87WtfwznhnmgUu7YhU5rz83OOj4+5vLyUzFXCY8mrMq78eZ4zm40NxrMsiynfSPzyrr7t5Rnpvo8ZkTzP6TuZsHmR0Q0Dymms7bzrnwHCVs2NpusbbCclCFqJkQ44TNM0nJycMAwDm5UYa+V8PVYPWRVEp2QdC/hJgEPbtsWpfVHngRFo3XUtIfMo4HsZ8Tet7/aqw33ZC9uH/dD9dTJWXx8D5Xe0SRox0wbXtVIJy4DSFo3ob8heRO9EXMMckJaBVkmXOlGG0miTy6RURtiSypCXhazOuUGXOdfX11xdvOT64jnHs4LKWIxyQnBzYDtfGWwdrnciItT3YBS7tqZpanAWox390IFyQqmuSvKqROcZzWCp+4Hj0wdcXd7EQa2GHuPjY+s5Kd3Qs9ltOb33gI9+8mPefucdPv3002gYLy4uyLVhWlYU+YSz0wdcXK744Uc/ZrfbiTKarRkyhSoMKhOvTuGYTiryXASZ8txw8fI5mba4ocf1HdvVLe1mzeb6irPlgmmeMckMldE8vndG22x58tZDLi9e8PLlC8Dx9a9/jfPzlzz75Kd84933Of/yOUWWkWlF2zXMFzPaZkNDh54aVqsbaTPa9SyXR2hluL1Zsd1sOH/5UrRVh47dds3QSg+bZldLFXc/4AYbAcQ46ZoGtKbH0Qw9WVGiTIZTks1wTjIx1jU4WpQaKHNDhqNQOXpQDF3nC+sUOsvJswnlZEHvNJ0dizGDFxB+r6YTEU3KDbrIIEv6ESG4yND10WsxRsBV7CD33f8b2gbbtRgcs8mU+XTCbFJRVYVPIjgGBgZc/GcVkZd0yDcJxLJgYFJ27+vY3ghPBBK3P1ndYy5ejZqasJ+6SgGoYGBkG72IsE/T7uLK8PDhQx4/fsz5+UsfvuzIczOSqkrROx0LvCxd3dDZAZSSAjbvmio7arEGGnTQBSmKwq+25zCMpeR1EzAgoVhneUnd7dAq4+TkhPv3H/LpT38aC8pCVuT4+JjlcsnFxaUHHAcWi0WsBclyje0lA7VarSII2e1qbm5XTKdTWUU3G7bbLettzdtvv81nn33Gw/v30Vrz7NkzTk5O4v29urpiW7cRzDS+xuSTTz7h29/+Ni+++JLtdsuTJ09Yr9c8efKUi4uLKAR9cXHFo+qB9KgxO7a7a+7fl0E/m83QRjGfzzk/PwftODk5EVbvdhslBsJzDQzSALyWeU7v09Jd19FpCYfKsozPLqWP73ZSyGlUFjM5vvzE7zuu2GVZRrJduBehgViaWk7TtCmhMaXjq/BdClAjsKqUoqhG0D5NANhAb0+8DdhnzsK+/GLYUtwo/czr2N4MI+KtquulFB+8t5GU3qcJqmB5D6ttzZ1NsEa2ZKjuvH//Pl988QWzyZSimtI0tTc44oZa5+jbFmgxJhcNVodXlhIuys31peh/dr2Py6Uxd/iOpmn4xje+wUcffUSz3ZAZQ2NHFzzz2ZGt1xp56+nbfOPt9/jiiy/49V//dWbzJWWVU/tze/z4MVVV8cknn3Bzc8N0Oov3ImQv2raVQW1dZJMCaAetc9h+oNnVFFXJcrkEYD6d8tFHH6G15sWLF2y3W46OjrzsgrjfgfgVJkzls1hPnjzh9vaWut6htaKuhefy5ZdfkmcllxfXUA8YXbBabTkpStY3t7zzwdfY7eoYooWewKenp5gs4+bmhuVxEQl9gXMznU4jsJhmuIxS9G0b+8M0vgAv9/gJWmNdi+ttxCX6rqWufYZsNt9LuwfeR1mWTCYCumrPa8E5Ss+VWd/eUlUVdV1H3ZV00oaUuVOgQ9bGn++QTOq0jN8NSaZGhzoZ4Z+YMB+C1+GSRTPJFir223h+ZYr457S9IeGMTFB41cqm4GkkXCkdlbPu2jdNdaWga1MLAHp9fS2qYn61ipiLN2ZpCXzKWRDugItEM8CzRUeRpHCe77zzDl988YWkKzOFdX1cXaV2ZkfbdxyfnvHu+x/wrW99i+9+97tcX4vE4WazYblc8v777/OLf+A7DLbjo598RDktqbx0wjD0keNS13U0Xm3dxIzS0PV0TUuzq3n69CmPHz9m8KBjSGO3bRt77h4fH0fvLazUxhi6uolGajqd8q1vfUukKfUochx4I6ESV7CLcTUUj0mqgsM9DEYqFM2FcgEYPc7Q8vPm5ia68Le3tyIWrXQUVgqG83BFl+drpArYSSFiVuTkhWGwXcxC7W92bwylkzBgZFU1Vhjf5YmErMhh7U3wuANuht3XU42AP/vAfBjradblq4xD2Od3Y3sjPJFIHVZWeoBo6QWCsmiySAWO4Uz0OIzUOzjJ2Eg3geD6pdqW8tDfffddttstl1fnknbzamFdJ1KCpTYMdkTQZdUq9vL4oR6l2e7iBFZK0bUt9TDqrl6cn8eUZbvZ+vSkXOd6teU7f+AXWSwWXF1dsV6v+ZW/83epqoonT57E9HJRZPz445/w8ccfc3x8zOOHwsXohoGuFiDx5uaGm5sbzs7OxtVHOWmn2Ta8++67kQH78ccf7zWAWhwtqeuGRw8eRGmBy8tLhmHg3j3pKTOZSMZmOpmzW2948OABn376Kffu3WM+m3F5ecm0LNlut9L/1ypWqxturlciN2A1Q99SFAVXl9dgIDcZu90WjKKsigis7nY7lBa92SCNKKpsbTTa1lqOjo5YrVYAXF9fy/PSEtIEbyko3Sul0FnSBqQsYLC0nW8ilo1lDnW9jf2IwYyM3fksUvRD1qPtu8iODS1Lg5cTvQo/Hm0oFnQO20vBHzBS8EM2MXG3x4UwEDG1pz7sa5tEQ6LGz/nKjz0jGryi17G9EUbEOYd1vagxOSvd3rIxXJEBQEScCWGMyfasu2PUewjZk5BVUUrz+eefRzXvaOEZVcpQhjwzDIMj9yxCo0ddisGHFmELVOu6rtFK8c1vfpNPPvkkrqYhm3N7KwP27Xff4/T0lKOTM/72//6/8c7b77FZr/nmN7/O1772NT755BPOzs7o6oa/9/f+H7JM853v/CLT+Zyrqys+/fTTiNnYfmC32/Gd7/wiq+NjPvvsM46Ojth1HV3f88477/Ct7/x+fvVXf5UvXjyPTcIDdmOMYbNa89bTt2MLjLZuePjwIZvNhjIvcIPlxZfPJaTQkiH54W9+yNN336Oua05OTsST2dVcXFyw2Wy5d3qfZ8+eUa8lq1J7Zun5+aVXhJdJttvtWBxLhmqxWHB7e8t8PqeuG7JsR+G7/wUcJggpN03DbreL2rcBswi6ILPFnLauY8hhjMEoyLPAPM1wyjHx3k3b12QF3rMQfkzfdvHZaa3p207ISVYma6YN5WxOrjTPnz+PnmN4NmNmxTc+q1usGZnWQd4zUAf6oY1jKjPFOC88R0RCGy20+sTzCJjfMAwMaShl9z2U153mfSOMCCQ3x4V+LXrPhbNWCvOUUmPvlsP8uP850p0FMcvznPl8ztXV5Z4SlrVWVLR0HqUDe9uRZURjkzaTUpmkkoX67lfXW8m49E3Lr/+jfxQFjhyCj3z8ySd87YN3yMtC+BXX1/zkk5/y9Q++xma35Q//4T/M+fkL/ubf/Jv8+3/q3+Py8pK//w/+Po8fP+bxwweYPOOjH/zAr6gFptAMWJbLJe+99x4ffvh9jDHMZjMuLi5YLBYcHR/z9a9/nV/5lV/h9PQ0utNhkAeg9vj4ONLJHz58yO31DXVdR17CZrOhLMu4ujZNw71799iu1tRdG3k0VV6w2WyZlNNozGxrvRK+FFUGZmbbdFxeXkq616+QwYhnWYbJpJ3FcS6Nyp0eCw+11rFYr/Dks5DeDd5EmReedDZSztPxFT6Te+/EGMN6vY4hVMi8BA+oqqasVjdRRT8YieDl3L9/n4uLi2jU0u+znoUdDHcwQikBTQo/x5B9rJshGo2Ax4SCu3TMh5+DD6eUx23C9f5u8ETeHEzEA6lxMBkjabJAC/ZNtFN3POAQKY040sK9FS/LkpOTEzb/f3vvFmNrcp2Hfavqv+1L9+7ruZ85PJwZh6TCDEXQEiU5dgJJlk0gYCxIgPwQ+UGAA0QCbCB5kOMXvThAEtgBAiQGZNiAExgRAthBlMAWEkVMGJMgR6RJajgkz3DIGZ05h3Nu09d9+y9VlYdVq6r+ffqQFDh9uqV0AY3evXtf6q+/al2+tda3ZrOYMejfW1UVRsM1jMZjVIMBx/XzEqO1CarhGIPROhMRKQVdFCCVwYApFbOswLLtYB3ho//Ox3D58lUURYUsK5BlBcpygI2NLVy+fBWtsdje3sUXXn0V9+7d882kCPvv7eHzn//XaNsWP//zP48/+urX0CwX+Nl//9+Da1t865uv4+03v8t5M53B3pNHGA+GeOHqddy7dw9vvPFGMKMBYHd3F9euXYMiwhe/8AVsTCboWmYk00rB+dL1ruvYalksMDuegojw+uuvo23bwJEiFoC08JTvkPYS6+vr2Nvbw+HhId793iNsbe6AfNQKhiuwt3c2kedcglAUzBOSZRmePHoErTUOD5lgaX9/H2VZ4vGjJ+w6DYchkiKp5Xt7e8wvojXy5MCSVigHVbBaHj94iCLLMT06hjMGtutgOxPcEbESODNeo6rGqAYF2q5G3SyCgtBaYzZb4OHDh8EKksiO4GaCRW1ubgalI0MsBMFgBGgVi0kEddrO8yT8L8X0JLQrvztnYeDgVOxwl2I7q/jMaY1zI0Qyz2QlVgYlknkVWNKkoClmeUoCkrxGTEUp8X7w4IF3jTQWC64IFYshJvIoDAZDlGUFY6zvC9OgLAbIsxJwnJymtEbrcZM8z3Hz5k185+23MFuyeb5z+RIsAQfHR1i2DW598DYePHqEe9/7Hj71qU+hbVu8+eabODzcx61bN1HXNb7zne9gbTTAw4fv4puvfwNf/MLn0dYLBo9Ni9nxFLlW+MALt/Dd734Xd+7cgVKM+2xvb4fivu3tbXz729/G8niGblHD1i0K0uGxYD1VUeC9997D8fFx0OJp7UpVVXjrrbfwwgsv4P79+5hMJjjwFAhN02C5XOLw8DBUNYslRES4ee06dnZ2cOPadcA67Fzewmg0gM7Z6th/b4+zZpsl6nqB6fQoVECvra3h1q1bQbBMp9OAc2xvb0PY3I3j/seOCNorkdHaGI6Ana1tLD0G1TV8aGEtt6BoW1jDZfWd9RSaYGUiodjUqhmPx1hbW8N8OoVpW6yNRmiWS7R1DeMtKIkcSUGeCI3UShLgVYQIOQTBVtec2JYCq7LPUyGQYoJAjFCm/z9JYIi1RStWzPs5zo0QSaUv8P0lpwCmAmTJRpaFTPEQ5gRd45vl06XF5REuDRZWERUPHBu6CM/JJhM03inCzs5OMPknk0kAI40xuHHjBm7cuIHXXnsNH/rQh3D79m28/vrrGAwG2N7exiuvvILxeIxXXnkFP/VTP4XPfe5zGI1GGAylMK6FJoXj42PcunkTr7zyCu7fv4/Sa/TJZIIPf/jDeO211/DkyRP83M/9HO7cucMRg4bfq3yPWljGUKa++dVsNgvRBedcYHzP8xylB0mvXr0aolhEfK1FUaCuOYzbLmtsb28jyzJsbe2ENHQhQDo+Pg75K6F5uecqEdBaIlUSJlVKhRoWAa0bT8OgfG5KanmmLgCAUBSX4lam7XoApOwxay1aG0P/sofksInVm5IzSbGjCBm59xJ+ls+Sz5e9mpI/S7QmFTQAAhh60l5PrzUVBqmVsho9ep6DnvcXnjQuba+5X/3Fn+EFsgaaouUhFZ3yGIip7hYZrO18sZSnw3Pcza6ofF4DopmoPWlz2za9LnvKf4fKM8DXq7Blo7G3txc2ta+87qW1i6lfaAYuNzc38frrr+PF2x/EcrnEm2++iQ+8/EG8/fbbuP3CLbz91lvYmmzge/fu+4MRTdBMF55rletAPvrjr+Czn/0sF5854KWXXsL9+/c5nT4bYjqdoij8AVCMPRARjI2l6ePxGO+88w5u3LiBxaIO61TXtWcWi9mM1iBwk25sb+Hu3XtBoOY+qauqhsjzAkXFVbhc/n8zHI48z7G/vx+SwgrDafykVQBwtdbofJvRvCxx7cZ17O/vY3d3F43psLu7C51leOeddzAajTCZTEK+yOH8AKPRCJcuXWNrozWARrgfeVZAafL9emLvZNHIladDSA96pnIfHZr5xmM2zBNACN9ynRSvcVmWWM6nPjzcRQEkDbGcQeFTCOAc4GJYtjWdd9f5uXIw9FE16rkwSqnAsMeRqn7KghQRBsyOONM69M9xcW911uDXfuO//rJz7hPv9/k9N5YIEEliVqe12lNDbmhd1yGUJyNYNHBQviZBEyFTCCalvC6V4p2zwTQVPGC55GiMuD/yWDShZAQScSuE0WiEO3fu4BOf+ASm8xkePnyI27dv4+HDh8EC+OhHP4rbt29hfTLGaDxAZw0cAa3pULcNSCs8fPwIr/z4x/CZz3wG4+EIa6MxPv7xj+POnTvMtKUyLBYz/KW/9O/KwoWN7JzDZDLx3eVaPHr0CJ/85Cdx2YeHRQtKyFTWQn5LstxiwXkhAqwaazEYjCCtN2ezYyyXc9y+fStYOPITBDqA8WSMalRhMKxQlDnW1sehD67kSyxm8wBMigA3xoScFcn/aNsWRZah89m7KX4h1g7BwRmLTGnAOk/sze6yaTvAcjM0cmCg0zpw3+Qu1mFRtGRkniKkQmcA/5jnzQdccCMGN4kraQEQVFCG8v408ngS/pHeEyAShst8xPVZzZWSx84xm1q07k/vqJ8LIcILYJPHgGO25acEhJiSfCDasPFlsXhD6bjotuNWCl7YOOFzoJjNFwQTYosIiVKUZRlK4POiQF4U6IxB23Vouw5Ka5QVV8e+/fbbuHz5Mr72ta/hvffeg9Y6JGi98m9/FNPjQ0ynR/ja177u2HmcAAAgAElEQVTmBaYBQTPnaTHA8fEx9vb28Jd/4efwB5/5fWxvbUBrjWvXruHVV1/FZLLJxDZw+MVf/EW88847qMocdb1AWk18eHgYGMKk8ve1117DeDwMLl7aPkLSyAUsNMb0ErCGoxF2di6F9dre3gquz2QywXK5xO7ubk8AA2yxWSAk9hVFEfrdiKXSti3nY1iH4XCIjBSaxRLLxQKbm5twzgWCIfkMOdSci2HRNT6Hg2LkZHVPyMGt6zrgHukQhZAmz63iEv1ooQWBXbTI5xr3q1IKprO9FpkcYct7PLargiMVJv3z0HdnVj2IIGxoBR+h/v9PY5yPEO9qko0sGLhgLGh7b6YJFiJaMs85+1B5bhHOAuzQNg2UIlgjCLhkDgpDGgsG51woglNaYTqdMl1fFX1iay1a02E5X4Qclckm98DVWYZBWWAwHmFeL1F5oRLaKHYmCKaHD9/1hMwZmmWN9Y1N7O/vY7K5hf3DA+xsbeNzn/88PvJjP4b9Pa6PeeuttzAajfDw8SP80i/9Er71rW/h9/7V/wYiwmw28767wmKxwHBYYbFYYDwe48UXX8Srr74aDvdisQjg3nA4Dq0wOQt1hNlyhjwvUQw4E/PS5ctYX19H29UAmEgoyxoYOOSFwltvv4lLl7dhbBcK7vYP9lANWLi8++672Ni8jNnRMRprsL27i6OjI2xvb2M+n2N3dxeLxQLT6RRd0wQC6I2NDVjN1cPj8ThEdqbTKQZDpjnce/wkRESaMgtrQCrWJwlfbj7gCmXlCYeWyyXmbWQDU3nslic1OGyNMFaWHkrJATLGBO7czY1tvgbTIPe8rs6xxeOct7sUR5WYgd1nBJexVaeMfpZt5CGRIEKK96yGreW5ztkejQYA7h52SuN8WCIrf6cRmdSEk8Qi0SpZrmKURUfSmbarYdoOWrFJyTmrCK0kOA9Fw4EZtbmvbg6CCqxVggMsFougucRPFvO5qirWttZif38/oPwiRG7c4EK0S5cuYTabYTKZ9BKodJ7h/v37WFtbw9WrV32JOWvkvb29XrvFtm3xy7/8y/i93/s9vPbaa8GkHY/HvfR9qUEZjUb4yle+0quhSNPKm2bZ26R5ngVwNcsKbGxuYnd3NzSvEoG4aOpQxPeTP/mT+Ma3XsfGxgaOjo5gjAl1NgKQdl2HncuXwn1dLpchoiKfKQAvkNAqKMJiMUNVFXjvvcfQGWGysRZcNdHiTdNgfjxFphDKD8R6CWnlQFA2YgVJDY4ksImCCoJFsqNVJPWR/SWfIXMwxmA4HIb3pIdXKnjT8gjBT+R7A2aXhGmf5aYI9rS6Xil3iHyHWJWnXcV7LoQIRGInwkNr7ZsR94lxUxM1RdPlgKR1L0RMQiPaV6S7bG6ANYv445JHInwVgomI5gnz8iHkvb09AAhuhHz/tWvXUJZlOOyTyQSPHz8OmkSSoLIsw0//9E/jIx/5CL785S+HxKvBYBRqT6SSeDAY4LP/9/+DYTXA7vZOz2wGWMhevXqVhdmgwI2b1/DkvUdwMFy3Y2KvX1mjdHMJxjAYDLC2toYsYzpGCbNy5zjnG0wx6dB33noTk8kkHCYBoKWQTwDIumamMdIK1XAQDpaERdu2RTkY9OqWtNbIlQ44Vsrpsbm5GegBBoMBlGKaxdwfbHF/0r0k15kefjlkRIwpyUFcNf05azRyp0qtjrhAznEfHonQyN7SWqNum+BeWdvB2i7sX9l/dduiblvYLs4h3aOyHs+KwBAxCVG6Fwwii9tpj3MRnbmyO3F//T/4CQBcQVlk3A9FFlu0rPi5QqAj7GRwClU1hLUdN/oBc4FIyM2pvumnvJlbSBNuzSzqadQC4C7sQNx4otUE0JPwHm/IDpd2dzGdTkNT7DLLMZ1OMR6PsPCakT/b4kMv/zkAwGtf/4oHeyPtf1Ew67ojwk/++T+PP/iD38d4OMJsehTT1hWbwsYYdNZhZ2cHR0dM2rx7+RIeP36cfJ/XWDYCyTFU6SKgqDNsb+8iz0s8fMTXsLOzBVIGi1rmxcC01LZMp1NoyrCzsxMOZVVVePDgAUajEaqqCPdPBP3a2hrMsgtUBXLQU3erGhQAcf7K0WyKq9evhejddDoHaYVLu1ewWM7gnIHxZN5lXvlwM4XQ8NbWVq+vEN/b2FNH3FwGgyMmkR5csRa6jkPO1loMfZZrxFgsiiwPykoahDVNA+tiuX6uc4C4/7KBA8GDrlmGpU/mC8EErQIgK61gZUgrN4ApOgFOlQdiOUAobKUMv/af/BenEp05F5iILAWRhiIXBIiYjmnuRur7Gd87JAu8DUyNx4LFS2+VsDopgBT1LBIi4lCctehsbAsQkXrfqCgpSRfNIHOcTqcgctjb28Px8XHQ6OMBm/2EGKoW7fXmm9/FO++8g92ddRRZ7lPIGRMwLR+IpbH4fz/3ORRFFdnFHUCkguYxxmF9PMTBwQFeeunPYblc4stf+RLW19cDF6gMnXmXjGLWrpQGKKW4uRURjo6PQ6nAdDrFvJmiLEbIc97Md+/exe7lS4H0eG20jidPnuDSpUuxQdVoBKUUZrNZyDUxzgKKUA4qzJsZiqoMQOewyLnJk+ESeMlunc/nIZlrMBjAdDaA3Z1pfO7Kgsl/PH/twcFBqBMSF6rwfXCk1a3KuKbGwsE0sdJY9hzf4xxKURAyIlgEXxJL1Zg2WKqBtBnc4LvpWqYPMQhKLfKbZCBFcNYnqK0AwkopNF3rw86A1nmYRxpZlPMg1iXSqE3mhYv5s1474zgUp0jwChWjBgSMBrwBjOHoSmtcECxR6jNVHZyCNRZKR7dHzNr5fA6nHIpMo6pKlIMKR7MpFvOatULbAmCcgen3eCM462C1g2sYXcmyAkQObVtja2sLR8f7GFUV9vYeA1DhMB1N54DKYElBFwrVoMBiyq0YWmtw6dpVtB0nR807g3zA3zuaTHDv3j1srOWAuHS5grMEaKY+VJShs5x5eTSd4ebNm+i6Dnfv3sWtW7ewXC5DRSvgyXw6h6IoAxbC6dPM6p5XJZquxWzBPCLr6+uYz49RlDmUHmJrY4srV5dz3LhxDaO19RjhIYtqVMEpB0sWxaBAY1g7D8sBRmtj7O3tcZRL5ZjPlkCmMSjGoDzDULGQaazBaFD5JK4K04MDtMfHKMsctm5xVDfIFSsGsUhnizmsBYpiiLox0JpT7w8P9wEwofR83gUMqBqPQvuNrmmRa4W5NcGdUyqWV3QdR/SM66DAqQK51ph791XcPJWUYiz9gSci2KZGXmTojEGmCEoRyHSw2veXWS5ASFqbaA2tSy+MMlhjUaoCOtdsdRB3PQAcnFOeb0doLDQXr+Z5z9qKSW9/5ukR09EvGGJ2bOoBRwIeAYhp8gnAJCi7oPfiyw4GA2RZho2NDSil8ODBgxC5kNeJ+yRh0BBys0n40M+nqio8efIkuB/Sv2WxWHBhWlX1Gi0J03sKwEmmZ5ZlWCwWMMbgpZdews7OTm9VCJHMl4hC9qiETLOM20SMRqOeXy9rASBoUWk+JUMspMCZQhSAR6UUdnZ2sFgsmJ7Rf1bavkI+T/q9CN+p3D+Zn4DQYuGJWyWg53A4xGg0CkWDUpaf1qqkJrxwroxGI6YL8K+XpDYiCsC4uIGSXySP04JM+S3WUardxcIS60NqiFbDwWmGrpAosfvtFaOLNTQAk5zJoQci5WHKcxM6UK+ArLJnT4IkTgodn9Y4N0KEF6wfC5e/5Sbyc9FfTcNuQZoDvU2aFo6JaS95FJL/kYKsRVFhuWygVIYsKyAcncY4ADbUR5R5AQJQLxco88KnNkdyaDGlxVpaX19/isRHKYXjoxkIGvWyxfXr1/GzP/uz+OIXvxgFpWMLJAWLxU3Y2trC4eEhNjc38fbbbwchKZs7BYJTQFrAyxS0FtBSWjfIQVgsFnj06BF2d3cDCc9wOIyM4863bAQwHAxgjeG2GgAan+4tQjKt1gUQErZkiHYX812+T9xJESSyNoJNCI2hCFYRslKbIhnAss+6rgsuo6yVzEdyV6Twj/8RhUlbN6wsPBub7Dc58CJEsiyDzjMMByNfOMiZ1CK0ZN3letKIjLGRO1XW+AfleTzrtaeZHyLjBwoRIrpJRJ8hom8Q0etE9Lf8879FRPeJ6Kv+51PJe/4OEb1JRHeI6Bd+4HeAyYPzQvuetIKLMHGQ+JI8YxU2eOAV9X5kURTBFxfBI67RxsZG0Gyt6UBaBXMUYH91PB7j+HiGyWQTRVGBSKNtDJwl5FkJpYCyzOFgcHy4j8O9PXTLGsf7B9A6x/b2NtbX12Nymg8Dyw1eX19HMaig8gx5XiDPC0wmG3AO+NjHPoYnTx7hD//wi5hM1gB0yHQRDl3YmCFPwOL4+BA3b16HMS2cMyjLHLPZcbAWROAJEDxeG2L/4D1sbK4HzCDLVFgzSQpLsagsy3B0dIQ7d74ZDjg3/s4DaDkYDLz7w9SKwpSW3gexwsZjbk05HA7D+k8mkxBW39vbw5UrV7Czs41FU+PS5csoqyEa03kN3aJtawAWo9EAjx8/xIMH38NwWOHdd++H8LkIjSzLQhq+WEl5zoD3w4cPURUF84/kObPkdw00fPp43YCsQ72YYT49QtfUaJolmuUC06NDjKsS6FqQ6ZATUCiCsszgX2UaRTVEXlZYn2wgywvookA5HCPPNbIsho51FgMIrWm4B7UGR9Vc53Ol+taGWCCpRZVG3FajN6c5fhhLpAPwnzrnPgLgkwB+nYg+4v/33zjnPuZ//iUA+P/9CoAfA/BXAPz3tJpHvDoIoRF3dFlOSOtNQliyYLJAadgufQ8XiG0FYFRclhQsFSBUeCVSkzLTmutSLJe364wwOzqGtQbOm9mj0SDkPcxmPruyGITvqoaDvgmbmJnGGNy+fRt37ryBoorZnlprZixXHDWBYqTewnGuS8bM4Q8ePcTlq1ewc2kXpFWvA31aBKaUCpGn1FSWyJJSCpnSoWhvPp0hUxrj4Qjbm1ueRW0fOzs7QZtrTYH9KxXoYhGEDeStCbEWJV1c7o8cIOE0lZL7tEmU1hoq00GwSY6FhFzF9ZQCPHmNtJaQ8LnxVoYoInFP5LO6jmux5HDKHiGfkyK5LZKkJ4JS9ozsT8BbtlWFzgKDwQhFwXlEWZEjK3IQSwdYx21ducUFt5MFLFviynHEkWxv36y6M3KvU4vkeY0fKEScc+865/6Nf3wM4JsArn+ft3wawO8452rn3FsA3gTwEz/MZKJ07fcQTfNC0tfJzRQzMsUMQjgtz7HnMz/Tg2uMCQVMYkYrpTAejzGfz4N/mx7qqqpCnYg0nB6NRug6afXoQqWqWDZS1atzToizJuIbRITrN29huWwCrtJ0bS9fJl5L7L0jh1gphdu3b+PBgwc4ODjoCQm5ThmCuUjqt9KRMoET7Koe1iRJY1JpKxjFbHYcBC8fvsaXH7jwWynAmBZra6Owwa21ofgtdUfluuXebmxsBGGbZRlUXkAX0QoTwSwHOhWQguXM53OfvcupAF3X4fHDR0ld0CJYQ8yoNgRR36UQQcJzY/C5bpYAORwdH6KsmJBJXpPmKKUuV9hHRMjLEjpnWgmCDq4PZ8b2M1Wd48xT2e+rAuQk62I1UrP6c1rjTxSdIaIPAPhxAF8E8DMAfoOIfhXAl8DWyj5YwHwheds9fH+hAwKhay1I+bCs4U54WvveMpq5PARTE1YshVj2LxrIOd9syLAJv5jOmJfDOiymfNNVngXMYnt7Gw8fPUHWMrB3cHAQWK4AoCrKoGUe3P9e0GgbG5uhh+/GxgZm9TJq2oxBvGVTs8VgI3Anm4poDAB49OhR2DB5VjKTGgyUKmFrA0WdFxjslgjBEgBcvXoV9+/fD67IsQ/NijsjwleARCH7kfwWLjzTwdWwzmI6Y+7SoihgnYGxHdquiWHVroOlDpONrQC0SkKZXKM0eRoOh6gqJmqSQy8WmrEtspyzi9uOrYVc5RgMS9QNt85o2xZr69zTtzONTyozaE0H6yyWTY0iyzGfzbwFM0dXWqyvjxNridPXB4MB6sUSusyx9IlpAjI/ePAAeZ5jMpn0slezjDfc7IgF5+bWNg4ODqBJ4fDgKLhFQGwKL3unbVum80wUIGfnDqF01Uusy7MyWMYkFpAx0Eozr6pWcIjMZqJoU2FiHXMUewp4IGkjy687B8Aq8a7/5wD+tnPuCMA/BPAigI8BeBfA3/+TfDER/U0i+hIRfWm+9ByTHkSMr1GhoEi0mWgwOYxpAZmYyhJZWaXwFyBRTGkQYc9zaUgBmdacF9C2NUzbwDmDplmibevw/Xmeo7UGlGmUw4HXGArWcoJaitbz75j3ItrQGIf5fMlmqnKBzzPLMk4kc+JueJDYSvITA70bG+tYLGbQmoLPrDUhy2JYW4SaUsoLjpjNK+HZlHNWTHXBn9JUb7FuBO8Qt4Lf7EJ1bNdw8+xYIRuL+8Q64vBp10sbT7W5CHixVFI2u9RNSyN0om3l/qdzd47zMCTiJJwy0l1P6CK5KrwOh172jHzmsvW9dwi+b7Lj6Irt0JkWeZHB2I57IXuXhAtAU/ay2MMm08xZI31sBgNmvdd+TikgLtZJz70/+VyF/S7jXFgiRJSDBcg/c879Cz+xh8n//xGA/93/eR/AzeTtN/xzveGc+20Avw1wxiqnFqeFd/EghvBpNYKFC/638ET4zwuaUnhERBuJ2SvCo/Omeem1w/b2Ou7du9fDVKqqQpHx9zx58gRroxG0Zi1PEhlS3Me19QdCDkXaPiCmUqtwYAajMeoFF+pRE/1pnRfeBeEDYMlCKU4y0lqjrPLAbl4URcBx5LqHw6G/BhfcGjH/ASTmfIOyHHgtGcOa4rOLlpSDLwdK1tgYw3SCNaejC8ZQliWm02kvWqYouX+DAWbTRbh/AuJK1ExY6oqigOmcx6cc8twhy6VFQgxFK6XRtMvgWg2GpU9OY7wm0AMk7pNEXkYjZnBfX1/H44cPMBgMsJwvsLO1jbpuw/USEVqtoXMWHsO1MerFgsmeKGZS13UdiiElK5ccAEXIMwXbdXB+v7k28sYSAWXJQnU+X6IscxSZQpaxUCedspvFcPCqDEldeREYci9Pe/ww0RkC8I8BfNM59w+S568mL/trAL7uH/8ugF8hopKIbgN4GcCrP8T3gEiDk00FZEUIoxVFAXguyel0GgAzgF8vpuVsNgvhXBEyKcs5EVeJGmNCfYwwtPPnWQyHFWbTI3zv3Xs4PNrH+phT6quqCpXDOs8wHI/QdB33dl3RABIqzLIMjvrENl3XJcS/bILmeY66S64VCIJJhIYcYvmc+/fvhwMuVAeyXimuIKChHDYRpgI4ploqzcdJc2340DWhM564cTLqug74ibh8KQaVhprTcKy4o3Jta2tr/H3jAfOJEAIvRlEUoV+vrItzMf+mXdZhbru7u9wczONbzjHrmmm7UN6gtcbek/dCdKppGk5IdBEgznNmuR+O2Xqp2waD0QijtTHKqkJZVRgMh9jY3MRoPA5/z+Zztkh8IptSfNjY2rKo6zaxMjTynN1F6R8k+yAKkH7XvDSUu4p7pIGH5zF+GEvkZwD8RwBeI6Kv+uf+cwB/nYg+BkYq3gbwHwOAc+51IvqfAXwDHNn5dSc23LOGN/OEohBas/9HhIIUqnKIQheAAzrD7Oxaa1hwfsKgLDE9PGCE2zmfZRoXXli7O2s5o/BwiuWS20c++N49FIq4N6siNMZg7vMPPvCBD+DBgwfonIWFA2UEp+TmEVsqywZlVoaQnXyfWD5N0wCWUBSRaZ1rPRw626HKy5AAVeUxOY6jM4a5XeFgwaxaztf7dI7Z56EV6q5FVhawZGHArPhKZXDOouuMD2pZqKzg5uDWIcsI1nBfHTnwTbNAphTgHAqdwylCZzs4DTRth+FwhOl0Cue4SnZrawulVnDST8fTB2ZKoa1rIM9hXYeq1IBj4NWhRV6UwdWQhDbRmOImEREODvegPZlUEDoqh1XsuhnD4fem7qB1BmgAroO1wJHvTsek0znmixZZWQGKi+1EQFoT8zygNFSWwwJoffYnwJgdLFBkJXJNaOoaa2usQJwj5JnPHRoUofBQ5wSriLsyOgdrOijtQEr5Mn2OxIjikr0zGEibzs6Hq8VVNyDK/b3sYGwL5yTomVghljxwCx+gOP08kR8oRJxz/xpPV+sDwL/8Pu/5ewD+3g87CXEB5HGaMFV6LROYthErIJWPnR8dHQWOBmgF07H5TFDokvi50kzw0zQNrly5gge+Q13aX3U8HqOqKty9exeHh4cBe0kL8DjfYc1ziWgUeYGureXaQxRCwEaJ/KSZpHJYTN0FrS+fH9yBpJWAEDBZjyksZ1MMyyHgLArN1obShEFRIjY8QhBcWmvUvmgu0zGPJPdcGoyRUE8QGjBdQQwF22DB7O7uBpyhLAcMXHoe2zRSkas8WCbiHqWWTipsZa7yOE3ME2HDCYFFsOasZQ5ZyZgV8FEiZ5JoNhqNfQQnamlJriPlgnvFbqXvZOjbVma+qM45h7bmRlWLxaIHwIvCWltbC65g0y5gQZx8J9cNB61ilDFNDJS1l722WCy4AT0icZdY6kopWCP4CDe2cs6HgxNyJCfFQice4fdnnIvamdQUExM7DT8610UgTwF5zofUUYf5jKMvmS8bD5hJZwEVQ8FtW6NZWK6qHQ7xyFeZOofgdhwdHWHR1BiPxyFHYTwehw0sQNtwMODScxEupj1Rq6a+eOqvyiGSMLMlzlJUIccD0IoAw6Y/nEOZD2HcFMoYbG9u4RCudyhkLoz/RB6MFJQTwNLYFkUeK1ABAVNjaF3rDEpx0dxoOITpeHNLXgVHSuZB4KcZoelIS9pFIKXYByDCLMdsNgsRlbbrkPv/S9c5nWVQGQXyZcCzp3UmpMen+S/L5TKUHojQ4SJEzkyWQ6ezAlCKW4ZoDe3vW3QJuXo5yzKUgwHausZotIaFd6lTty2tqckLjXq+QGdsgmEowHPhppm76WcASTNwrwSFhjFgHC61YBxIJe40WcDFUhDnXK9P9fs9zk3aO9Cnn5MN1nW2B/DxTXM+ahLrG1Lt5ZwLfXXl0DZNA2cM1rwWGY1GgVZwb28P11+4ibpr8fLLL4fchdEoNs0WkDK98asaRDRwGjFKfVqZ37OuPQWTg7WlYvk3EYUMWDlsSmXQOu99TxqdSVF817Grk5FvOeocFMDE2DbOzTkXmNBTfEY2uIDX8h2C9whuc9LhSLMqZZ6Cv6SHP8WO0v0g60HEgi1dqxDV8lEVESiyViE93XdV5ALKeMhSYR8zgqNy48hXTHQTASNJcnI9MmQ+RV71WOSN4aQx+dzVlHeZS/ojuE/kyXk60vKsyMsPiuS8X+N8WCKImz90C4PfhIi1KAFh97H81rbc8d52KDIP5Lmn6weuXbsWurw9fvwYdb3AcsmA22QygSXg9ddfxwc/+EG8c/c+U/KV3AOYvE/bth2q4cBvPAqd7OV7TgKxovmdJUAw+/NNwxaDgIRygNJN1TnnS8tZkFblEFubEzx8+BBFzkRJxsocmJOWyKLrLPK8DFZJKmDk4DAvSBRsWgNt3YXDm/kEr0xpj9doLJZcjj/yPXgp06BMo9JsRQiNoVgWaYhSKe7ZIwDvZLLmrRpWCl3H7tR8PgXzz8Y5S0tLUSZVVaHV3BZjsVhwHoW1GBRMfC35GPw+zoJtPGgtbmMqnC1c6HsEG4v9iiw2S09d2sonqYmQIqJgmQpQzcBvARoS6mbBu1wrvl8+x0MsbhFGIjiAGG0BUWh8Lv2ZgdVaGevvW6LUyAbaAyKKfBunMM6FEAEit6S4FmGzW+t951gG3TRLv1C8QLnmm+9EY4OgdY7FghtQf+c73wmJZEopEByatkFRlHjjjTdw6eoVXL9+HXfv3sVouBZbYbpYgyH+u2gkAMgyFQ5+6oemkQmuN6l7iLnkSrRtiyzJR5CkMMkZER/dmmglTKdzNE2HXEkmK4PMwgKndQ6tVEjO4vTpvqCLmsuAKBImiwZ1ft7ynjIv0HYNhoMKIGC5XCArc5+t26GuF8gyBWNaFEUGa2MpelEMQfBVws76iEcWXCHJfpV7HrS8txYEZBYspG4WoTDQJZWyoeBRR/xCkutS/ES0e2odSKNs5xyUv/Y0a9i6FnXTwboc2moYk4fMZsFwUoJqyfEQa4g5ar210lk4Qz1LLLUa02JAIoIJe40/kyOOWcIFG4WJtS20zqNFo5hMmsc5yVg9tZGEqNKNJH5zlmWMG/jy66D1PeuTAiHzZrUDQA5ojcGlS1fw+PFDfPjDH0bXdbj/zj20dYPp7BjXrl3Dk/few60PfgB5XuDo6AiTjY0Y+bH9kuw0PCkbx1qg85pHZ0VP+Im7k+ZqiLbRWuP4+DhsGDGNB8LYZrhBs/joHDlQAXuQDUsAKPSasQBpTj5znlgHBs4pWCtFWca7ADpsUtH6AdB2XJVbDnximIp8LNZyxMI5h3WfSaq1RuMFn1AZyIFYxYayIvd4QUznlvUUt0Y0dFbkaNqlBy8lIa0LZf9CT5B2mCvLkomHXMyNie6huMPaM4nFxLfGg7IiVOTAhrB/wwe9RbTmjDEBTGbOknnEMRL3brFYYLQ29tmovneS67e8lOQ4WRNRQKm7LHuKG8WbQNpExLSLMdxrevdXhAy5c5CxepojdWfS6AUQfU1JEmLLwAXwEEBvoeUwMPBKmEwmmM/nuHfvXsApPvShD4X+qnt7e5wnoJ/m3pQbGwqzEA+TbBbZpEiuITWVe2ZzonWKogiRA/HjU1wk9c357zg3ea38yPeyho31PjJWa3EEkEsPbgoQpsJP3CwRXimwGij4knmk9yy12tLvSO+VvH4V/0i79zljuRTCIQgNOexiocjnp31dVu8FEUXN7JJsYiD0KZb1spa5P5qEd0UwLwFcZd1T7CjFgGQ+KbIhYlIAAB2FSURBVNF34S2leL/ivU9T4WUEjM/FhDvJYYmJjH2ms5OwEHuKsMi5sEREIMhGkMMrh7ppGjTt0lMD+g1LnpyWlCAXrNHArxl4ns8XbtzAvXt3+cCaJVzn8MYb3+KM1KLASy+/jMePnwQNqygSIMkP4OcHjc41sC3/v2vr6PoggnwpVgIggHvynDyu6xobGxvhGoE+GBlqVXwUJ89zWNGOQdh6xJ4YoW+6FspKxSzBuDYeIsSoEHcK5IiEggu9jSWtv7NJurt1GA+GmM1myH2+Ru0LBY2zGBWDUGaQJvXJ+51tQ5aqgL4pWdFqZqz8T6Jz6WfWpsNswfksznGiWaaz4FoJbUIqpAQDSgVlCJNag1zHVplZlqFL7rvsT+ccbGvQKS7N6KxBYfJQ2ChRmbTqdzY/Rl4W0HkJsg6ta5HrLFiPAkCLKya4h8yZGNAK67JcLlGVQxgTeWnFQqMsCnb4MK98DnC64Oq5ECJpDJvj/pZr7siFikuufBXN7qW5U7DOee5Oxd3OiAHG6cEh/q0XX8Ldu2+HTXPV54gczmZM8U+EBw8ehvJ/WIcaol11wBgAYHNrC9OjQ3YznGM+kqJC5gG3NEKT4iFsPXXIfAp90zDAJ02PlH9vVpTomtZvHh1M86abQWnp7NZCZQTnrG+bye0aCQ6ZztB1DdPwZRnq2jDPp4oVwF07B7ywi5XEOlxj42qMCp6XqdsAUkMR6m4Bax26li2YUpVwxmJYFFjMuQBOkSeYttYnVREyR8wRoxzgBVVnW4zKYSjVl0OfmvVp1XZqdVSqgIWFJXAejReDHJqNPZiBp4l6eC06wD8WoZGRQtMaWOfTFzWQae4X5OBgHYVQfjefQQ8qaF1BIQcsEzY3PmemV/dTDlhAogvcMuKGGGNQ5AKSMvUiJ7p5t1FzC03467GuQ6k4JSHLYuSOsTWFpllCFxXn5VjDgs+y67p6xt7vcU6ECE7YPCyZ4alIFGJ/2dQ9aE0XtBmsxZUrV/Dk0WO8+OKL+OM/foszLInTsheLeSgPBxBMzeVyye0JABjlYC2zmDnH2bFKKRzuH0DraKrCRVLd1L2RmL5YGgKQSo6FtK+UPiWtienpSMKsWZZh2fi0cNPBWQutcjSOQ6uSsGRtzF8hYrKbppH2GBoKaRuGBNl3EgqOuQnlgGkimV4wMpLxe2JGacQLYmm+JAOmxXDWWm4R2jKXqfVh48Fw0AM75f4JoElEvXCxuFRAZEsziGTZgHeDMg2n+j1cZL8Y069qle+x1ob2Cm3bwYm1lPRwpkzDGc4tmbXHMMZB21hGIG7J2tpa4BiR98ZcJxdyVlJLNA05Z1kW+FREickeI2hYQ739Jm6qRDXTtqesYJ6PJXIuMBGsmJ5i/ltrvQZjghalhDLRgZz1JioXJuWFxmSyhvl8iu3tTeztPQGAwJh169YtjEZjZBlbDjvb29jb2+vhGtay7+2sYRfCcDuB0Yg5QriuIjawEvdlFccRrZomQMmGSAv1ZKSfk4Z8WbtKKXkWWmSk35Oum/+03sZ2qZ/szWMQExw54vAmvGtoTew/o1TceKl7l+JWAjCmPrmMVXdOfrquA7lYIdyf+9Pvlc+Pr7MMEMu+UPxcIPGhfpg0xXlWsZf0sK/ONX0Nr2eM+qzyh8j7xKVLBRSAnqW1il+kbhMQQ/7p+vIXqBOvS55L82Nikd7pp7wD50SIOMQLlk180s2UG2S7SCgsgJbkKEiLgePpETrvB4/HY7z77rueSMhiw7Opj8djFgrgOD8AmLbmn6YBjMHWxjqa5Zxp85LkolQQyM2TDZBqUCGBFm0hQkQ2dRpOFjxC8IMUgJQUczjFVAFEHLTzLGc6z5AVORcp5kmI/MQNJQBnv/+rjJirEzlAgRi6lnRvqaQ21oY+xcZyx0Fh7ZLQsbUWyidtyXMyN7nWNDNYtHUKZFprAyuYYBCpUDPOnnjQxOyXdQeioJf9J/eIbOwml4L9RVGAlEJRVKF4M83Wlc8WS1OS8YQsSSp9Ze8opcJ6yjWKQBEaT8m1ScFsmdfqNYoll1qBq685rXEu3BlZBFkABaAo+KYrBy7eAqPwUs+Q+styWLquwwsvvIAnjx4DYDbw8WgNOeDDgHzQDw4OQqRBOcDpyFruLCdhZVpBZzmnwi8WnOxW6ORGSe8Q0ZaxuRYQM1rFpAViHYtcsxxOAfWkj6to/a6RJKvGb7oCuors8845LBb+exA1tjUAlAU5z0eS+Q1kI6ENE0/H+hQA0IUOVa8xYuBrmrQOFI2t6VC3DRRlKLxLEgmA+pwWdb2ELjJYqSD25f1sOUQdlmXau2FA07RwTkGqaTtPiqSUDnU4WsU0ccGZieK6phEPtvT4ewJ42sWm5oqUzzHJ0MIfZmdhfIPwumlh8hxrQwZvQTGCJ4pFsA4RWFrr0MdIBE6e5wE3idedwdoIvotgiREoxta4784o7PVVwSDzyPMc8JXDWSJgTzNP5FxYIkhANQHRUrwB8Gae0kH7AFHKiuasqgr7+/uhSfT169eDcBLJL9JdOE/Tdg8Aehqha2ssl4teqBJITX7Ve49YFPJdqZBIQ6yphpR5yOvTkKtgBGmSFHfviwdfNh3QD60qyjzDuPKbtB9iFeCXiGCdxxvSFhmJOR5xERe0a3qt8r1A3/UBAPK8qHJ9fABcSKxTSvXaTKRRmSBMk3sia8QEQjFJLZYBxKZn8vnpnISqIEZn+uFu2/XdM+dcmHtjOuR5AWv7Zffy/dbjJLI3m2UNBUK9WPLnOgRXTvZFailKRC29l3JExSJJvze11NPrkb0SU+X/f2CJOMTKVXEJUkmvtUZVsFuQ+pxEnJ6tlMKyXmK0th44RW7cvI79/f2QGaq1xtbWJuq6RT1nwHNQlOH/puU2ArnWsKAAbq2tMyv5bLmAtjYQB5e+Ule0mdwkEUZA3BgAeocTQE8oBTwk0ZDyfv7N1Ahrk1Hwu5umgSWCU5zynqkK1nbIigLkkwJc5wB04cCbrgNAyPNyRUtzOj6s8ocy1rcAUtQVcxbk/oggS0Pb6XMANyTjA+rdM2sBitqVyZCKkDUr2ILOFDrTAsTKYb6YseArSnQ2JsFJYhcUwcJBg4vd2rYOikjreLhSASXXk1aQ883hqA9l3DSq8A2lupabmTHFwLzn2sq80+jMcDgM1b4iQLXWqBuxLKUfUCKEnQN/LFNaSEZtXpWwbb8nUyroRFmk+07raOGLW30a41wIESBiDHJjlaKwAQCHtosNqTWYIbsxHYZqhOn0GC/c/gDu330HSilcv3ENR4fHKHJu3SDkx0+ePOGWjZ4BLAVwA6BruBZhbX0Dly9fxt3793E4PcbW1lYPKBNLJGqq6Galnyn4hozUVwUQXB7nHJZeO8doE/e3sdoiL3nzk8qQ5dGvXyxMsFiyzLenSIiu87KA7VgTa5/paj1uoURYB4sibay1AnaqvukMgK0dInSOS9yhOe/EOc5ZIaJeApdLtLD21mZ6EFOeXGMinaKkl7PgEo6YGpoUX2umkWUaxsRm4PJesTLlfqfWiRxI+btrW0gVkgP4uvweUVlUbp2z4bHsAVkXsXpEsAx8xXeKgaQN4lfB6BQfdC6C8qkykscp+bgMnkvcW/I/EZSnMc6NEBGzK0YqoiugqG+KiUTf2trC8XSKK1eu4J133sHWxgaWyyWOj49R1x2qSsPaFtbXbBjTYWNjguUythUwxsC0iYmr2fTP8xxPnjwBKYXReB3WRaReNqqEKVkA6h4oKK9N3amToimpRSIaS8x/8gVgZVnCONtzebjDvEVZDQDi/rpiXRh0wV1xMIDqV+iSbz8Q8QTRaDHVuut8ab+Wzf10l0HyOSc62bSr1yb3U9Zs9R6KNSfWmNyTtFAuXcPFYpGEMOMhduHgRhY5mUOair8ajZG5yD5L749QWsaojENZFmjqRRCWITVeqZ4QEUvNWhvqe6TnTZe0sWAAtYxr61yyz5QvXfBcr155yf5Koz4spH3Ex5in9ttpjnOBichlpuY/kudWF0I2m3BzSiOkR48eYXNzM/jX4jcrxR3otOaaFTFzZXMKKAv0Aarlskbqk6aRBUHf04iNfFaq4YKvnWAbq1pRNrg8lgMG9Iu50mhNqv3S3z0XBACcCvSC6c/qesuBTdda/l6N8KxuzmeFTnnYMN/03qYRhHRtohDm0H3XNchzbk3BBNptPLiIeFOqaVOcQ36flIW8agUAEahPsYR0ful9OAmXSK9NrA3Zj+nekHR9+YzVOa3iaNbanuucznG1TCHFElev7zTGubBEHJzneuDMRqd87gIRFGXQWQ7ub+J9zdHQm/9L3LpxE2+99TZ3b9vI8e737iHLFGBrDMoCTnHY7fjoEG3LmaOwDo5YmzvTwnRcVq7AyVuXr1zBbMY0d8OyQGfBDOYKqAYVm9e6QFmUIBLz2wR2NAFvRSOmgnD1AIrXQIgbQ3xl0hx2MMGSSrRcQseoXEzSWi6XQGt6TbhkDp0HUMkpuK4LmjZwiahEUysN4xxcB5TlMMxdKQU4ZkeLh+Jp4S8g42AwSDS5gQahq2tQAgjLwRDLjcmfl0FLwxEK7xbmGXHiXVHAwMA4i4wIWiksfcIbl84z1gIiWMOgq/NUiA6cUBjAWlh0pgPgrRk4wAHKeMuJPClEZ5HpHLnKUYPbeBD5vBUiODgopb2y4ebiAMK9Gw6HmM/nGJQlAEJbN36fSG2Ngta5p5/wB5+5tXh/aE6yo8zjQc7yvBShKnyDNGNAluCguBRiBXQ/jXEuhIiY3qIl0wKzXGsw34SYqDGppywK3L9/P2jLerkIUrosSsxmM+xcvoJ93xairLjoru2EzMjAdk04DIoyOMONv4+OuP9K0zSAVkwwkyksfCgv0xyysysuSqrR+i5E36JKsYCT1iO1WACsaPcI5s1ms7BuoQal9LUmSvdwDu1ic2xK/OVUg8r3p5YSEaFL8kXKkrlapYo6zTZejTZYOMBrZGstLMAM3KZP2iSvT90b+b60zsYlfKTiEoSwr9Y4PDwMER7R3KLpeQ6y3py0aC2CKRyt0Tw8yaCyvEj1QukyrLVcwKcUtIph/dV6HYBd1sa7M04OOBQMhJwpRsLSNVm1emQPifB1xEpHk7cqAebTXXnPaYxz4s4woa0GIVc69EIVX1uASgA9V0I6zKWJPLJpJMKRLjQcRwlgOv6xHeq2RefBRacYUX/vvffCppfPFL4O8WPTAyAHGOibtUA/GzPdTKkLk74nPVSrP6n5uvo58pMmVIlAXj2sRFxfs/redIgAEWEl65G6QykonLpG4uaJgBQCbaBvpqdrIP8LuIkjKNKwxnGv2kxB6f5cUwxFUgSEpiHFb+Szre1HN2SkFqMxT7sq4TeExYz/Wl0v+Z26afJcWHelGNA+Ya+cNM/VvbR6DSe5Qul9ltecdN3v1zgXlgjQ76yeDumcprVCnmdByg8GAzgwheH6+joODw7gICEt3lTSLU6sHKllcabxGrnhsKDWyHSBqhogzwocHh5hMpmEXirGH4LpdIbcd9+Tuo+TckDSQycHDejf5FUcIbViUpwkxVFSk7RrfR1KNQwbSfmojXUGw6qMFpZ/32I2h1IU2LFgu6cOmVgAQoyUbj6tNapqGB4DBGsj34qEbQUM1lqH3sDOJDy15JApFUr4BWfqutj4WzI9RTikoHOKgaRJZc65AGJGvg3qCYXWNVAJCC7CQKyAtAiQjzoQqRP4cVrDFQSBF1gqiwmDMq+0Vai4NV3XhSzpIFDRFyrpvSeiwPInPwLcdl2HQvcbfAGAJoLBybji+znOiRDhm8mtAdPEpc4vvgo3ous6XLlyBVmW4e0//i4u7bK7wjkQjAEUmUK5NubyeUUgONiuBVkDazq03TKauJn2fVE5/Lm5udlj2HbOQWcxU1Ip5XvSzlj4FDFiIu8B0AvpASdrAzm0q8CiCB6usGV3zjnni+tifYb0RRF3LuAQ1ZAPgoq1ONZaJq/2B8daZoIjasPBkapja9mlkzkZYwDSGAyqgFvkeZHkhUSe29SCA+IhnzdzjIph71CL5SDCVg69WBNlEpKeTqeh8lkOj3zGYDAIczHGhGxkuR8hqU6AVljkFHu6aJWh9bhETDFIfssuDVZXP3yaZVlg0pd7z5mxfG/rug55GgKcy7zkXqbWmBx6WZ8QaVESUeu7yelnypyNZ4LX4vqcoiVyLtyZdKSIeroZU21NRDg+PsZ4zIxRLkHMc92vZ5H3yefJYUv9feFv1VlxIrIt+Qap+Rx8/sRklZHWOaTXJPNfNXlTa2HVDI15E6b3vrS2AojAmVgQMr8Uzc+yjBnTdXRlLKIb0RoD510d3wQSzr9GvvMkN2vVLUvXqAckq747IvcnrT0S4SHXlLpcaW5FTCSLpMyrEbD0nqcafFWYs5bvu1YyTsKzOGu43zA9xSnSosHUOu193wn3J7UG0/ed5F6tYiSGg8FPr/lzGOfCEiEiZEkOgU3CVVAOWiss6znguJhOGjA7yxWhwae1HOkZDisQaSwWs1BQ5ZwLpDzaWzvcU3WIqhoiLwYYjdbw8OFjlIMimNLWmlAqnmcxZT73LS+J1FOCQIZzLhRPSb2E4DkS3pNND/RdHNbwyoc0OZXa2i6kye/s7IT3i2CUA5XmYMh1cNSDXZG2rdEB6LoljHEgyX2hfhsDmQ9bXCV0zsKhrDxPhggrX+5/dHQEyYuQwsLGdGF9JK9GgQBSIVy7vr6Otm0DoDqdTjGZbGI2O2ZiJiN9axq0LWtlaYMpzaKstVhfX8f+/n6IkKXXEat8PdDqhFu1rzTSBDjuuUYgZODeLjq0Dq2qAQ4O9oOblZYo8P3rh9ElzCtRMAABDJam4APPIZMSG8m6sTXSB69XsRZ2p7Svq+qD5qcpVM6VJbJ6oasagH3yKrCS9UzUxCKQLvXibwMAqehPpxo0ywqknBqy6VbzBVZNVXlt+jvVECkI+6z8i1Uts3r9zlLvswJWoOAPA4F7GOvwY20EHFNrqA/kaq4CXrm21fWRa0r/VimjOPptHcXUFjNcDhdWLAmV6TBHmVt6GMWaKYoqWY0Iuso9ki52EpUSV0auKQWBn6XRfcPc3tqnVkT4LXSKlAXBf5LVKiO1UlKMLHwvWIkBCAmLqTv41DyTcZJAeOb9QmzCdVrjnAiRpyMD8jvV0tJZDmDinNSkVK5/WFK3Jf1c/uFwnTTKZm1tYU0MpaY8I+kNSIVWesNX5y2vTd8v1kJanJe6Kuk1p98j/xONlDKLpxtarl/7H0nh1kohT8oKVgVaukbPitikQigVTEplYa3luRCO9UIhxQ/STS6CTrKFU6oEsSZW35eur0SP0rVKK6lX3Up/B+OuW/m81cfxybgmqbW5Wpi56tal3/Gs58TSS4Wx3NdVwXeSskn3zVP38hTZzNJxLtyZAPQlmIH4i9y/VWEwHEFpi+lsD8t5C6W4ORCbwA7aa52qqvDek0M4yyFeDu0Czia0ebqAzjLfvrFDXihkmcLB4RNUwxzL5QJ5XoQNCutAcIACmsUSxaACKEYbMqUjiTM48gAARZYDnUGWa5iugc4yXwzGfBRw3BIjEAglLhEz1y/5YOg8lLBvbW2xFeLzApR357g1RRMOb2c8PtCL9MDTCqR5LNynxjnn3Z30wAnLWo68Kpl5TXsQD8DA0/01XY2mqaHQQUGjaTuQ0hiOxgzY6hzDwRrqeoGuZSulqgboOouyzLBcztGZFtWwxGLeYDyaoG5mvC7SNa9r4BygNK/5fD5HrjPuDVNVWHjWuKqqYKxF7Zu5ExGW8wWq4aBnOfaBzIgpZVqqX+P18111IZmMqxGzAC4TESghDQIRSEcKABYQTO/J7qMHZEmBMh3Y7XTCIwPrgw0SPSILZyKVREYKxrfmgLHQKoN1Ftp3giRC4Edwzp2qtXAuLJFVEy6V6KlQEX9f/r/qE65aByGkuGKRCCWAfLc8p7UOqH7akT0F6tL3pCP9ntRSkfelpr5gFPJcah2IFbQKEsbN+LT1k2pI0b7pOqXh4lWNtnqN6f/kOyRqsmryByvC9OeaDsFn0urW1fBsuobys2qtrWr41IJLc4PktasRC5lzem2phZhaN6vXcaJ1kqz1SXiYjDQdf9WFlZHeI1ECq995kkXyw46T7sv7Oc6FEFkdT2EDTppaxz4wnG349GEKh0P7NG7yyU7kfVBFPZNXXAMJMUonM9kc6WFLTVcRFAFI8wCdpqfpElN3ZTXq1MdHTPgRi0CsJzF7V98PxEOegqnynlUBJXkF8t0ptiHzWzXvV4Xnau1KKuiVUtDJWolwTpng0giTPJemvDOxdbayNk/TGKb0AWnxm1zbarh01Z141liNCslYfV8qnOX/6XtShvv0M1bnkX6fPHbOMSFXcr3ye9WtWcVPTprzn3khkrovqUbkWpQOw+EQdd1gsajRdYyyAwgbSIBHyd9INw6AnhZPCXZk4xIxAHtwcIDJZBIES3oApVgv7Y7Wtm0A8ogomNNieSwWiwDs5nmO+XzeywuQzSUbfD6fB+KZlCJSrKO0glOuqSiKMIfULRKwLt3AaRZpVVVB6wndobBvpfchzUWRtRDcYjqdRvcpKUjMsowjbNaGLn5KcctSYe9vWm5GrjV3sZPDJuA5wIz4eZ4z9WNiDWml4Ayv8Ww2w2KxgPZrspjPYU0ktpI9UNd1z/JbDf+mlm0q9FJrVvZNqkBS4bV60AGETnnpnks/T/ZBWhRaZHnIi4LpYy7yven3rSq4VeErrzmtQX8Ss+jUJkH0GMAMwJOznksydnAxnx80ztucLubz/cct59zu+/2h50KIAAARfck594mznoeMi/n84HHe5nQxn7MZ58KduRgX42L86R0XQuRiXIyL8SON8yREfvusJ7AyLubzg8d5m9PFfM5gnBtM5GJcjIvxp3OcJ0vkYlyMi/GncFwIkYtxMS7GjzTOXIgQ0V8hojtE9CYR/eYZzeFtInqNiL5KRF/yz20R0f9JRN/2vzdPeQ7/hIgeEdHXk+dOnAPx+G/9mv0REX38Oc3nt4jovl+nrxLRp5L//R0/nztE9AunMJ+bRPQZIvoGEb1ORH/LP3+Wa/SsOZ3ZOp3JOCkn/3n9ANAAvgPggwAKAF8D8JEzmMfbAHZWnvuvAPymf/ybAP7LU57DXwTwcQBf/0FzAPApAP8KXKT7SQBffE7z+S0A/9kJr/2Iv3clgNv+nur3eT5XAXzcP14D8Ib/3rNco2fN6czW6Sx+ztoS+QkAbzrnvuucawD8DoBPn/GcZHwawD/1j/8pgP/wNL/MOfdZAHs/5Bw+DeB/cDy+AGCDiK4+h/k8a3wawO8452rn3FsA3gTf2/dzPu865/6Nf3wM4JsAruNs1+hZc3rWOPV1Ootx1kLkOoB3kr/v4fvfhNMaDsD/QURfJqK/6Z+77Jx71z9+AODyGczrWXM4y3X7De8e/JPExXuu8yGiDwD4cQBfxDlZo5U5AedgnZ7XOGshcl7GX3DOfRzAXwXw60T0F9N/OrZFzzQWfh7mAOAfAngRwMcAvAvg7z/vCRDRGMA/B/C3nXNH6f/Oao1OmNOZr9PzHGctRO4DuJn8fcM/91yHc+6+//0IwP8CNjEfivnrfz963vP6PnM4k3Vzzj10zhnnnAXwjxBN8ecyHyLKwYf1nznn/oV/+kzX6KQ5nfU6Pe9x1kLkDwG8TES3iagA8CsAfvd5ToCIRkS0Jo8B/GUAX/fz+Bv+ZX8DwP/6POflx7Pm8LsAftVHID4J4DAx6U9trGAKfw28TjKfXyGikohuA3gZwKvv83cTgH8M4JvOuX+Q/OvM1uhZczrLdTqTcdbILhhFfwOMVP/dM/j+D4IR868BeF3mAGAbwP8F4NsAfh/A1inP438Cm74t2Ff+tWfNARxx+O/8mr0G4BPPaT7/o/++PwIfiKvJ6/+un88dAH/1FObzF8Cuyh8B+Kr/+dQZr9Gz5nRm63QWPxdp7xfjYlyMH2mctTtzMS7GxfhTPi6EyMW4GBfjRxoXQuRiXIyL8SONCyFyMS7GxfiRxoUQuRgX42L8SONCiFyMi3ExfqRxIUQuxsW4GD/S+P8Ae2Yc/gGaPKUAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import tensorflow as tf\n",
     "data = get_image_data()\n",
@@ -967,25 +413,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAC7CAYAAABrY1U1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsvWnMZdl61/d71lp7OsM7VHV19e3q7uvrEQtBEkCEEAQ45hqDEtlSJMIliYdrck1CjJljRMwQg0IiA4YkSmQkC/MhIL5ERopFgiySKDMOZMAk9vVwue57+3Z3De9b7xn23mvKh7XXPvucqr493Kqu6qrzSEfnfc/ZZ589rPOsZ/2f//N/JMbI0Y52tKMd7dk19aQP4GhHO9rRjvZ47ejoj3a0ox3tGbejoz/a0Y52tGfcjo7+aEc72tGecTs6+qMd7WhHe8bt6OiPdrSjHe0Zt8fm6EXkW0XkZ0Xk50XkBx7X9xztaB+mHcf10T6KJo+DRy8iGvg54JPA68A/AD4VY/wnj/zLjna0D8mO4/poH1V7XBH9rwd+Psb4izHGHvhbwLc9pu862tE+LDuO66N9JO1xOfpbwC9P/n99eO1oR/so23FcH+0jaeZJfbGIfAb4DEBZFL/2xo3zgy2+DKQUv+y7e59NyFQkRogxDp+NECNaQGsh+kiIcfxcjHHYZjxWlBJihBAiSgkAIUZEBEEQARGFDO/F4XMxxuH99LooIQ6vxxAIIQ7fkb9LDZ9P3x9CGN9TWqFE7TYGBMlHTYgRbz3OO9abLd4FRASj03GVZYFSiuA9iIzHB+B9AMAYTSQSfKTvLcZoRITeOpRSdG0/Xl2lFMSIKQx9b1EyXKMYhuOKk2OM472A3fG/2/3bbRv335Z0b3eXYvgjCgjjVUEghkiI8d2+9JHZdGwDv/bD+t6jPZ8W38PYflyO/gvAq5P/XxleGy3G+KPAjwK8cutm/AP/9r/GwfvDs5+8qiavp+fsbPNr+QHJSeaH9xHvA946QvCoYGmKwElT4FYe6zpCsAQiLniC80QfiINDnM1mVPUM7z192w0OWDDGYK1Fa40pC6ISTF1RVRV97yjLEu89dV0PE4YilAXKGEII3Lt9QQgOJJ2nYFBSYmOHhEjfdmijqKqC2WJOWZagzLAvjdYaFzwxRkIIrFdbXn/9i/zsz/0idVnjvaeZlTjX89JLL9I0Dc4FIGCtTddNFJvNBkGzPJkTo2e96rh9+x4npw1aFdxfbek6yy/8/Ot473HOcePGDfq+ZT6f8/btC6y1FEXBxcUFZVkSY2Q2m4EyXFxcEgJ478GDj+m6ipre33c2hSeQnHsg3fMYBK2LdA7DbkQi85lh1ihOT0rm84Z//P+99Z6+4z3Yu45r2B/bInIUkzraE7fH5ej/AfB1IvIJ0g/hdwO/5yvZYZxE3PuvPfgsInjvx4g1PQbnHUOKskXwITk75ywhBIwxBCJaDBQxbS9CCIGrqyvWm5a6rnHeMZvN2KzWbNZXzOdzlAjBeaQ0BOe4t9lQmYZCFdRljbUeYwyGSOh7YoSiLJjPG6zr2Ww2BGcJwaKkxwY7TEqOmZmhhlNXSiFaE2NEa53ONy0fEBHm8zmvvfYKhVH0rmO73XJ6espms+H87BytdZr4Qo9SM/q+pzAV86YmRqFpKpDArG7QCuaLihiEk9MFt2/f5hMff5k333yTplly69ZNrLXcvvMWL710xmq1ous6vvqrX6bveyR4FqcnxCjMKs3tO5fYPhJEEb1/4H5mm640dvdV0KbA2YBSgkgE0dRGISqw3Wz5qq96ia/9+AnzecWN81PqqgACn/vly69k6E3tkY/rox3tw7DH4uhjjE5E/l3gvwE08GMxxp/5cp85jMof9v77JQjtTQAxjtG3EPDeUwzBltYaYwy6kBTNhwBqOJaQHGpRFPiQHK1zjtVqxaxuEpzRWWLs0VpTqxkBaKqKbtuiJAIBVRhCcKy3Paau0CKYuqZpGuI2TTLWB1T0xOBw1hKjR0WoTEFZlqNjH88peFAKpdJkFGNAxDBfNJyfn4IS+r7DGJNWJGVDCAGlwTmF1ibtVxRlURBiRCmFNkJRFMQYqZuSvu9RYoBrlEVLb9csFgvOr52w3a5BzvEe5k2BtT0vvvgid+/e5fRkwenpki++8Sb377WczCpWRDZ9AA9IOLi/ce//fJ7GGAqlccP1j9ETo2NRFzSVoq4Vt37l1/CNv+JrOSnT6svENBkqEbQq3t/Aeefx9L7H9dGO9jTYY8PoY4w/Cfzk+9j+oa9PHcChMzj8/DSCn76eYY3gA1oplBiMRKpCqAtN7wJIwMcIShNFsF1PDIHoA1pr5vM5RVljreXmSy9w585det8RRdBlRQw9IXjWq/vUs4bt2nLt/AWcc8TgkChEBOd6ylhhtKbfbqgWC0L0eOsgJNio3bZEH4lYyqbBFCrh4QyObnJuRgQ3nGNpCtAF0QcWiwUowYdZTlRgdIl13ZBvaMbrYgZH2PVpBVGWJWqYU5pyQas3lFVFURTUZUtZpMh/sVjQtgXXrs3ZrluMMUD67m/8ho9jrSXiUNpy88Vr3H5ryz/5f3+OdWepakPfO0RMcshKjauwfK/z30VRYIzQX60pjKEykcVyztd8/AU+8YmPc362ZFaXKASCTt87YPgheAiPDj15v+P6aEd7GuyJJWPfyd6N1//lnP3DPp8dhlIKGTJ4Whs0AZEhgtUCWoGLRCWE4CnrBtdbtElYvLWWECVh4s5xfn5GZx0hKLbbLSfLJZvNBu89tuvx3nN574Lz69dAKdbrNc18PkbKhEiIga7rUEqlFYP3RKeBgFGG3vdoPTl+2c+5pOg2Ofmqqogx4pSg0RhTpgi9EIK3lEWNc4GqbFA6Dk4wEIMggEawLhCjHnIPmqqq0EpTFjVFYajrmhACN2/eQGtNWRnqpqRtW04WS4qiACJKQ1kWVFVJxAJn9Fa4c3tDWRWcSDkkrgPeqRGGCiE8cO9ijCwWC3zYcHZ+ytXlfV6+9TF+9a/6Bj72oqEuSowyOOfpe0tAUsQvKTejlCLE95YHONrRnlV76hw97KLz9LdwyNIY0XoRiNnxJ2gn4okhQRkCSFQJJik1IThEVEqyqpKoNFYUujIoI4jv03fb9PmirHC+J3iom3mCWaIQihTunp1W2LajbhpcdBQi+M2Wa6dnbFZrettyef8eKEPV1LSbDfW8ZrNdIUaDaMK2Q2udMHgfMKakqhf02w2FVhRFukVR6QTVAISA1gaUoreWxWKB9Q4iFAIuOkyp2W63EKCua5QStNGj84tBCBJQhUp5ihBwPuUgqqpM53d2Rt85RIMyBTpETk9T9C9D7oICClOhVdpPVeX3IRDQesZyUdB1Pa99zWv87C/8ItfOGmaLhot7wr07doBi/F4ULyFSasWtV17i6uqS09kMZ7d882/+TXzVqy9iDETvcb2ldV3627kEb8WIhIgGvLfvGjwc7WjPuj0ljv5BXP69/jgfwPajIsYUGeaINYRAsAHruvSZmHB5pT2otJ2KiqZpxkSut46+7zFa0XUdV5s19+5fJtZIaThdntD3LSLC6cmStneEqmExP4EYUZWjENj2HYtFw6xuWK1W2NYSfcC2Hc1iybbv0j5hhGeccwCUZYp8Y47o9QBDIRjZrVastYhWe3mMHB1rrcf95uslIiMen1cLMUaKohhZQkWRqJg5NxAFrFVIHKLkgXUkkvB8rRQhJApm2l8YcwpptQGuu8fZyYybN2+CFkqjcd0lnY1Y61mYmhDA2g5TG5qm4PLyTb7maz7B/Ttv8Bt+y2/k/HRBoTyEgHeR6AMSE7XUKA2TFV9mXL3v5M7RjvaM2VPi6Hf2Xhz8FLMPIe79n/ny3kcICaNNWHQk+IHeFyP4FsqIVyXKB3wU1psNWmu89+jsBHXBYllz7QWDMWqgMyr6PsEzShnuXa5HQnddVfR9z/L8GpvNioYT1qv7tO2G0igu7l0wq2b00lHXNbZvqaoqOffoh1yCZb5cIOJHCicEYhxgjmLn4Muy3MftfUBimsyqotzD9tPxpmcEZHDISKCsDKZYoHWCbpxzw/lHtDGEKEO+ISbmErt9aKUgxOE40+QS487Z5/tU6Miv/BVfz2zRoHRgfb7AWkvfG6yN2B4265bT0xOUgmtncz7+8ZssTxq+6p//lfhgkeiJzmPblhgVEtPEaCRdG+sTLTaEAD68K2P/aEd7HuwpcfTv/HOcYvKHk0AIAYlqZOmFEAgxHO4hYd8xooYMY/CeiML7Hm8dtkvwiSOgVYXRgnMW7z1dnxxeUWqaJiUki2qJiEYQlBTMZwVREnSwbVu891R1TVU1bLdryroCFC4ElsslRgyeSNd1e4nIHIHWdY0xCh9BdOLMRyElkovEvzclGFMBA1YvyeHFGFKdgBJE0sQkOkfgDMycXWHWNPmZcfJplA/JcWtJuYntphsnjAyxpSgenLPD98ro3LOj11qnlU2zoCg1oiNlWfLx115itVoRg+aNL95GS0ldG65dP2M+q/iGr/04dW1QDlQk1Ts4D0GNo6ZQemAdRYQAElEEgoRhpfcBh+XRjvaM2FPi6JNNmTPT1w7tnRKy6Uedo/q0ZM+QjvdudPhEjxZDjCCKFEn7kBgs7TYVBA14eFU1lGWJMYbNZsNld5+u+yJaF5ydX8c5h7WOclYnCuOQFG3bls36ildeeYXtdsvFnbtYa1kuFqy2G5qmYbPZMD9b4FxPUWj63lMUGjXASUVZYMoS0QpjFOgd+8Y6R2n0zuEOr2eHZ4zZsZB8SJNbCCNMZIaCprwtMEIymUJaFMW4vxBSMdTGBxSCHqqAlSiaqqbrN1RVtXc/8v852frCjWtsNw5TFIiKaFXziU/MsH2aHOezMjGHQs/Nmze58cJ1VPDQe7xNE693iZ20x7BSApIcvwpxd5/JENbR0x/t+banytF/OXsnx56d+fS18RHi3v/ee0J0CaNXBoWkpN2AJStioliGgAKstVhr2YpQFjXz+ZJFs8CHlrZtuf32F3j55Vewhab3ls36KkWvhQGJ3LhxnaurK9q2pWxmlA30XaIhRsCzi4gz1m2tHfHy2XyOjxFdmBQZGzOwSCKFMRQmMXW895ghas9mhsrb7Nh3UXbYKygDxtem1NQ8oeykGdIEmp1/Yivp8ZqnVUUkBtmbaKbvJ3aRRmmNKRTEkiIYYl3StlteufUiAOfLRYKk8j10WabBIgLO22GC260eMty0D+ulSeloR3ve7Slx9Lsf53vaeuKQAh4GfDYrPoxRKCFprEh6T0QgJK2YNrR4CQRVoY1DKY2PnkIUotWIdQdiYqXYlu0mwQ3bKGhTc+uV68nJGgNajVTA1WrF5eUlSl3D2oS3Z5kESMVR3nuid4QAWhtEKSRAUWrKpqbve6yPA1Y/OGlSDYACqqJOBUdDAVTwqRAMFYcANyJEQkyJ3aIocJ1DVFrdRDewXNDjtVeFIgZL9EIxTBSiZIRj+mgpmnLk3zMktUULKhT4ATKC3USRk8HWWogFZZnopd5FtAalCoJXSAXLek6hDSF2w7WJROfwNq3GhLziSMNWdJpUQsz3OyatGxSQzi8JJxztaM+3PdUdph7m+A+rJ6fbPAzyGbHbSeQcY3LYZVmO2zvnKMsKELQ2A667w6/73nL37l0uL66oTYHdtlxeXvL666+P0ITWmrt371KWJbduJVHD5XLJF7/4Re7evTs6yHv37o0O8PBRluUY2eeoOWPi00RphlnGYrAhKs/7ze8dwmF5f9PJclpUFsMuChdR4zXL1zlz/vPx7nB90FoNk0LOBeyOJ+0jppoFUjLXB4uzHd5bSm2YzxpMoQd5hHRPnHPj+U/PaXqvD6+hTjPIA+PjaEd7Xu0piej3f4zv5cf5blWyh47ee59UGyef7buOVhmWhUm8bxuHwiJHMBBRRN9TlTOEHttHQHHvrbc4PT2l6ztee/UWLjgUieGyXC4TZDIkha213Lp1KxVSWcvZ2RknJyes12tu3LhBZ/uEhw8OvigKrPfM5/MRfsgURzGp6rOZVYToRqgmO3M90cDJFM0YIxrB9zaJpPU9ZpKIFRVhgFu8G7R0RBEjKCWjOBkkOGicLH3YwTuRhJMP55thG2PMuHoxxoBP98VO8gZVYaiqCkVku1rv7pdNkXwcWFJ5HyN/H/DDZJLPJR9P9KnwKw7nf0Rvjva821MX0U9x3WwPi+LeUeYgZBnchClnp5W3CyGkBGrXj0nHKNk5CF1nqaoGY0qiJKikrmvKsmY+n9P3PV3bst1sqOuae/fucf/+fSREttstbdvS9t1QJcoYfSdNnI4ocH91Re8sLvhxJZBohv0Ykc5mM4wxw0pj52zzs7V2jymTbYrB522z08/RcfrOnWPMDjk72Sn8knMA+d5IZJSFACi0GZ3slImTP5NXG8YYitIgCiQGCq1oqpLZrCZ6Bz4lz5UIrrfjZ4FUI6ATs8jHkO6XMK5w8nePeP2QtFbGIFpz9PRHe97tKYnod7bPid+Had6JgTNdAEwnhZ1E8U61ctzOebZ9j6oFpWbY4IgkHH29XVHXNb0TEEPf91xdXXLz5sdYLpe07Yau60Zn6l2K1gulUzS+XBDCzhnmxOf5+Tld37NYLtFa0/U9s6YZHXxeeZR1NUbELvid0/ZhSB6ngqd8jlOxMwmREByaQU0zDDr1fn9SMaJQKlXiFoUZuPUD5z26AbuPIw0TBojEJOjIGJP2nyPpTGUcIBlT7DRs8rNEj1IF0bsR/rFth4qw3W7GlYUWNU5k+dbmVUqO6POEMv3/cDLM2xztaM+7PSUR/YNVsTmaO/wRP/DJuM+smX7+8L0pVp8VK7O2+nQl4b2nbVuqWYPzPc73LJdLNpsVRaEpZiXVoqZsSuq6xNqO9XqNUqmQqus63nzrrUGMK00UeaKa8tOnVEhgpw8f47gS6Pt+hHQOHRkwfna6vxyF5wg+TzQ7Jo1MnqdMnVTdCoPCpe9HZ5ohofydRunRycrEoU5ZMCPzZVK0la9JXdfIQIX0zqEGcbP82nBC4+fyhGaMGSesjP9P8wD5GHJi/ujoj3a0pzCih30+/fSHGh7q7LNs7a7SPUfy+8nItJ8cHWsJiBq6D4WADNz5oiiYNw02ePoQmV+/jut7br/xJlpSd6ZYGW7ceDHBNpdXLBYn+N7jbMdiliJk6vl4Dk3TACTxr9NTQkhiZicnJ7vjMUJjKnrfYyhH+GNWNyP0wiDElh4QXECiELoOVHas7CVbs6yv1ulZJDn0HFFDatZhTKIrRvEJnhkmy5wUzhW4ojMk49FGcM6jip0kQsbxs4xCGCYskcS9jzGynM1Zr9cpag8eb3tAgXc4n4qdvLfjxBKCGxuMZAqliKAGxpB1iTUlCFHl+y5J4EweFIM72tGeN3tKIvoH7WEY/HvZ/mHL+gfYGtGPDiOrRooI0Vl837Fa3U84eVUTh+5QL7zwAihBDc7n8vKSpmkoqnKEar7whS+kZKO1zGZJ0jiEwGq1wjnHcrlku92O3zuKcMEIh+SIdZQg2NOp0ShlsNaPFMMp/p7zD1OWCrC3igBGJz+NvMdEZtzx6Kdc+N0x7D4znZCnCeH8/rT5y+GKKUtI5Ei9bdsBDrPj90wx+GyHEfz0vmebVvcenfzRjvYURvSHDv2dMPtsUyf+UKc+mBzg/SmC9VgXWMct1+YnZLJl8JHLu3coZzWmrCnqBn2yxDRVglcGeEFEOD0/RwZGzMnJCSFAWSYH1bZJxyYzcTIWD8nZdl23SybqgjfffJOXh0raqqpGh5Xhj+y0jDGjvLHzHh8DwaUOWoFd8ZAxZphQ+hF6mTJziqLYu64iMhZsZQecmSt5mzwxTiGZEYOfJGHzc/5O5xx1mT67urrauzebzYaiKBE9QFiuoyimmHwqL5tOXOne7yb0fBxhKHYjJ46PRbFHO9rTG9FP7b1EZe80QUz3ISJotauaHJO1LmHSIkknXomgEQgR23YpalaSnKsxaHZ4u1IKPyg6rjctd+/eHZzlvgZ6jt4zj316TtnZJzlhtRcpTyPmfF4xRjz7E9uIa7OfhHwYdr7Pf9+Pzg+x/On7h/s/5NcfftfhvcirnenxpWPYMYf26LAH8Nt0X9P7N53o1UO+82hHe97tK3L0IvI5Efl/ROT/FJGfHl67JiJ/T0Q+Ozyfv9f9TSPLQ0dx6GgO3ztMwAIPRIDFBJvOkS0orHd0tqeoqyQOZgOg8NZiu557t++wWa05u3aNpmmYn5wiotmsW7QuCAFuvvQSt27dYnFyhlKKzXbFfD4nhMB2u6Wu6zFhewjbLBYLYhyqbrdbRNKkkuUGxusdB8etB9ojiRffti19P0TtkuiLWpKkQ2a4GGPGArG834dGw5OiIxHBKI1CdpXCE/mD6bZT55+veZSdLIGWRC/NbJp8n5OKcLpnfd/T9/3efcsTT+7ApSX9nVtuTyGaPCGFkDqDHU6o78ce9dg+2tGepD2KiP6bYoz/bIzx1w3//wDwUzHGrwN+avj/kVr+8U6Tjg9j3uTnqeNQSlEXhqoqOD8/H4uR2q7DlAWCQg/t+GzXURhD9IF2vWG7XtNuNohSXLt+HVUkoTMR4a07twnC6Ky1VlRVgUhkPm+AQFUV4zHnwqL5PCUm8/E1TTMe09jIe+Sx65Rk9EBMFMRciAUQBrz+cDVwuEp42PWZPjI+Pq02hTxx7j+UAqX2V11TTD3GOEJd+XjzceRcQq45UBq0kQei+SnjZjoJTaGjvM1UgwdS56yvwD70sX20oz0OexzQzbcBPz78/ePAt7+XD305bP4wKjuM6A8hjOlrwADPDJHvdjNGjqvVChHhhRde4Pr16/gQwBQUZU1R1eiiZL1e452j0IaLt+9QaMPl6opNl/D3+XzOdp2UG2WQ8s3R6Z07d2iahvV6nUTKZrOxeGg2m43slLZtx8Rn16XmKLnAKid0Ly8v6bpuV9Q0KFeaqhy6QlUPROV5P9kBZtw+xjg6zelKKH92moSdUhkPE90Z658mRkeGzUFS1ra7Bis5cZzurx45/l3X0fc9dTWjMBV1NUOrAqPLvXubbZq7yOcnAzavlBrlix+heuUHGttHO9qTtq/U0UfgvxWR/0NEPjO8djPG+Mbw95eAmw/7oIh8RkR+WkR+er3eHr43PocYd60DSRTA/JzVC6fwhhqwdYkkOl+GHKIQotB56Fwqp583DaUpuby84ktv38b3luXZglAErCSHVhcl0fmRKXP37l3YtlRAUxi0Fq69cD4ch6MsTRIZC5HV6v54XJeXV2idnP399YqoBDsUQ81mM3wUXICyrNNEsW130a9PiUzre0JwRG8R78BaGmMo9BDpDsnVzL4ZI+sgeBvQYiAkWuLUYXoiLk5gLm3GVUWIjkhS/dRGENFoXQy4+v79yvDTdDUAg85YoUFplCnwCFFpgij6vmVeN7iuR5kSXdWI0UQlIxxFjJRljVImPXRBRGGKgshupTbWI3hHINJHTxfcBy2MfSRj+wN98yO2P/bdv/VJH8LRnrB9pY7+N8UYfw3wO4DfLyK/efpmTN7koeFUjPFHY4y/Lsb46xK0sffe+Pc7sW3GpOQEvplG9rBjfkxleHMEuF6vRy73bDZjuVyy2qzZbrc452iahqqeoQpDVIlBA7BoZlhref3110f8PU0CGuf6FOXPlgia69dvcHFxMcoZZMe1aGaj3nvG1wGapmG73RJCoJqla5KZOX7onJSx6uAm3aLY4dmH+jd5HxlHHytwrdvBWj7sOeuksW8fSOACCBrv0r6T3vxORuFhK6/MuMn3IDOPMo20qqrU2xbGlcm0mvYwMZ2PI/cIyOec73nf93uyEGVZftCA/pGM7Q/0zY/YlsslP/hvffOTPoyjPUH7ihx9jPELw/NbwH8F/HrgTRH5GMDw/NZX8h3vlEw7xOR3UIDsTQB52+kkEEIYqYXe75zaYrEYHWaSCQ6gFcuzU/q+x/WWbttS1gmy+fznP8/p6WlqUN1tuH496c9nJknG4fOx3L9/f9S4b4dOVPP5nOUgiTDlt7dtO04GWeI4Y9dT/Zx8ztO/p9ckrQpSkVXG1UWGIrHIWDmbr+UUA5861ykMczhx5v+nqpYiSTBNKdA6KVdOj3Hn/DUewZgSY0qIak/z51CNsx0mvunKZbrPoijGz4zJ7A+QkP0wxvaHZSLCD/21n3rSh3G0J2gf2NGLyFxElvlv4FuAfwz8HeA7h82+E/iJ97vvQwd9SK07xJWzQ9rp2uwid9hnb+T/Ry64hr5vubq64v79+6yuLqjKJPrlnCNo4Wqz5uTsFEiOcb1e03vHa6+9xi989rMsFgvmiwWXVxcsT09wIXJ+/Rrz+ZwYI6vVakxaxiFpOK8bokuFQ5lymLbb4eYZT9+u12zXa6K3EBzedri+HXHt6WQoooHBWaukRz9Vk8yJ4Mz8SWJuSeFy6tRzVDylYQ73OiU74w7LV8rsTawZcsqPvF3f9yO0kyeFfpgMq1kzYuz5vKaSEjEIPkDTzNFlhYsQo+zlGnIiV0So63qnePk+sZvHObY/bPuj3/1NXF1d8Se/55v409/7ySd9OEd7QvaVRPQ3gf9RRP4v4H8H/usY498F/gLwSRH5LPDbhv8fqR0mYw8dPuzzrKcTQH4k/RhDjD414ogR13d427NZXxG8paqqUWRs23fUswbrHbpMLJEvfukNbt26xS/90i+NDi+tJixXV1dY61kuT/ewa2s7Zk1Fb9vUHER2XZ8Wi9RZqa7rpNIYk5DZKJ426NcopcYVwTTa1VojIVIojVEqCaANDjxDN2MydUgYTx30tDJ3WgA1LbQSmVAe3W4VkCPpvJ+xxmDSXzavoqbvFVU5iq7llcx2u2W5XI7QmtaaKIx1Bvtw1aCvTzqPDP1kuGrKwHkf9sTG9qO2w7H9Z7/3W570IR3tCdgHroyNMf4i8M885PU7wGMDBKfOehrVh6FtYDhgZkzZO6NmjESsjYgRjBaapsE7R6Wh3VxhZcXJ6Q3azqHqgqooaaqazWbDbLnAe892u+X8+jUuLy85Pz2lbR3n52d8/vOf5+bNm/R9m4qo1mvOzs6GY3TMZgsuLy+T9K7wmScqAAAgAElEQVQIQnJuYjRlOdG4mc1wvR0nCdslcbMI9D6gJUW7zjlms9kYOVsGqEbtKIc+DBrxSqEkVYuGECi0pneOYkhijrTKotxbUWTnKpJ6xMKEphmEyK7PbN7eWovRJWJkOI4iaeEbAyGODKDNOtUY+M7SdxalNMvlkqurq5FSGUPqn+u9B72baCQAJL1+6zrKshyvyVQ59P0mY5/U2H4c9rCx/ed/37fyJ/+Lv/ukD+1oH6J9JCpjs02d/MMStMBeRH/4ufx6jo5TZJgExrJeulFCcI57d29T1QXdNiVLe2fRhaFq6pHrniPIrC+zXm+Zz+dY23F2dgaQGDXec3FxQdM0XFxcpGMM6bMZx7fWjlFoPo+iKqmqiqoo95KOOULOSdzsoIuiGI8rJzyN0XtUx/x3jsBHTvqkm9aUOvmwJGtaIe0SoMJOT78s0yRRluWY+xjlFCbHnnMXs9kM2ClbNs0Owsl007Isx4lmrBkYJCXyxJhWX3YPtsmrkfcL3Twr9oc+/U3vOLb/3O//V/a2/TPf9238R3/8d/MX/sjvekJHe7THaU+doz+MxrPTeRCuYYjidxFqcoTpIUM7uxgDIXhcCPiYescGMtYPzoUx0XnRBWZnL7BcLnH9hou33yDajuh7CB6tJTX77iwf/6qvZrNu6TvHrFlQlob1+mqoQi25uLjPYjHDuX6MMpUyXLt2LTncwnD37l3q+Wzkwk8F0Lx1uN6ybrdgCoJK2HuMka7r6LotipA6RA3mYyCaAIUQGKiSgdTUwweii9je413E+nRNYoxjYw+t9VB1a4GAhDQRikyLrNLD+50zBjC6pCqbsZgrBgEJWNuNuZGqaYb7EEZNfELqFSBaUEbhvaNte+p6hqlqrl17AVEGY1SCvaqSYHuis6AUuigR0XStRSmTFEY7S2NKqqLck3F+3uwv/9jf/7Jj+4//m7+ZP/W9vx1gb2wf7dmzp87RH9ohtn4oc/Buf4+vhanAWXrOnZTyd5RlSdd1bDvLSzdfxrrEx3bOsdmkQqvlcokY4fa927z86suoQrHtEyXz9PR07NSktebtt99msViwWCy4ceMGn/3sZ1mtViMb5OTkhO12O0bNdV3vsV2stWM0m5PHU535+Xw+tgWMMY4SCRljTyc57QEre9cmR/bTJOwU6ppOslMoZBqZT5lA08jbGJPUPYeka942ryTyOYukdoXK7PD0Gy++iAzaP7139N6xXq9ZLBa0bTsycgqtWN2/xLueqjR46+i37R6ElFcsz6u9l7H97336m/fG9n/wh/7VJ33YR3vE9tQ7+umPdOqs8v8Ps4c5+5HyHOJA9Uv/5uTjSNlDMEXF5XrD8uw0RUADFbAuKy4vL6nrmu12S+8szXxGUIxMkbquuXv3LrPZjKZpWK1WVFXFYrFgNpuN9Mrs6KZ6NnVdM5vN9hgv+Yc6m83wA1yR+fg5+mdCHRURSlM8sBKaMo6y9s0hkyZV9+7L+2aIxVq7R2V82LXOXbe01my3W+5frgiB0bnbrsNM6JiqMKB32H6eIDbtFl0YWtuz2W5ZLJc0izmds5iqHD8Xg6OpDUagbzf07Sb1sh0S0CjBv8MYeV7sg47toz1b9lQ7+ndyKO8U2efnaWS6B/sMdMq878RYccO+PPhAVTa4CKaqR2ZLPZ9RVRV37tyhb5Mswc2bN1PCsDAjHl2WJW3b8uKLqSnJfD6nLEs2mw2bzYZXX30VEeGtt96i73s2m80YrecEZnbuUw759DoEhvMLgb5NcgnGGPSwAlATmuRei8EDBz6N3LNNe8NmZkx27lOBsLyymBakTeWPsyNPvXbL0fE3TbP3fSNfXw05gcKgC7Mn13B2djZ8t048exRKGYwpRwps3/fY3o/fP44PH/Lged9j71mw7/+u3/KBx/af+v5v5y/+me960qdwtEdkT4ejj++9ucjD4JlpZeR0273JYJKMlRHGCQMbZbJfJSxPzlmttzTzGbpMLfzquh4VKG+/9SWuLu+hFdy/uEdVFXtaLZvNhpdeemnUsMlc+aurK65du8aNGzfYbrd7MMxUIyezXLKSZYZXHqY5o5C9AqppVaknEga/OhUVy/z0Q758LjgCxiRntik9c7pKyEnRKUWzbdvhGDR11XB1lXIXVVGyvlpRmgJl9CjvXNc1pipHGCiEQFPVY0GXHXIcWYHTOZciUZJjr2ZNWgmpAlRaFRQ6yUmL3yXlnzd7FGP7L/6Z73jSp3G0R2BPh6M/sPfi8PPzwx6HUggpitxVc0Z2BT1TYSxQdF3Ppk3UyfV6PTJA7t+/T9M0vPrqq9y88eLQLKMYoZf5fD7u7/T0lNu3byOSElwvvfQS3ntOT0+5d+/e2Fgkyypk2uEUX7fWcnZ2Nk4USYMmOcWMxWf6Iwyc8hhR7Efr06KxHOVPdXDyhJGj8GndAbAX0ef95Mkpf3a6csjCa/n9y8tLyrIc2UnL5XKvKCwfw7TxtxnEyJIYXfr+xSJ18Wrbdic1rQpMUeFcwIZI2cxGmEgktS40Ax30ebRHNbZ/5M9++kmfytG+QnuqHP0eDTLGoUfsTsAsJ/RgRzX0MR4I50YCA7smxJGZE6IQ2NEOkxNMsr8xCFoXKB3wvifGBOfcePFlyqLC9o4QYLXZYr1jtdlSNfMUQQahb+1YhVnX9ejAr9YrosBqs6aZz1hvNyyWp9TNHCVmLO7JNMsQUrWnSOLU50rZTFdMPViH5KgpMWVFlNz8JBIlYdLZcQbPeG65Z+5ms0kTBJ7oberpOrme+JCc40CflCBEt4vWne8xhUKbxKoJ0aE0RO/x1hK9R6OY1zPazZpmVo/JWut7tl2LdR6tdk2+Y4yUejdpRYHeWZTRFHVF2dT0BKIS9JAz8N6DSw8zOPRSG0RXSFETdUlQBcrUiHo+Hf1f/rG//8jG9g//4Hfwwz94jO4/qvZUOfpDO4z6HmDSkFoE5se7nUyObqcRaY4urfMQ1Sj327btyHxZLpcUVTnKBs/nc5xzvPnmm+M+c6MQ5xzXr18nxsiNGzfG0v8Mi+QJAXY6Mzkq9t7uJWabptnD7afn4b2HkKpNY4xjE+4cgU+hnIy5w66F4a7x9k4j6BC/P1wZ5et1WH2cruUO39da0/c9s9lslF3O7JqqqkZmUo6+8z5yLUCGabTWGKWRCIWLxM4S2p7+ak3cdON9zJFrKo4KIAFTKIpSM1RVPbf2KMf2H/2hv/GEz+ZoH9SeakcPO5GuKZwzhWgkMj4I8QHoIW8/TQIqpdCTAiQ9OKAgitY6dFlRz2d88c0vjY707OyMmzdvjvtumoYbN27sVWKuVquRDRNCoK5mCInjHTxc3V/vOcuUnIxst+uxEMj7xMrZbDbj8WaMPmviKKXGQqy6rMZzdM6BBHywON/jg00SwyGMQmpKKebz+Z4swVTtMV+3qXOfTk5TEbOp009Od+g3Gz2RMJ5TnlQy22eaB8jboNWYy6iqKlUJR1Kls3Ws7l7Q3l9h11u0i2D9yPeP0Q99cVOtQ4yett2w3a5JkN1TP8wfmz3Ksf0f/sCn+E///Gfe/UuP9tTZU/ULyE59GkkeYu/T/6fVorvJQIa8q5CLew5p1Mk5JWnhHC33fc+smWN0Qd9ZqrLmhes3aNuWtu+IMdJZy3xo9J2Tp4vFIiUaq2qUO/bes1gsuHPnzgjNXF5ecnp6yuXl5RjJO+fQIpydnCDRE51HRdDEvWg8R7e5FeCIZZvU4cp2g/SvUkTn0QiF0miEyhRsNhsyRRMSfJMbmkxXTFM7ZO1M2UxTfH/6/iH2Pl1J5MlGZCf5nD+fk8T5HPP39n2P7y0XFxdJ014Jpi5RVUE5T9XJWRuormucc6MYWtM0VFWV9vWc8+gf9dj+qz/0e5/0aR3tfdpTVzZ4CB9M/95NAhM5A0nuPOPy78beSU7SEyN45zCVpiorjC7p+h5dlDTzGduuTU5EJ4dx7/JqZKdorUEpLi8v+djHPoYuDM6FAUZIDuratWuIsqNDfu211/De8/LLL++qNSVw584d2rYdSv/tCHEEYSwwylBGhmVG1UhkFETPkbj3boy6jTGsVqs9LrzOUsgq0m2242eV0Q9c+5ysy9daKTVKHOSJKn9eK8akcRZ3y5PDLvkbxm0S/OTwMTBbzBNVVANKEawbHVRZlpxeO0/icgONNZsOelwdxBhZVqnAynuPF4UqDOqDiZo9E/bHPvNJqrJ8LGP7P/nzv2+E3/6dH/jPxu/8sR/5IwB8+g/+xSd12kd7iD11jv7QDp12jsan7x1y5x/22RgjTGAgNbBbphNDZrhMNdBzJDpt7GGUggF6Wa9TojXTFkWE2WzGxcUFVV2Py968j2xlWbJar1gul7Rtu4fFK6VwfudkMyY/ZQrlcxrPMEQ8O9hlSo/MP2KYSAhPr+dBxPuwfEiGP6arrvy31ppg+zGxOr32+RgSPJRXXDsobQrr5FXEur9KK6Gmpi4rNpsNdV2Pn8sTV1mUo1JlZir5uC+RLCIfsO/IR98+rLH9V37oM+PYzhXSR3u67KmCbqZ2WCx16ECys8tsGx/jqN3yThF9hheKoqCszB6sAKCLisXJCcoYPJFNlyCG3O+1qiqKohh/MLnk//79+9TDwPfej45ns9mMPygRGbXjrbXcvXuXtm3ROjmuTDvMCdVp84/8gxw15CcwiWJHbzxMlk658nkVMa24zRz2acJ2x2zaTRijwzxw3lOJ5DSB5AnGjhWXOeqbTjrZoWen45wjSoJwVqsVTdOM8AtKmC3m4wqiqqokaxwCPkJnHQHBhYgyBVU9Q4Z2g6ao0Ob5djpPamz/8J/+zi93WEf7kO2pieiz/oyQZG99LmOfRO9xqHuaOnMVBh2bEIkh4oMgUUH0hCGaCzGgRBDxGMBohRJPVQ49SJXCB4uITsJYWjMzC2zRETz4KGi960va9/1Y6Zk1RO7duZ0aaDQ1SglKCTFq7l9eDnK8SaslF/sURYHrHO3WsdmuR6fXuxYVAuKTOFpywIbttsPIMEnN59iuJRRgSpMKj0QNKYnBGTuH0QqtVeIrhogPfuDhR1zXU80a1u2asmpGpw3DCoJIa3uasiKEiIqA1mOPVhigJZWqXrUYgguAEENqsBLz5BHAu7TvPGF1XTckj5OKZ6alVlLj26TKuV6vR6cjSlEYgx8mqjQ5pfPLOQ3nHELADBObKYudNPVzZH/40980Unef5Ng+2tNjT4ejHxJtkOEIlRxFzCqV+wnXhyVqx/diHPjdcSiBj+MkYkQhshNJy9FLLs2fVTWd6/A+YMoiNZ9WjInLrA1SVOXY7zU7lNXVJSEWKCMTRxgpSzMcL7TthrKsqUoDRNrtFUYLEmGzSsJodV0TvSIEi7eWsqgpiwJfJLxdRNhs0nMRA67vRgZOjBE7JNPy8XrvicGRmnoLua2gUokrn+QTFN4NUbrZVd4uFgu6zXYH0SiFOoBu7IC/x7CvKZQYUQlW8XrXurEoih2XP0a0UTvYJRdhDfdn6mzqoQNVcHHQ1RcIeVWxa8hihyrdokjaQGlV8uEO5ydtT8PY/uN/7sef7EU42p69K3QjIj8mIm+JyD+evHZNRP6eiHx2eD4fXhcR+asi8vMi8n+LyK95T0dxKIEQ97HzXTT/ICyzv00c6YRT2CFFNuxVS44KiMNyNcaI7VvKIdEZY8SFnWpjLu3Pn8lUx+ygcpLy6v79sepQIXTblu06iW1tVmuuLi9Y3b9is76iMJrV1SWb9RVlIWiB4Cyb1RV9u00TwHbFdrtlNpulRuTkxOm+Ln1OkOaIuWmaverVTJvLUArs2DOwkzjIFNUYI9H5kfGTIZesgQ/gup0ePux39cr/Z/bLFCbL9M7cMGVamQvQ2h50Sqa2tsdU5QhZZXpm/pxzduTqW9ch0Y9QUW5U8kTH9hOwJz22v+/f/2tP+Aoc7dDeC0b/14FvPXjtB4CfijF+HfBTw/8AvwP4uuHxGeA/f78HFIMMSbtUEZuc1cPFzGJMTBsfw/iII3MkRfMhBEKW+A0petGD2uSIDw8OJBfg5PLvsWhn0FjJkecUusisEnygUEkB0g80v81qRfQeoxTtZoPre+5fXHD/4i7b1RrfO15+6QaFhre+9AXu3n6Ti7tvs1ldUpuCwiiMEvpuy/3LeyzmDRIDhHQ+2cF1XaLIZZgi/1Czs8vnl5t4iEiCQbzDSFrah7hTkCy02UsAhwlckp04PuySem7XMDxj8RmOmWrsTKl746QRBds7nPUICq3M2DwFGHMLmWmUPw8ph5xzLtrIgDNrjFEJ/DMaJV+WdfPX+RDH9odh3/9d3/xEx/af+I//1hO+Akd7mL2ro48x/g/A3YOXvw3Ia7MfB7598vrfiMn+V+BMRD72rt9BHBJsEwmD0ZmPx/FAQvYQtsmv+cnfAkyrNo3a6clkHvZyuRyuRmrIkZkkWsxeFeE0yQmM0r75h5OjIKUU3SDslXHL/F5pNATh7u17bFZbPvdLX+DNL92lqReUZTUWNr3xxS9wcedOgm28xdoO37UIoJVQFgZiwDuL7TuCdxDDeFxTdUmlBVNoRMAYTRgmCiVC17UDpJX6yMK+GmWmM8YYx6hPJvTW4HaCbPlzWSMlyzHnSti8unLO7bE9ppz97JhysjYnBbM1TTNOSBmuKcqdPpAWtbeq8PGdK2M/jLH9YduTHtt/4vf+dv7Ap37Tkzr9o72DfVCM/maM8Y3h7y+RmikD3AJ+ebLd68Nrb/AeLYSYovq4DwHAgRZOCGOUePh6JDkxYtadV0TZleFnKd9cpNO2LSGEocBmoGD6QGkKqqUZk1TZCWWO97br0ZKa8BVlPbQcDGhjUBKwXTtG1tkRJuyz5M6de9y9c59ffv1t1usrrO0oSs2tWy/xK77x62nXSdp4u91ycn7OxeUlftthCk0x/Ihb249FQRlTFRh597m5eXbamc0yjfKywxyLm/K1HvD7vEoIIaC0Idgdm8b1dmT1TJk6mTXk/OAIwi4i30Fpaq8yNoutwU6wTURG3n1rU8/c3juss6MTsjatRpJzM9jtmt46yvnJmDt4n6Jmj21sP277/u/+lqdmbP8b3/KrHzq2f+J/+tyTvkzPpX3FydgYY5Tca+59mIh8hrQE5vR0AaghaRaIJOEykdRabvgeXEgSwzGEsWNUlj6QgZKjJQmgSYQoqfw9Rk9lNIWAioF5M2O1vRoUFQN1XaeoBg1RUTZDA44yRYc2etAGQbFuW5R4tl3L6fXz0Vl1XY8YzaJa0g6FSIVWbPuOru8oYkF7taEPlrXW3Fmt+MXPvk61FJbNktPFCUZFLm9/iX/4v13x6q1XOD9vuHjzCzRGc1bPeHO9RgXBtVsKgWgdNkQYqkmVBtGkhOXgwI0xqKGYqaobrA0UVUWkIyIYnYaA1hoX2FsNKdSYyCaCuKFdYYwEt6NLBuswGePXMlyTDlFFXmSMUXxumZidxFSBc9QACg7ndrILZVmiYmJkKdGU85KuW1OESGEEZSqc7RBnMVGIpkGrOgl6vf+hOdqjGNsfpn0UxvYnf9X1cWx73/Ejf/sffdiX6bm0D+ro3xSRj8UY3xiWr28Nr38BeHWy3SvDaw9YjPFHgR8FuPXyi3GaZE0RwoOyw7DPr4cdIydjySOGPMA2ioQvFlpRlwV1kaLUZiJpO1L11K4FX4YN8v7rKiUOT09P6bt10mOpk0iU5CTWIEWwWCxYr9eEHpQ4CmUIXXJsVuCzP/s6Pq549dVzzuYK2yuCV7S2hbLiqrP83C/+ErPa8DVf/XHe+NJbnJ+foxXYdovPkEdRjvh8M5slpoUyaF2MidDg4/iDz1Wrh03F88oI1BiZTwuzEuyiCcHhg8f1OzgnOj8m+BIe34+yD2rodJVzCdOoPUf1+Z5N9XZCDCNOn1cVu25b0K43FCapkW7bDgjUVTFGl7oqUIUZIMAd7PMe7ZGO7Q8yUXwQ+0Pf860fybH9Bz/1L/Ajf/N/+TAu0XNtH7Rg6u8AuSLiO4GfmLz+HQND4TcAl5Nl8LtaduzZmT/o/B+ugTOFbhLWDMSdOmVVlhilKLQBBn63GIgK23uCT82tRVLT7gwdZIc2ZXkolXDia9eujfBBbgG4PB3gAoGiKglRI6Ipi6E9W1Ss21R0cv18yckCTLQQe4KEoUm3pqhKosDF/S2f+6dfom07NpsVKni868fz7ft2EBLzY0I1s26KooC4qyKd5jCmCdEde8V92eudO3EF5/e0bvJ2uelK3keGZPKq4lBvf+ro80SRHxnjz68bY5BM+/SBWVXjrRsVF8uyJLoh8aw1pixSP9QYcF8Go38Heyxj+3HbR3lsH+3x27tG9CLyN4HfCrwgIq8Dfxr4C8DfFpHvAf4p8LuGzX8S+J3AzwMb4Lvfy0EICRNOP/w44dDHByJ4eDjNcqzSA0LwlFpQIlQGqkITiaNkrag4qiRm6YHMIc4Jp0wJHMu5JdB23V4j70IJKIUajqUoisQ97zq6bUtwwtnZGXdu30bpkour+/zTL9zlE5+omDeOoqjZtpG6gq53VCphzraNrASkKLm42rD52V/g1q2bfMNXv0YsI73rKUKFEOm3LVVV0W1TQw6tFK63WBxnZ6kZyvl8Ttu2dJ2lKIbJMBeK+RTJO+coVYK+cvVjwsT9XjI0s3dCCAnPl8h2u6Es6uQ0zE5jPvqAt26XjFV6zAdMcf28/Uj9mzQhyThzTthGIm+//Ta2W3N27QXOF0uiD1hnqYuaLgqYAkRhUHj/zvj8hzG2H7f9ke/5nUTcR3ps/55Pfj3/5d/7uSd1CZ8Le1dHH2P81Du89c0P2TYCv//9HkRkBxVMHfs00sxRx6Hff2AiGKRq68oQo6cuy1SUJCWQtMpjFOq6Ybvd7tgaww8iP7dty6xuRi5y1vDIFYBKKQLQDPi4tQNmLYGqTN2PbB8pjMEUK0w9x8sGJZGm2XJ21qD0DKs9ynoUFms3VGXD+spTFQJVSd9ZnA98/pff4KUXXqAo9/vhikjis+skGaBEEv996OiUch+pMtINmLhSCgV7DnWq+zON8iVGyiFhl6UN0omGMZI/WSxxfoDP2OnhTBPBSUhNjd81ZQSFQZ8mEkD2VwopBTHQ/9qOdttydnZGWV5j2/VsN91Aly1oNyvUbDlGnrnZyjuOuw9hbD9O+6O/93c+M2P7D3/qN/KX/ub//ESv57NsT5XWzYivs3MWsA8jHDJwppF9ilQ9RgUUntIIxngKHTEKlGaUrfXBoo2k7kikhhU+hpGZU5pEK/Nu13DaGEXX7Xq9ZuVEZdKStKgSG6ZsatCKxckcHwL1Yok3FW9crPn4azNunNc0ZYM2hkUDZ3PPreslr9xc4sTwM1/sOF/OaSpQ2hMQYij5mZ/9BTZ9wtP7vh+7O/lg8d6y3a7ptu0Ij8QoI28eGGmLkKCVDHtkQbFDKGysNrWWEIYJN0bc4BxijJghSs8TRN5/un+erBfv/Y6hkyt3p5P0lOI3Xcnlich1qd3i4mRJ7x19cCMP3BiDxMTdL4skflZqQ6H00Erw2bLv+87fxh/89CefubH9fZ/6DU/4yj679tT8CqZL94dBM/Bg9D7dbsrcMCZVwhIjvu9xLjmqQk311QMxhoFT7nEuMUJ0YUZYITuk3Kc0UwNFUsu+DCdkHDqfg/dJU6ZuSs7OzlBKcbXecrXaMJuBMSWgMVXJrFKczQx1GdF4+gDUZ8yaisJAMytTUUs944tvvDnyy0MIFHonB6xFRix+s9kcRNOGEHbFRZn3nKI1O17bvH0+/0xvhCyQtivGyhNBPu9ROnkSte/w/USF3W4TY2OEdoZHFljLxzHNw0wF2fJ21awhyk45M9/70hR7vO+RMvoQ+O+jbM/y2D7a47Gnw9HH/Qg9Com+FxLOmx/id44jxlSur0URY0BUxBDRQWGUxmih0IrSlMhQYTtivUrhQyTxcoZmGhH8doPrWiQmp9j7ls36KhXhOI+3AdcnzFrLTtWxNEVq66fNkMCaUVUNRTWnaBpOr7+QfiBVwbwxVLMlnQbre1wR8KGnKmeYs4p/9DO3+dqXFKI3/Ouf/l7+uV//L3G6qJjJHRbzc/77/+4f4mOkKIXegjI1qBKPAaXpejdq0IfggICPjjBIQ4QQ0ENCbmzMwf4k6m0qcY8+aem0my1GVdjO7q2uMme7KAaWS3SsLu7RrjdcXl6Bh27o8oQSiIGu3eKdHQu8gvPD99ixw1SezKqqAiVEgWrWoMsC5ywaIViQOBQGVQ16tiDOTohmujJJippZf+dZsWd5bB/t8djT4egnln+kUx2Ww/enNqUDisSkZEgunPJjQ5KchMrUsrIsUUMUKyFFlSE6ZCis6roOJamcPjmLQOrpusO1c6XoWIU5lPvnIp9cXp4gpcQmMVrjnU3yBjpx4pUUtLHn7trT9xUnS4upO775t/3L/NCf+yssr51AtcXZbojAFYIeGBaaPjNPYmQ+nzM/WcLwQzVlkeoPtCYA1nt65zBlSWdtit6MwcedZEKO3HLlY/p/aHXoOogOrSJaC8Fb7t25y+uf+wU2V5eUhUKrQKk8MaQGF/22x/c7Cmxm6FxdXY33c8rkyfmBvDLIxxNCwFTlWABU1XWaQFSauKLaXxHGGAk7AdRnwv7Ad33LMz22//B3/ItP9gI/o/Z0qFey/+OEfcVKeOfOUXH4IUsMGC2YRLsh4MY3tU5t9bz3RCUjBJCTUflHAUkLxBQKKPA+4n0/bj+bzfbK9qMI6/V6aGOXuiE5F8gKkVVT4npP0yTdF2OysJdDFxXtekOtFERDrzdcbAqir/mqlxVn5TV+8E98Fz//ubd58ewas+olmqYF3XD/asN8PqcyFdvtFjPw1QtdDU7SJ7iGiBJDXSfmSlVVo2447CpQs1RB/hFnh58eEWu7JHPsPWVlsH1Kytre05QNd966AzFydeeK7XZLVVUsFguWJ3GgATcAACAASURBVCeIaRGtiP8/e28eJFl2nff97vK2XGvpru6enh0zAAYLwQUEJVMWCYMiJYs2zQgHw3IIhGBKpMIgSBCERIoOBxeZIhTcKdqSqSAJSqatoEOSzbAVtkGFZEfQohEQJHEBMQAGs/VMT3dXdS2Z+fZ7r/+47758VbP1DGbpnq7TkVHVmVm5vHfueed+5zvfqUuk6lrqhaRqm55GGWoBQq2DemDq9EPVMaRJ5vncHU3QDTD/xg2E7KRXtjR02vpvJOTmNvDtU3vl7SYJ9MdXojEGBvLEPVTDswuzznnapBTS62RbTzXrynr+1YWfqCSEH7U3VGT02GYnu4ulqgqE8BmzlB5zjLsBy9Bh1NaRpilxdx9AnPqMyonuM+PANCB9l+g4TXHG0FSO6Vj2nZ+2ranqCpFGFLmlLnaJ7BZtDVnsOH9WI+sCqxzOWVoD1/YOOXtmG52u1QZDfSOvSiaTqeej68Tj43YtTxAUI9vW0yqtBSECvVHROgdOYp2gbozvNlaCJy49wdZ8C1N7meEoivjSl75EVdQ8/vjjuNYync6pTUuxXHD27FnOnj/HhTt2iNMIGXm4SWCRSnWBwSJl1BeDxUBpclhPEELQdjuBIKvctq2/gAho7XoQSjAn/ajF5/KvW9U+/P734TBveN8+tVfebpJAf7wLFjgW4F8wyEuBs47WGISwpJFEa0UURwg3KO6deEdrLWowc1UKgVRR3zkaRRFSaMLABuf868RxSmDthZb+oUKjF+EKDBSBtb4JZTzJ2N/fo9qZE52d0ZqGuqxxSCYxmMYRNZo/9Se32M4mNMpRNo75OIXUUkUVelfiCsVi6alzpnWgJEmUoXWEc16fRkhJ1dRIFZGMMpqmRWpFaw1KaJq2QeuYpmoBQWtNn8l5Tff1XFafYbfM53OMMXzx84+wu3uV3d1dnwmmMVq16CxFpQLdwObZGSpq+f3PfArhvprRKGXr7BY431AVS9kNgllz5ZVSfUNPONdDf9Ba4/oisSNK4h7OiSKPI3t6Zzija7jnjWJCutvCt0/tlbebCqN/LpjmJOZ6EsLppRGk53urSHq9F2s9JbA1SLfuCO2x4Hat5CdYzywNdL00TdDaj9oLuGZQZBx2lvbFQ+1XyFDJ0UnfbZikMffddx9ntrZZrQqkULSNh1eEVFjXkOoEZRzveGiHRKbIaIRQkKSSJEtwwvcF9DUMpYnThCwd992wriu0tW3LaDQ6tjAD5j2c/xnGFQZqZa8gKb3kb9zxqJ1zzCdTvvCFL/Dww39Eni/Z2p6zMcuYb4zYOTdn60zCZKbY3BkxmkqmmzEXL27zhc9/lrq25CsvlmU6UbTh8Q/nOQSV8HtgDimlkNpTRtM0BTgWxG0nw6CCoFf399baY7uEW91uF98G+G/+2nc832E4tZdhN8Uq8BPw1qMCsc/mdA+zOw81CKyRCNOxb/Aj0bRwSOcQrUVYL4zmx9t1hb1usEZjW2rTUJsGI8AIPGTRtLi2ZbVagXUUhZ/8hPSFzThN+mAaKI1CCGzj+qxSSk+BM7WjqhqMs2SzlHd//deyWypoW6IoQ6UzpDMIFaNdxdvvL5ixYGFXVGWOloYsjqiKCuUihJIc1TVtG6+DW6TJ0jFI7dUFZUQcp5jWYfAyCWk8RomYOB7hnMI5hTEOpaJjNydAKE2UpBBFkKS0rSWKR/zv/8v/wdHlPb767ffzlnfMuXiP5i33b3H3+ZbpTswqr9k+v8V4DmfvmLG9vcWb3rTNg/ed5fOPPkzbWtqyQliHFn6EY6zi9YVHrYfBDPn4PT2zMYhOgtgJgZNr+qSKtJ85i+1F2XqJhdbwRqjGfv8Hv/m28W3wu5WP/43//HU95m8kuykCPTy3tny4/7meAz6LR66pYEM7CQGEWwgiYeDx8PkhMwqYtzHH4SPfHbqeuhQExYadpUOoIHDAw33T6Zj9vUPqukYrixSW1jrqxpAXFarbXksZIYQiiVOMcWAsTeN1S5qmxVqDULLfhoeCahguETDXnkcO/dSl5zouw+84/JtYec2URx55lCLfZ2t7zGQ6Io494yKKFVGaYIzj+tEKLWpmacwoSamdH3Iym01wtqshwDGd/Oc8pyd6KYbndXjfsKA89JPhRWL4+BvJ3ui+DfS+fWqvjN1UgR6CEz8bVz3OuFk/LqVA4RDO+kIsHAsEzlkE68aaflhCa0ijuO+gDDrrsG7oCVBC0AgJRa6wQKLID5+uqqpvVhp2mFrrVSO3t7eZTCZcvHiRr3/Pn+by7hHTBJr8kCybEyUTUCNUOqN2EUUtMFayWlXYxqKIKfOS2krqxgfKOEt7wTLj/LZ7NBqRjUfs7e0NOh71mvc+YNQEfDcEXb+o1lr11jjiOKbIW648dZW3PXSOnfOK2eaMKFYkqUBpixBw9eoRu0tBUeyylaVoBaMNiZEt40nM2956L0bI9e6ha8AxuF6S4aRsQqAKhvMZLj5rdVJ5TPwsPG944ep3gG+AYuzt5Ns/8dFv73371F4ZuzkCfQfZDANPL1Imns2N9mYBPx5QYImlJNYK6fC3znml8MNHhHBEseoznbZte52PgAtb19J2lLMQ8JIk6bHNwB0OnZrB+UPnYNu2FEWxxo6tf4+yLBHSoiP42q//Oj77aM6jf3yJc5lmtVpRNw1GQm0dKhnhdIJWEWkUU5cVR0dL2gau7RVsb29T1QWz+ZzJbNovyq2trf5zzeebXWCUuG4+bgjuAZdVUmNaizUOz0+RREnCaDLxv0cRi8WCS5eeYf/qAeOkBLfiaLGP1pCkmij23+nRRw+4eijZXY4xcYKOHNMkQmcxo4ngzEbM4fIQpTRC6T5IBJXNHoIJWSJeFz/ckJK2bQh0wuHgkmPMnK4OEXykx6xvcejmw+9/323n2//1z/zPJ5K7U/ty7OYI9Dxbohie3Q5/fJvub1JCrCWRlv3AEue8AqY1zSAD6WR4O4pYEMqC9QUmFPCCM7etOXFxoe/eDC3/gX9e13X/mlLKXrI3FM6UEiSpJjub8TXveR95mVGuaubTjLbKGY8zwFKWObGWCBzWNEipyWvLorTktUEiyFLdDwAZTyfEcczlK8/0tEkdRegkPtagFAJiKNKFxR6+w1pbaJ0xPvrIY+wvFownCc5atByjVBdUG9+Ek44yliVEesxP/txv8mM/+3NsbW2gGo+dN6ZFiMbjsl1AybIRYeQg0OPyQxtm+UPIIOish96B4BfD7zM8X1LKWz6jv918+yM/+gkAfuhv/eZrfKTfuHZTBHp3gl5prTm2yIfB3t+3dlKN13mReBhhbaGr0oENjIT13NJQ+ZVC9DetZc80CYFmyEv24l7rjDFQ+6IoIkmS/vMGmd+yzPsZsHVd0poSKeFr3vMu7v/a9/L7TxzCquTi2bNoY3BNjUZAZdEtNIXjmd2cRT3iyV3D5tZZlLC8+YE3IcRaA8Zay3w+98W0Lmi2rUXHXk9cq4g4SpBCUZU1bWN6xcLwHb1ioeuDbhKltG3LwaqmZkEUp+h0TJx5dWLpYqwRVFVBOoa2XPCD3/dd/He/+PNe00b6XYPTCVKCrVY0xuvuREkMSoJca6oEfPkkthweC7UIH6j8BawxxncHa43UmnYQyIYXh1s9o7/dfPvUXnm7SXj0a3POHgv6z8W+8YU9gxCgxICTLZzvkmXN1pBYhMQrPdI1Bsn1qgk8br/tb7AW4kgh5XrIdZqmSL2W2x1efGyXLdO9Zyh6OucbT5xbD8Qej8eURcNkanjg3e8g3YxZ/OH/zdVLTzPdnPXzXpvGEcURy0VBWSqu7eXkbUqqHTjDhXM7vWYJAFJ4mQFjGI2n/fcKW+7QfBZa5UPx9qSMMFb02K1EdbICCTpxOCEw0qKkw49qVDirQFmkhjiGe88Zrn7pc2TjOblaIeoEoWMiAdglsIaRfEYOSgfu/LOz7pDlex369fCUcL/v1gwSDeYYfj0MTre63W6+fWqvvN00gX4dyH1CYpyltb7Q6Pp/IeMQeNa0BRxOWAwG6QSC0AXaFXK6du61zrmnjiEipPSOauoK6RxaRuAsri0plw20LSqJaZuSNBt12afPLLEO67zmisURo2mdJZIRzoljgTRNE/I8Z7UsmG1usFw6XFFx/31vxt11J9evXOPffOr3uPzkY9xz90WatuCp3UPqNuHRp1bIaMpkrFH1Ne64sMV0Y9p3iNZ1jXC+cUUIgdKikx+2CAdNVTOdTqnbBoHASUHroKirHgYRWuGAUZThnMHGMV/8wmMcHVbEWuPKCdIdoBE40yKMpjGOOHYYE/HWixv8v7sHpJED2dK0K7JIkusWSYUta/aPDhHCECUKncWECXsW42fB+uuMh5aE6uozdF2fDttKpFrDOUMcPsBRPkD5HUfTGHBeqvlWhm4+8sFvuq18+6f+/v/2Oh7tN67dVIH+mOQBz98wJYQA553RyW7Rd2t5jeOvC0rQPWw7bZBu6Lg19AEF66hq33EqIy/KBL5DcDweH3v/gFHqOKIsSy8sFXmt77Is/fNwSOmDT1EUTCYTiqLg+rVdZrMZrjW0dU1tLNPNM3zDN/1ZTFvz7z7zGT79e79LWxnyGu669wF27riLumrQzRbGVCjlt+Kh+BiGSiilfMdkh6VWVdU/Nh6PMR0XuuwarMI2Phw3JwSu9TNm9/cOcNYfg6Plkro2TKzFWf89m1VBWzeMxhlnz87ZOVuTxTFR5APNapmj4jlNW0AjOX/+PDrWqEivYQd8EBciMGbWAlpDzN7vRlS321sLnw2hhuPMmxZjjjNUblW73Xz71F4du5FRgr8GfCtw1Tn3ju6+HwP+CnCte9qPOOf+WffY3wC+CzDA9znn/s8X/RTueFdsv4Bt16jRPacbReW3450ErZYgccS9xrntF3jY0nefq4cNPITgJxqFOGCFhwgMBmccAkNerlBR0o1mS2FQ/AuZZKQ1SIl1LXUTcFKBdKClD75lWVKXFbY1/VDmKIo8V9kKnNZEcYYG3vMN38LX/QffSrlckJcF1jUURUFRrNh96hr56gghXSdOpnq9+GGhTUnJ0dGRP8FaI6aekVJWddfKnqJifTzIO4dS0HTBHBRSJGSZ42oNziTUq0PaSKOziCxLME1Fna/Y2Rrx5jtTkshhO/gn0hlNVaJlTFnDXXdfJMuyTl1xSJ1bny+t4v67nCyqhotOOP5D7Xyg54C3pkYYcK7t9HyerXj6mvr2l2lvdN/+0Md+EYDv/8A3k6+OXu3DedvajWT0nwB+GfgHJ+7/eefczwzvEEK8DfjPgLcDdwC/I4R4s+v3ms9vw6xi+P/jz+kWrfPUSoclihIi6betUkqEseDWWWLApumcd731Xwt9hUVjTNOp+9EVMkfg5DGestbxOoukU1tsW0SnwxLHMUVV9eJhZVkymUzI87wvJFZVRZqmTCYT6rLwz6trTOu/j3KSVhiSUYLET4Caz+coK3nqiZzlcslWN7w5MCUCluo7TdeBNEkS38SiNc5YVquVHw7RZXyhuSoUOk23k7IGP4NVWESUYIG2KUiyLaTWLPIVkVIoFdPaiofefA6JoagaX2RtBUkSka8q/uCzX+Ir3nMvOo48dBTUKoUjcPellNhBsAnZawg6xh7H24f1hdCq77tDPXxljA9KL8LF/gSvgW9/OebZUm9c3/6VX/wYQgj+yvf99Kt5GG97u5GZsf+PEOLeG3y9bwP+kXOuAh4VQnwReA/wr17wPZ5DpjjYSUw2tGILi9fTxoL1gmaCdWAImX+/dbcWHVgdTkBYn10hsBfWUqKTy1U0tUFr4RtOYuuHOjQtSNeN4NNgDRLn5XOlpHJecycEmLZtuX79utdP7+a4Simpy4qmWSJsw2g8wZoChAQniCJNqjVlXrFclEgUQig++/DnePP995DGCc6pnsc8Ho9ZLBb9zzNndtBS9QOhJ0JyeHhIpGM/VET67wdQVU3Hl46RWmDyFh1JoliBjEhKyXxjh73lNaItyzzSVKYmSTXOaJoqx2lB5HJMm2FEDMbhWsuyqnn8set8xbv/NOcv3olOBVILrADhjL9wYxD4SVeum5IUqKCBcWOtxSmDYx3MxADOCBerft6pAa3BWocQ8nnFK18L3/5y7KPf9c1g2ze0b3/vX//FV+vwndrAvhx65fcKIX5fCPFrQojN7r6LwJOD51zq7nuWCSG+WwjxaSHEp4uiehbDRjie+xZgBi36rNB3x4pe62N4YRhyrUNDjg8gx3n5XurWy/aCH4AsQ7FSCPI87zOXuq774RlFUVCWJcY0KOWLis4Z6jIHa0njmI3ZDAnkyyXL5bKXhk3SiNrAwXIFOkJoRWsbhDC0lWM6mTOZjpHKsVhe5+6778Y54Xcx2i+sLMt6nvxkMuHM1jZN5eEc0/huyrqu0UKyv7/PfD6nzIueUheOQcDFtdaUZY7EUFU5GsfG1lmevrqgMrBaHOKcn1FrnUQnM6yTKBlj7ITVStDUElsprl223H//u5htX0SPPK2y588r2Z/PwP/2tRfvkkPBtfAz3MI5e3YPAEihu+xe9dTN19O3X86br1/nje/bf+9nf+DLOUSndoP2cgP93wXeBHwlcBn42Zf6As65X3HOvds59+4sS54N3Qj6MXIepHH+0yqLEAaNIxUSJbttrFTYXn7cQzuBfShYdww2TUPdlN0TLUmkGKWa2SjpCpQRcRdEpXP9pCXwwac1NarjKgf62lDa1Rloa4MScZ/5FFVFay3j6ZQzZ854GEWAjhKm0ynjbEQiNcr62VF5njOdTvsFVzU1KtJsTP0wj8lszCo/7OsZdV2jVERRVAidEKUZcZqSjkZk2YiqaTEOtra2QArSUYJrDaITtgrb+9YYlIop84b5dMJ8pqGpGcmGUp3l+mIbQUJ5UJAaQaYtQkGUnKWVEkfOWBpSJ1ksFmRbF4inW8w3UsZZShQpjGkQ1qsuSq2QQuNs1xmLQ0vbt+YPpRuEcH1mmiYj0mTUt8kHjZ8A7WitiSKN1l6P/SXaK+rbL/Vvg330g99yW/j2X/3Bn3+5h+jUXoK9LNaNc+5K+F0I8feBwIl6Crhr8NQ7u/te5AWfXYwNvw+Dv58WZJHSoUMbvG37QdGim5QZLGxv5YDREfDcoJo4HFiNjDsHFzSmJc1iBF5zxbDOMoOTB865ijRtF2icEz17IcnSTh3Q89eD8FjoPizrCmcsk8mkz67DezjnGGcZVVF4zjyCbDLpm1ZCJleWpedCS98QU9d1z6TwjVMtm5ubNE3DcrlkvrnRDfpWnXyt7rP5QJ2TEkaTsWfrTFOO8hWr4g6+9Ll/RxorkghMBGMVIU1DLCPaRtA0hqt7BUerlgcefIidO+4mzcboJPbic4i+ySuc32HWHs6XEB0u3+HwPhh5Wi3QD6yGgUrloAP0ZNb7UuwV9+2XabeDb7//L//4q3X4Tu2EvaxAL4S44Jy73P3324E/7H7/beB/FEL8HL5g9SDwqRt93X77zjrIP2u76izC+ezeOdNziJ9rOT8XvU7r9XALY7zzeuzTUzbj2OPaceqdN028uJMbLJzw2mnHIinrilhHfcAJQShojiRJ4vHNOAZrUVpTliWjyRis67PXMPfVL4bQAOTQWrK5Oedo/wAhBFVV98+dTCYEXRtrLXGWouLIb7vrhiTxPOdQIBtu9X2AV31Bzkv6AlIQxxrnEtLJiGmbofUGVX7ApWce5ezZGWXrKPKKVDoS5YiSGdf3FxwsWt70lq9k+/x5xpMxyWiM1AFOWLflh3MzLCL2jA/WVMl1Ru+7fY0xPTtnKJPgz+e6aWr4Hi/FXi3ffql2O/j2qb12diP0yv8J+EbgjBDiEvCjwDcKIb4Sn2Y9BnwPgHPuj4QQvwV8FmiBD90Q44bjQX3Yxn4syOMn5yRaEWkI2/LQVLPmWHev2/0euL8hYwm4bQh24b2MqTpcVBIGIfTt4l1HaSgSNk2D6jpM4zhGCb/IQsdhrxLYZdVp91yJx8yFUv0c1tFoxGKx6DPV0WjEYpVT1zXT8YSqKPsMVwjRUyrDQOjlcslkMuuy35q9vQXz+SZKWVrjs6nFYsFsNvP64R2u748RNE3lcW10v5iNEIziiGiUYvMFd9yhOXfxfcha8sTjX+Lq1Wd45uAaylnuueceZuc3efO9Ce9MJ1ghSeIUGYHUAqEFTdOSRvpZF+/A9gnnxlqL6AJLeNx/ToMnmMi+0/fkzm9IOxzuFJ6vYeq18O2XYx/7rj/D7eDbv/XrP87u7i7/5V/7O6/GYTy1gd0I6+YvPMfdv/oCz/9J4Cdf7gcaQjjD+5xzKCmQ+KzeOZDKQxphISivC4B1fqsfshApjhf0Qha4pvn5x5I47YuFjWn7baoQAtsFkSDqJKWfwAM+k3T4lnwfQC3gZX9xfuxdVVVkWYZzjjNnztAMMOW6rsmyjDzPOTo66rMfrGNv30sOH17fR2vNcrnsFxzA4eEhWZYBcO3aNbbPnCHREcvDI3Z2djg8PCQZJ704VZKlLLvC2ebm5nFNGNcNl458MNBxBCiUTHHKoKRAiIZ77r/AHfee8d9fKk/htNbTLSXEApQwqCj13O3WEMcJ1qyldofnNnS1Di0MBQ8XBSnp/y/FWlHxJEQTzlGAcHzwf15fe019+0bNOXdb+fapvfp2U3XGnsTkh52P0IlcOYsUAoRX8wPnaXTWYYXFWU/PUWrdDCSEQA0EwMA34DgnEFJ1g8U9K8EY32iTpGn/3lEUoTt97vBZpZS03ZAPB30mNB6PsbbtIQcpPbsk4OgBK9dao7sGk9BSPp/PSdOU69evE0VJn5EFbfH9/X1gPZQhYNJ+aITzc107nHRra4uD6/75ZVkynU57XZI4jtnZ2cE5R5ylfccj3fewViKSGCkFaaTJK+W58ViMbmhMhZOOdOwD78bmiLq1YDxXWgiBcGBc65tugLY5rhsffoYMPzBGnHM01vU7mOGFYIjlDzPScE6GGX74KYR46eXY19uE56TfDr79PR/9hdf00N6udlMGeqB3hJ421205w+8Kg7Ettsdzw5hBgZCSoICplIauiDSk2wWmR5AICMW8IMcatr4hM6o6uYGgox4mORkTMl/PDLly5QqjUdp1CdJTIJuyRAjBKM0oS8+MSEej/vW11j2c4gduOAK7oihXfWt6kiQsKo+nenZJp0+C55MfHezTNIY9s4tSUT/gOWTIw595nhM160k+CgF9cdN4Hn6dk47HFG2OMIbGJaRx0LQXWNsiWohp0XGCihLq1iCkIJaS1tTd91PAGrIZwgzhfK/PtTp2/D2EI9cNQp2FC8VJMa7wWM87v4Xsox/8FhTNbePbp/ba2M0R6N1xqCaME/OUSgHWu3zsHEKEYAEK6WdNCYvnXlq0Aq/bLRFiPTlHCo0U/jnO+e7asKOvjQ8gtq4oTIPUCuscUZqQdAUu27ZoKXFtS9FlP+AzImEdxvru01GaIZEooZFaMJ3OPc+9y3h2d68SRQnj8Zij63tcuHgni8UChGB/b4/pdIoSgoNOwsC1fjZnUzcIqX0vjNMkSUy+LLBNiylbdJKyXOSAJMtiNjc32dvbYzTaoDZeMsEJ/3mLomA0nZBNxvjD5499I/x2PY4j6tphmhaHpjE5SSRx2hENGLnWWhKddoFm4kfBmBYhQCnpz5EMU6B8MTYE5F6DXslekVHJdbHWuRAIQuem/79nkHgJXvAXBecc1jlEV7h0OIRd4zW3UtnPdY1kt4Nvf89Hf+m1PLS3td0cgZ7nlkAIi9Y5h6Sr1ktx7DmE7atUdDQFYE27C1tSIR3GNv37WWsxzi8CLQWNbRHSoSOf9WSjhLq1FHXVa3iExRN3eGTY0vaskK5RKYpT6qZE2oi2XbG5uUlVVUwmM2azBq1jDg8Pmc1m7O/vk6YpR0dHzOdzAFarFVL6blZhfVt5mADkg6/BGc+nHo1GXQOSRmmNsd3Mz6YmHWVIrUgjr9cep4nPuKyjreoe2w8a40ONmYCHB1jFD7ew/fcOzUpr9s5af0acCMJ9pnmi7iKEwD7PLm7IxhnaEO4ZvtZJfZzjf3frhPrbybdP7bWzmy7QP+t3nk0v84FkvUUXJ4LBMNjAgIZ34jX6NvJuaxzHMVIodOKdny4bCtzg8HdlWXrdj6LoVSDDZw7b5NFoRFH6LsPABfcLYNLLDgSucnj+wcFBHzyDbvwkm1CWpYdZogjTtGRJitbd9ltbTFkSpQkqjhglE65du8Z8Pmc+22S1XBFFMdlY9XQ4267pbUOlyJBpw3GdGGs9pXUYtNfnYX2Mw8Xi5OMBUnmu5zu3hlxOiqz5n8/9Widhmee6KJz8jLeC3U6+fWqvnd00Rzss1HCTCIyzfRbjnEEqukKUz2R6+lwHCUis10nAQzuhcQT8cIZA1xv+DM7rjKG2AucqVFNikUynU5rG9pOYoq4hSUVRTz0LiyXgzlJ6qQEvtSxZrVYURUEcx0yn034BLhYLlBLMNjYpy5LDQ9/pmmVZ34YegqtXGEw4PNxHAKap2d87Qscxq8Uhs+kGUkry1QKbjNje3u4m/9Qd1uq/Y9s0rBZLr1kOVK5Ex34xN9Z0olYhq15rq0RRhG19wTdS+li2LRG0xlK2ed+GH7L9EPSHQVlKP482NNiYQVAbUiQhCJdFx3YLYYcRglmw8B7rQiHd93C3UkJPGHx/O/j2r/3CD/JffOQlNx6f2suwmyLQO/BQhOs0bgDXDRXxPGjbcaG7LToWBowLay3SgVCefhmyGyEEzvrRg1IPdE+cpDFd4IF+cYTAIYSA1lIXJUJHfSGp6QqZkVQIpVFS9cUnz0BwlEXOaDTyDJQ0YmNjxng8ZrlckiR+LFtZ1l0mLbl27RobGxt9e39oXAldjquyIOoaXIwxWNNgqpozW9sIJSlWOYcH1zlz9hy2NRjV0kqJVoqqLD1nvvCfMRmP+uzcdNvyuqw8botDlxeHpgAAIABJREFUa4//hmMaRTHGeHkBKXyx1zTrAp8Qov+cSupjBVAvoyyOQUKtC3z5rvaCRJzgwgcLkNAQKlrDSGsGz8ld4LAgOyzc3ipm7e3j26dB/rWzm2olnFyoOD+9Xlh/AQDPnfet++uPrlgHlKB7El5r3ZzT9ba4ABl4CpqzAmu8AFhTdfh13aAkuE5uIM/zfsiHMYaqqiiKoh+a7PVmKpqm7ihsDUWRUy6XVKsVe1euID1Ngd3dXaqq6hfAzs5OLx51eHjYZ04huE0mk05N0Cs61nUJWPb29lgdHmDqhu3ZBge719i9chXXWuqiItFeRVJ2rIxYR+TLJc6YvgM2BPuQZa9prZ4yF2bJeqbE+vwECYbAww687XALwWUIIYT3OAn9rDPXtcpi+NthyzysefRDnD5Q+E5CP0N441ZJ6D/ywW+6rXz713/5r79OR/r2s5sio2ewzVzf1fG6u5mwgQ8ccF3XTSKRUuI63rXDMzeG2V34m3ALKk1xlPhdg7E4ZzBtKEAakiTr+eYSH2yFEL3mh5SKNE37z+zhEQ8nBWxSCEFZ5T300Zqaqi6IswmTyaRrXlH954rj2E+BMoayLD0P3a6Ln875NvOqcBjjF/1Tu1fZ3jjD/t51ds6fYzSdsVwuGY1GXL9+vQ+kuit+2a7pKMAvxhiUtcQ6wXSQQOiADBr2QThMa91dZPy5KcuyzxTbtkUo2V8YwHP3A/VzWHgdUiTDZxjy6kMQDxm9UrrvmB1i88OC7DC7XxeCh/LWt0aovx19+9ReG7s5Aj2+EUQqgTWuc9jAvJBI6VAMMMmOrhe49QK82JmQQecSoNNYEUitQGqc0kgRMGTPJbe0OGvRscI5iXM1RZUjEdTNkrox1FKTpWO08hzjvF5RVWXPER4yVUL3oZQSSs9VbhuLwFHZBhUb6toHyXy1QkiJ6xZA3WW3SimIIkY66xpdDJubmywOFuC8BvzyYJ/ZOKEpckY6JT9YohPN1sZ2N7jZce3KFRpjiMYZZb7yjTUmwUhJFCdoHSOsQAhFphNKU0EXSLSQSEfPxQ4X4QAfSKV6DXQlBMuy6Iu5IRgPM9FjxdPugkL3PkOGibWW1g0ZOOZYcHfOoRA4a/vW/2EheAj5rAP9rRNQbjff/tVf+hij0Yi/8Jd/4nU86m98u0kCvcBTuQVOdAuYdQHOGNM15zhM2yJxKL3Ofpw4jkENM8PgmEJpX2BU66DQOx5eAArX+uKf89taXStwjrJc4YxFSt3xuAV15WGLwvopTWk6QgDT6dRj1G1DUfkM+MEH3kRtOmW/KF4r/bUtTcd+kDrq28y10sTdZKjwnlVVMR6P2d+9xuHedTAWWxn8x6/QKkPgGRDLo6M+82qqmqMyZ2NjgyQbU9YVSoSM2qyhlVgiK4k1BrCgFEoqtPazQ/3nsFjT9Jl0gG6EEIzHY5/Zdxl1yORDwA/BOpyX/sIxyO6DDXH3oTxCX7CnY98InvV6z/U6t0pGX9f1bevbv/y3PsT3/sh/+3oc9tvCbpJAvxZlCnasqCZ8hmes9fLEymdpoksvfbDopk2x1u0Ir9M35yAGHZhrrrewFqUknorsENIxziKkhLbwQ7CxDim7w6V9dpKmKTiIlfY8Y2Opm4Yo9Zrf99xzD09dvsLTV54BBDqKaJojJpOJhz267x0mJAU+e13Xnvcexz3rpCxLphtzNhabHF7d5dozl4nPnWU6SRGiRVhLliRUqyVKKeaTScdZho1shhIaLSW0hqpu0Q6SaUKcrOGXSGsq09ArWgpoTctoNKJpPS5vafoLMNAXZFvrZ4XSFdNlYOUMsvFhsA8XgqHi5BB2GYpnhffqM0wTirHHZ5yGHcGQkXIrsW5++R/+Sz7ygfdyu/r2qb16dpME+uONLie5wuv7gm62wT/ssE707AI/Stkca68PgUg7gRO+0Bc6A6XrWA46wlnT67kbY2maLrBZjz+rKH4W82NxtCKOYxaLVT81yTQWOi2S/euHjJIUJwVZNiLLMky3OBvTIpE9FznP82M845Adr1YFWZaRZRmLxYpz589zeG2P1eGiK35CFAlGozE6ihDGqwRWRekzd5/+YuuKRVV3MK4jUhJnLLu7u9xx9z0URYFSom+BB4dSGmehbhskChVHmAqqrnkGggyDwjhxDG93zmHa4/TKobLi8Byvi8AdA4fjEsbhFi7+USeRIAdKjsMLSuCV32oceggZO9yOvv3rv/gxPvj9P/N8h+bUvgy7aVg3/ahA6LKX4xYCfeAMCyGRotu6dltAK0AIhTGOoqgwxmGMI9CtQ0DI0tQP1bZmPVTbOlZlhUFgpUBIjVQRQml0nFDWFXlZYNya5eGV+ARtazB4pkmWZSQ68oUw629t1XD92i6PPfYYu1f3WCxWZNmYvKxxQtEYh9Qxxgnq1tJaT0ELqoBN07Ba+YVnleLcnXehsowvPPEkX3r8Gf7573yKa1cPKZcHOGOxraGpapyxPgiYFts2SFo/X9cYFvsHCGOgtRwd7Hvcuw2ZsC/2tdb0rBhPa1XHdMWHjTEhSAfWjbXWz61VmlhHvaY5sObQm+N1l2DPxb8H3/TjM8F1oS9gyeE9TyYIvhbwirnpq2of/s733va+/Qs/9t2v4xl449pNktFDmF4TJA9gvWVfZ3a2K856DnbY+mutSeKE+XyOMw2Hh4dUVXWskFjXNWky6l8rTVOyLCNNU0ZJ2gUPn5XWVUUc+y1roO8VRdEHtaIu8NOYDFpFjMdTdCx7hkpdVWRp2rMXtIoYTcZcu7YHXfBaLBYdsyVmNBr1MgehSSUUv0JQDAqBzrRkswlvecfbUK7liS8+w2S8xe988l/w7f/pn0HgM3WM1+53QqKEw+ADA+CnPVnB7tWrHCyXvPP8jr8ASNGxaRTGWYRb0xUJEImUzGYzP7auE1qDTo2lg38CTny8eC56SuCQPjjsmh3CQcPHgg9AR7HsZuEOsfvh34T7enz/Fkns/cXz1Lc//kPv54f/9j98vU/HG8puikDvcFjXgMBzcvHj0ZxzaCVwrZ9cI2iJVETdlNxz331cvXIF1ziErSlWK/LlAdjuoqAkUaQQHQ4oVQI6AiE81qg15XLJouv0U0pha9/QYYyjbWukXBcckyRDSklrDcKFGZstaZrQFCvieI5E0roWpMNKx97eFYTSFHnFzoUL6ETTtOCso8wrplmKimKK1YLRaETQL9ESbGtw1qG0wrjAZvB4q5Sa8WzMV/2pf48o+jcc7R3gVMXeU0ecPWtQOkG0JciYWia0lWacTfhHn/gf+PPf+udIspiDVcnW+R3uefB+GmOQxiCzmDiKBrRM5esiWmMDd10qWus8VINDd0MmLJ0I1gCbr+u6D+z9a3awQ8BwA3UyPK/H5EPgFl37vgwDSByuw/CF7T6T8BOVfFF/KNV7i6TywIf+4r9PpOSpb0t9GuRfBXtR6EYIcZcQ4l8IIT4rhPgjIcT3d/dvCSE+KYT4Qvdzs7tfCCF+SQjxRSHE7wshvvpFP8UJfH6d2XkcUWnhG6eEYDqdEscxTz/9NLZjBRwbMqFkTz0TQh3L9tZMhDUn2Ll1y7jPROk/y2g0YjKbEqcZUkU0rUXJhBaBiGLSyRinJEVbUpQ5i+UR21sbbGxssLWxwZmdc0RRxOaZ7Z5LrNQ688zznN3dXZqmYbFYsLu7S9u2fZNJURS9cFUax2A99NJUJUI6Hnv8cVSkibOUJEu4fn2XpqkwTYNpHaax2MaQRhP+6T/5bZIs47N//DDX9g+QWqAijYw0cRaTjkbHGpSGfQ0hEIciqlIKqddUu7Dlz/O8D+4Brz+paTJsmgmvGUVR34ofdgPDzPxkk9S66DicSHZcnnh43l9X375BO/XttW//8k99zyt1WE+tsxvJ6FvgB51znxFCTIF/LYT4JPCXgH/unPu4EOKHgR8Gfgj4c/h5mg8CXwf83e7nC1pfSCMwJVokAolvxc/SmLouWSwPfZBoW5SWtG2NkB7ZD1tea0FqjQMi7TU7pIqONXAE/DK0Y1dVhbQKHeELkzqmampq03raYtVgrePcuTOMpmOapuLy5cssFodEscI1JfPNDR595AsAVE1DlE24cOECCMnRYtUPCmkaQ1GsSFOv6x1NPRQyzka0dUOsI6xcdz4qpVgsFqRxhG0bZuMxR23DxvYGW5MZdV6xWh2xNZn6LbmRKOvnwSIEV69e56GH3s75O86xrHKkdszObDHemPjsGGgwCDfUmFHd+6+hlKZpUHJNl7Qo2rbsMd0QoOu67mQR1gF32ORjjEHqNd8ejuPxcZz2FxmlOqZN62EMZ6yXzh021xEYNh6m8RcY1QeS19u3X8x+6K/++VPfPuHbp/bK2o2MErwMXO5+Xwgh/hi4CHwbft4mwG8A/xK/GL4N+AfOr9rfE0JsiOMDl5/vfXwg6BaqdQ5jW+Ybc6oypyzbjk3hMKZFyU5oiTWG7xw44YczKBUdCx5D9oYPACHz87cw6k46gS1KH7SalqL029t3PPQVXLlylWeevoyO/GtUVeG3pcIvoDzPQfrManl0xFvuuZ/5fIOi6yItyxqwbGxsURQFRbFiucx7FsJyufR4a5qSZCmL1ZIxY+I49p85jvrnGWPY3t6mOFyR5zl33n0Xbu/QXyhbi5AK60AqjWgrts9ucenKJd76zrcQpzFOxB0zZa1K6ZzXqAmDSZRSvdxtX/S0bVcY7JgwSJRaD7oIGXrAmMNFIwT7EHxjmfTQTTj/4TNoHfXnqefhCwBLmFUgJX0zmRNrqqEUGmss1nmtHSGfH755rXz7hezD3/leyjI/9e0Tvv33fvbDFIcrfuAnfu3lHtpTG9hLwuiFEPcCXwX8f8C5gYM/A5zrfr8IPDn4s0vdfS+4GMKWm062VklNOh75inwk8Nt0T73zTozv4sR0fGMBTiH1cLxcoORZlD5O83PO9XoeoTgYpWPyRY5Qksl4g1hDcekyURTx8Oc+i3Aeh26qblssFW3tGQStbTh37gJCSR555BFmG1skOuLpp58C6JQB/RDlsqy7hhH/3ePYF63CZwIoqpLxeIyWCtsa5tOZL4g1LasqZzKZsVgtSbKUi/fcS72dc2nxh1jnM3TXtkSRJgJUpHDacfeDdyNSDZFCd7NeozTBPAeNMcArGM+GMo3vbrWdMJlOUmAN6wQmTMDcwQ8vHwbzvqDrXD+TdAivhPcNO4IoihB+2kY3f2Y9RHzIzTfYHvIZUjKHn+XF7NX07Rcy7wOnvv18vn1qr4zdML1SCDEB/jHwEefc0fAxF2gyL8GEEN8thPi0EOLT5YCX7ZzrNVKCAqJzfqJQfzHoXyOMUPMiTgGbVUqBUD0WGXdzTIE+GDkpiLMUFUdYASiJNTCdz9nePstyuWSxWJBlmX9vZ5HO0tY5rW2o2wrjLMt8xYNveTPj6YyiKpFCc+/9D3D//ff74Qod1CAlNFXJ5uYm0+mY+XzOZDLr2QvL5ZKyLGmahjRNGY/HSCn9tjZN2d/fZ7HMKesGayEvKkbpmMl4hlCK0XxKY7rxc0IhpMdzq6ZERpr73nQ/080txpM5o9GGb5F3XXatZU93HCpFBumC4cDoKI573D2Kkp6NURSFp/dlGUqtaZhDjDn8f4jBD3VshqMDhxj98JwPA3m431+A2mOvf7wQ+8Ku+Wr69os999S3X9i3//uf/oGXcuhP7XnshjJ6IUSEXwi/6Zz7J93dV8K2VQhxAbja3f8UcNfgz+/s7jtmzrlfAX4F4Oz2vFtIvgDVlgUogcahhEQ4X9iTKKQEBX7KkgDrfFOQXwAemxVC+NFozmFqLwUgu228weAUCGdpWy/9O51OfQakFGWZk+erbqq9IV8tqKqKUZawfeYM1lp29/YwTUWSpqSjjMtXnukLk1Xrm0T29q4xHU05LCsmsy20jVCqJV8VPbVMCIHUUa9g0lQNWimKokIoGI/HZFlGXhSkowxrW6azeU9rNMZnW1prqkXJ6MwOTZ6TtA4STSUEVVMQzUYs25bN7R0aayjqivF8y6sVNi2Zjnw3Ko6i6sTKnKVtDRkSKRVN0+KcFytrW6+hMkriXsysMoa6bcnLkjjphlU3PlgHvL81xnc2S0lrLHlZkkQxOvLH4HghvtOb73cLuoOZDNa1nmXjNLBWx/QXgA7SMCDwUr4vFKZfbd8WQrzgRUJ0NZBT335+3z61L99uhHUjgF8F/tg593ODh34b+ED3+weA/3Vw/3d2DIU/ARy+KD7POlNrmqrPULyDrxkXQ80U/9lUDzEMs8YADbStx5OH+h9SSpRYZ55nzpxhsVh0204/ySk05sxmXm97NBpR1zVPPPEEi8WCCxcu9NBCKH5JoWkb23OQpdQsFivOnj1La2qUEv00n7ZtUVJSlSVKBBnZGtXNRI2iiMPDQ4qi6Hc44bNXVUVVVV6NsmNmhEw68JhbY2jalsXCU9suXLhwTJFwPp0B9M1HoYNRCNFLEmdZRhzHNNb00IyO11LG4W8DZzuKVV8ErErP+unhH9bF9j6bt7bP+kPD1RA+OsmfD+cX6Idfh//3HbWD5wA982R432vt2y9kH/7O95769g349q//9A++3EN8ap3dyOXy64H3A38ghPi33X0/Anwc+C0hxHcBjwPf0T32z4D/EPgikAMffLE3ENBJ45ZIucYc6RxbaY2QriusdVvcsHbdiWDQySlEnS6KEBIrwBmD6OCJMzs77O8fIqXk6MjrczjnqHIPPyyOjpBSslotsN1Q6nPnznHlyhXquuTy05cYTzKsaykKw5kzZ3BWcXBw0C1QQZKmjLcnXdXQYGuDaxrKwsu7tlVNHEXUVUnbmn6qT5qMME3N1sYm165d4+zZs9jWD/44ODzsJAcilJCsFjmLRUGajBhnYyYbMxZlTb68ThpnqEgzmW0ghBcd2z88YLox7+GNyWRC3frpVcsuCGAdzljKvOgLq144yx/wNE291KwQCB2xPDxA4pt02rZlLMcI4bM609Z9o4xzDkWXWVh3LDgrpXxHb3dObdey75zrfcC64+MDTevplT5IrINgj8ubgVbO86f0r7pvv5Cd+vaN+faH/qtTsbMv18RxLPP1sbPbG+4//rN/AulalLTEUoIUWNOQJFGfDfjMBj9xp2MYxNE64xkKWSVJ0mVKussOIi5cuMD+4QFCCKomsDc8nlyWJcI6sI6mrZEOjPFb0KIoqKuiz6aSxGclX/3V7+YLj3yRLB0TJZ6HPhqNUJH2uiJO4DAcHR0irUPhuPv+N/kZmwcHLBYLxuMxVV1T1z4jaqxhPp/TGh8AV6uw1XbE2n+nc+fOcXh4yNWrV3HOUVYNDz30Nh7+w8+RGHjscw9z170XGZ3ZREWawlouXLjAeDLhcHHEbHMD8HIFo8nYb7W7LsuQvftjM8gWA3/brYuicaJRCBaLQ5I0oqlqTOuoqoZERxjbHMvUQvYW68hDE+CnXXU+qCLdBba1RK5OfEFRseaMh6De7xK6zNarbMqejhl2Dz/+8d/g0ccvvy79sc8H3XzoL37DqW+/BN/+wPd//LU7abeYOede1LdvkkA/d//Jt3wdUlkkDg04YVHSQwhB+8Z1XY+RHIhiuXWxD9bFu0AHNNZPnv/Kd72Tz3/+8yRJ4udltrbjHSdrGh+Co6MjlJYI66c55XnuXxfbF5Yu3rHDZDzj6WcuYxykyQgdZ4zHY1zXyVmWJUerJefO7XBh5xx/+Ad/wMHBAdY5xuMxcQdzCCFwFpIs9b8LxebmJkjVT+UJ2W2WjDjqJIgnkwkASmva1j8nX64odo947HOfY2Nrxtl77+T64QE7d1xkNpsxmU4RSiK0h2tmsxl123RCVGttlCG7ZdisJLUijf2CjOOYpq16zfrFcp84Sr38QlfIHS7mMMUoYNJKKZySqO585d2gEgDjvFhakiQ960axhms8i8cXKtu2pe2YWkMoSNg1TPSjP/XrPPb4MzdNoP/Q+7/x1Ldfpm//2K/+01f/pN1idiOB/qapdAjh1oUl5xAKlFSsh1U7r8HSd0XSb+3D78OMD3zhUEcJZ86c4dKlS4xGI4QQ5HmOkJo0TXuuN0CeF1026/qiUk8H7KhmDzzwAONRzGc+8xmUjpltbPoOwe3NTicm4uBgHykl9913H0898QSXnngM4STz2QYIv10PaoJKKKbTqdeWURFHR0fkZYG1sL297f+f514d0BiyLOu7U6M4Zn9/n8lkSpakXLn8DKJ7jhUeZtl//Ih73vQA4Glwo8kY0/pj6KlzXYDvOlmHHZXGGLQEcBjhi5qBidNDL1Kg4ghnhdc0kQrhDFGkvF6K1iwWi16uNnTGCiFAir4+c7xTNj6GwQ/PKYBS4YLU+jZ+va4PQLcTMW2P999sJk99+2X79qm9PLtJ1Cudd/6+sSYE/uMdkKbLOk+qF4ailZSyn4wEa453nuccHR1RlmUPIwR4IgSs8DOOY9rKT6q31musOwxvfetbsbbl6tVnePizf8wkGzGZTJCdDnjTNOzt7ZEkice/5zOeePRR2qZiMhpzz733IZRGIEnTDAOkkwkqisnLinQ08R2E0xmz+SZN2xInCQ7Y3NqibhqPUyuFA+qmQaUxSZZRliUPP/ywF51qPWPjwh13IiPNhTsv8tRTT7FYeIbF0dERy+Wyp0/GcUye537RG0OsNZPRCNM0ZEnipY6t60XS2qrBBRqkXWf9W2d3mExmGNv40XNuXVxNkoQ8z6kKf/zL3M8kbbr5pHme47qgNAx2QzVKIVzXyFP1zTehYBfa/IcWdiE3yqN/Le3Ut1+eb//NT/z2a3iW3lh2UwR6gSCJYpTzQ4aFtEgUQigE6wWvukk6titECeHbv4XUCKmJkhinJfE442u+5qs4u73JNFVENKSxRjqPgcZKg/MNHAZLWRbgLFIJWtMQZyk6iUnHE/K64Z77HvSNIpMprql98a8rAB4ujijqCqU1o/G43w7niyVKaR562zsxFooiJ04E0605TkIcR4yylCxLyLKEy089yThL0FKwONhnksTsX71CphU0NXee26HIl1zfu0bbtsxmMy5/6Qlm6YjdZ654LrQSHB3uIVLFql6yWq0YpxkXds6Trwoee/RRXGsQWLTwW/jl0YJIaaTtipzGcLhYILWmtoYoSYmSFK1jjHFEMcSxJFIO2oYIjXYK21i0jplONlFRSuv8MPDAnBiPxwglsThUEtFa00MK2LVWvXGWuiwoVkuK1ZJ8cURblV5yWQqiSDEapVhhMThaFwZkH1fAHEJON5N9+Dvfe+rbN+Db3/PRn3uWb5/ay7ebAqPf2Z677/iP/mQnbGSJtERFneKhWBejjjM41hRMaz3sEAYz3HfffTz6yJd85uQckdKgu6lJXfOJqY0v4nXb2FGW0Vb1se7OixcvcunyJeqipCxWvjiofYZrnKW1jm947/v43d/9Vxhr2dnZ4dq1azz44IOd9KvPmrPMM1WccwhjOTw8JIoiFosFs41NnICdnR12d3c5f8edXLlyhbQbvRaKmB52mfnvj2S5XJJFMcZYz0fOc4wxPP3Ik1R1wbkLZ7FKcObsOXZ399g6c4bJdNw1SjmQgo2NDXQS9/Q+IQTpKOuLs+G+UAi01uJMdQxmcaaTDkZ4zLxuerpdmCoUIAXbMUMCR14p5fWMpL8A6E7YLPik1toLr0nZKzc6AVJqWnecdnsS5rFN23di/vjHf4PHnrg5MPqPfOB9p759A779N//OPwbgZ374L/Gxj3/iNT9vt5LdOhi9wA8zwK2ZZV2GFjI9LdZBxzlHWD5hGlLQ1n7gwft54oknepxQCi+JG+AGH7Rk19EnaZuWOIrIF0cd00PRNBXnz5/n0UcfQWlB03UKRjpiVZSsViseeOABnFB88pOfREjNXXdfZDweMZnew5NPP8l0OkU6v1CXy2Wv+60tNHVNU9Vo6YtTu7u7XL16FWstzzz9NHGacnh42POhm6bppV4PDw/J85IojlnsH3DhwgUef/xxNuZbnSpgNyu2MWgRsVqtmM/nlGXJfGOGMYbxaERrTV8sDY01RVGwWq3Y3t6mrP0UonQ06jXDnXNYLTB11cM+lpqyqlA6RUrPsy9LP1QiyOAGpkg1kCgIjTC29XrqToBQ64Yg08Eu0ljPyukCvdTdRUYKz8TpghfBN+RxNccbEDZ7ze3Ut1/Yt3/+E/9Xf6xOg/wrYzcFdAOdU1uLkA6lBEr45g+tdY9LSqHBSaTQSOlvaZr2Codnz57l8uXLPT1NSglS44SX1ZVagVSdnrcfmRdJhbB+679cLKirirIouPTkk5i25XD/OovDAwDe8RVfidQpb37r2/jUpz/DmTNneNe73sXb3/ZWLj91iX/7mX+NUoqtjQ3y5RJjWi5dukSSJKxWK5+hKYFMIt789oe4vjhkb28P8AEvND7VZcl0OgV88TMUzq5f2yWLfQFuc2ODc+fOcfXqVR9Ey5InHnuSvCioKsNy4XnwSRRzcLDPeDLi8PCw55onSdKrG85m6wYqIQTXrl3DtoZIaRaHnpNd1zVNN6ZQRjHJaIxSirws0HEE+BF1bet1ap566imy8agrxHk5huVy6bH6DiOGdV0GPNUyMHZk939jDLZdyyUPJRKG0snhviCjEGQQhrICr7d97/u/8dS3X8S3h0H+1F45u0mgm5n79m/+KiSQxJo41msKnvETaTw8sM58VHjceSeaTCbs719HKrpZqj6Ty5KRb9Fvyo7O5rOoqswRdi2utX90SFNWPV84yO1uzMeoKCZKEn7v9z7FW9/2EBfvuAuc8dvTyYhPf/rTvOud70BFmscffxKpY+I0YZyNSNOUZ555huXy/2/vzWMlz677vs/dfkstb+9lFpIz5DB0FDOWBIJkEkdwnD8kC0HoREGgwNESK7GQODElGw4kx5aHkR04VmIzzm5FiuxAiBHABqIgsRPJcKDYsOkMHJmmKFDUlMepAAAgAElEQVQzUs/SnF6n+y31quq33Hvzx13q92Y4nB6qm+91+3eAQlfXe6/qt5x76tzv+Z7vWbKzs8MLH/0oL730Ent7e6EgpoKuT9u24XMRzGYzjg+P4hzXQIW01jLf2gnQhw7X49abNzg+PqEuJ3Rdx/0793GxmHlwsIdQMJlPw7Fszdnf3w/FTgRFFTRrVGFy0HeEzLtr2jhfNDTMLJanFHGqkFQbpVEhBArP3bt3mUwmobkKwd27d9nd3efo6H7o2CXAMO06ZIwpUGmtUWLzfinDJWLERVFgY7OTkiYzdYwpQb2TW9+2bVbWxG6C/k/+1P/Ea6/fOnfo5rPf/7tH335A3/5jP/Xz53C3Hk97fKAbAiXOKIUxGomHmLlUhclYbmrqyQvFe5Qy1HXJYrEg6Jyk8Wt1brm21jGPCnoAAoXsOpxwuKaj947f/vHfwavXruWmnr29PV599VW29w946aWX+J7v+R6+/OUvc/3112hWLfv7u1za32VxfISRnldfeTloa69aPv47/mlevfY67XpF14VgeXh4zOXLl7n28ivszrdwbchkpAIlBHVds1gsSKqETdOwXgdJ2dVqxfb2NkVRcPPmTba2dnj9xg3KYsKVy0/hrA08c+tZNUvWy8BmMaVmcXzMbhl0ba5du8Z0MmO+vUXTxfFuRjOZhEUbiqWhcak2muXilNPjEwpj6JombP+0CDxpL4ni7+zvXeXo5DYei/SKnZ0dDg8PMUpik7yB37BM6simsDaML0zZd9phOBd2AZl2KULGq7UOYxBFhGycCzOGRZC1FlpBxKBl9KmLRK8MX4Sjbz+Ib3/2+76Tuihx1vJnf+5/P+c79/jbhdnXarnhQidcV4mB5g2brsAkv1qWZYAtYlaQWvbLsmQymUQ62Ea61RhDWYROvN4HGECXBVeuXMlc5IODA46Pj3Pm2fc9H//4x/nlX/5l9vf3+eQnP0lVFTz33HN84e/+PV579TeZ1TXeOo6Pj/ld3/HP8+Uv/Srr9To3g7z66qsURcGNGzfo1y2+sygvsE0YjLxcLkOxMsr0Ji0Qay2z2YzZbIYxht945ZV8TLu7u8xmW+zu7nJ6egoEaGNvf5fZLGT4pycLgDj9aYHWmvl8noPpcrmkLMvQONW2CBXVIHXouNza2UaJiIE7nymNfeTCW2vprEMIlbnQKbCmWaGJ7tc0DV3XBY5/pPal+5xolSnTdM7Rt90ZmeEcyAaBe0gjzPj22wL7RYFu/vDv/y5g9O1v1LdH+63ZxVgFeMpKI4VFCQs4jBIUhc74qy7CNrDrG3rbgpQ4JJ0nbicneftqO8d6tWJ5eor3LiafAm0CrW+5XlHXE6ZbW+xeuoQVgnIyQZsC52G+tc3+3gFGF5h6xutv3EAIw8c+/Nv4ypd+ndPDO/yDL/xtZtMSgeJ4seJbP/0pein5f/7O3+aFFz6M0bBaNPyLv+tfYGs6Y14XuHaFrjQ9PaY2VLMKKQXGaFzfYZQM23lBpj9qrVkslhwfL5hvbTGbbdH3lvlsh9u336T3PVeeuYrVcPCBq8zqGVtbW2zvbrF3sE9ZVKxOliyPTplPptiuZXFyzNZsTrtuOLp7jztv3qRShsPbNzFCQueyTLSsSlRVIFSQNlken9CvG9bLBcJb+nZF250yrXYwctOko5RgOp9TT6f0DqrJLDdP9X2L6zu87UGC1BKlQ3AL4myCsq5QQlIUFYWpcvFWeEKjke3pmxbshiueoI9Chd+VBDxcnPN08D/yb3/n6Nu/Bd8G+PEf/gx//N/6l871Pj7OdiECfcjCUmNLYA6kTC9huWm7l5tHtKYsDVoKhLd4222GWSQmBmG4tFCh6WS1WtF1HVtbW1R1zWw+x3nPcrUKHX11xZ07d3j66ad57Y3X+fCHP8wbb7zBJz7xCZ5//kO8+vo1JtMCpQucF2hTcv/okMtPXeKL//D/Y3u+Rd/33Lx5G6Ti9/ye7+T/+sW/QbNe5hb9xWIRWAtSxkKqyee12bKHbfx6vebevcOQdW9vU9dBl0YVGu8tH/rQh9jf389yA8YYJtszLl29xNb2nCtXL2Nd+Fnftty9fYfJZEJdlNy/d4/nn38+6Jcoxc2bN+niNW7ayFvXEiUF3rocNKuiZL1c0azWUe7A43pL06xi81JQvxxqs6QpQmVRM5/P6ftNIdX2PUooRNS3MaaM80dVfgybhpIl7fyE7w+z+SSO5qMGDucI31zenzP69m/Nt3/8hz+TfXu0b8wuRKBPCVfuZPSbrsC+70PnpPdhDFlRh4EJsQ2/a1Y4Z3G2x9k2F6qMMdSDgddJQS8NYHYIFssVvfNs7+4hlKaua+rZlPv377O/v8/27k4Wx7p16wbaADh0UeIQfOyf/G0cXN6n63vKskTpoBJ5685tnn76af7GX//fKI0mxJrQDdm2LR/5yEe4e/cuZVmyWq1YLI5p25bDw0MOD+8H2GV9SlEHRcid3V2c79HaBElgo7j26itY19N2DbP5lKou2dvfpZpPcVIw29qii+MGy7JkZ2eHdr3m2m/8Jje++ia7u7u8/tpr3L93j/V6HX/ecO/OXZYnCxaLY/q2wbYNRgqMVGgRsuVSGypT8NbtO6xPlzTLVYZpNmJb5KDlvaUodJa8raspWhcYU1KoChl1LU1ZBfaI81RFSVGV2UWGw0RSg9SQOjlsmspuJcJA7fc3NuQh2+jbD9W3AV789/7V87mXj7FdiECf5FfTQ+kNF9q5ACMURUFZhS1u38Uh1N0arYI6Ytf3gVpWVTjnKcqKvrdobVBSZ5W8xWKR8dykt71cLqmqiuVyiTGGVduwu7vLyy+/zEc/+lGuX78eF6emrCvu3r3Lpz71Ka5du4aUOuupKxmO78qly9x880YOTmVZsl6vuX37Nk274hd/6f/Euo6ub1gulzGrWw2YJz5ilfscXLpC13X5uGfbW2xvb3NweZ+Tk5OsN350dMTNmzdRSjHf2WYym4IU1NNpCCJlmbF5ay1v3b5F36yxtmM6qzk8useVK1codCgQrk+X9HEcXcJ0gZx1CrGRJg7Y+jof/6aJSWWMPTcDKUVZmZzZGROULI0xnJ6esF4v88zZpmlYt20u5A4nUKXPGQqvJfPeQ6w3DGUGzsNG3364vv35P/nvBN8G/tQf+te/zpUfbWgXItBDGPScFjBxBqi1gWVQ13WYPNX3cStocD6IVq3WDVqb0OEpQoajilDUlVIiYlaZpt7MZkF3o9AGozTeOuqywvUWISVPP/00AK9df4Onn36a4+NjqrJE64rFyZKP//ZvYz6f8sUv/gp1PcV7QVlOQZV86p/5Z8M2enmMd22GO8IczZ6y3Ig3DZUIEwxhjMpc9oODA/b29nJx6oMffDZva1fNmtlsK0MvVVXx3HPPxSyxDbr+RlJOSibbU/YODvBCsLO3F7nZitVyGQqwzm+6aq/f4Oj4Pl27RuBYLI65e+cW3vUcHx2xXq2w+NCUpMLCLCdBQC18gXR5/ONmkEgI9rdv3+Z0ecJqfRqHTliqqmDVrdA6HLcUIPB0ccqQith1KtKvVivW63Wmfg4hnaxpIzZzb1vbx2aq8/DojY2+/fB9+3M/8q8x2Z7yU3/0+87xzj4+diHolYnKH5TrwiCJRLWrqmrTuo3H6DI3y/R94CFbPEJIkIFnbIzJuGHvHKtmnRtU0lT6lA2mrW/f9zz11BWuf/WrOUM6PDykie3d3ns+8k98jNdfv87B3n74m7bDKE3XWT79Hb+Tv/lLv8jObIrWmu3ZjPW6o+k6PvjsB+isY71eY8oit+YDaCMxusyNI1qHQR9VXbM4PaWqKm7fvk01K5hOtpnNZrx1/x4A9+7dQ2vN3t4ei8WCg4MDTk9PQgOUFGwZjdKaZtkE6mSkLUqvsgiWtRZZmjzEeTab4QWs10uUCIt1tVoxmwVmjqwKpJJ4ETBwUxa0fYcfiIdZG26olORgXNc1bdMgRJQR9iDiz9u+Q+mQveIsThX01lJMa/qupwFsvJ9Shs8OM25DgEsyDkKI3EcgiM1Y+nyj/Ojbj963/8S/+3txzvGn//tR9Ozd7EFGCX5ACPG3hBBfFkL8qhDis/H1F4UQXxVC/Ep8fPfgb35cCPGKEOIrQojvfO/D2LR9g6TrHIU2VFVF03Ss256msxhdRudtcBaULCjqKo+101JTSs20CCyNddcCEtf7vI31woH0SAzeQqEN02nABu/euYntG7a3twKmiqSebVNNtyjKivuHhyzWK6wyOF3gpKLzkh7B3/87/zez2gSmijIs1i2qnHDlqWd59fU3MsyRaHJaB9aFQOUM1Qlo+g6UpLM9q/UJnoa9/S2uXrrMtC5ZnZ6ws7XN3t4ek/kEiw3BTIHFMt+eUdYBqmmbnr61mLpivrvDzsE+890dDq5ewZmC6WwrDLdoe1brltVqxcnJCUVRUNdTlCoRImSh9+7dRimPW6+h7+jbhrYN4+ImVZkx6LYNo+Wc61k1S9r1EhtH2ZmypKgmVJMZxWSKEyFbX6/CFl8SgnXveqzr6ddrXNtguxbpBMIJpJdhviqKoohFSyExUlEojVEFVVFjdImSge//bqyb0bcfP9/+7Iv/A5/9iZ/+mr79p//o7+PP/Nj3v/ct+cfQHgS66YE/4r3/FuDTwB8UQnxL/Nmf995/a3z8HwDxZ98L/FPAdwH/jQjR4uua1jIWl4IEgsOzXq8BshztsKkmzbRs2zZrqCdY4vj4OG+NE2e77x11PaUoKtq2p+uanCE26zUaOD4+pigq1uuG+Xye9bGBCCNEKEGXFKbCecFyuWAyqdCqAC8zXziIVMG9e3d54YUPc/366yT98XT8UkpMsWEjDP9WCMH29jZKhcXS9z23b9/m3r17tG24Lvt7exitmc9mTCcTzECuV8RGlQRrJK2ahH9/8IMfxEuBtZ5ls47XKEgcHMWxbmkYRcLGb926xVtvvcViETj5RczQZDyndC+y1rnr6fuWrlmzuz2na1bgegot0RLqMvz9pctXODleBJXMoszXPAUPay1eOHrbYl1HGCH4Ts78sFibMOTw2rtWY0fffgx9G/i6vj3aO+09oRsfhh/fiM9PhBC/Bjzzdf7kM8Bf8d43wDUhxCvAJ4G/+25/IETY5jkXJgd573AuNpNISRG3q0qpnOEMNT/SQOukca6NDlKrzlFWExaLBVtbO3m7X+iSdr1ia3vCnZu3cDawH+a7O9R1Tdf1KGmopoZVs95wnJ1Ha4MQiqtX97hx403KQiOEp1lZJIJCyYwRn8YZmkJJTFnQ2f5METEVIyfTCu+CPGz6+TQ2qiwXQWTs5OgYYxRXr16l7XuMCVN6tre3OTw8zJh13/esVit2dnawfVhk8/mck5OTTFe7c+cORoUOVukdR4sTbB8GOK9Wpzg8JydB4yZct3VukplOp5yehOKZMiHLm0+nELtRnbeB3w7YvqNdN5lON5lMAg/eOpSQQQOlKEEqdg4u4SPsYt0aZ+NwbxEmvroYvITwYWB8LAgnqCIvcCkybJGw4ncD6Ufffvx8+8+/+EP86Is/wx/6if8uX+PPv/gH+A//k5/7OrdttPdVjBVCPAd8G/CF+NK/L4T4ohDiZ4UQu/G1Z4A3Bn92na+/eDZZW8y+Eq6bHH+o9pe1QWLGljotk+CVE9B7l52taRp2dnbye6QFdPnKAXfv3s083/39feZb23jC8GOhJKtmHRaQd9jeI5ShqCZcunKFN2/eDoU+KUJRE4UUGu9FFgrTWnNwcMCbb76ZO0GH3aOJgiaEwBQq46xSgsfR24751ozl6pS2a2K23OTz8t5GzDs8X61OKcsyyBnE6+WiUJyQHus6hPQ88+xT4eZLiSXQ5larFdY7mq5lazbHKB1wWmPiLNESay3337rHfD7n/v37WRwt/Gsy5dH5ntPTU6QUNO0a63qcDV9ATdPk4m/KVtOxFlVFUVUoaSJ8VKOUztfOOZf157MQ2qDwB+CxeCwIh8fi/IOpV46+ffF9+w9/7uf40Rd/5p3XWI5Z/HvZAwd6IcQM+KvAj3jvj4H/FvgI8K2ErOg/fz8fLIT4A0KIl4QQLy1XLd4JpNA455FSBd2SWEA0ZUEZ8coEIxRFEah/xyf43mLbjna1zlu43b09tDE8++yzESfs6PuWQits1/L6tVdpVyHLlEVBMZlgbeCAa11sgk+hc6FyOp0Cknv37lGUGl2WaFVQVjOMKTGmRApN3zsWiyVVVWSO8Xod/l9VVabUhYJckRtenOuZTqcBX0/Y5kCx0RgTNGRi8HW9pVmtkYjcwJQyqfB+oWiXWBlJUrZt2xBUioKiLBFKMp3WGfI4Pj7OkgWHh4eZYpdolUdHR0wmE44PD+nblpOjY+7fv5/PxVqLNpKmaannc8qqRkhFbzu6vsV5y+lygVQC24Uu26R9AlDPZhR1TVnPMGXN1s4B29u76KLC6BJtShAb6YD0dynIpC39g06XGn378fDtd7PP/sRPv5/b84+lPVCgF0IYwkL4ee/9XwPw3t/y3lsfphr/NGELC/BV4AODP382vnbGvPd/0Xv/Ce/9J+qqQEqd6XgpS+v74BxDXnXapqfCX/q9tm2DPkhVoY3J8r3Xr1/PI+jSSLu7d+8ihKKqJkhdIJVBl8FJq6oKFyZmiWlReAFN0wVnNjLPtlRKh8UbGSpFUbC1tYUQgqIoODo6okrKjwORrQQ1aK1zJp4oZE3T5EEUQ964MXFgtvR5/F9ibwxnsVprqaoqZ8zDeZwp0DvfR/pazWw2y6wQCBzutltTT8o8VWg46i7poxdxgETXdUgEq9NlwO0RFNqgiwohNdP5NsaUebdhrc2dlElnvtByw5XvHIWpAre7rFku1yB1uF9SRx9RX1PfZojRPojOzejbj49vj/aN24OwbgTwM8Cvee//3OD1pwa/9q8AX4rPfwH4XiFEKYR4Hvgo8Pe/7od4T9Az77DeY71A9I75ZI4SgtXpGtcH+KEqNO3ylMXxIb1t6buwICaTGUjNfLrDydEC5SUn9w8RtqfSiqo0nBwf0rQrJtOK2faMoi4wpWZnZ4eutZmvLaXMQTJN7ZFSUlQGR1CKLLUJ3aJxUegy8J11WbBue9CG1vaowgSGhIJ1t45FKwc4nOuxXqBMCTloqSgbvML1a4wUKCPxCoQIWuPtas3ufIbwnma14vbNm/io52/7Fm97mmaFkBYhfS7MCRHmt06n07AohaOqAwNkNtvCmJK6nkbWh6HvHNDnImHTNLTW4fCR2hjghdl8O/CoPVgBpq5QdUk9nVGaCiUEewe7mGpKNd1iZ/8yqIJqukXjOsDTdy3C90hcVjgMdEQoS5W38WVpBt2YobUe0QOOpNbqnQAvsb3Hu3d38dG3Hy/f/vyLP/B1L/Vo724PwqP/54DvA/6REOJX4mt/DPg3hBDfSqA0vAr8MID3/leFEP8L8GUCq+EP+lSSfzcTG6nalDHqotxgvnEbbiLX2lqLMhpnXd6mHx4eYqLa3/b2Nk1UyJMybEevPvM0dV1z79693C0ppcTFzxjifInVkDDPYQZkrUXJ8kynqHMuBBc2WaS1lr7t0UZG+KTJ2dxQjra1XWA1xL9No9VSdtR1HaIIc0CH+jHhfbq8FU6MmZQRhkxM5GuXGo+GBcykkhgamHzOkNPnhP/LzOBp2xaPxJgQeFOXrZIG73x+fyBw8LUOErzeZiZOUrBM5+b6AAvpdB29R8TrMex4TceddPNDJryRPmCQ2XtC4XP07SfPt0f7xuxCDB65erDlf9+//MnMOJhOpyjhsTYo3JkolrVanyB9kDRuY0MJbLaKbe/4yPPPc+3aNSaTsE1NHOPJfJb/n7b71lomEZtMdLWhLG4KfCl4poUpYoaWAlHf92A349yWqwU7W9sc3X8rsyESlJKCLERMWYUtbGGqQQDWgAtMFqHphQ9ZOGGIw3w+5/T0lKqaZApeCibVNBYzo05M6kxNLfGnp6dBQjji9FKG6VGr1QopAu1PCIHrbZwdu5HWNcagTU1R6rhYw0Dwsqhx4qwGvHOOsp5GOChMi1rFGaHJlFL0tuX0+CT+XQwm0mSY6O0BxHtPZ4P+CoSAsPly09g4ei8FJ2stP/ln/keuvXbjXDqnRt9++L79o//xz31T7+FFN/84DR4RQmSOrfeeLo6P2wSj0PquhcT6TYcgBMfd29ujbXtee+0axoQt/dHREeuu3Uy8iQtBSkkbmSTOBZ5zcvZUJEoZiBAe7x0h4Qj8bRtHow31W/rexn/7XFBKz5OFQREeIQaLrrcUSiO8xyetGBcWVe8cVlim02nMtlTOshJOnrLtIX89ZYIhGAd4ZTi2bb1eI6MOejpG7z1tt85FQTRUSuGFyxlaVVW4SFUc7g6E9Gilc2atlMLbsH0XIkAAq9NTqjhwJN1r70M36GwmYnt7Q+c7lNvMeh3i8CkTTLUBY8ozGL33Ps5CEXg487PztNG3H65vj/b+7UJctbQok6M6FwZC66JASujbNe06FGgkIvC1ozN1Xcfe3h6Hh4ecnp4g8DTNGiklJycnvPDCC2ERqYKqnKCkwfYerQu0LuLn2tCRGN8zMQdSJpm22UOp1eTkoRNUocsCEYtMWhWcnJxSmAq8zIVFIVTo1kSecdoQhMO81a7rshIkUuZilBISKUApCXjmO1toLfOxd13AtMuyxBiTG2ySqJQxYTSdUgJrNyya4TmFQO7z4GZdGIqioqomUcvE54JqFuOKzT7pvbTWWd+kaVd0fUPbrZnO57Rtm987XWtrPZPZDKEV5aSmLOrsFymjS/dgGPwSpz7gzDq+brMsgpCBb3/egWH07Yfr25998We/+TfxCbALEejxG4lZpVQu/qXOuTShRosNBxnCEIrLl69y584dnnnmGYQnSO5ub7NcnvKhDz/H8fEx2zs7OUtKDp+m2STook26L1KeWQRpgeZsrOsQUtK0LR6YTKc4H5p6hl2BZVkitEEajdCK3oXJTWkLH2AHS5oLChvOdcoA+77Po/O89wFekZKm73JgTYOghxmvEIH/nK5TOt+0hRdCIBW03RqlRebZSyk5ODjAepeDeFGVKKNRJqgbKiU2RTpVxAAc2BMi3kPvPcgwt/XtzJ80QjAdkzGBfjedzyjLiroOQzYSxTAFogQtBHc5q0Efsj2d/59g8xzwz1PVbPTtcD4PybdH+8bsYgR6QQ4eqViU+Lenp6cEuO9sY0zaft64dYunn36WN998k6Zd87GPfZTDw3tsb2+zv79PEeV5k9M3TUPf98zm27kVfRnHlSUnTM/TAk3Ut7SdFCK0cCfamFKBTSCVQgwyXW1M5nwXVRlYKdYjxeYzlJSRKROGeAjvMHFC0nQ6zQHOxualRHM8Pj7OcEzqrExBLwUTIP8sZZPpue16jNLYrkf4UDztYrNK4lYLIZhMJmFYSV2fwYBDA03IAOu6hqht3lkLUtL2PUJAtw5DNVbNmq7rMpdayoAd265BaLBeYB25m9eYoE8+n8+zPEP+7FQH8Kl7NFLwFGd2C/lL5zxjxOjbD9W3/8LnfugcbuLjbxcj0MeV6JzD9T1KhG/4oHWikNIgVYH3gs46Gk/EiiUf+8gL3Ll1E+89Tz39NL/5xleZ7x1ggZs3bwVVxd6yapb0ztI7i1Ca1eIE24TGDFNUaLPRWElZb8iMe4wpaZoOkMzn20xmc5CKoqjwXlAUFaYM+LVSMnRlCoeSEik8AgfOoqVAFSoULqWM2+sNhJKClpSa3ocMXCRmiRT0/Zq+a2hOFwjrUFJgtKIqC7yz4B3aC4wSdE2Q+u1dWERpQSesNmGwAGnKUSULpNBxsUpKEzREEr68yf4siB7nU7NOjxCe3vegPB6LEiGTlsLRL09R3gZni0ydtLtAB7jBdT1VVWHKAqkV1juU0UhtqCZTdBEau7yImvgKlCyz7koQcXMIJzAyFjJjo9L52ujbD9u3R3v/djEC/WArnoqFCU4oijjFxju6rgnPpaeqCiaTitdffxXnXMQygxjXwf5+7rQUcai17Tu6do3terZm0zyaLWVPKZgNIQ/vfdbXns/nbG9v5/+n7XdqGBFCUJoCKRVInYOpUiYGVYHWafBzjS6KkK1og9I6wyMOj4tFypOTE5J+edqap8xMKcVyucz67LkgKQK2igiCZJOqzg01qcU+Be0h4yIwJ8LM0jAcw+XCXwr2Cd9NhdR0DdL7KURugBIiyAdX1YTeBQZPCnDpCwPInaAJUgDydj2dl9aa2WyGEJuhJmkQRrqHQJZjSL8z/DI7Nxt9++H79mjv2y5EoPdwBnbImaaQmX2RdFUgsC4SttnbgOnduHGD9XqNVorr169nDDJ1dvbtGtu2zKd1Ln6lwJIcaQhtJIdLn5cC3XDxJLYDnB1vt16vQ2Eqsj+kVpiyAClQRmfMeoM7pkxZvINdMsSj04JN16O3FlMUmKII11DKzE4AMiY85D+nImxShkxmrUUXJk+iEkJg/Sb7S8F80zWp8pfEkPVibWi6Se8hYiaXOiLTv+nap0asBCO0bZuvc6L3JSgmQTpJw2WIMadHgpeG8M155oCjbz983/4vf/L3P8pb9kTahQj0glBoWsVGEGMM2PAtXxUlOnbpAbmQM5vNuH//Pjs7OwF2qKocUKSUYB1Gqtyk4W2PVoK6DmPVprOaybSKzIzA2PDe53butBCSAyb9jpQppuwoBzu/wWLrekI1neYMSasiLyQpNFIrlDIIZTI7wkVFw5RRwSazda4PNDlCkbPtO7pYXE3BIi2a1nb08VySpMF6vURKWC4XaC0JnZoN6/WSvm8BlztdbddilEQpkTN62NAchyyWlB2mximcR/pNwLfWosuSyXSWX5NSslgscvbWNS1KSI4Pjyi0oTTFmaw/FfG8F7GFX1LXYZeSPvftFMt0HdP7nKeNvv1ofHu092cXItB7yJS8pMcCG6526n7Zq7sAAA44SURBVBhMjt51HcvlktPTUw4PD7PD7u/v5sCwKfb14WFtHkVXliWHh4e5IzRlXMNgkZwyvc8wM0o6JGm7OewIlSK0nRtj6L3HVCUoiRcKHbMnwSZ4WuujaJTZBCnpSY0u6TiGTS5AvlZfq8sxbYW9c+BDo9NisaAoihxwpBL0tgPhWa5OKUpD7zZysFLGxZf41bajKHTODFMgSJ+Xg62LHbN4tCroOxdEvNjMb033MDVypWCWFC1TN+RG9RGs97R9eC8nJKYqz9yTt8M0KaA1TfPoHPcBbPTtR+Pbo70/uxCBHshZAaQB1AK8o2nXCAl926C1om0bnLMsl6ccXNrHWZ8Xyq1bN8OUodj+PwwY1nr2Dy5ztFhw//goUAdjJpOGQCTYYshCSDZ0sGG2mZo7jAqDOHb2dvFIirKmqusgDVtXVJMaqTdNRmUduejVBBEzIKEUDhARGlFq8/vafA2IQgosHpk0yuUGMvHeZZpdgl1S4EyzOxP7Ig0bkVKwblb0XUtvO5zbSAk753Iwats2B/cUEKy1QYZgcK2C1K1Cqo38bgr23vv8PinTTJz5tMATZJCu/5BJlLLEYQAYBqx0zgEi+GZ48Lvb6NsP37f/i8/9IP/VnxoZOA9qFyLQC3gHTgcbfNH3Qe2w73uuXr2KlJJnn32WxWKRsb/Lly/nIcvJoZ0LsyxTNpHev6qnOdNJv5uCTYIYgLx1fXsQGWLDZVnmJqBUDBxmKsk5k9aMi6wRvMxZS976Sp3x0RTEAKQiZzZvhynScaQCaeIup3NNQTidb3pP53qUCqPrmiYM6A5CYuod55hkZVO2nb40hhl9+tIYZozDzGsY/IfHnyy9d/osIF/7nNVbi4vKMsMmqnSdh8eS3iM72DnZ6NuP1reTff5zP/hNuJuPr5039yxbUWqkAhRIpQNFTniss5jC0HnHpUuXePnlV7h06RJfvf46RaHRQlJNZ9y9cxupNFVRxsyoDQ08dHir6Lzi+PiEUhtAoBAUVcXp6SnbW7uAyIsnOVf6FzaO1/d9EGFSMtAAU1ExFqJKU24yoUKD2ASj9XqNkQpfyLidL+lcB05huw4dIQ7tA8PAOQdS0fWOqprGbbugLEJbePr9FOCsDfS6FJyNDMVYBgXUtNik1PS9papq8CKfV4I7Kq1o1muWy2UcbhGgIGfB2yiE5QmB1wnabg04iqIKs11RID2id2gVrrmUHu97PBqtNtr1CQpKW/yuaUApECKyUSTGlJAydSEQxIxPK7q+R+JBSVQv6Z3FI/GR1XHehLzRtx+db3/+cz+IUor/4I+/cyDJaBu7GBm9EBipNvKoQiLlhkqV2CN37tyhrus4/7I447xCCJQU9G2D61r6tuV0taLteyye/f39/HlKh6zk5OQkSwUAeUubsothhropCm6ys2GGkx7pb1PxapgtFUWB0AppdGwr32RiCeOUUiLUppsw/Z33Hi8EXgh671DFZuubMqzEkuhdCJ6ds2fYJ+nYjDF4B0pqnPVIJdBmk2XlIl889+VymSGcruuwboifb1gTQwGqnG2niU9sxK6GNMr0u2dYIlLSJGEtvyn2DrN72LBB0hcGgFDhS0gN79lD99gHt9G3H71vj0H+ve3CZPQpu0i2Xoei4Ww24/T0lMuXL3Pv3r1Y3SfiuR2X9i6xWBznYcreNrFa77DOUlfTMDjZlLSxKcfiOT4+xlQlk8kE21scPjtfWgBDXHjDHVbv+HnYYqqssxJgix7voCyC0mDaJptigz9rrVkuTjFmIw3r+s30HSFEFiQL5x26UENgdEi5UZVMxVZTRHErzsI2k8mE1WpF27ZMJpMznZBCiCwulYJL+tzJZJJx3iE80rseE1kVSW89nYfRkpBDJOz3LP6bin4pECQef7quie+fBlAIxJnglLf1bBgZGbaJ/uO9R6bs9ZF67nvb6NuP1rdHe2+7EBk9BBW9KAFF17X5JqfpOm3bMt+aYuPEHeEtRila21Nqg207XNdiu9CtmTK9sqxBqDw+b9iYkXDHlBkMs8ohNpicPmW56XeHTAHvPWVZx6BDzm7LsjzTbKSkRklNVdZIoSirGqU3srw+Oa6UITzKMIS7j9lPwCjNGXbMEI+FGFjkhvcOG2ZK0pVPDTGp1Txd71S0Cx8tM5860SVT9p143ulaSbGhYqbjGOL2uROWTXAeYsKpMWaI/Q7np6aicrp/w2JwMmstUZ34DNZ7vrXY0bcftW+P9t52Ia6UEAKdGBXWhgwsdg/2nWU+n7NcLhG4M4WbyaQKGaiLgSD+XCmFNiVSa6p6xnQ65+j+IdWkzAGqiloeXdcFVFNseOKpW3O5XOYGksQtTkFnGAThLGXQuTDe7eDggNVqlbe6aeElylrbtlTVJHSkAn0f56ZG6GGDp0fNkbrasFLsZjD38fFx5FoXYb5PLLTVdY1EgAi46dbWVhzaLdnZ2ePo6H7IoiLXvixrptMpR0dHCCHY2tri/v37Z9gugW4ZJgJBGPQ8tJS1e28RaJQ0cUxdzeHhfabTaZBI9gnLHdLxogiWFEipKAjjBuuyBLkJ8pln/zZqZ7rGUitErMX6yAQ6Lxt9+9H49o/+yb98Xrf0sbQLktG/c+ZnWvjT6ZTDw8MzzA5syO7Sdr9tW4RMHXlhnmhVVZRlTdN0OEtusknvnT5nSB+EDY0vfV4KREOMMi2IociXs2RmirWWqg6DMYZzTkGiZHh45yhjFiOlDp2GMVNLx5Gog+kzpJSxsLnhiadMu+vCAIjJZIIaZM/K6Pw+qWEnZfXT6TwH5RwkpWQy2Qx9SGMHh9l1uE+bbfOQuSGEyMFfELnaqsjvMaRXDjP0tFMYsmUS5JS45ymYDLP5VFcY+k2mVxIe52ujbz8q3x7twe2CBPqzW3mlwuAKgUYqhzYOZy1975DSoXTAlN+6e0S/PkVJh7dxsIHSqHKCF4a2DV13h0d3afrT7FzYOLVntd7MU437eyEEqybg1JOiROPpuwatw3Djrl1jbccQd+66js4u6G2Ydi+lZFLP8SIwDNLvaa1RusA6h5ASnTOmzXY5OX9VTfICVMpQVVMEmwVQVxVt39G2ayRB81tIhfACowxSGPpu0xFZ19MAFUwMq6YNMsIyLb7wGR5YLsOA76qqchu6ioU0JSL7Jf5+puol2psyQVHdh/cUYbpsaJKRGmMKnPNILzFKoeVmKEbIODXeC2wU9ZLa4PCo9AXhfH4458AGvReFQHriQ2KkiQW+zfU/Pxt9+1H49mjvzy5EoB9irsOGjcRICDjdRlr1DNdWqyCWRFjYCWe21mZRprIsMwshfcaQjZIWoiTAAvP5PBcMUzaZtq7W2ryFdq7HuTBOzbnNXNbEi06flXS8N5ziDRc4ZSzDjCf9bJjp5YXMZuEkzRilFCr+vpQya7mnLTRshL+6OH0oiVUlPZtk6byllLmLVsf7kLLuIfY+vBewyQ7T7wzfewgFpPuYlDWHLfLDHUK6ZrkT12+OMz2Gxz48lnR/z7NgN/r2o/Ht0d6fXYhA//ZFEDom+8gU2bSwp61713VRy3tD1UuBIlXuk0N2Xcfh4WHkgp+dUpTgiBT8MhOg7c5ACAnbTEXMNG6v67qsJJgCH5Abk1LBKxWtUhAbikqlf9PUpmRDClvimCcrioBdG6XpYxFNa40bYJvGGFarVbieXQikk8kkU+XStKf0uV3XhW23dZyenmb8dbVc5vdPEEG6X+l8htnasFt1WMzLAWcQiNIXx2w2Yxk/Jz2G+O0QWz7TCAXvCPbJMhRyzjb69qPx7f/sT/ybj+iOPZl2IYaDCyFOgK+c93E8JDsA7p73QTwke1LO5UPe+0vn8cGjb19Ye1LO5YF8+0KwboCveO8/cd4H8TBMCPHSeC6jDWz07QtoT9K5PIhdCOhmtNFGG220R2djoB9ttNFGe8LtogT6v3jeB/AQbTyX0Yb2JF3D8VweU7sQxdjRRhtttNEenV2UjH600UYbbbRHZOce6IUQ3yWE+IoQ4hUhxI+d9/G8lwkhflYIcVsI8aXBa3tCiF8UQrwc/92NrwshxF+I5/ZFIcS3n9+Rv9OEEB8QQvwtIcSXhRC/KoT4bHz9sTyfi2ajb5+PjX79NWzYpPLNfgAK+A3gw0AB/EPgW87zmB7gmL8D+HbgS4PX/izwY/H5jwH/aXz+3cBfJwiefBr4wnkf/9vO5Sng2+PzOfDrwLc8rudzkR6jb5/reYx+/bbHeWf0nwRe8d7/pve+Bf4K8JlzPqava977Xwbuve3lzwB/KT7/S8DvHbz+l32wvwfsCCGe+uYc6Xub9/6G9/4fxOcnwK8Bz/CYns8Fs9G3z8lGv36nnXegfwZ4Y/D/6/G1x82ueO9vxOc3gSvx+WNzfkKI54BvA77AE3A+F8CelGv1WPvC6NfBzjvQP3Hmw17wsaIyCSFmwF8FfsR7fzz82eN4PqM9GnvcfGH0642dd6D/KvCBwf+fja89bnYrbfXiv7fj6xf+/IQQhrAYft57/9fiy4/t+Vwge1Ku1WPpC6Nfn7XzDvT/L/BRIcTzQogC+F7gF875mL4R+wXgB+LzHwD+18Hr3x+r+p8GjgZbx3M3ETRxfwb4Ne/9nxv86LE8nwtmo2+fk41+/TXsvKvBhIr3rxMYCv/ReR/PAxzv/wzcADoClvdDwD7wN4GXgV8C9uLvCuC/juf2j4BPnPfxv+1cfidh+/pF4Ffi47sf1/O5aI/Rt8/tPEa/fttj7IwdbbTRRnvC7byhm9FGG2200R6xjYF+tNFGG+0JtzHQjzbaaKM94TYG+tFGG220J9zGQD/aaKON9oTbGOhHG2200Z5wGwP9aKONNtoTbmOgH2200UZ7wu3/B//EQwgRPDgQAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "req = np.expand_dims(data[0], axis=0)\n",
     "explanation = sc.explain(deployment_name=\"image\",gateway=\"ambassador\",transport=\"rest\",data=req)\n",
+    "print(explanation)\n",
     "exp_arr = np.array(explanation['anchor'])\n",
     "\n",
     "f, axarr = plt.subplots(1, 2)\n",
@@ -996,24 +430,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "seldondeployment.machinelearning.seldon.io \"image\" deleted\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!kubectl delete -f resources/imagenet_explainer_grpc.yaml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/resources/imagenet_explainer.yaml
+++ b/notebooks/resources/imagenet_explainer.yaml
@@ -16,7 +16,7 @@ spec:
       requests:
         memory: 1Gi
     explainer:
-      type: anchor_images
+      type: AnchorImages
       modelUri: gs://seldon-models/tfserving/imagenet/explainer
     name: default
     replicas: 1

--- a/notebooks/resources/imagenet_explainer_grpc.yaml
+++ b/notebooks/resources/imagenet_explainer_grpc.yaml
@@ -46,9 +46,11 @@ spec:
       - name: SELDON_LOG_LEVEL
         value: DEBUG
     explainer:
-      type: anchor_images
+      type: AnchorImages
       modelUri: gs://seldon-models/tfserving/imagenet/explainer
       config:
         batch_size: "100"
+      endpoint:
+        type: GRPC
     name: default
     replicas: 1

--- a/notebooks/resources/income_explainer.yaml
+++ b/notebooks/resources/income_explainer.yaml
@@ -11,7 +11,7 @@ spec:
       modelUri: gs://seldon-models/sklearn/income/model
       name: classifier
     explainer:
-      type: anchor_tabular
+      type: AnchorTabular
       modelUri: gs://seldon-models/sklearn/income/explainer
     name: default
     replicas: 1

--- a/notebooks/resources/moviesentiment_explainer.yaml
+++ b/notebooks/resources/moviesentiment_explainer.yaml
@@ -11,6 +11,6 @@ spec:
       modelUri: gs://seldon-models/sklearn/moviesentiment
       name: classifier
     explainer:
-      type: anchor_text
+      type: AnchorText
     name: default
     replicas: 1

--- a/operator/api/v1alpha2/seldondeployment_types.go
+++ b/operator/api/v1alpha2/seldondeployment_types.go
@@ -229,14 +229,24 @@ type SvcOrchSpec struct {
 	Env       []*v1.EnvVar             `json:"env,omitempty" protobuf:"bytes,2,opt,name=env"`
 }
 
+type AlibiExplainerType string
+
+const (
+	AlibiAnchorsTabularExplainer  AlibiExplainerType = "AnchorTabular"
+	AlibiAnchorsImageExplainer    AlibiExplainerType = "AnchorImages"
+	AlibiAnchorsTextExplainer     AlibiExplainerType = "AnchorText"
+	AlibiCounterfactualsExplainer AlibiExplainerType = "Counterfactuals"
+	AlibiContrastiveExplainer     AlibiExplainerType = "Contrastive"
+)
+
 type Explainer struct {
-	Type               string            `json:"type,omitempty" protobuf:"string,1,opt,name=type"`
-	ModelUri           string            `json:"modelUri,omitempty" protobuf:"string,2,opt,name=modelUri"`
-	ServiceAccountName string            `json:"serviceAccountName,omitempty" protobuf:"string,3,opt,name=serviceAccountName"`
-	ContainerSpec      v1.Container      `json:"containerSpec,omitempty" protobuf:"bytes,4,opt,name=containerSpec"`
-	Config             map[string]string `json:"config,omitempty" protobuf:"bytes,5,opt,name=config"`
-	Endpoint           *Endpoint         `json:"endpoint,omitempty" protobuf:"bytes,6,opt,name=endpoint"`
-	EnvSecretRefName   string            `json:"envSecretRefName,omitempty" protobuf:"bytes,7,opt,name=envSecretRefName"`
+	Type               AlibiExplainerType `json:"type,omitempty" protobuf:"string,1,opt,name=type"`
+	ModelUri           string             `json:"modelUri,omitempty" protobuf:"string,2,opt,name=modelUri"`
+	ServiceAccountName string             `json:"serviceAccountName,omitempty" protobuf:"string,3,opt,name=serviceAccountName"`
+	ContainerSpec      v1.Container       `json:"containerSpec,omitempty" protobuf:"bytes,4,opt,name=containerSpec"`
+	Config             map[string]string  `json:"config,omitempty" protobuf:"bytes,5,opt,name=config"`
+	Endpoint           *Endpoint          `json:"endpoint,omitempty" protobuf:"bytes,6,opt,name=endpoint"`
+	EnvSecretRefName   string             `json:"envSecretRefName,omitempty" protobuf:"bytes,7,opt,name=envSecretRefName"`
 }
 
 type SeldonPodSpec struct {

--- a/python/seldon_core/seldon_client.py
+++ b/python/seldon_core/seldon_client.py
@@ -36,7 +36,7 @@ class SeldonChannelCredentials(object):
     Channel credentials
     Presently just denotes an SSL connection.
     For GRPC in order to be properly implemented, you need to provide *either*
-        the root_certificate_files, *or* all the file paths. 
+        the root_certificate_files, *or* all the file paths.
     The verify attribute currently is used to avoid SSL verification in REST
         however for GRPC it is recommended that you provide a path at least
         for the root_certificates_file otherwise it may not work as expected.
@@ -58,7 +58,7 @@ class SeldonChannelCredentials(object):
 class SeldonCallCredentials(object):
     """
     Credentials for each call, currently implements the ability to provide
-        an OAuth token which is currently made available through REST via 
+        an OAuth token which is currently made available through REST via
         the X-Auth-Token header, and via GRPC via the metadata call creds.
     """
 
@@ -1637,9 +1637,7 @@ def explain_predict_gateway(
                     + gateway_endpoint
                     + "/seldon/"
                     + deployment_name
-                    + "-explainer/models/"
-                    + deployment_name
-                    + ":explain"
+                    + "-explainer/api/v0.1/explain"
                 )
             else:
                 url = (
@@ -1650,9 +1648,7 @@ def explain_predict_gateway(
                     + namespace
                     + "/"
                     + deployment_name
-                    + "-explainer/models/"
-                    + deployment_name
-                    + ":explain"
+                    + "-explainer/api/v0.1/explain"
                 )
         else:
             url = (
@@ -1660,9 +1656,7 @@ def explain_predict_gateway(
                 + "://"
                 + gateway_endpoint
                 + gateway_prefix
-                + +"/models/"
-                + deployment_name
-                + ":explain"
+                + +"/api/v0.1/explain"
             )
     verify = True
     cert = None


### PR DESCRIPTION

 * Uses a new image `seldonio/alibiexplainer` created in https://github.com/SeldonIO/kfserving/tree/seldon_grpc_explainer
 * Allows http or grpc explainers
 * Allows seldon API path `/api/v0.1/explain` and updates Seldon Python client to use this path
 * Updates explainer types to be consistent with kfserving, e.g. `AnchorText` not `anchor_text`
 * Updates notebook examples

