### PR TITLE
minor fixes in tests

### DIFF
--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -16,7 +16,7 @@ kind_build_engine:
 kind_build_operator:
 	cd ../../operator && make kind-image-install
 
-kind_build_images: kind_build_engine kind_build_operator
+kind_build_images: build_protos kind_build_engine kind_build_operator
 
 helm_setup:
 	helm repo add stable https://kubernetes-charts.storage.googleapis.com/

--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -18,6 +18,7 @@ def run_pod_information_in_background(request):
 
 @pytest.fixture(scope="module")
 def s2i_python_version():
+    """Return version of s2i images, the IMAGE_VERSION, e.g. 0.17-SNAPSHOT."""
     return do_s2i_python_version()
 
 


### PR DESCRIPTION
1. Running [kind_test_setup.sh](https://github.com/SeldonIO/seldon-core/blob/master/testing/scripts/kind_test_setup.sh) fails currently on a fresh machine without built protos.This PR fixes that.
2. Add comment to clarify meaning of `s2i_python_version` fixture.
3. Make sure that `test_s2i_python.py` cleans after itself

This is a simple fix for the issue.