### PR TITLE
fix tensorflow==2.1 in outliers example

### DIFF
--- a/examples/outliers/alibi-detect-combiner/requirements-dev.txt
+++ b/examples/outliers/alibi-detect-combiner/requirements-dev.txt
@@ -8,3 +8,4 @@ seldon_core==1.0
 scipy==1.1.0
 numpy==1.15.4
 scikit-learn==0.20.1
+tensorflow==2.1


### PR DESCRIPTION
Outliers example depends on both `alibi` and `alib-detect`. 
These two have contradicting dependency on tensorflow, former one currently requiring TF<2 and latter requiring TF>=2.0 .

Because in outliers detector example we use `alibi` to only fetch a dataset this tiny PR fixes tensorflow to be compatible with alibi-detect.