### PR TITLE
enforce tensorflow<2.0 in Tensorflow MNIST Model example

### DIFF
--- a/examples/models/deep_mnist/deep_mnist.ipynb
+++ b/examples/models/deep_mnist/deep_mnist.ipynb
@@ -18,7 +18,7 @@
     " * [S2I](https://github.com/openshift/source-to-image)\n",
     "\n",
     "```bash\n",
-    "pip install seldon-core\n",
+    "pip3 install seldon-core \"tensorflow>=1.12,<2.0\"\n",
     "```\n",
     "\n",
     "## Train locally\n",

--- a/examples/models/deep_mnist/requirements.txt
+++ b/examples/models/deep_mnist/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow>=1.12.0
+tensorflow>=1.12.0,<2.0


### PR DESCRIPTION
This example is incompatible with Tensorflow 2.0, therefore enforcing a lower version.