### PR TITLE
Adding a way to pass extra index urls to s2i python wrappers

### DIFF
--- a/wrappers/s2i/python-conda/s2i/bin/assemble
+++ b/wrappers/s2i/python-conda/s2i/bin/assemble
@@ -51,6 +51,10 @@ echo "---> Installing application source..."
 cp -Rf /tmp/src/. ./
 
 if [[ -f requirements.txt ]]; then
+  if [[ -n "$EXTRA_INDEX_URL" ]]; then
+     echo "---> Adding extra index url to pip..."
+     pip config set global.extra-index-url "${EXTRA_INDEX_URL}"
+  fi
   echo "---> Installing system-wide dependencies ..."
   pip install --find-links /whl -r requirements.txt
 elif [[ -f setup.py ]]; then

--- a/wrappers/s2i/python/s2i/bin/assemble
+++ b/wrappers/s2i/python/s2i/bin/assemble
@@ -51,6 +51,12 @@ echo "---> Installing application source..."
 cp -Rf /tmp/src/. ./
 
 if [[ -f requirements.txt ]]; then
+
+  if [[ -n "$EXTRA_INDEX_URL" ]]; then
+     echo "---> Adding extra index url to pip..."
+     pip config set global.extra-index-url "${EXTRA_INDEX_URL}"
+  fi
+
   echo "---> Installing dependencies ..."
   pip install --find-links /whl -r requirements.txt
 elif [[ -f setup.py ]]; then


### PR DESCRIPTION
**Issue**:
Our python modules are hosted inside an Azure devops pypi server. Currently, there is no way use this pypi server while building seldon container using s2i and seldon python wrapper builder image. We need a way to configure pip to use an extra index url inside the seldon python wrapper builder image and pull the python modules from the index. 

**Proposed Solution**
 Changed the assembler to accept an EXTRA_INDEX_URL environment variable passed through  s2i environment and used that to set extra index url in pip config.