### PR TITLE
Update Helm

### DIFF
--- a/core-builder/Makefile
+++ b/core-builder/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE_NAME=seldonio/core-builder
-DOCKER_IMAGE_VERSION=0.10
+DOCKER_IMAGE_VERSION=0.11
 
 build_docker_image:
 	docker build --force-rm=true -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) .

--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.10
+          image: seldonio/core-builder:0.11
         stages:
           - name: pr-build-comment
             steps:

--- a/jenkins-x-lint.yml
+++ b/jenkins-x-lint.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.10
+          image: seldonio/core-builder:0.11
         stages:
         - name: pr-build-comment
           steps:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -21,6 +21,8 @@ pipelineConfig:
         - name: build-and-test
           parallel:
           - name: test-python
+            agent:
+              image: seldonio/python-builder:0.2
             steps:
             - name: test-python
               command: make

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -10,7 +10,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.10
+          image: seldonio/core-builder:0.11
         stages:
         - name: pr-build-comment
           steps:
@@ -21,8 +21,6 @@ pipelineConfig:
         - name: build-and-test
           parallel:
           - name: test-python
-            agent:
-              image: seldonio/python-builder:0.2
             steps:
             - name: test-python
               command: make
@@ -61,7 +59,7 @@ pipelineConfig:
           command: echo "skipping tag"
       pipeline:
         agent:
-          image: seldonio/core-builder:0.10
+          image: seldonio/core-builder:0.11
         stages:
           - name: build-and-push
             steps:

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -38,7 +38,14 @@ install_cert_manager:
 
 install_seldon: install_cert_manager
 	kubectl create namespace seldon-system || echo "namespace seldon-system exists"
-	helm install --wait seldon ../../helm-charts/seldon-core-operator --namespace seldon-system --set istio.enabled=true --set istio.gateway=seldon-gateway --set certManager.enabled=false --set executor.enabled=true
+	helm install seldon \
+		../../helm-charts/seldon-core-operator \
+		--namespace seldon-system \
+		--set istio.enabled=true \
+		--set istio.gateway=seldon-gateway \
+		--set certManager.enabled=false \
+		--set executor.enabled=true \
+		--wait
 
 install_istio:
 	kubectl apply -f istio-1.4.2.yaml

--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -5,8 +5,8 @@ from subprocess import run
 
 @pytest.fixture(scope="session", autouse=True)
 def run_pod_information_in_background(request):
-    # This command runs the pod information and prints it
-    #   in the background every time there's a new update
+    # This command runs the pod information and prints it in the background
+    # every time there's a new update
     run(
         (
             "kubectl get pods --all-namespaces -w | "
@@ -60,7 +60,7 @@ def seldon_version(request):
     seldon_version = request.param
 
     # Install past version cluster-wide
-    retry_run("helm delete seldon -n seldon-system")
+    delete_seldon()
     retry_run(
         "helm install seldon "
         "seldonio/seldon-core-operator "
@@ -72,7 +72,7 @@ def seldon_version(request):
     yield seldon_version
 
     # Re-install source code version cluster-wide
-    retry_run("helm delete seldon -n seldon-system")
+    delete_seldon()
     retry_run(
         "helm install seldon "
         "../../helm-charts/seldon-core-operator "
@@ -82,6 +82,17 @@ def seldon_version(request):
         "--set certManager.enabled=false "
         "--wait",
         attempts=2,
+    )
+
+
+def delete_seldon(name="seldon", namespace="seldon-system"):
+    retry_run(f"helm delete {name} -n {namespace}", attempts=3)
+
+    # Helm 3.0.3 doesn't delete CRDs
+    retry_run(
+        "kubectl delete crd --ignore-not-found "
+        "seldondeployments.machinelearning.seldon.io ",
+        attempts=3,
     )
 
 

--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -68,6 +68,7 @@ def seldon_version(request):
         "--set istio.enabled=true "
         "--set istio.gateway=seldon-gateway "
         "--set certManager.enabled=false "
+        "--set executor.enabled=true "
         f"--version {seldon_version} "
         "--wait"
     )
@@ -83,6 +84,7 @@ def seldon_version(request):
         "--set istio.enabled=true "
         "--set istio.gateway=seldon-gateway "
         "--set certManager.enabled=false "
+        "--set executor.enabled=true "
         "--wait",
         attempts=2,
     )

--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -65,6 +65,9 @@ def seldon_version(request):
         "helm install seldon "
         "seldonio/seldon-core-operator "
         "--namespace seldon-system "
+        "--set istio.enabled=true "
+        "--set istio.gateway=seldon-gateway "
+        "--set certManager.enabled=false "
         f"--version {seldon_version} "
         "--wait"
     )

