### PR TITLE
update maven in core builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-api-frontend:
     docker:
-      - image: seldonio/core-builder:0.3
+      - image: seldonio/core-builder:0.7
 
     working_directory: /work
 
@@ -21,7 +21,7 @@ jobs:
 
   build-engine:
     docker:
-      - image: seldonio/core-builder:0.3
+      - image: seldonio/core-builder:0.7
 
     working_directory: /work
 
@@ -40,7 +40,7 @@ jobs:
 
   cluster-manager:
     docker:
-      - image: seldonio/core-builder:0.3
+      - image: seldonio/core-builder:0.7
 
     working_directory: /work
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
   - deploy
 
 cluster-manager-maven-build:
-  image: seldonio/core-builder:0.3
+  image: seldonio/core-builder:0.7
   stage: build
   script:
     - cd cluster-manager
@@ -26,7 +26,7 @@ cluster-manager-maven-build:
     - release-0.1
 
 engine-maven-build:
-  image: seldonio/core-builder:0.3
+  image: seldonio/core-builder:0.7
   stage: build
   script:
     - cd engine
@@ -41,7 +41,7 @@ engine-maven-build:
     - release-0.1
 
 api-frontend-maven-build:
-  image: seldonio/core-builder:0.3
+  image: seldonio/core-builder:0.7
   stage: build
   script:
     - cd api-frontend

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v ${HOME}/.m2:/root/.m2 \
           -v $(pwd):/work \
