### PR TITLE
Integration tests for rolling updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,12 +95,13 @@ You can do so as:
 $ pytest
 ```
 
-### Integration
+### End to End Tests
 
-As part of Seldon Core's test suite, we also run integration tests.
+As part of Seldon Core's test suite, we also run end to end tests.
 These spin up an actual Kubernetes cluster using
 [Kind](https://github.com/kubernetes-sigs/kind) and deploy different
 `SeldonDeployment` and resources.
 
-You can read more about them and how to add new integration tests on [their
-dedicated documentation](testing/scripts/README.md).
+You can learn more about how to run them and how to add new test cases on
+[their dedicated
+documentation](https://docs.seldon.io/projects/seldon-core/en/latest/developer/e2e.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ warrant that you have the legal authority to do so.
 
 ## Coding conventions
 
-We use [`pre-commit`](https://pre-commit.com/) to handle a number of Git hooks
+We use [pre-commit](https://pre-commit.com/) to handle a number of Git hooks
 which ensure that all changes to the codebase follow Seldon's code conventions.
 It is recommended to set these up before making any change to the codebase.
 Extra checks down the line will stop the build if the code is not compliant to
@@ -35,12 +35,12 @@ accordingly on your local repository.
 To format our Java code we follow [Google's Java style
 guide](https://google.github.io/styleguide/javaguide.html).
 To make sure that the codebase remains consistent, we use
-[`checkstyle`](https://github.com/checkstyle/checkstyle) as part of the `mvn validate` lifecycle.
+[checkstyle](https://github.com/checkstyle/checkstyle) as part of the `mvn validate` lifecycle.
 
 To integrate these on your local editor, you can follow the official
-instructions to [configure `checkstyle`
+instructions to [configure checkstyle
 locally](https://checkstyle.org/beginning_development.html) and to [set-up
-`google-java-format`](https://github.com/google/google-java-format#using-the-formatter).
+google-java-format](https://github.com/google/google-java-format#using-the-formatter).
 
 ### Python
 
@@ -62,10 +62,10 @@ $ make test
 
 ### Python
 
-We use [`pytest`](https://docs.pytest.org/en/latest/) as our main test runner.
+We use [pytest](https://docs.pytest.org/en/latest/) as our main test runner.
 However, to ensure that tests run on the same version of the package that final
 users will download from `pip` and pypi.org, we use
-[`tox`](https://tox.readthedocs.io/en/latest/) on top of it.
+[tox](https://tox.readthedocs.io/en/latest/) on top of it.
 To install both (plus other required plugins), just run:
 
 ```bash
@@ -75,7 +75,7 @@ $ make install_dev
 Using `tox` we can run the entire test suite over different environments,
 isolated between them.
 You can see the different ones we currently use on the
