### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,10 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: ''
+labels: bug, triage
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for Seldon Core
+title: ''
+labels: triage
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
Fixes #1152 

## Changelog
- Create two issue templates for bugs and feature requests
- Add label `triage` to both and an extra label `bug` to bug reports

## Notes
I've left the issue body empty in purpose, to keep it as lightweight as possible. We can add more process later as we see fit. 