--- a/testing/scripts/dev_requirements.txt
+++ b/testing/scripts/dev_requirements.txt
@@ -1,8 +1,11 @@
 pytest==5.3.1
 pytest-xdist==1.30.0
 pytest-cov==2.8.1
+flaky==3.6.1
+retrying==1.3.3
+
 # 2nd lvl dep on cov required to avoid sqllite dep
 coverage==4.5.4
-retrying
+
 # local seldon-core
 -e ../../python

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -179,11 +179,11 @@ def initial_rest_request(
         if r is None or r.status_code != 200:
             if attempt >= len(sleeping_times):
                 finished = True
-
-            sleep = sleeping_times[attempt]
-            logging.warning(f"Sleeping {sleep} sec and trying again")
-            time.sleep(sleep)
-            attempt += 1
+            else:
+                sleep = sleeping_times[attempt]
+                logging.warning(f"Sleeping {sleep} sec and trying again")
+                time.sleep(sleep)
+                attempt += 1
         else:
             finished = True
 

--- a/testing/scripts/test_rolling_updates.py
+++ b/testing/scripts/test_rolling_updates.py
@@ -23,8 +23,9 @@ with_api_gateways = pytest.mark.parametrize(
 )
 
 
+@pytest.mark.flaky
+@with_api_gateways
 class TestRollingHttp(object):
-    @with_api_gateways
     # Test updating a model with a new image version as the only change
     def test_rolling_update1(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -60,7 +61,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph2.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # test changing the image version and the name of its container
     def test_rolling_update2(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -96,7 +96,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph3.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # Test updating a model with a new resource request but same image
     def test_rolling_update3(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -126,7 +125,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph4.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # Test updating a model with a multi deployment new model
     def test_rolling_update4(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -156,7 +154,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph5.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # Test updating a model to a multi predictor model
     def test_rolling_update5(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -192,7 +189,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph6.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # Test updating a model with a new image version as the only change
     def test_rolling_update6(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -228,7 +224,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph2svc.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # test changing the image version and the name of its container
     def test_rolling_update7(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -264,7 +259,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph3svc.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # Test updating a model with a new resource request but same image
     def test_rolling_update8(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -293,7 +287,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph4svc.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # Test updating a model with a multi deployment new model
     def test_rolling_update9(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -322,7 +315,6 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph1svc.json -n {namespace}", shell=True)
         run(f"kubectl delete -f ../resources/graph5svc.json -n {namespace}", shell=True)
 
-    @with_api_gateways
     # Test updating a model to a multi predictor model
     def test_rolling_update10(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -358,6 +350,7 @@ class TestRollingHttp(object):
         run(f"kubectl delete -f ../resources/graph6svc.json -n {namespace}", shell=True)
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize(
     "from_deployment,to_deployment",
     [


### PR DESCRIPTION
## Changelog
- Update the `seldonio/core-builder` to use Helm 3.0.3
- Fix error when making initial requests
- Mark some tests as [`flaky`](https://github.com/box/flaky)
- Sync SC install options between `Makefile` and fixture

## Notes
Helm 3.0.3 introduces a few fixes related to CRD updates, which were breaking some of the integration tests.