### PR TITLE
Remove log4j from Java wrapper example

### DIFF
--- a/incubating/wrappers/s2i/java/test/model-template-app/pom.xml
+++ b/incubating/wrappers/s2i/java/test/model-template-app/pom.xml
@@ -1,80 +1,74 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.seldon.example</groupId>
-	<artifactId>seldon-core-model-template</artifactId>
-	<packaging>jar</packaging>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>Seldon Core Model Template</name>
-	<url>http://maven.apache.org</url>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.1.RELEASE</version>
-	</parent>
-
-	<properties>
-		<java.version>1.8</java.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<grpc.version>1.0.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
-		<micrometer.version>1.0.0-rc.1</micrometer.version>
-		<start-class>io.seldon.example.App</start-class>
-	</properties>
-
-	<build>
-		<finalName>${project.artifactId}-${project.version}</finalName>
-		<extensions>
-			<extension>
-				<groupId>kr.motd.maven</groupId>
-				<artifactId>os-maven-plugin</artifactId>
-				<version>1.4.1.Final</version>
-			</extension>
-		</extensions>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
-	<dependencies>
-		<!-- https://mvnrepository.com/artifact/org.nd4j/nd4j-native -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.seldon.wrapper</groupId>
-			<artifactId>seldon-core-wrapper</artifactId>
-			<version>0.1.2</version>
-		</dependency>
-
-	</dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.seldon.example</groupId>
+  <artifactId>seldon-core-model-template</artifactId>
+  <packaging>jar</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>Seldon Core Model Template</name>
+  <url>http://maven.apache.org</url>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.5.1.RELEASE</version>
+  </parent>
+  <properties>
+    <java.version>1.8</java.version>
+    <project.build.sourceEncoding>
+    UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>
+    UTF-8</project.reporting.outputEncoding>
+    <grpc.version>1.0.0</grpc.version>
+    <!-- CURRENT_GRPC_VERSION -->
+    <micrometer.version>1.0.0-rc.1</micrometer.version>
+    <start-class>io.seldon.example.App</start-class>
+  </properties>
+  <build>
+    <finalName>${project.artifactId}-${project.version}</finalName>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.4.1.Final</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <!-- https://mvnrepository.com/artifact/org.nd4j/nd4j-native -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.seldon.wrapper</groupId>
+      <artifactId>seldon-core-wrapper</artifactId>
+      <version>0.1.2</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/incubating/wrappers/s2i/java/test/model-template-app/src/main/java/io/seldon/example/App.java
+++ b/incubating/wrappers/s2i/java/test/model-template-app/src/main/java/io/seldon/example/App.java
@@ -6,10 +6,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
-@SpringBootApplication(scanBasePackages = {"io.seldon.wrapper","io.seldon.example"})
-@Import({ io.seldon.wrapper.config.AppConfig.class })
+@SpringBootApplication(scanBasePackages = {"io.seldon.wrapper", "io.seldon.example"})
+@Import({io.seldon.wrapper.config.AppConfig.class})
 public class App {
-    public static void main(String[] args) throws Exception {
-        SpringApplication.run(App.class, args);
-    }
+  public static void main(String[] args) throws Exception {
+    SpringApplication.run(App.class, args);
+  }
 }

--- a/incubating/wrappers/s2i/java/test/model-template-app/src/main/java/io/seldon/example/model/ExampleModelHandler.java
+++ b/incubating/wrappers/s2i/java/test/model-template-app/src/main/java/io/seldon/example/model/ExampleModelHandler.java
@@ -1,18 +1,18 @@
 package io.seldon.example.model;
 
-import org.springframework.stereotype.Component;
-
 import io.seldon.protos.PredictionProtos.DefaultData;
 import io.seldon.protos.PredictionProtos.SeldonMessage;
 import io.seldon.protos.PredictionProtos.Tensor;
 import io.seldon.wrapper.api.SeldonPredictionService;
+import org.springframework.stereotype.Component;
 
 @Component
 public class ExampleModelHandler implements SeldonPredictionService {
 
-	@Override
-	public SeldonMessage predict(SeldonMessage payload) {
-		return SeldonMessage.newBuilder().setData(DefaultData.newBuilder().setTensor(Tensor.newBuilder().addShape(1).addValues(1.0))).build();
-	}
-
+  @Override
+  public SeldonMessage predict(SeldonMessage payload) {
+    return SeldonMessage.newBuilder()
+        .setData(DefaultData.newBuilder().setTensor(Tensor.newBuilder().addShape(1).addValues(1.0)))
+        .build();
+  }
 }


### PR DESCRIPTION
There was still a usage of the `log4j` dependency which has been recently flagged as a security vulnerability. The example also installs `SLF4J` so `log4j` wasn't used anyway.

## Changelog 
- Removes `log4j` from example using the Java wrapper. 
- Format Java code according to code conventions.