### PR TITLE
treat config as yaml in the values

### DIFF
--- a/helm-charts/seldon-core-operator/templates/configmap_seldon-config.yaml
+++ b/helm-charts/seldon-core-operator/templates/configmap_seldon-config.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
-  credentials: '{{ .Values.credentials }}'
-  predictor_servers: '{{ .Values.predictor_servers }}'
-  storageInitializer: '{{ .Values.storageInitializer }}'
+  credentials: '{{ .Values.credentials | toJson }}'
+  predictor_servers: '{{ .Values.predictor_servers | toJson }}'
+  storageInitializer: '{{ .Values.storageInitializer | toJson }}'
 kind: ConfigMap
 metadata:
   labels:

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -46,7 +46,46 @@ usageMetrics:
   enabled: false
 webhook:
   port: 443
-credentials: "{\n   \"gcs\" : {\n       \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n   },\n   \"s3\" : {\n       \"s3AccessKeyIDName\": \"awsAccessKeyID\",\n       \"s3SecretAccessKeyName\": \"awsSecretAccessKey\"\n   }\n}"
-predictor_servers: "{\n    \"TENSORFLOW_SERVER\": {\n        \"tensorflow\": true,\n        \"tfImage\": \"tensorflow/serving:latest\",\n        \"rest\": {\n          \"image\": \"seldonio/tfserving-proxy_rest\",\n          \"defaultImageVersion\": \"0.7\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/tfserving-proxy_grpc\",\n          \"defaultImageVersion\": \"0.7\"\n        }\n    },\n    \"SKLEARN_SERVER\": {\n        \"rest\": {\n          \"image\": \"seldonio/sklearnserver_rest\",\n          \"defaultImageVersion\": \"0.2\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/sklearnserver_grpc\",\n          \"defaultImageVersion\": \"0.2\"\n        }\n    },\n    \"XGBOOST_SERVER\": {\n        \"rest\": {\n          \"image\": \"seldonio/xgboostserver_rest\",\n          \"defaultImageVersion\": \"0.2\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/xgboostserver_grpc\",\n          \"defaultImageVersion\": \"0.2\"\n        }\n\
-    \    },\n    \"MLFLOW_SERVER\": {\n        \"rest\": {\n          \"image\": \"seldonio/mlflowserver_rest\",\n          \"defaultImageVersion\": \"0.2\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/mlflowserver_grpc\",\n          \"defaultImageVersion\": \"0.2\"\n        }\n    }\n}"
-storageInitializer: "{\n    \"image\" : \"gcr.io/kfserving/storage-initializer:0.2.1\",\n    \"memoryRequest\": \"100Mi\",\n    \"memoryLimit\": \"1Gi\",\n    \"cpuRequest\": \"100m\",\n    \"cpuLimit\": \"1\"\n}"
+credentials:
+  gcs:
+    gcsCredentialFileName: gcloud-application-credentials.json
+  s3:
+    s3AccessKeyIDName: awsAccessKeyID
+    s3SecretAccessKeyName: awsSecretAccessKey
+predictor_servers:
+  TENSORFLOW_SERVER:
+    tensorflow: true
+    tfImage: tensorflow/serving:latest
+    rest:
+      image: seldonio/tfserving-proxy_rest
+      defaultImageVersion: '0.7'
+    grpc:
+      image: seldonio/tfserving-proxy_grpc
+      defaultImageVersion: '0.7'
+  SKLEARN_SERVER:
+    rest:
+      image: seldonio/sklearnserver_rest
+      defaultImageVersion: '0.2'
+    grpc:
+      image: seldonio/sklearnserver_grpc
+      defaultImageVersion: '0.2'
+  XGBOOST_SERVER:
+    rest:
+      image: seldonio/xgboostserver_rest
+      defaultImageVersion: '0.2'
+    grpc:
+      image: seldonio/xgboostserver_grpc
+      defaultImageVersion: '0.2'
+  MLFLOW_SERVER:
+    rest:
+      image: seldonio/mlflowserver_rest
+      defaultImageVersion: '0.2'
+    grpc:
+      image: seldonio/mlflowserver_grpc
+      defaultImageVersion: '0.2'
+storageInitializer:
+  image: gcr.io/kfserving/storage-initializer:0.2.1
+  memoryRequest: 100Mi
+  memoryLimit: 1Gi
+  cpuRequest: 100m
+  cpuLimit: '1'

