### PR TITLE
Ensure unique names for webhooks

### DIFF
--- a/helm-charts/seldon-core-operator/templates/webhook.yaml
+++ b/helm-charts/seldon-core-operator/templates/webhook.yaml
@@ -23,7 +23,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /validate-machinelearning-seldon-io-v1-seldondeployment
   failurePolicy: Fail
-  name: vseldondeployment.kb.io
+  name: v1.vseldondeployment.kb.io
 {{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
 {{- if not .Values.singleNamespace }}
   namespaceSelector:
@@ -67,7 +67,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /validate-machinelearning-seldon-io-v1alpha2-seldondeployment
   failurePolicy: Fail
-  name: vseldondeployment.kb.io
+  name: v1alpha2.vseldondeployment.kb.io
 {{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
 {{- if not .Values.singleNamespace }}
   namespaceSelector:
@@ -111,7 +111,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /validate-machinelearning-seldon-io-v1alpha3-seldondeployment
   failurePolicy: Fail
-  name: vseldondeployment.kb.io
+  name: v1alpha3.vseldondeployment.kb.io
 {{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
 {{- if not .Values.singleNamespace }}
   namespaceSelector:
@@ -170,7 +170,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /mutate-machinelearning-seldon-io-v1-seldondeployment
   failurePolicy: Fail
-  name: mseldondeployment.kb.io
+  name: v1.mseldondeployment.kb.io
 {{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
 {{- if not .Values.singleNamespace }}
   namespaceSelector:
@@ -214,7 +214,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /mutate-machinelearning-seldon-io-v1alpha2-seldondeployment
   failurePolicy: Fail
-  name: mseldondeployment.kb.io
+  name: v1alpha2.mseldondeployment.kb.io
 {{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
 {{- if not .Values.singleNamespace }}
   namespaceSelector:
@@ -258,7 +258,7 @@ webhooks:
       namespace: '{{ .Release.Namespace }}'
       path: /mutate-machinelearning-seldon-io-v1alpha3-seldondeployment
   failurePolicy: Fail
-  name: mseldondeployment.kb.io
+  name: v1alpha3.mseldondeployment.kb.io
 {{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
 {{- if not .Values.singleNamespace }}
   namespaceSelector:

--- a/notebooks/resources/model_v1alpha2.yaml
+++ b/notebooks/resources/model_v1alpha2.yaml
@@ -1,4 +1,4 @@
-apiVersion: machinelearning.seldon.io/v1
+apiVersion: machinelearning.seldon.io/v1alpha2
 kind: SeldonDeployment
 metadata:
   name: seldon-model

--- a/notebooks/resources/model_v1alpha3.yaml
+++ b/notebooks/resources/model_v1alpha3.yaml
@@ -1,4 +1,4 @@
-apiVersion: machinelearning.seldon.io/v1
+apiVersion: machinelearning.seldon.io/v1alpha3
 kind: SeldonDeployment
 metadata:
   name: seldon-model

--- a/operator/apis/machinelearning/v1/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning/v1/seldondeployment_webhook.go
@@ -499,7 +499,7 @@ func (r *SeldonDeploymentSpec) ValidateSeldonDeployment() error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-machinelearning-seldon-io-v1-seldondeployment,mutating=true,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,verbs=create;update,versions=v1,name=mseldondeployment.kb.io
+// +kubebuilder:webhook:path=/mutate-machinelearning-seldon-io-v1-seldondeployment,mutating=true,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,verbs=create;update,versions=v1,name=v1.mseldondeployment.kb.io
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *SeldonDeployment) Default() {
@@ -512,7 +512,7 @@ func (r *SeldonDeployment) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-machinelearning-seldon-io-v1-seldondeployment,mutating=false,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,versions=v1,name=vseldondeployment.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-machinelearning-seldon-io-v1-seldondeployment,mutating=false,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,versions=v1,name=v1.vseldondeployment.kb.io
 
 var _ webhook.Validator = &SeldonDeployment{}
 

--- a/operator/apis/machinelearning/v1alpha2/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning/v1alpha2/seldondeployment_webhook.go
@@ -39,7 +39,7 @@ func (r *SeldonDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Defaulter = &SeldonDeployment{}
 
-// +kubebuilder:webhook:path=/mutate-machinelearning-seldon-io-v1alpha2-seldondeployment,mutating=true,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,verbs=create;update,versions=v1alpha2,name=mseldondeployment.kb.io
+// +kubebuilder:webhook:path=/mutate-machinelearning-seldon-io-v1alpha2-seldondeployment,mutating=true,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,verbs=create;update,versions=v1alpha2,name=v1alpha2.mseldondeployment.kb.io
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *SeldonDeployment) Default() {
@@ -52,7 +52,7 @@ func (r *SeldonDeployment) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-machinelearning-seldon-io-v1alpha2-seldondeployment,mutating=false,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,versions=v1alpha2,name=vseldondeployment.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-machinelearning-seldon-io-v1alpha2-seldondeployment,mutating=false,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,versions=v1alpha2,name=v1alpha2.vseldondeployment.kb.io
 
 var _ webhook.Validator = &SeldonDeployment{}
 

--- a/operator/apis/machinelearning/v1alpha3/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning/v1alpha3/seldondeployment_webhook.go
@@ -39,7 +39,7 @@ func (r *SeldonDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 var _ webhook.Defaulter = &SeldonDeployment{}
 
-// +kubebuilder:webhook:path=/mutate-machinelearning-seldon-io-v1alpha3-seldondeployment,mutating=true,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,verbs=create;update,versions=v1alpha3,name=mseldondeployment.kb.io
+// +kubebuilder:webhook:path=/mutate-machinelearning-seldon-io-v1alpha3-seldondeployment,mutating=true,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,verbs=create;update,versions=v1alpha3,name=v1alpha3.mseldondeployment.kb.io
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *SeldonDeployment) Default() {
@@ -52,7 +52,7 @@ func (r *SeldonDeployment) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-machinelearning-seldon-io-v1alpha3-seldondeployment,mutating=false,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,versions=v1alpha3,name=vseldondeployment.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-machinelearning-seldon-io-v1alpha3-seldondeployment,mutating=false,failurePolicy=fail,groups=machinelearning.seldon.io,resources=seldondeployments,versions=v1alpha3,name=v1alpha3.vseldondeployment.kb.io
 
 var _ webhook.Validator = &SeldonDeployment{}
 

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -13,7 +13,7 @@ webhooks:
       namespace: system
       path: /mutate-machinelearning-seldon-io-v1-seldondeployment
   failurePolicy: Fail
-  name: mseldondeployment.kb.io
+  name: v1.mseldondeployment.kb.io
   rules:
   - apiGroups:
     - machinelearning.seldon.io
@@ -31,7 +31,7 @@ webhooks:
       namespace: system
       path: /mutate-machinelearning-seldon-io-v1alpha2-seldondeployment
   failurePolicy: Fail
-  name: mseldondeployment.kb.io
+  name: v1alpha2.mseldondeployment.kb.io
   rules:
   - apiGroups:
     - machinelearning.seldon.io
@@ -49,7 +49,7 @@ webhooks:
       namespace: system
       path: /mutate-machinelearning-seldon-io-v1alpha3-seldondeployment
   failurePolicy: Fail
-  name: mseldondeployment.kb.io
+  name: v1alpha3.mseldondeployment.kb.io
   rules:
   - apiGroups:
     - machinelearning.seldon.io
@@ -75,7 +75,7 @@ webhooks:
       namespace: system
       path: /validate-machinelearning-seldon-io-v1-seldondeployment
   failurePolicy: Fail
-  name: vseldondeployment.kb.io
+  name: v1.vseldondeployment.kb.io
   rules:
   - apiGroups:
     - machinelearning.seldon.io
@@ -93,7 +93,7 @@ webhooks:
       namespace: system
       path: /validate-machinelearning-seldon-io-v1alpha2-seldondeployment
   failurePolicy: Fail
-  name: vseldondeployment.kb.io
+  name: v1alpha2.vseldondeployment.kb.io
   rules:
   - apiGroups:
     - machinelearning.seldon.io
@@ -111,7 +111,7 @@ webhooks:
       namespace: system
       path: /validate-machinelearning-seldon-io-v1alpha3-seldondeployment
   failurePolicy: Fail
-  name: vseldondeployment.kb.io
+  name: v1alpha3.vseldondeployment.kb.io
   rules:
   - apiGroups:
     - machinelearning.seldon.io


### PR DESCRIPTION
Fixes #1385 

https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#webhook-configuration

` If multiple webhooks are specified in a single configuration, each should be given a unique name. `
