### PR TITLE
Update Storage.py and initialiser image

### DIFF
--- a/python/seldon_core/storage.py
+++ b/python/seldon_core/storage.py
@@ -249,6 +249,12 @@ The path or model %s does not exist."
         use_ssl = (
             url.scheme == "https"
             if url.scheme
+            # KFServing uses S3_USE_HTTPS, whereas Seldon was already using
+            # USE_SSL.
+            # To keep compatibility with the storage init layer we support
+            # both, giving priority to USE_SSL.
+            # https://github.com/SeldonIO/seldon-core/pull/827
+            # https://github.com/kubeflow/kfserving/pull/362
             else bool(getenv("USE_SSL", "S3_USE_HTTPS", "false"))
         )
         return Minio(

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -520,21 +520,17 @@ def extract_request_parts_json(
     if not isinstance(request, dict):
         raise SeldonMicroserviceException(f"Invalid request data type: {request}")
     meta = request.get("meta", None)
-    datadef_type = None
     datadef = None
 
     if "data" in request:
         data_type = "data"
         datadef = request["data"]
         if "tensor" in datadef:
-            datadef_type = "tensor"
             tensor = datadef["tensor"]
             features = np.array(tensor["values"]).reshape(tensor["shape"])
         elif "ndarray" in datadef:
-            datadef_type = "ndarray"
             features = np.array(datadef["ndarray"])
         elif "tftensor" in datadef:
-            datadef_type = "tftensor"
             tf_proto = TensorProto()
             json_format.ParseDict(datadef["tftensor"], tf_proto)
             features = tf.make_ndarray(tf_proto)

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -1,3 +1,4 @@
+import os
 import json
 import sys
 import base64
@@ -593,3 +594,27 @@ def extract_feedback_request_parts(
     truth = grpc_datadef_to_array(request.truth.data)
     reward = request.reward
     return request.request.data, features, truth, reward
+
+
+def getenv(*env_vars, default=None):
+    """
+    Overload of os.getenv() to allow falling back through multiple environment
+    variables. The environment variables will be checked sequentially until one
+    of them is found.
+
+    Parameters
+    ------
+    *env_vars
+        Variadic list of environment variable names to check.
+    default
+        Default value to return if none of the environment variables exist.
+
+    Returns
+    ------
+        Value of the first environment variable set or default.
+    """
+    for env_var in env_vars:
+        if env_var in os.environ:
+            return os.environ.get(env_var)
+
+    return default

--- a/python/tests/test_azure_storage.py
+++ b/python/tests/test_azure_storage.py
@@ -1,0 +1,189 @@
+# Copyright 2019 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Copied from kfserving project as starter.
+#
+
+import unittest.mock as mock
+import itertools
+import pytest
+from azure.common import AzureMissingResourceHttpError
+import seldon_core
+
+
+def create_mock_item(path):
+    mock_obj = mock.MagicMock()
+    mock_obj.name = path
+    return mock_obj
+
+
+def create_mock_blob(mock_storage, paths):
+    mock_blob = mock_storage.return_value
+    mock_objs = [create_mock_item(path) for path in paths]
+    mock_blob.list_blobs.return_value = mock_objs
+    return mock_blob
+
+
+def get_call_args(call_args_list):
+    arg_list = []
+    for call in call_args_list:
+        args, _ = call
+        arg_list.append(args)
+    return arg_list
+
+
+# pylint: disable=protected-access
+
+
+@mock.patch("seldon_core.storage.os.makedirs")
+@mock.patch("seldon_core.storage.BlockBlobService")
+def test_blob(mock_storage, mock_makedirs):  # pylint: disable=unused-argument
+
+    # given
+    blob_path = "https://seldon_core.blob.core.windows.net/tensorrt/simple_string/"
+    paths = ["simple_string/1/model.graphdef", "simple_string/config.pbtxt"]
+    mock_blob = create_mock_blob(mock_storage, paths)
+
+    # when
+    seldon_core.Storage._download_blob(blob_path, "dest_path")
+
+    # then
+    arg_list = get_call_args(mock_blob.get_blob_to_path.call_args_list)
+    assert arg_list == [
+        ("tensorrt", "simple_string/1/model.graphdef", "dest_path/1/model.graphdef"),
+        ("tensorrt", "simple_string/config.pbtxt", "dest_path/config.pbtxt"),
+    ]
+
+    mock_storage.assert_called_with(account_name="seldon_core")
+
+
+@mock.patch("seldon_core.storage.os.makedirs")
+@mock.patch("seldon_core.storage.Storage._get_azure_storage_token")
+@mock.patch("seldon_core.storage.BlockBlobService")
+def test_secure_blob(
+    mock_storage, mock_get_token, mock_makedirs
+):  # pylint: disable=unused-argument
+
+    # given
+    blob_path = "https://kfsecured.blob.core.windows.net/tensorrt/simple_string/"
+    mock_blob = mock_storage.return_value
+    mock_blob.list_blobs.side_effect = AzureMissingResourceHttpError("fail auth", 404)
+    mock_get_token.return_value = "some_token"
+
+    # when
+    with pytest.raises(AzureMissingResourceHttpError):
+        seldon_core.Storage._download_blob(blob_path, "dest_path")
+
+    # then
+    mock_get_token.assert_called()
+    arg_list = []
+    for call in mock_storage.call_args_list:
+        _, kwargs = call
+        arg_list.append(kwargs)
+
+    assert arg_list == [
+        {"account_name": "kfsecured"},
+        {"account_name": "kfsecured", "token_credential": "some_token"},
+    ]
+
+
+@mock.patch("seldon_core.storage.os.makedirs")
+@mock.patch("seldon_core.storage.BlockBlobService")
+def test_deep_blob(mock_storage, mock_makedirs):  # pylint: disable=unused-argument
+
+    # given
+    blob_path = (
+        "https://accountname.blob.core.windows.net/container/some/deep/blob/path"
+    )
+    paths = ["f1", "f2", "d1/f11", "d1/d2/f21", "d1/d2/d3/f1231", "d4/f41"]
+    fq_item_paths = ["some/deep/blob/path/" + p for p in paths]
+    expected_dest_paths = ["some/dest/path/" + p for p in paths]
+    expected_calls = list(
+        zip(itertools.repeat("container"), fq_item_paths, expected_dest_paths)
+    )
+
+    # when
+    mock_blob = create_mock_blob(mock_storage, fq_item_paths)
+    seldon_core.Storage._download_blob(blob_path, "some/dest/path")
+
+    # then
+    actual_calls = get_call_args(mock_blob.get_blob_to_path.call_args_list)
+    assert actual_calls == expected_calls
+
+
+@mock.patch("seldon_core.storage.os.makedirs")
+@mock.patch("seldon_core.storage.BlockBlobService")
+def test_blob_file(mock_storage, mock_makedirs):  # pylint: disable=unused-argument
+
+    # given
+    blob_path = "https://accountname.blob.core.windows.net/container/somefile"
+    paths = ["somefile"]
+    fq_item_paths = paths
+    expected_dest_paths = ["some/dest/path/somefile"]
+    expected_calls = list(
+        zip(itertools.repeat("container"), fq_item_paths, expected_dest_paths)
+    )
+
+    # when
+    mock_blob = create_mock_blob(mock_storage, paths)
+    seldon_core.Storage._download_blob(blob_path, "some/dest/path")
+
+    # then
+    actual_calls = get_call_args(mock_blob.get_blob_to_path.call_args_list)
+    assert actual_calls == expected_calls
+
+
+@mock.patch("seldon_core.storage.os.makedirs")
+@mock.patch("seldon_core.storage.BlockBlobService")
+def test_blob_fq_file(mock_storage, mock_makedirs):  # pylint: disable=unused-argument
+
+    # given
+    blob_path = "https://accountname.blob.core.windows.net/container/folder/somefile"
+    paths = ["somefile"]
+    fq_item_paths = ["folder/" + p for p in paths]
+    expected_dest_paths = ["/mnt/out/" + p for p in paths]
+    expected_calls = list(
+        zip(itertools.repeat("container"), fq_item_paths, expected_dest_paths)
+    )
+
+    # when
+    mock_blob = create_mock_blob(mock_storage, fq_item_paths)
+    seldon_core.Storage._download_blob(blob_path, "/mnt/out")
+
+    # then
+    actual_calls = get_call_args(mock_blob.get_blob_to_path.call_args_list)
+    assert actual_calls == expected_calls
+
+
+@mock.patch("seldon_core.storage.os.makedirs")
+@mock.patch("seldon_core.storage.BlockBlobService")
+def test_blob_no_prefix(mock_storage, mock_makedirs):  # pylint: disable=unused-argument
+
+    # given
+    blob_path = "https://accountname.blob.core.windows.net/container/"
+    paths = ["somefile", "somefolder/somefile"]
+    fq_item_paths = ["" + p for p in paths]
+    expected_dest_paths = ["/mnt/out/" + p for p in paths]
+    expected_calls = list(
+        zip(itertools.repeat("container"), fq_item_paths, expected_dest_paths)
+    )
+
+    # when
+    mock_blob = create_mock_blob(mock_storage, fq_item_paths)
+    seldon_core.Storage._download_blob(blob_path, "/mnt/out")
+
+    # then
+    actual_calls = get_call_args(mock_blob.get_blob_to_path.call_args_list)
+    assert actual_calls == expected_calls

--- a/python/tests/test_storage.py
+++ b/python/tests/test_storage.py
@@ -69,6 +69,21 @@ def test_storage_blob_exception():
 
 @mock.patch("urllib3.PoolManager")
 @mock.patch(STORAGE_MODULE + ".Minio")
+def test_storage_s3_exception(mock_connection, mock_minio):
+    minio_path = "s3://foo/bar"
+    # Create mock connection
+    mock_server = mock.MagicMock()
+    mock_connection.return_value = mock_server
+    # Create mock client
+    mock_minio.return_value = Minio(
+        "s3.us.cloud-object-storage.appdomain.cloud", secure=True
+    )
+    with pytest.raises(Exception):
+        seldon_core.Storage.download(minio_path)
+
+
+@mock.patch("urllib3.PoolManager")
+@mock.patch(STORAGE_MODULE + ".Minio")
 def test_no_permission_buckets(mock_connection, mock_minio):
     bad_s3_path = "s3://random/path"
     # Access private buckets without credentials

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -410,3 +410,21 @@ def test_proto_tftensor_to_array():
     array2 = scu.grpc_datadef_to_array(datadef)
     assert array.shape == array2.shape
     assert np.array_equal(array, array2)
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ({"FOO1": "BAR1"}, "BAR1"),
+        ({"FOO2": "BAR2"}, "BAR2"),
+        ({"FOO3": "BAR3"}, "BAR3"),
+        ({"FOO1": "BAR1", "FOO2": "BAR2"}, "BAR1"),
+        ({}, "DEF"),
+    ],
+)
+def test_getenv(monkeypatch, env, expected):
+    for env_var, env_value in env.items():
+        monkeypatch.setenv(env_var, env_value)
+
+    value = scu.getenv("FOO1", "FOO2", "FOO3", default="DEF")
+    assert value == expected

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import numpy as np
 import pickle
 import base64
@@ -165,7 +164,7 @@ def test_create_grpc_response_strdata():
     request = prediction_pb2.SeldonMessage(data=datadef)
     raw_response = "hello world"
     sm = scu.construct_response(user_model, True, request, raw_response)
-    assert sm.data.WhichOneof("data_oneof") == None
+    assert sm.data.WhichOneof("data_oneof") is None
     assert len(sm.strData) > 0
 
 
@@ -176,7 +175,7 @@ def test_create_grpc_response_jsondata():
     request = prediction_pb2.SeldonMessage(data=datadef)
     raw_response = {"output": "data"}
     sm = scu.construct_response(user_model, True, request, raw_response)
-    assert sm.data.WhichOneof("data_oneof") == None
+    assert sm.data.WhichOneof("data_oneof") is None
     emptyValue = Value()
     assert sm.jsonData != emptyValue
 
@@ -209,7 +208,6 @@ def test_create_rest_response_jsondata_with_array_input():
 
 
 def test_symmetric_json_conversion():
-    user_model = UserObject()
     request_data = np.array([[5, 6, 7]])
     datadef = scu.array_to_rest_datadef("ndarray", request_data)
     json_request = {"jsonData": datadef}
@@ -247,7 +245,7 @@ def test_create_grpc_reponse_binary():
     request = prediction_pb2.SeldonMessage(data=datadef)
     raw_response = b"binary"
     sm = scu.construct_response(user_model, True, request, raw_response)
-    assert sm.data.WhichOneof("data_oneof") == None
+    assert sm.data.WhichOneof("data_oneof") is None
     assert len(sm.strData) == 0
     assert len(sm.binData) > 0
 
@@ -311,7 +309,7 @@ def test_json_to_seldon_message_json_data():
 def test_json_to_seldon_message_bad_data():
     with pytest.raises(SeldonMicroserviceException):
         data = {"foo": "bar"}
-        requestProto = scu.json_to_seldon_message(data)
+        scu.json_to_seldon_message(data)
 
 
 def test_json_to_feedback():
@@ -332,7 +330,7 @@ def test_json_to_feedback_bad_data():
             "response": {"data": {"tensor": {"shape": [1, 1], "values": [2]}}},
             "reward": 1.0,
         }
-        requestProto = scu.json_to_feedback(data)
+        scu.json_to_feedback(data)
 
 
 def test_json_to_seldon_messages():


### PR DESCRIPTION
Fixes #1341 

## Changelog
- Import latest version of `Storage.py` from KFServing, including tests.

## TODO
- [x] Update default `kfserving/storage-initializer` image.

## Notes
To make SSL optional in S3 URLs, both Seldon and KFServing introduced different environment variables with the same finality: `USE_SSL` and `S3_USE_HTTPS`. You can find the respective PRs here:
- https://github.com/SeldonIO/seldon-core/pull/827
- https://github.com/kubeflow/kfserving/pull/362

In order to make `Storage.py` compatible with the `kfserving/storage-initializer` image and to avoid any breaking changes on users who were already using Seldon's `USE_SSL`, I've made both compatible (with priority for `USE_SSL`).  