### PR TITLE
Update seldon-core-s2i-python2 -> seldon-core-s2i-python3. Closes #593.

### DIFF
--- a/doc/source/tutorials/openshift_s2i.md
+++ b/doc/source/tutorials/openshift_s2i.md
@@ -86,11 +86,11 @@ API_TYPE=REST
 SERVICE_TYPE=MODEL
 ```
 
-Finally we Use ```s2i build``` to create the Docker-formatted image from source code. Examples for python2 code are:
+Finally we Use ```s2i build``` to create the Docker-formatted image from source code. Examples for python3 code are:
 
 ```bash
-s2i build <git-repo> seldonio/seldon-core-s2i-python2 <my-image-name>
-s2i build <src-folder> seldonio/seldon-core-s2i-python2 <my-image-name>
+s2i build <git-repo> seldonio/seldon-core-s2i-python3 <my-image-name>
+s2i build <src-folder> seldonio/seldon-core-s2i-python3 <my-image-name>
 ```
 
 ## R
@@ -172,7 +172,3 @@ More details can be found in the seldon-core docs.
 By utilizing Openshift's source-to-image tool data scientists can easily build Docker-formatted images for their runtime components to be deployed at scale using seldon-core. This allows data science teams to use the best machine learning tool for the task and deploy the resulting model in a consistent manner. The seldon-core project is working on providing full Openshift integration in the near future so that Enterprise customers can easily utilize machine learning models within their organisation.
 
 Seldon will be joining Openshift Commons and will be present at [Kubecon Europe 2018](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2018/) and the OpenShift Kubecon Europe event on Tues 1st May. Feel free to contact us to discuss Seldon-Core and Openshift and how they can work together to help data scientists put machine learning into production.
-
-
-
-

--- a/wrappers/s2i/python/s2i/bin/assemble
+++ b/wrappers/s2i/python/s2i/bin/assemble
@@ -7,7 +7,7 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
-# If the 'seldon-core-s2i-python2' assemble script is executed with the '-h' flag, print the usage.
+# If the 'seldon-core-s2i-python3' assemble script is executed with the '-h' flag, print the usage.
 if [[ "$1" == "-h" ]]; then
 	exec /usr/libexec/s2i/usage
 fi

--- a/wrappers/s2i/python/s2i/bin/usage
+++ b/wrappers/s2i/python/s2i/bin/usage
@@ -8,7 +8,7 @@ To create a template application clone https://github.com/seldonio/seldon-core.g
 Sample MODEL invocation:
 ------------------------
 
-s2i build https://github.com/seldonio/seldon-core.git --context-dir=wrappers/s2i/python/test/model-template-app seldonio/seldon-core-s2i-python2 seldon-core-template-model
+s2i build https://github.com/seldonio/seldon-core.git --context-dir=wrappers/s2i/python/test/model-template-app seldonio/seldon-core-s2i-python3 seldon-core-template-model
 
 You can then run the resulting image via:
 docker run -p 5000:5000 seldon-core-template-model
@@ -19,7 +19,7 @@ curl  -d 'json={"data":{"ndarray":[[1.0,2.0]]}}' http://0.0.0.0:5000/predict
 Sample ROUTER invocation:
 -------------------------
 
-s2i build https://github.com/seldonio/seldon-core.git --context-dir=wrappers/s2i/python/test/router-template-app seldonio/seldon-core-s2i-python2 seldon-core-template-router
+s2i build https://github.com/seldonio/seldon-core.git --context-dir=wrappers/s2i/python/test/router-template-app seldonio/seldon-core-s2i-python3 seldon-core-template-router
 
 You can then run the resulting image via:
 docker run -p 5000:5000 seldon-core-template-router
@@ -32,7 +32,7 @@ curl  -d 'json={"request":{"data":{"names":["a","b"],"ndarray":[[1.0,2.0]]}},"re
 Sample TRANSFORMER invocation:
 ------------------------------
 
-s2i build https://github.com/seldonio/seldon-core.git --context-dir=wrappers/s2i/python/test/transformer-template-app seldonio/seldon-core-s2i-python2 seldon-core-template-transformer
+s2i build https://github.com/seldonio/seldon-core.git --context-dir=wrappers/s2i/python/test/transformer-template-app seldonio/seldon-core-s2i-python3 seldon-core-template-transformer
 
 You can then run the resulting image via:
 docker run -p 5000:5000 seldon-core-template-router

--- a/wrappers/s2i/python/test_fbs/run_test_python2
+++ b/wrappers/s2i/python/test_fbs/run_test_python2
@@ -1,5 +1,0 @@
-s2i build . seldonio/seldon-core-s2i-python2:0.4 test-wrapper-py2:0.1
-docker run --name "test_predictor" --rm -d -p 5000:5000 test-wrapper-py2:0.1
-sleep 2
-seldon-core-tester contract.json 0.0.0.0 5000 -p --fbs
-docker rm -f test_predictor


### PR DESCRIPTION
Update references to deprecated python2 wrapper such that they use python3. Closes https://github.com/SeldonIO/seldon-core/issues/593.