-[`setup.cfg`](https://github.com/SeldonIO/seldon-core/blob/master/python/setup.cfg)
+[setup.cfg](https://github.com/SeldonIO/seldon-core/blob/master/python/setup.cfg)
 file.
 You can run your tests across all these environments using the standard `make test` [mentioned above](#Tests).
 Alternatively, if you want to pass any extra parameters, you can also run `tox`
@@ -94,3 +94,13 @@ You can do so as:
 ```bash
 $ pytest
 ```
+
+### Integration
+
+As part of Seldon Core's test suite, we also run integration tests.
+These spin up an actual Kubernetes cluster using
+[Kind](https://github.com/kubernetes-sigs/kind) and deploy different
+`SeldonDeployment` and resources.
+
+You can read more about them and how to add new integration tests on [their
+dedicated documentation](testing/scripts/README.md).

--- a/doc/source/developer/contributing.rst
+++ b/doc/source/developer/contributing.rst
@@ -1,7 +1,1 @@
-.. _contributing:
-
-========
-Contributing
-========
-
 .. mdinclude:: ../../../CONTRIBUTING.md

--- a/doc/source/developer/contributing.rst
+++ b/doc/source/developer/contributing.rst
@@ -4,4 +4,4 @@
 Contributing
 ========
 
- .. mdinclude:: ../../../CONTRIBUTING.md
+.. mdinclude:: ../../../CONTRIBUTING.md

--- a/doc/source/developer/contributing.rst
+++ b/doc/source/developer/contributing.rst
@@ -1,5 +1,7 @@
+.. _contributing:
+
 ========
-Contributing to Seldon Core
+Contributing
 ========
 
  .. mdinclude:: ../../../CONTRIBUTING.md

--- a/doc/source/developer/contributing.rst
+++ b/doc/source/developer/contributing.rst
@@ -1,0 +1,5 @@
+========
+Contributing to Seldon Core
+========
+
+ .. mdinclude:: ../../../CONTRIBUTING.md

--- a/doc/source/developer/e2e.rst
+++ b/doc/source/developer/e2e.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../../../testing/scripts/README.md

--- a/doc/source/developer/readme.md
+++ b/doc/source/developer/readme.md
@@ -1,6 +1,9 @@
 # Developer
 
-We welcome new contributors. Please read the [code of conduct](https://github.com/SeldonIO/seldon-core/blob/master/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/SeldonIO/seldon-core/blob/master/CONTRIBUTING.md)
+We welcome new contributors.
+Please read the [code of
+conduct](https://github.com/SeldonIO/seldon-core/blob/master/CODE_OF_CONDUCT.md)
+and the [contributing guidelines](contributing.rst).
 
 ## Operator Development
 
@@ -52,18 +55,15 @@ go run ./main.go --webhook-port=9000
 
 If running inside an IDE and you are using Kind then make sure you set the KUBECONFIG env as well.
 
-
-
 ## Tools we use
 
- - [github-changelog-generator](https://github.com/skywinder/github-changelog-generator)
- - [Grip - Local Markdown viewer](https://github.com/joeyespo/grip)
+- [github-changelog-generator](https://github.com/skywinder/github-changelog-generator)
+- [Grip - Local Markdown viewer](https://github.com/joeyespo/grip)
 
 ## Building Seldon Core
 
-* [Build using private repository](build-using-private-repo.md)
+- [Build using private repository](build-using-private-repo.md)
 
 ## Seldon Prow
 
- - [prow status](https://prow.seldon.io)
-
+- [prow status](https://prow.seldon.io)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -128,7 +128,7 @@ Seldon Core is an open source platform for deploying machine learning models on 
    :caption: Developer
 
    Overview <developer/readme.md>
-   Contributing to Seldon Core <developer/contributing.rst>
+   Contributing <developer/contributing.rst>
    Roadmap <developer/roadmap.md>
    Build using private repo <developer/build-using-private-repo.md>
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -128,7 +128,7 @@ Seldon Core is an open source platform for deploying machine learning models on 
    :caption: Developer
 
    Overview <developer/readme.md>
-   Contributing <developer/contributing.rst>
+   Contributing to Seldon Core <developer/contributing.rst>
    Roadmap <developer/roadmap.md>
    Build using private repo <developer/build-using-private-repo.md>
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -128,6 +128,7 @@ Seldon Core is an open source platform for deploying machine learning models on 
    :caption: Developer
 
    Overview <developer/readme.md>
+   Contributing to Seldon Core <developer/contributing.rst>
    Roadmap <developer/roadmap.md>
    Build using private repo <developer/build-using-private-repo.md>
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -129,6 +129,7 @@ Seldon Core is an open source platform for deploying machine learning models on 
 
    Overview <developer/readme.md>
    Contributing to Seldon Core <developer/contributing.rst>
+   End to End Tests <developer/e2e.rst>
    Roadmap <developer/roadmap.md>
    Build using private repo <developer/build-using-private-repo.md>
 

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -78,15 +78,15 @@ test: build_protos install
 		--verbose \
 		-s \
 		-W ignore \
-		--ignore test_s2i_python.py \
-		-n $(PYTEST_WORKERS)  2>&1
+		-n $(PYTEST_WORKERS) \
+		-m "not only_serial" 2>&1
 	# Then run the s2i tests in sequence (as they currently fail in parallel
 	pytest \
 		--verbose \
 		-s \
 		-W ignore \
 		-n 0 \
-		test_s2i_python.py 2>&1
+		-m "only_serial" 2>&1
 
 .PHONY: clean
 clean:

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -24,8 +24,7 @@ helm_setup:
 	helm repo update
 
 install_ambassador:
-	helm install ambassador stable/ambassador -f ambassador_values.yaml --set crds.keep=false --namespace seldon --set replicaCount=1
-	kubectl rollout status deployment.apps/ambassador --namespace seldon
+	helm install --wait ambassador stable/ambassador -f ambassador_values.yaml --set crds.keep=false --namespace seldon --set replicaCount=1
 
 install_cert_manager:
 	cd ../../operator && make install-cert-manager
@@ -33,7 +32,7 @@ install_cert_manager:
 
 install_seldon: install_cert_manager
 	kubectl create namespace seldon-system || echo "namespace seldon-system exists"
-	helm install seldon ../../helm-charts/seldon-core-operator --namespace seldon-system --set istio.enabled=true --set istio.gateway=seldon-gateway --set certManager.enabled=false
+	helm install --wait seldon ../../helm-charts/seldon-core-operator --namespace seldon-system --set istio.enabled=true --set istio.gateway=seldon-gateway --set certManager.enabled=false
 
 install_istio:
 	kubectl apply -f istio-1.4.2.yaml

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -78,14 +78,14 @@ test: build_protos install
 		-s \
 		-W ignore \
 		-n $(PYTEST_WORKERS) \
-		-m "not serial" 2>&1
+		-m "not sequential" 2>&1
 	# Then run the s2i tests in sequence (as they currently fail in parallel
 	pytest \
 		--verbose \
 		-s \
 		-W ignore \
 		-n 0 \
-		-m "serial" 2>&1
+		-m "sequential" 2>&1
 
 .PHONY: clean
 clean:

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -79,14 +79,14 @@ test: build_protos install
 		-s \
 		-W ignore \
 		-n $(PYTEST_WORKERS) \
-		-m "not only_serial" 2>&1
+		-m "not serial" 2>&1
 	# Then run the s2i tests in sequence (as they currently fail in parallel
 	pytest \
 		--verbose \
 		-s \
 		-W ignore \
 		-n 0 \
-		-m "only_serial" 2>&1
+		-m "serial" 2>&1
 
 .PHONY: clean
 clean:

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -20,6 +20,7 @@ kind_build_images: kind_build_engine kind_build_operator
 
 helm_setup:
 	helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+	helm repo add seldonio https://storage.googleapis.com/seldon-charts
 	helm repo update
 
 install_ambassador:

--- a/testing/scripts/README.md
+++ b/testing/scripts/README.md
@@ -1,11 +1,15 @@
 # End to End Tests
 
-## Prerequisites
+## Running the test suite
+
+### Prerequisites
+
 We use [Kind](https://github.com/kubernetes-sigs/kind), [S2I](https://github.com/openshift/source-to-image) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md).
 
-Install ```python -m pip install grpcio-tools```
+Install `python -m pip install grpcio-tools`.
 
-## Setup
+### Setup
+
 To get everything setup run:
 
 ```
@@ -18,21 +22,73 @@ Activate kind kubernetes config:
 export KUBECONFIG="$(kind get kubeconfig-path)"
 ```
 
-## Run
+### Run
+
 Then to run the tests and log output to a file:
 
 ```
 make test > test.log
 ```
 
-## Logs
+### Logs
+
 To view test logs in a separate terminal:
+
 ```
 tail -f test.log
 ```
 
 To also follow controller logs in a separate terminal:
+
 ```
 export KUBECONFIG="$(kind get kubeconfig-path)"
 kubectl logs -f -n seldon-system $(kubectl get pods -n seldon-system -l app=seldon -o jsonpath='{.items[0].metadata.name}')
 ```
+
+## Writing new tests
+
+### Invididual namespaces
+
+Each test should run on its own separate Kubernetes namespace.
+This allows for a cleaner environment as well as enables some of them
+to get parallelised (see [Serial and parallel
+tests](#Serial-and-parallel-tests)).
+
+To make the creation and deletion of the namespace easier, you can
+use the `namespace` fixture.
+This fixture takes care of creating a namespace with a unique name
+and tearing it down at the end.
+To use it you just need to specify the `namespace` parameter as part
+of the arguments passed to your test function.
+The fixture will create the new namespace on the background and the
+`namespace` argument will take on the namespace name as value.
+
+```python
+def test_foo(..., namespace, ...):
+  print(f"the new namespace's name is {namespace}")
+```
+
+### Serial and parallel tests
+
+We leverage `pytest-xdist` to speed up the test suite by
+parallelising the test execution.
+However, some of the tests may have side-effects which make
+them unsuitable to be executed alongside others.
+For example, the operator update tests change the cluster-wide Seldon
+operator which could affect the other tests running in parallel.
+
+To differentiate between parallelisable tests and tests which are
+required to be run serially you can use the `only_serial` mark.
+Marks in `pytest` allow to [select subsets of
+tests](http://doc.pytest.org/en/latest/example/markers.html).
+
+To mark a test to run serially, you can do:
+
+```python
+@pytest.mark.only_serial
+def test_foo(...):
+  print("the scripts will run this test serially")
+```
+
+The integration test scripts will make sure that tests marked as
+`only_serial` get run with a single worker.

--- a/testing/scripts/README.md
+++ b/testing/scripts/README.md
@@ -51,8 +51,8 @@ kubectl logs -f -n seldon-system $(kubectl get pods -n seldon-system -l app=seld
 
 Each test should run on its own separate Kubernetes namespace.
 This allows for a cleaner environment as well as enables some of them
-to get parallelised (see [Serial and parallel
-tests](#Serial-and-parallel-tests)).
+to get parallelised (see [Sequential and parallel
+tests](#Sequential-and-parallel-tests)).
 
 To make the creation and deletion of the namespace easier, you can
 use the `namespace` fixture.
@@ -68,7 +68,7 @@ def test_foo(..., namespace, ...):
   print(f"the new namespace's name is {namespace}")
 ```
 
-### Serial and parallel tests
+### Sequential and parallel tests
 
 We leverage `pytest-xdist` to speed up the test suite by
 parallelising the test execution.
@@ -78,17 +78,17 @@ For example, the operator update tests change the cluster-wide Seldon
 operator which could affect the other tests running in parallel.
 
 To differentiate between parallelisable tests and tests which are
-required to be run serially you can use the `serial` mark.
+required to be run sequentially you can use the `sequential` mark.
 Marks in `pytest` allow to [select subsets of
 tests](http://doc.pytest.org/en/latest/example/markers.html).
 
-To mark a test to run serially, you can do:
+To mark a test to run sequentially, you can do:
 
 ```python
-@pytest.mark.serial
+@pytest.mark.sequential
 def test_foo(...):
-  print("the scripts will run this test serially")
+  print("the scripts will run this test sequentially")
 ```
 
 The integration test scripts will make sure that tests marked as
-`serial` get run with a single worker.
+`sequential` get run with a single worker.

--- a/testing/scripts/README.md
+++ b/testing/scripts/README.md
@@ -78,17 +78,17 @@ For example, the operator update tests change the cluster-wide Seldon
 operator which could affect the other tests running in parallel.
 
 To differentiate between parallelisable tests and tests which are
-required to be run serially you can use the `only_serial` mark.
+required to be run serially you can use the `serial` mark.
 Marks in `pytest` allow to [select subsets of
 tests](http://doc.pytest.org/en/latest/example/markers.html).
 
 To mark a test to run serially, you can do:
 
 ```python
-@pytest.mark.only_serial
+@pytest.mark.serial
 def test_foo(...):
   print("the scripts will run this test serially")
 ```
 
 The integration test scripts will make sure that tests marked as
-`only_serial` get run with a single worker.
+`serial` get run with a single worker.

--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from seldon_e2e_utils import get_s2i_python_version
+from seldon_e2e_utils import clean_string, retry_run, get_s2i_python_version
 from subprocess import run
 
 
@@ -19,6 +19,19 @@ def run_pod_information_in_background(request):
 @pytest.fixture(scope="module")
 def s2i_python_version():
     return do_s2i_python_version()
+
+
+@pytest.fixture
+def namespace(request):
+    test_name = request.node.name
+    namespace = clean_string(test_name)
+
+    # Create namespace
+    retry_run(f"kubectl create namespace {namespace}")
+    yield namespace
+
+    # Tear down namespace
+    run(f"kubectl delete namespace {namespace}", shell=True)
 
 
 def do_s2i_python_version():

--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -23,6 +23,12 @@ def s2i_python_version():
 
 @pytest.fixture
 def namespace(request):
+    """
+    Creates an individual Kubernetes namespace for this particular test and it
+    removes it at the end. The value of the injected argument into the test
+    function will contain the namespace name.
+    """
+
     test_name = request.node.name
     namespace = clean_string(test_name)
 
@@ -32,6 +38,50 @@ def namespace(request):
 
     # Tear down namespace
     run(f"kubectl delete namespace {namespace}", shell=True)
+
+
+@pytest.fixture
+def seldon_version(request):
+    """
+    Ensures that the cluster-wide version of Seldon Core is set to a particular
+    version. After the test finishes it restores the code base version
+    (SNAPSHOT).
+
+    Since this fixture needs a parameter (the version we want on the
+    cluster), it needs to be used as an indirect parametrization.
+
+    ```python
+        @pytest.mark.parametrize("seldon_version", ["1.0.0", "1.0.1"], indirect=True)
+        def test_old_versions(seldon_version):
+            ...
+    ```
+    """
+    seldon_version = request.param
+
+    # Install past version cluster-wide
+    retry_run("helm delete seldon -n seldon-system")
+    retry_run(
+        "helm install seldon "
+        "seldonio/seldon-core-operator "
+        "--namespace seldon-system "
+        f"--version {seldon_version} "
+        "--wait"
+    )
+
+    yield seldon_version
+
+    # Re-install source code version cluster-wide
+    retry_run("helm delete seldon -n seldon-system")
+    retry_run(
+        "helm install seldon "
+        "../../helm-charts/seldon-core-operator "
+        "--namespace seldon-system "
+        "--set istio.enabled=true "
+        "--set istio.gateway=seldon-gateway "
+        "--set certManager.enabled=false "
+        "--wait",
+        attempts=2,
+    )
 
 
 def do_s2i_python_version():

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -365,5 +365,5 @@ def grpc_request_ambassador2(
 def clean_string(string):
     string = string.lower()
     string = re.sub(r"\]$", "", string)
-    string = re.sub(r"[_\[\.]", "-", string)
+    string = re.sub(r"[_\[\./]", "-", string)
     return string

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -381,3 +381,10 @@ def grpc_request_ambassador2(
             rows=rows,
             data=data,
         )
+
+
+def clean_string(string):
+    string = string.lower()
+    string = string.replace("_", "-")
+    string = string.replace(".", "-")
+    return string

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -160,19 +160,11 @@ def initial_rest_request(
     dtype="tensor",
     names=None,
 ):
-    r = rest_request(
-        model,
-        namespace,
-        endpoint=endpoint,
-        data_size=data_size,
-        rows=rows,
-        data=data,
-        dtype=dtype,
-        names=names,
-    )
-    if r is None or r.status_code != 200:
-        logging.warning("Sleeping 1 sec and trying again")
-        time.sleep(1)
+    sleeping_times = [1, 5, 10]
+    attempt = 0
+    finished = False
+    r = None
+    while not finished:
         r = rest_request(
             model,
             namespace,
@@ -183,32 +175,18 @@ def initial_rest_request(
             dtype=dtype,
             names=names,
         )
+
         if r is None or r.status_code != 200:
-            logging.warning("Sleeping 5 sec and trying again")
-            time.sleep(5)
-            r = rest_request(
-                model,
-                namespace,
-                endpoint=endpoint,
-                data_size=data_size,
-                rows=rows,
-                data=data,
-                dtype=dtype,
-                names=names,
-            )
-            if r is None or r.status_code != 200:
-                logging.warning("Sleeping 10 sec and trying again")
-                time.sleep(10)
-                r = rest_request(
-                    model,
-                    namespace,
-                    endpoint=endpoint,
-                    data_size=data_size,
-                    rows=rows,
-                    data=data,
-                    dtype=dtype,
-                    names=names,
-                )
+            if attempt >= len(sleeping_times):
+                finished = True
+
+            sleep = sleeping_times[attempt]
+            logging.warning(f"Sleeping {sleep} sec and trying again")
+            time.sleep(sleep)
+            attempt += 1
+        else:
+            finished = True
+
     return r
 
 

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -1,4 +1,5 @@
 import requests
+import re
 from requests.auth import HTTPBasicAuth
 from seldon_core.proto import prediction_pb2
 from seldon_core.proto import prediction_pb2_grpc
@@ -385,6 +386,6 @@ def grpc_request_ambassador2(
 
 def clean_string(string):
     string = string.lower()
-    string = string.replace("_", "-")
-    string = string.replace(".", "-")
+    string = re.sub(r"\]$", "", string)
+    string = re.sub(r"[_\[\.]", "-", string)
     return string

--- a/testing/scripts/setup.cfg
+++ b/testing/scripts/setup.cfg
@@ -1,3 +1,3 @@
 [tool:pytest]
 markers =
-    serial: mark a test as a test which needs to be run serially (as opposed to in paralel).
+    sequential: mark a test as a test which needs to be run sequentially (as opposed to in paralel).

--- a/testing/scripts/setup.cfg
+++ b/testing/scripts/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+markers =
+    serial: mark a test as a test which needs to be run serially (as opposed to in paralel).

--- a/testing/scripts/test_api_version.py
+++ b/testing/scripts/test_api_version.py
@@ -4,7 +4,6 @@ from seldon_e2e_utils import (
     wait_for_status,
     initial_rest_request,
     rest_request_ambassador,
-    retry_run,
     API_AMBASSADOR,
 )
 from subprocess import run
@@ -18,10 +17,7 @@ from subprocess import run
         "machinelearning.seldon.io/v1",
     ],
 )
-def test_api_version(apiVersion):
-    version = apiVersion.split("/")[-1]
-    namespace = f"test-api-version-{version}"
-    retry_run(f"kubectl create namespace {namespace}")
+def test_api_version(namespace, apiVersion):
     command = (
         "helm install mymodel ../../helm-charts/seldon-single-model "
         "--set oauth.key=oauth-key "
@@ -41,4 +37,3 @@ def test_api_version(apiVersion):
     assert len(r.json()["data"]["tensor"]["values"]) == 1
 
     run(f"helm delete mymodel", shell=True)
-    run(f"kubectl delete namespace {namespace}", shell=True)

--- a/testing/scripts/test_helm_charts_clusterwide.py
+++ b/testing/scripts/test_helm_charts_clusterwide.py
@@ -1,11 +1,9 @@
-import pytest
 from seldon_e2e_utils import (
     wait_for_rollout,
     wait_for_status,
     initial_rest_request,
     rest_request_ambassador,
     grpc_request_ambassador2,
-    retry_run,
     API_AMBASSADOR,
 )
 from subprocess import run
@@ -15,9 +13,7 @@ import logging
 class TestClusterWide(object):
 
     # Test singe model helm script with 4 API methods
-    def test_single_model(self):
-        namespace = "test-single-model"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_single_model(self, namespace):
         run(
             f"helm install mymodel ../../helm-charts/seldon-single-model --set oauth.key=oauth-key --set oauth.secret=oauth-secret --namespace {namespace}",
             shell=True,
@@ -35,12 +31,9 @@ class TestClusterWide(object):
         r = grpc_request_ambassador2("mymodel", namespace, API_AMBASSADOR)
         logging.warning(r)
         run(f"helm delete mymodel", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
     # Test AB Test model helm script with 4 API methods
-    def test_abtest_model(self):
-        namespace = "test-abtest-model"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_abtest_model(self, namespace):
         run(
             f"helm install myabtest ../../helm-charts/seldon-abtest --set oauth.key=oauth-key --set oauth.secret=oauth-secret --namespace {namespace}",
             shell=True,
@@ -59,12 +52,9 @@ class TestClusterWide(object):
             "WARNING SKIPPING FLAKY AMBASSADOR TEST UNTIL AMBASSADOR GRPC ISSUE FIXED.."
         )
         run(f"helm delete myabtest", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
     # Test MAB Test model helm script with 4 API methods
-    def test_mab_model(self):
-        namespace = "test-mab-model"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_mab_model(self, namespace):
         run(
             f"helm install mymab ../../helm-charts/seldon-mab --set oauth.key=oauth-key --set oauth.secret=oauth-secret --namespace {namespace}",
             shell=True,
@@ -83,4 +73,3 @@ class TestClusterWide(object):
             "WARNING SKIPPING FLAKY AMBASSADOR TEST UNTIL AMBASSADOR GRPC ISSUE FIXED.."
         )
         run(f"helm delete mymab", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)

--- a/testing/scripts/test_local_operators.py
+++ b/testing/scripts/test_local_operators.py
@@ -1,7 +1,4 @@
-import os
-import time
 import logging
-import pytest
 from subprocess import run
 from seldon_e2e_utils import (
     wait_for_status,
@@ -10,14 +7,11 @@ from seldon_e2e_utils import (
     initial_rest_request,
     retry_run,
     API_AMBASSADOR,
-    API_ISTIO_GATEWAY,
 )
 
 
 class TestLocalOperators(object):
-    def test_namespace_operator(self):
-        namespace = "test-namespaced-operator"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_namespace_operator(self, namespace):
         retry_run(
             f"helm install seldon ../../helm-charts/seldon-core-operator --namespace {namespace} --set istio.enabled=true --set istio.gateway=seldon-gateway --set certManager.enabled=false --set crd.create=false --set singleNamespace=true"
         )
@@ -31,11 +25,8 @@ class TestLocalOperators(object):
         logging.warning("Success for test_namespace_operator")
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"helm uninstall seldon -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    def test_labelled_operator(self):
-        namespace = "test-labelled-operator"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_labelled_operator(self, namespace):
         retry_run(
             f"helm install seldon ../../helm-charts/seldon-core-operator --namespace {namespace} --set istio.enabled=true --set istio.gateway=seldon-gateway --set certManager.enabled=false --set crd.create=false --set controllerId=seldon-id1"
         )
@@ -54,4 +45,3 @@ class TestLocalOperators(object):
             shell=True,
         )
         run(f"helm uninstall seldon -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -17,6 +17,11 @@ def assert_model(sdep_name, namespace, initial=False):
     assert r.status_code == 200
     assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
 
+    # NOTE: The following will test if the `SeldonDeployment` can be fetched as
+    # a Kubernetes resource. This covers cases where some resources (e.g. CRD
+    # versions or webhooks) may get inadvertently removed between versions.
+    # The `retry_run()` method will **implicitly do an assert** on the return
+    # code of the command.
     retry_run(f"kubectl get -n {namespace} sdep {sdep_name}")
 
 

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -29,8 +29,8 @@ def test_cluster_update(namespace, from_version):
         "seldonio/seldon-core-operator "
         "--namespace seldon-system "
         f"--version {from_version} "
+        "--wait"
     )
-    # TODO: Need to wait for CRD, webhooks and operator to get deployed
 
     retry_run(f"kubectl apply -f ../resources/graph1.json -n {namespace}")
     wait_for_status("mymodel", namespace)
@@ -38,16 +38,17 @@ def test_cluster_update(namespace, from_version):
     assert_model("mymodel", namespace, initial=True)
 
     # The upgrade should leave the cluster as it was before the test
-    # TODO: There is currently a bug updating from 0.4.1 using Helm 3.0.2 This
-    # will be fixed once https://github.com/helm/helm/pull/7269 is released in
-    # Helm 3.0.3.
+    # TODO: There is currently a bug updating from 0.4.1 using Helm 3.0.2.
+    # This will be fixed once https://github.com/helm/helm/pull/7269 is
+    # released in Helm 3.0.3.
     retry_run(
         "helm upgrade seldon "
         "../../helm-charts/seldon-core-operator "
         "--namespace seldon-system "
         "--set istio.enabled=true "
         "--set istio.gateway=seldon-gateway "
-        "--set certManager.enabled=false"
+        "--set certManager.enabled=false "
+        "--wait"
     )
 
     assert_model("mymodel", namespace, initial=True)

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -1,0 +1,44 @@
+import pytest
+
+from seldon_e2e_utils import (
+    initial_rest_request,
+    rest_request,
+    retry_run,
+    wait_for_status,
+    wait_for_rollout,
+)
+
+
+@pytest.mark.serial
+@pytest.mark.parametrize("from_version", ["0.4.1", "0.5.1", "1.0.0"])
+def test_operator_update(namespace, from_version):
+    retry_run("helm delete seldon -n seldon-system")
+    retry_run(
+        "helm install seldon "
+        "seldonio/seldon-core-operator "
+        "--namespace seldon-system "
+        f"--version {from_version} "
+    )
+
+    retry_run(f"kubectl apply -f ../resources/graph1.json -n {namespace}")
+    wait_for_status("mymodel", namespace)
+    wait_for_rollout("mymodel", namespace)
+
+    r = initial_rest_request("mymodel", namespace)
+    assert r.status_code == 200
+    assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
+
+    # The upgrade should leave the cluster as it was before the test
+    retry_run(
+        "helm upgrade seldon "
+        "../../helm-charts/seldon-core-operator "
+        "--namespace seldon-system "
+        "--set istio.enabled=true "
+        "--set istio.gateway=seldon-gateway "
+        "--set certManager.enabled=false"
+    )
+
+    # Improve health check and move to func (e.g. also checking list of sdep)
+    r = rest_request("mymodel", namespace)
+    assert r.status_code == 200
+    assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -20,7 +20,7 @@ def assert_model(sdep_name, namespace, initial=False):
     retry_run(f"kubectl get -n {namespace} sdep {sdep_name}")
 
 
-@pytest.mark.serial
+@pytest.mark.sequential
 @pytest.mark.parametrize("from_version", ["0.4.1", "0.5.1", "1.0.0"])
 def test_cluster_update(namespace, from_version):
     retry_run("helm delete seldon -n seldon-system")

--- a/testing/scripts/test_prepackaged_servers.py
+++ b/testing/scripts/test_prepackaged_servers.py
@@ -1,5 +1,4 @@
 from seldon_e2e_utils import (
-    get_deployment_names,
     wait_for_rollout,
     initial_rest_request,
     retry_run,
@@ -14,10 +13,8 @@ import logging
 class TestPrepack(object):
 
     # Test prepackaged server for sklearn
-    def test_sklearn(self):
-        namespace = "test-sklearn"
+    def test_sklearn(self, namespace):
         spec = "../../servers/sklearnserver/samples/iris.yaml"
-        retry_run(f"kubectl create namespace {namespace}")
         retry_run(f"kubectl apply -f {spec} -n {namespace}")
         wait_for_status("sklearn", namespace)
         wait_for_rollout("sklearn", namespace)
@@ -29,13 +26,10 @@ class TestPrepack(object):
         assert r.status_code == 200
         logging.warning("Success for test_prepack_sklearn")
         run(f"kubectl delete -f {spec} -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
     # Test prepackaged server for tfserving
-    def test_tfserving(self):
-        namespace = "test-tfserving"
+    def test_tfserving(self, namespace):
         spec = "../../servers/tfserving/samples/mnist_rest.yaml"
-        retry_run(f"kubectl create namespace {namespace}")
         retry_run(f"kubectl apply -f {spec}  -n {namespace}")
         wait_for_status("tfserving", namespace)
         wait_for_rollout("tfserving", namespace)
@@ -50,13 +44,10 @@ class TestPrepack(object):
         assert r.status_code == 200
         logging.warning("Success for test_prepack_tfserving")
         run(f"kubectl delete -f {spec} -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
     # Test prepackaged server for xgboost
-    def test_xgboost(self):
-        namespace = "test-xgboost"
+    def test_xgboost(self, namespace):
         spec = "../../servers/xgboostserver/samples/iris.yaml"
-        retry_run(f"kubectl create namespace {namespace}")
         retry_run(f"kubectl apply -f {spec}  -n {namespace}")
         wait_for_status("xgboost", namespace)
         wait_for_rollout("xgboost", namespace)
@@ -68,13 +59,10 @@ class TestPrepack(object):
         assert r.status_code == 200
         logging.warning("Success for test_prepack_xgboost")
         run(f"kubectl delete -f {spec} -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
     # Test prepackaged server for MLflow
-    def test_mlflow(self):
-        namespace = "test-mlflow"
+    def test_mlflow(self, namespace):
         spec = "../../servers/mlflowserver/samples/elasticnet_wine.yaml"
-        retry_run(f"kubectl create namespace {namespace}")
         retry_run(f"kubectl apply -f {spec} -n {namespace}")
         wait_for_status("mlflow", namespace)
         wait_for_rollout("mlflow", namespace)
@@ -102,4 +90,3 @@ class TestPrepack(object):
         assert r.status_code == 200
 
         run(f"kubectl delete -f {spec} -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)

--- a/testing/scripts/test_rolling_updates.py
+++ b/testing/scripts/test_rolling_updates.py
@@ -4,7 +4,6 @@ import logging
 import pytest
 from subprocess import run
 from seldon_e2e_utils import (
-    clean_string,
     wait_for_status,
     wait_for_rollout,
     rest_request_ambassador,
@@ -19,16 +18,15 @@ def to_resources_path(file_name):
     return os.path.join("..", "resources", file_name)
 
 
+test_all_gateways = pytest.mark.parametrize(
+    "api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY], ids=["ambas", "istio"]
+)
+
+
 class TestRollingHttp(object):
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model with a new image version as the only change
-    def test_rolling_update1(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-1" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update1(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -67,17 +65,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update1")
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph2.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # test changing the image version and the name of its container
-    def test_rolling_update2(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-2" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update2(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -117,17 +108,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update2")
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph3.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model with a new resource request but same image
-    def test_rolling_update3(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-updates-3" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update3(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -161,17 +145,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update3")
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph4.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model with a multi deployment new model
-    def test_rolling_update4(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-4" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update4(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -209,17 +186,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update4")
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph5.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model to a multi predictor model
-    def test_rolling_update5(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-5" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update5(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -259,17 +229,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update5")
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph6.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model with a new image version as the only change
-    def test_rolling_update6(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-6" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update6(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -308,17 +271,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update6")
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph2svc.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # test changing the image version and the name of its container
-    def test_rolling_update7(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-7" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update7(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -358,17 +314,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update7")
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph3svc.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model with a new resource request but same image
-    def test_rolling_update8(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-8" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update8(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -401,17 +350,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update8")
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph4svc.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model with a multi deployment new model
-    def test_rolling_update9(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-9" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update9(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -448,17 +390,10 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update9")
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph5svc.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    @pytest.mark.parametrize("api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY])
+    @test_all_gateways
     # Test updating a model to a multi predictor model
-    def test_rolling_update10(self, api_gateway):
-        if api_gateway == API_AMBASSADOR:
-            ns_suffix = "ambas"
-        else:
-            ns_suffix = "istio"
-        namespace = "test-rolling-update-10" + ns_suffix
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_rolling_update10(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
             retry_run(
                 f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
@@ -497,7 +432,6 @@ class TestRollingHttp(object):
         logging.warning("Success for test_rolling_update10")
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph6svc.json -n {namespace}", shell=True)
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
 
 @pytest.mark.parametrize(
@@ -507,12 +441,7 @@ class TestRollingHttp(object):
         ("graph7.json", "graph8.json"),  # From v1alpha3 to v1
     ],
 )
-def test_rolling_update_deployment(from_deployment, to_deployment):
-    from_name = clean_string(from_deployment)
-    to_name = clean_string(to_deployment)
-    namespace = f"test-rolling-update-{from_name}-{to_name}"
-    retry_run(f"kubectl create namespace {namespace}")
-
+def test_rolling_update_deployment(namespace, from_deployment, to_deployment):
     from_file_path = to_resources_path(from_deployment)
     retry_run(f"kubectl apply -f {from_file_path} -n {namespace}")
     # Note that this is not yet parametrised!
@@ -551,4 +480,3 @@ def test_rolling_update_deployment(from_deployment, to_deployment):
 
     run(f"kubectl delete -f {from_file_path} -n {namespace}", shell=True)
     run(f"kubectl delete -f {to_file_path} -n {namespace}", shell=True)
-    run(f"kubectl delete namespace {namespace}", shell=True)

--- a/testing/scripts/test_rolling_updates.py
+++ b/testing/scripts/test_rolling_updates.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 from subprocess import run
 from seldon_e2e_utils import (
+    clean_string,
     wait_for_status,
     wait_for_rollout,
     rest_request_ambassador,
@@ -12,13 +13,6 @@ from seldon_e2e_utils import (
     API_AMBASSADOR,
     API_ISTIO_GATEWAY,
 )
-
-
-def clean_string(string):
-    string = string.lower()
-    string = string.replace("_", "-")
-    string = string.replace(".", "-")
-    return string
 
 
 def to_resources_path(file_name):

--- a/testing/scripts/test_rolling_updates.py
+++ b/testing/scripts/test_rolling_updates.py
@@ -18,13 +18,13 @@ def to_resources_path(file_name):
     return os.path.join("..", "resources", file_name)
 
 
-test_all_gateways = pytest.mark.parametrize(
+with_api_gateways = pytest.mark.parametrize(
     "api_gateway", [API_AMBASSADOR, API_ISTIO_GATEWAY], ids=["ambas", "istio"]
 )
 
 
 class TestRollingHttp(object):
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model with a new image version as the only change
     def test_rolling_update1(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -66,7 +66,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph2.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # test changing the image version and the name of its container
     def test_rolling_update2(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -109,7 +109,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph3.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model with a new resource request but same image
     def test_rolling_update3(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -146,7 +146,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph4.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model with a multi deployment new model
     def test_rolling_update4(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -187,7 +187,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph5.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model to a multi predictor model
     def test_rolling_update5(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -230,7 +230,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph6.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model with a new image version as the only change
     def test_rolling_update6(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -272,7 +272,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph2svc.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # test changing the image version and the name of its container
     def test_rolling_update7(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -315,7 +315,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph3svc.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model with a new resource request but same image
     def test_rolling_update8(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -351,7 +351,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph4svc.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model with a multi deployment new model
     def test_rolling_update9(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -391,7 +391,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph5svc.json -n {namespace}", shell=True)
 
-    @test_all_gateways
+    @with_api_gateways
     # Test updating a model to a multi predictor model
     def test_rolling_update10(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:

--- a/testing/scripts/test_s2i_python.py
+++ b/testing/scripts/test_s2i_python.py
@@ -42,7 +42,7 @@ def create_push_s2i_image(s2i_python_version, component_type, api_type):
     kind_push_s2i_image(component_type, api_type)
 
 
-@pytest.mark.serial
+@pytest.mark.sequential
 @pytest.mark.usefixtures("s2i_python_version")
 class TestPythonS2i(object):
     def test_build_router_rest(self, s2i_python_version):
@@ -111,7 +111,7 @@ class TestPythonS2i(object):
         run("docker rm -f combiner-grpc", shell=True, check=True)
 
 
-@pytest.mark.serial
+@pytest.mark.sequential
 @pytest.mark.usefixtures("s2i_python_version")
 class TestPythonS2iK8s(object):
     def test_model_rest(self, s2i_python_version):

--- a/testing/scripts/test_s2i_python.py
+++ b/testing/scripts/test_s2i_python.py
@@ -42,6 +42,7 @@ def create_push_s2i_image(s2i_python_version, component_type, api_type):
     kind_push_s2i_image(component_type, api_type)
 
 
+@pytest.mark.only_serial
 @pytest.mark.usefixtures("s2i_python_version")
 class TestPythonS2i(object):
     def test_build_router_rest(self, s2i_python_version):
@@ -110,6 +111,7 @@ class TestPythonS2i(object):
         run("docker rm -f combiner-grpc", shell=True, check=True)
 
 
+@pytest.mark.only_serial
 @pytest.mark.usefixtures("s2i_python_version")
 class TestPythonS2iK8s(object):
     def test_model_rest(self, s2i_python_version):

--- a/testing/scripts/test_s2i_python.py
+++ b/testing/scripts/test_s2i_python.py
@@ -42,7 +42,7 @@ def create_push_s2i_image(s2i_python_version, component_type, api_type):
     kind_push_s2i_image(component_type, api_type)
 
 
-@pytest.mark.only_serial
+@pytest.mark.serial
 @pytest.mark.usefixtures("s2i_python_version")
 class TestPythonS2i(object):
     def test_build_router_rest(self, s2i_python_version):
@@ -111,7 +111,7 @@ class TestPythonS2i(object):
         run("docker rm -f combiner-grpc", shell=True, check=True)
 
 
-@pytest.mark.only_serial
+@pytest.mark.serial
 @pytest.mark.usefixtures("s2i_python_version")
 class TestPythonS2iK8s(object):
     def test_model_rest(self, s2i_python_version):

--- a/testing/scripts/test_s2i_python.py
+++ b/testing/scripts/test_s2i_python.py
@@ -138,9 +138,7 @@ class TestPythonS2iK8s(object):
 
 
 class S2IK8S(object):
-    def test_model_rest(self, s2i_python_version):
-        namespace = "s2i-test-model-rest"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_model_rest(self, namespace, s2i_python_version):
         create_push_s2i_image(s2i_python_version, "model", "rest")
         retry_run(f"kubectl apply -f ../resources/s2i_python_model.json -n {namespace}")
         wait_for_status("mymodel", namespace)
@@ -157,11 +155,8 @@ class S2IK8S(object):
             f"kubectl delete -f ../resources/s2i_python_model.json -n {namespace}",
             shell=True,
         )
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    def test_model_rest_non200(self, s2i_python_version):
-        namespace = "s2i-test-model-rest-non200"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_model_rest_non200(self, namespace, s2i_python_version):
         create_push_s2i_image(s2i_python_version, "model", "rest_non200")
         retry_run(
             f"kubectl apply -f ../resources/s2i_python_model_non200.json -n {namespace}"
@@ -182,11 +177,8 @@ class S2IK8S(object):
             f"kubectl delete -f ../resources/s2i_python_model_non200.json -n {namespace}",
             shell=True,
         )
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    def test_input_transformer_rest(self, s2i_python_version):
-        namespace = "s2i-test-input-transformer-rest"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_input_transformer_rest(self, namespace, s2i_python_version):
         create_push_s2i_image(s2i_python_version, "transformer", "rest")
         retry_run(
             f"kubectl apply -f ../resources/s2i_python_transformer.json -n {namespace}"
@@ -205,11 +197,8 @@ class S2IK8S(object):
             f"kubectl delete -f ../resources/s2i_python_transformer.json -n {namespace}",
             shell=True,
         )
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    def test_output_transformer_rest(self, s2i_python_version):
-        namespace = "s2i-test-output-transformer-rest"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_output_transformer_rest(self, namespace, s2i_python_version):
         create_push_s2i_image(s2i_python_version, "transformer", "rest")
         retry_run(
             f"kubectl apply -f ../resources/s2i_python_output_transformer.json -n {namespace}"
@@ -228,11 +217,8 @@ class S2IK8S(object):
             f"kubectl delete -f ../resources/s2i_python_output_transformer.json -n {namespace}",
             shell=True,
         )
-        run(f"kubectl create namespace {namespace}", shell=True)
 
-    def test_router_rest(self, s2i_python_version):
-        namespace = "s2i-test-router-rest"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_router_rest(self, namespace, s2i_python_version):
         create_push_s2i_image(s2i_python_version, "model", "rest")
         create_push_s2i_image(s2i_python_version, "router", "rest")
         retry_run(
@@ -252,11 +238,8 @@ class S2IK8S(object):
             f"kubectl delete -f ../resources/s2i_python_router.json -n {namespace}",
             shell=True,
         )
-        run(f"kubectl delete namespace {namespace}", shell=True)
 
-    def test_combiner_rest(self, s2i_python_version):
-        namespace = "s2i-test-combiner-rest"
-        retry_run(f"kubectl create namespace {namespace}")
+    def test_combiner_rest(self, namespace, s2i_python_version):
         create_push_s2i_image(s2i_python_version, "model", "rest")
         create_push_s2i_image(s2i_python_version, "combiner", "rest")
         retry_run(
@@ -276,4 +259,3 @@ class S2IK8S(object):
             f"kubectl delete -f ../resources/s2i_python_combiner.json -n {namespace}",
             shell=True,
         )
-        run(f"kubectl delete namespace {namespace}", shell=True)

--- a/testing/scripts/test_s2i_python.py
+++ b/testing/scripts/test_s2i_python.py
@@ -112,34 +112,9 @@ class TestPythonS2i(object):
 
 
 @pytest.mark.sequential
+@pytest.mark.usefixtures("namespace")
 @pytest.mark.usefixtures("s2i_python_version")
 class TestPythonS2iK8s(object):
-    def test_model_rest(self, s2i_python_version):
-        tester = S2IK8S()
-        tester.test_model_rest(s2i_python_version)
-
-    def test_model_rest_non200(self, s2i_python_version):
-        tester = S2IK8S()
-        tester.test_model_rest_non200(s2i_python_version)
-
-    def test_input_transformer_rest(self, s2i_python_version):
-        tester = S2IK8S()
-        tester.test_input_transformer_rest(s2i_python_version)
-
-    def test_output_transformer_rest(self, s2i_python_version):
-        tester = S2IK8S()
-        tester.test_output_transformer_rest(s2i_python_version)
-
-    def test_router_rest(self, s2i_python_version):
-        tester = S2IK8S()
-        tester.test_router_rest(s2i_python_version)
-
-    def test_combiner_rest(self, s2i_python_version):
-        tester = S2IK8S()
-        tester.test_combiner_rest(s2i_python_version)
-
-
-class S2IK8S(object):
     def test_model_rest(self, namespace, s2i_python_version):
         create_push_s2i_image(s2i_python_version, "model", "rest")
         retry_run(f"kubectl apply -f ../resources/s2i_python_model.json -n {namespace}")


### PR DESCRIPTION
This PR introduces integration tests for updates between different versions of Seldon Core.

## Changelog
- Add fixture `namespace` which creates / tears down the namespace of each test.
- Move gateways to parametrised fixture `with_api_gateways`.
- Add custom `serial` mark to `pytest` to flag tests which can't be run in parallel. 
- Add `seldonio` Helm repo as part of setup.
- Introduce test for cluster-wide updates from each old version to the latest one (the one in the repo).

## TODO
- [x] Add tests for namespace-scoped updates.
- [x] Add tests for id-scoped updates.
- [x] Make update tests more reliable (i.e. wait until CRD is installed, etc).
- [ ] Test both in Helm 2.x and Helm 3.x? (out of scope?).