-          seldonio/core-builder:0.3 bash -c 'cd engine && make -f Makefile.ci build'
+          seldonio/core-builder:0.7 bash -c 'cd engine && make -f Makefile.ci build'
     - docker images | grep 'seldonio/engine'
 
 notifications:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     }
     agent {
         docker {
-            image 'seldonio/core-builder:0.3'
+            image 'seldonio/core-builder:0.7'
             args '-v /root/.m2:/root/.m2'
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ run_core_builder_in_host:
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${HOME}/.m2:/root/.m2 \
 			-v $(SELDON_CORE_LOCAL_DIR):/work \
-			seldonio/core-builder:0.3 bash
+			seldonio/core-builder:0.7 bash
 
 
 run_core_builder_in_minikube:
@@ -37,7 +37,7 @@ run_core_builder_in_minikube:
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v /home/docker/.m2:/root/.m2 \
 			-v $(SELDON_CORE_VM_DIR):/work \
-			seldonio/core-builder:0.3 bash
+			seldonio/core-builder:0.7 bash
 
 show_paths:
 	@echo "local: $(SELDON_CORE_LOCAL_DIR)"

--- a/build-all-in-minikube
+++ b/build-all-in-minikube
@@ -13,7 +13,7 @@ function do_build {
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /home/docker/.m2:/root/.m2 \
         -v ${SELDON_CORE_VM_DIR}:/work \
-        seldonio/core-builder:0.3 bash -c 'make -f Makefile.ci build'
+        seldonio/core-builder:0.7 bash -c 'make -f Makefile.ci build'
 }
 
 SELDON_CORE_LOCAL_DIR=${STARTUP_DIR}

--- a/build-all-private-repo
+++ b/build-all-private-repo
@@ -12,5 +12,5 @@ docker run --rm -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $HOME/.m2:/root/.m2 \
     -v $PWD:/work \
-    seldonio/core-builder:0.3 bash -c 'make -f Makefile.ci build'
+    seldonio/core-builder:0.7 bash -c 'make -f Makefile.ci build'
 

--- a/core-builder/Dockerfile
+++ b/core-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u141-jdk
+FROM openjdk:8u232-jdk
 
 ENV PYTHON_VERSION "3.6.0"
 

--- a/core-builder/Dockerfile
+++ b/core-builder/Dockerfile
@@ -91,6 +91,17 @@ RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomiz
         chmod +x kustomize_kustomize.v3.2.3_linux_amd64 && \
         mv kustomize_kustomize.v3.2.3_linux_amd64 /usr/local/bin/kustomize
 
+# UPGRADE MAVEN
+RUN cd /usr/local && \
+    wget http://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
+    sudo tar xzf apache-maven-3.6.3-bin.tar.gz && \
+    sudo ln -s apache-maven-3.6.3 apache-maven && \
+    rm apache-maven-3.6.3-bin.tar.gz && \
+    export M2_HOME=/usr/local/apache-maven  && \
+    export MAVEN_HOME=/usr/local/apache-maven
+
+ENV M2_HOME /usr/local/apache-maven
+ENV MAVEN_HOME /usr/local/apache-maven
 
 WORKDIR /work
 

--- a/core-builder/Makefile
+++ b/core-builder/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE_NAME=seldonio/core-builder
-DOCKER_IMAGE_VERSION=0.6
+DOCKER_IMAGE_VERSION=0.7
 
 build_docker_image:
 	docker build --force-rm=true -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) .

--- a/engine/build-private-repo
+++ b/engine/build-private-repo
@@ -13,5 +13,5 @@ docker run --rm -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $HOME/.m2:/root/.m2 \
     -v $PWD:/work \
-    seldonio/core-builder:0.3 bash -c 'cd engine && make -f Makefile.ci build'
+    seldonio/core-builder:0.7 bash -c 'cd engine && make -f Makefile.ci build'
 

--- a/engine/push-private-repo
+++ b/engine/push-private-repo
@@ -13,5 +13,5 @@ docker run --rm -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $HOME/.m2:/root/.m2 \
     -v $PWD:/work \
-    seldonio/core-builder:0.3 bash -c 'cd engine && make -f Makefile.ci push_image_private_repo'
+    seldonio/core-builder:0.7 bash -c 'cd engine && make -f Makefile.ci push_image_private_repo'
 

--- a/incubating/wrappers/s2i/java/Dockerfile.build
+++ b/incubating/wrappers/s2i/java/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM seldonio/core-builder:0.3
+FROM seldonio/core-builder:0.7
 
 LABEL io.openshift.s2i.scripts-url="image:///s2i/bin"
 

--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.6
+          image: seldonio/core-builder:0.7
         stages:
           - name: pr-build-comment
             steps:

--- a/jenkins-x-lint.yml
+++ b/jenkins-x-lint.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.4
+          image: seldonio/core-builder:0.7
         stages:
         - name: pr-build-comment
           steps:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -10,7 +10,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.4
+          image: seldonio/core-builder:0.7
         stages:
         - name: pr-build-comment
           steps:
@@ -54,7 +54,7 @@ pipelineConfig:
           command: echo "skipping tag"
       pipeline:
         agent:
-          image: seldonio/core-builder:0.4
+          image: seldonio/core-builder:0.7
         stages:
           - name: build-and-push
             steps:

--- a/push-all-private-repo
+++ b/push-all-private-repo
@@ -13,5 +13,5 @@ docker run --rm -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $HOME/.m2:/root/.m2 \
     -v $PWD:/work \
-    seldonio/core-builder:0.3 bash -c 'make -f Makefile.ci push_images_private_repo'
+    seldonio/core-builder:0.7 bash -c 'make -f Makefile.ci push_images_private_repo'
 

--- a/release
+++ b/release
@@ -9,5 +9,5 @@ STARTUP_DIR="$( cd "$( dirname "$0" )" && pwd )"
 docker run --rm -it \
     -v ${HOME}/.m2:/root/.m2 \
     -v "${STARTUP_DIR}":/work \
-    seldonio/core-builder:0.3 python3 release.py "$@"
+    seldonio/core-builder:0.7 python3 release.py "$@"
 


### PR DESCRIPTION
fixes https://github.com/SeldonIO/seldon-core/issues/1094

apt-get doesn't give a particularly new version but can override with steps from https://tecadmin.net/install-apache-maven-on-debian/