### PR TITLE
see if delay in creating new service affects the failing test

### DIFF
--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/seldonio/seldon-core/operator/constants"
 	"github.com/seldonio/seldon-core/operator/utils"
@@ -919,7 +920,11 @@ func createServices(r *SeldonDeploymentReconciler, components *components, insta
 		err := r.Get(context.TODO(), types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, found)
 		if err != nil && errors.IsNotFound(err) {
 			ready = false
-			log.Info("Creating Service", "all", all, "namespace", svc.Namespace, "name", svc.Name)
+			log.Info("Creating Service", "namespace", svc.Namespace, "name", svc.Name)
+			if all {
+				//don't create new ambassador service too quickly
+				time.Sleep(300 * time.Millisecond)
+			}
 			err = r.Create(context.TODO(), svc)
 			if err != nil {
 				return ready, err


### PR DESCRIPTION
Using this to run integration tests in cluster and record results.

Investigating rolling_update_test5 after it [failed three times consecutively on PR1253](https://github.com/SeldonIO/seldon-core/pull/1253)