--- a/operator/config/manager/configmap.yaml
+++ b/operator/config/manager/configmap.yaml
@@ -62,7 +62,7 @@ data:
     }
   storageInitializer: |-
     {
-        "image" : "gcr.io/kfserving/storage-initializer:0.2.1",
+        "image" : "gcr.io/kfserving/storage-initializer:0.2.2",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -45,6 +45,9 @@ HELM_VALUES_IMAGE_PULL_POLICY = '{{ .Values.image.pullPolicy }}'
 def helm_value(value: str):
     return '{{ .Values.' + value + ' }}'
 
+def helm_value_json(value: str):
+    return '{{ .Values.' + value + ' | toJson }}'
+
 def helm_release(value: str):
     return '{{ .Release.' + value + ' }}'
 
@@ -103,9 +106,9 @@ if __name__ == "__main__":
 
 
             if kind == "configmap" and name == "seldon-config":
-                res["data"]["credentials"] = helm_value("credentials")
-                res["data"]["predictor_servers"] = helm_value("predictor_servers")
-                res["data"]["storageInitializer"] = helm_value("storageInitializer")
+                res["data"]["credentials"] = helm_value_json("credentials")
+                res["data"]["predictor_servers"] = helm_value_json("predictor_servers")
+                res["data"]["storageInitializer"] = helm_value_json("storageInitializer")
 
             if kind == "serviceaccount" and name == "seldon-manager":
                 res["metadata"]["name"] = helm_value("serviceAccount.name")

--- a/operator/helm/values-patch.yaml
+++ b/operator/helm/values-patch.yaml
@@ -1,4 +1,43 @@
-credentials: "{\n   \"gcs\" : {\n       \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n   },\n   \"s3\" : {\n       \"s3AccessKeyIDName\": \"awsAccessKeyID\",\n       \"s3SecretAccessKeyName\": \"awsSecretAccessKey\"\n   }\n}"
-predictor_servers: "{\n    \"TENSORFLOW_SERVER\": {\n        \"tensorflow\": true,\n        \"tfImage\": \"tensorflow/serving:latest\",\n        \"rest\": {\n          \"image\": \"seldonio/tfserving-proxy_rest\",\n          \"defaultImageVersion\": \"0.7\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/tfserving-proxy_grpc\",\n          \"defaultImageVersion\": \"0.7\"\n        }\n    },\n    \"SKLEARN_SERVER\": {\n        \"rest\": {\n          \"image\": \"seldonio/sklearnserver_rest\",\n          \"defaultImageVersion\": \"0.2\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/sklearnserver_grpc\",\n          \"defaultImageVersion\": \"0.2\"\n        }\n    },\n    \"XGBOOST_SERVER\": {\n        \"rest\": {\n          \"image\": \"seldonio/xgboostserver_rest\",\n          \"defaultImageVersion\": \"0.2\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/xgboostserver_grpc\",\n          \"defaultImageVersion\": \"0.2\"\n        }\n\
-    \    },\n    \"MLFLOW_SERVER\": {\n        \"rest\": {\n          \"image\": \"seldonio/mlflowserver_rest\",\n          \"defaultImageVersion\": \"0.2\"\n        },\n        \"grpc\": {\n          \"image\": \"seldonio/mlflowserver_grpc\",\n          \"defaultImageVersion\": \"0.2\"\n        }\n    }\n}"
-storageInitializer: "{\n    \"image\" : \"gcr.io/kfserving/storage-initializer:0.2.1\",\n    \"memoryRequest\": \"100Mi\",\n    \"memoryLimit\": \"1Gi\",\n    \"cpuRequest\": \"100m\",\n    \"cpuLimit\": \"1\"\n}"
+credentials:
+  gcs:
+    gcsCredentialFileName: gcloud-application-credentials.json
+  s3:
+    s3AccessKeyIDName: awsAccessKeyID
+    s3SecretAccessKeyName: awsSecretAccessKey
+predictor_servers:
+  TENSORFLOW_SERVER:
+    tensorflow: true
+    tfImage: tensorflow/serving:latest
+    rest:
+      image: seldonio/tfserving-proxy_rest
+      defaultImageVersion: '0.7'
+    grpc:
+      image: seldonio/tfserving-proxy_grpc
+      defaultImageVersion: '0.7'
+  SKLEARN_SERVER:
+    rest:
+      image: seldonio/sklearnserver_rest
+      defaultImageVersion: '0.2'
+    grpc:
+      image: seldonio/sklearnserver_grpc
+      defaultImageVersion: '0.2'
+  XGBOOST_SERVER:
+    rest:
+      image: seldonio/xgboostserver_rest
+      defaultImageVersion: '0.2'
+    grpc:
+      image: seldonio/xgboostserver_grpc
+      defaultImageVersion: '0.2'
+  MLFLOW_SERVER:
+    rest:
+      image: seldonio/mlflowserver_rest
+      defaultImageVersion: '0.2'
+    grpc:
+      image: seldonio/mlflowserver_grpc
+      defaultImageVersion: '0.2'
+storageInitializer:
+  image: gcr.io/kfserving/storage-initializer:0.2.2
+  memoryRequest: 100Mi
+  memoryLimit: 1Gi
+  cpuRequest: 100m
+  cpuLimit: '1'


### PR DESCRIPTION
Follow-up improvement to https://github.com/SeldonIO/seldon-core/pull/1309
Allows the config to be yaml when in the values file and json when read by operator.