### PR TITLE
Create and use seldonio/core-builder:0.10

### DIFF
--- a/core-builder/Dockerfile
+++ b/core-builder/Dockerfile
@@ -90,8 +90,8 @@ RUN apt-get remove -y --auto-remove && apt-get clean -y && rm -rf /var/lib/apt/l
 
 # INSTALL GO
 ENV PATH /usr/local/go/bin:$PATH
-RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
-        tar -zxvf go1.13.3.linux-amd64.tar.gz && \
+RUN wget https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz && \
+        tar -zxvf go1.12.5.linux-amd64.tar.gz && \
         mv go/ /usr/local/go
 RUN curl -sL https://go.kubebuilder.io/dl/2.0.1/linux/amd64 | tar -xz -C /tmp/ && \
         mv /tmp/kubebuilder_2.0.1_linux_amd64 /usr/local/kubebuilder/

--- a/core-builder/Makefile
+++ b/core-builder/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE_NAME=seldonio/core-builder
-DOCKER_IMAGE_VERSION=0.9
+DOCKER_IMAGE_VERSION=0.10
 
 build_docker_image:
 	docker build --force-rm=true -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) .

--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.9
+          image: seldonio/core-builder:0.10
         stages:
           - name: pr-build-comment
             steps:

--- a/jenkins-x-lint.yml
+++ b/jenkins-x-lint.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.9
+          image: seldonio/core-builder:0.10
         stages:
         - name: pr-build-comment
           steps:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -10,7 +10,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.9
+          image: seldonio/core-builder:0.10
         stages:
         - name: pr-build-comment
           steps:
@@ -54,7 +54,7 @@ pipelineConfig:
           command: echo "skipping tag"
       pipeline:
         agent:
-          image: seldonio/core-builder:0.4
+          image: seldonio/core-builder:0.10
         stages:
           - name: build-and-push
             steps:

--- a/operator/README.md
+++ b/operator/README.md
@@ -80,3 +80,4 @@ You should delete the Operator running in the cluster at this point.
 # Build Helm Chart
 
 Use the Makefile in the `./helm` directory. Ensure you have `pyyaml` in your python environment.
+


### PR DESCRIPTION
* create a new core-builder image that uses go version 1.12.5 (same as the operator container build)
* update CI pipelines to use this new image