### PR TITLE
Fix CVE-2019-18224

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -2,8 +2,10 @@ FROM openjdk:11.0.5-jre-slim
 
 ARG APP_VERSION=UNKOWN_VERSION
 
+# Run dist-upgrade to install security updates
 RUN \
     apt-get update -y && \
+    apt-get dist-upgrade -y && \
     apt-get remove -y --auto-remove && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/engine/Dockerfile.mvn
+++ b/engine/Dockerfile.mvn
@@ -10,8 +10,10 @@ RUN mvn clean verify -Dlicense.useMissingFile -B
 
 FROM openjdk:11.0.5-jre-slim
 
+# Run dist-upgrade to install security updates
 RUN \
     apt-get update -y && \
+    apt-get dist-upgrade -y && \
     apt-get remove -y --auto-remove && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Fix #1286 

## Changelog
- Run `apt-get dist-upgrade` to fetch updates from Debian's security APT repository.