### PR TITLE
set deployment replicas

### DIFF
--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -1108,6 +1108,10 @@ func createDeployments(r *SeldonDeploymentReconciler, components *components, in
 				desiredDeployment := found.DeepCopy()
 				found.Spec = deploy.Spec
 
+				if deploy.Spec.Replicas == nil {
+					found.Spec.Replicas = desiredDeployment.Spec.Replicas
+				}
+
 				err = r.Update(context.TODO(), found)
 				if err != nil {
 					return ready, err


### PR DESCRIPTION
set deployment replicas when operator reconcile, if replica have been defined in crd that will be used,otherwise use the found replicas which is controlled by hpa
