### PR TITLE
make initializer configurable via configmap

### DIFF
--- a/helm-charts/seldon-core-operator/templates/configmap_seldon-config.yaml
+++ b/helm-charts/seldon-core-operator/templates/configmap_seldon-config.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   credentials: "{\n   \"gcs\" : {\n       \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n   },\n   \"s3\" : {\n       \"s3AccessKeyIDName\": \"awsAccessKeyID\",\n       \"s3SecretAccessKeyName\": \"awsSecretAccessKey\"\n   }\n}"
+  storageInitializer: "{\n    \"image\" : \"gcr.io/kfserving/storage-initializer:0.2.1\",\n    \"memoryRequest\": \"100Mi\",\n    \"memoryLimit\": \"1Gi\",\n    \"cpuRequest\": \"100m\",\n    \"cpuLimit\": \"1\"\n}"
 kind: ConfigMap
 metadata:
   labels:

--- a/operator/config/manager/configmap.yaml
+++ b/operator/config/manager/configmap.yaml
@@ -15,3 +15,11 @@ data:
            "s3SecretAccessKeyName": "awsSecretAccessKey"
        }
     }
+  storageInitializer: |-
+    {
+        "image" : "gcr.io/kfserving/storage-initializer:0.2.1",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }


### PR DESCRIPTION
This makes initializer configurable via configmap. Changes default to `gcr.io/kfserving/storage-initializer:0.2.1`

Part of https://github.com/SeldonIO/seldon-core/issues/1106
