### PR TITLE
Check there is no downtime during operator updates

### DIFF
--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -59,7 +59,7 @@ def seldon_version(request):
     """
     seldon_version = request.param
 
-    # Install past version cluster-wide
+    # Delete source version cluster-wide and install new one
     delete_seldon()
     retry_run(
         "helm install seldon "

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -25,7 +25,7 @@ def get_s2i_python_version():
         "grep 'IMAGE_VERSION=' Makefile |"
         "cut -d'=' -f2"
     )
-    ret = Popen(cmd, shell=True, stdout=subprocess.PIPE,)
+    ret = Popen(cmd, shell=True, stdout=subprocess.PIPE)
     output = ret.stdout.readline()
     version = output.decode("utf-8").rstrip()
     return version

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -77,10 +77,19 @@ def get_deployment_names(sdep_name, namespace, attempts=20, sleep=5):
 def wait_for_rollout(
     sdep_name, namespace, attempts=20, sleep=5, expected_deployments=1
 ):
-    deployment_names = get_deployment_names(sdep_name, namespace)
-    assert (
-        len(deployment_names) == expected_deployments
-    ), f"Expected {expected_deployments} deployment(s) but got {len(deployment_names)}"
+    deployment_names = []
+    for _ in range(attempts):
+        deployment_names = get_deployment_names(sdep_name, namespace)
+        deployments = len(deployment_names)
+
+        if deployments == expected_deployments:
+            break
+
+    error_msg = (
+        f"Expected {expected_deployments} deployment(s) but got {len(deployment_names)}"
+    )
+    assert len(deployment_names) == expected_deployments, error_msg
+
     for deployment_name in deployment_names:
         logging.warning(f"Waiting for deployment {deployment_name}")
         for _ in range(attempts):

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -38,10 +38,10 @@ def get_seldon_version():
     return version
 
 
-def wait_for_shutdown(deployment_name, namespace):
+def wait_for_shutdown(deployment_name, namespace, timeout="10m"):
     cmd = (
         "kubectl wait --for=delete "
-        "--timeout=3m "
+        f"--timeout={timeout} "
         f"-n {namespace} "
         f"deploy/{deployment_name}"
     )

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -41,7 +41,7 @@ def get_seldon_version():
 def wait_for_shutdown(deployment_name, namespace):
     cmd = (
         "kubectl wait --for=delete "
-        "--timeout=1m "
+        "--timeout=3m "
         f"-n {namespace} "
         f"deploy/{deployment_name}"
     )
@@ -450,7 +450,7 @@ def assert_model_during_op(op, *assert_args, **assert_kwargs):
             # to finish before raising
             cancelled = future.cancel()
             if not cancelled:
-                wait(future)
+                wait([future])
 
             raise err
 

--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -17,11 +17,12 @@ API_ISTIO_GATEWAY = "localhost:8004"
 
 
 def get_s2i_python_version():
-    ret = Popen(
-        "cd ../../wrappers/s2i/python && grep 'IMAGE_VERSION=' Makefile | cut -d'=' -f2",
-        shell=True,
-        stdout=subprocess.PIPE,
+    cmd = (
+        "cd ../../wrappers/s2i/python && "
+        "grep 'IMAGE_VERSION=' Makefile |"
+        "cut -d'=' -f2"
     )
+    ret = Popen(cmd, shell=True, stdout=subprocess.PIPE,)
     output = ret.stdout.readline()
     version = output.decode("utf-8").rstrip()
     return version
@@ -60,7 +61,8 @@ def get_deployment_names(sdep_name, namespace, attempts=20, sleep=5):
     # The `deploymentStatus` is dictionary which keys are names of deployments
     deployment_names = list(data["status"]["deploymentStatus"])
     logging.warning(
-        f"For SeldonDeployment {sdep_name} found following deployments: {deployment_names}"
+        f"For SeldonDeployment {sdep_name} "
+        f"found following deployments: {deployment_names}"
     )
     return deployment_names
 
@@ -209,7 +211,7 @@ def initial_grpc_request(
             rows=rows,
             data=data,
         )
-    except:
+    except Exception:
         logging.warning("Sleeping 1 sec and trying again")
         time.sleep(1)
         try:
@@ -221,7 +223,7 @@ def initial_grpc_request(
                 rows=rows,
                 data=data,
             )
-        except:
+        except Exception:
             logging.warning("Sleeping 5 sec and trying again")
             time.sleep(5)
             try:
@@ -233,7 +235,7 @@ def initial_grpc_request(
                     rows=rows,
                     data=data,
                 )
-            except:
+            except Exception:
                 logging.warning("Sleeping 10 sec and trying again")
                 time.sleep(10)
                 return grpc_request_ambassador(
@@ -401,7 +403,7 @@ def grpc_request_ambassador2(
             rows=rows,
             data=data,
         )
-    except:
+    except Exception:
         logging.warning("Warning - caught exception")
         return grpc_request_ambassador(
             deployment_name,

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -14,7 +14,7 @@ from seldon_e2e_utils import (
     "seldon_version",
     [
         pytest.param(
-            "0.4.1", marks=pytest.mark.skip(reason="doesn't install in Helm 3")
+            "0.4.1", marks=pytest.mark.skip(reason="doesn't work with K8s 1.16")
         ),
         "0.5.1",
         "1.0.0",

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -1,40 +1,17 @@
 import pytest
 
 from seldon_e2e_utils import (
-    initial_rest_request,
-    rest_request,
     retry_run,
     wait_for_status,
     wait_for_rollout,
+    assert_model_during_op,
+    assert_model,
 )
-
-
-def assert_model(sdep_name, namespace, initial=False):
-    _request = initial_rest_request if initial else rest_request
-    r = _request(sdep_name, namespace)
-
-    assert r is not None
-    assert r.status_code == 200
-    assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
-
-    # NOTE: The following will test if the `SeldonDeployment` can be fetched as
-    # a Kubernetes resource. This covers cases where some resources (e.g. CRD
-    # versions or webhooks) may get inadvertently removed between versions.
-    # The `retry_run()` method will **implicitly do an assert** on the return
-    # code of the command.
-    retry_run(f"kubectl get -n {namespace} sdep {sdep_name}")
 
 
 @pytest.mark.sequential
 @pytest.mark.parametrize(
-    "seldon_version",
-    [
-        pytest.param("0.4.1", marks=pytest.mark.skip(reason="fixed in Helm 3.0.3")),
-        "0.5.1",
-        "1.0.0",
-        "1.0.1",
-    ],
-    indirect=True,
+    "seldon_version", ["0.4.1", "0.5.1", "1.0.0", "1.0.1"], indirect=True,
 )
 def test_cluster_update(namespace, seldon_version):
     # Deploy test model
@@ -49,15 +26,18 @@ def test_cluster_update(namespace, seldon_version):
     # TODO: There is currently a bug updating from 0.4.1 using Helm 3.0.2.
     # This will be fixed once https://github.com/helm/helm/pull/7269 is
     # released in Helm 3.0.3.
-    retry_run(
-        "helm upgrade seldon "
-        "../../helm-charts/seldon-core-operator "
-        "--namespace seldon-system "
-        "--wait",
-        attempts=2,
-    )
+    def _upgrade_seldon():
+        retry_run(
+            "helm upgrade seldon "
+            "../../helm-charts/seldon-core-operator "
+            "--namespace seldon-system "
+            "--wait",
+            attempts=2,
+        )
 
-    assert_model("mymodel", namespace, initial=True)
+    assert_model_during_op(
+        _upgrade_seldon, "mymodel", namespace,
+    )
 
 
 @pytest.mark.sequential
@@ -74,21 +54,23 @@ def test_namespace_update(namespace, seldon_version):
         f"kubectl label namespace {namespace} seldon.io/controller-id={namespace}"
     )
 
-    # Install on the current namespace
-    retry_run(
-        "helm install seldon "
-        "../../helm-charts/seldon-core-operator "
-        f"--namespace {namespace} "
-        "--set crd.create=false "
-        "--set singleNamespace=true "
-        "--wait",
-        attempts=2,
-    )
+    def _install_namespace_scoped():
+        # Install on the current namespace
+        retry_run(
+            "helm install seldon "
+            "../../helm-charts/seldon-core-operator "
+            f"--namespace {namespace} "
+            "--set crd.create=false "
+            "--set singleNamespace=true "
+            "--wait",
+            attempts=2,
+        )
 
-    # Assert that model is still working under new namespaced version
-    wait_for_status("mymodel", namespace)
-    wait_for_rollout("mymodel", namespace)
-    assert_model("mymodel", namespace, initial=True)
+        # Assert that model is still working under new namespaced version
+        wait_for_status("mymodel", namespace)
+        wait_for_rollout("mymodel", namespace)
+
+    assert_model_during_op(_install_namespace_scoped, "mymodel", namespace)
 
 
 @pytest.mark.sequential
@@ -100,31 +82,34 @@ def test_label_update(namespace, seldon_version):
     wait_for_rollout("mymodel", namespace)
     assert_model("mymodel", namespace, initial=True)
 
-    # Install id-scoped operator
     controller_id = f"seldon-{namespace}"
-    # TODO: We install the new controller on the same namespace but it's not
-    # necessary, since it will get targeted by controllerId
-    retry_run(
-        f"helm install {controller_id} "
-        "../../helm-charts/seldon-core-operator "
-        f"--namespace {namespace} "
-        "--set crd.create=false "
-        f"--set controllerId={controller_id} "
-        "--wait",
-        attempts=2,
-    )
 
-    # Label model to be served by new controller
-    retry_run(
-        "kubectl label sdep mymodel "
-        f"seldon.io/controller-id={controller_id} "
-        f"--namespace {namespace}"
-    )
+    def _install_label_scoped():
+        # TODO: We install the new controller on the same namespace
+        # but it's not necessary, since it will get targeted by
+        # controllerId
+        retry_run(
+            f"helm install {controller_id} "
+            "../../helm-charts/seldon-core-operator "
+            f"--namespace {namespace} "
+            "--set crd.create=false "
+            f"--set controllerId={controller_id} "
+            "--wait",
+            attempts=2,
+        )
 
-    # Assert that model is still working under new id-scoped operator
-    wait_for_status("mymodel", namespace)
-    wait_for_rollout("mymodel", namespace)
-    assert_model("mymodel", namespace, initial=True)
+        # Label model to be served by new controller
+        retry_run(
+            "kubectl label sdep mymodel "
+            f"seldon.io/controller-id={controller_id} "
+            f"--namespace {namespace}"
+        )
+
+        # Assert that model is still working under new id-scoped operator
+        wait_for_status("mymodel", namespace)
+        wait_for_rollout("mymodel", namespace)
+
+    assert_model_during_op(_install_label_scoped, "mymodel", namespace)
 
     # Delete all resources (webhooks, etc.) before deleting namespace
     retry_run(f"helm delete {controller_id} --namespace {namespace}")

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -11,7 +11,16 @@ from seldon_e2e_utils import (
 
 @pytest.mark.sequential
 @pytest.mark.parametrize(
-    "seldon_version", ["0.4.1", "0.5.1", "1.0.0", "1.0.1"], indirect=True,
+    "seldon_version",
+    [
+        pytest.param(
+            "0.4.1", marks=pytest.mark.skip(reason="doesn't install in Helm 3")
+        ),
+        "0.5.1",
+        "1.0.0",
+        "1.0.1",
+    ],
+    indirect=True,
 )
 def test_cluster_update(namespace, seldon_version):
     # Deploy test model
@@ -21,11 +30,6 @@ def test_cluster_update(namespace, seldon_version):
     assert_model("mymodel", namespace, initial=True)
 
     # Upgrade to source code version cluster-wide.
-    # Note that this upgrade should leave the cluster as it was before the
-    # test.
-    # TODO: There is currently a bug updating from 0.4.1 using Helm 3.0.2.
-    # This will be fixed once https://github.com/helm/helm/pull/7269 is
-    # released in Helm 3.0.3.
     def _upgrade_seldon():
         retry_run(
             "helm upgrade seldon "

--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -39,9 +39,7 @@ def test_cluster_update(namespace, seldon_version):
             attempts=2,
         )
 
-    assert_model_during_op(
-        _upgrade_seldon, "mymodel", namespace,
-    )
+    assert_model_during_op(_upgrade_seldon, "mymodel", namespace)
 
 
 @pytest.mark.sequential

--- a/testing/scripts/test_rolling_updates.py
+++ b/testing/scripts/test_rolling_updates.py
@@ -6,8 +6,12 @@ from subprocess import run
 from seldon_e2e_utils import (
     wait_for_status,
     wait_for_rollout,
+    wait_for_shutdown,
     rest_request_ambassador,
+    get_deployment_names,
     initial_rest_request,
+    assert_model,
+    assert_model_during_op,
     retry_run,
     API_AMBASSADOR,
     API_ISTIO_GATEWAY,
@@ -26,76 +30,6 @@ with_api_gateways = pytest.mark.parametrize(
 @pytest.mark.flaky
 @with_api_gateways
 class TestRollingHttp(object):
-    # Test updating a model with a new image version as the only change
-    def test_rolling_update1(self, namespace, api_gateway):
-        if api_gateway == API_ISTIO_GATEWAY:
-            retry_run(
-                f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
-            )
-        retry_run(f"kubectl apply -f ../resources/graph1.json -n {namespace}")
-        wait_for_status("mymodel", namespace)
-        wait_for_rollout("mymodel", namespace)
-        logging.warning("Initial request")
-        r = initial_rest_request("mymodel", namespace, endpoint=api_gateway)
-        assert r.status_code == 200
-        assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
-        retry_run(f"kubectl apply -f ../resources/graph2.json -n {namespace}")
-        r = initial_rest_request("mymodel", namespace, endpoint=api_gateway)
-        assert r.status_code == 200
-        assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
-        i = 0
-        for i in range(100):
-            r = rest_request_ambassador("mymodel", namespace, api_gateway)
-            assert r.status_code == 200
-            res = r.json()
-            assert (res["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]) or (
-                res["data"]["tensor"]["values"] == [5.0, 6.0, 7.0, 8.0]
-            )
-            if (not r.status_code == 200) or (
-                res["data"]["tensor"]["values"] == [5.0, 6.0, 7.0, 8.0]
-            ):
-                break
-            time.sleep(1)
-        assert i < 100
-        logging.warning("Success for test_rolling_update1")
-        run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
-        run(f"kubectl delete -f ../resources/graph2.json -n {namespace}", shell=True)
-
-    # test changing the image version and the name of its container
-    def test_rolling_update2(self, namespace, api_gateway):
-        if api_gateway == API_ISTIO_GATEWAY:
-            retry_run(
-                f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}"
-            )
-        retry_run(f"kubectl apply -f ../resources/graph1.json -n {namespace}")
-        wait_for_status("mymodel", namespace)
-        wait_for_rollout("mymodel", namespace)
-        logging.warning("Initial request")
-        r = initial_rest_request("mymodel", namespace, endpoint=api_gateway)
-        assert r.status_code == 200
-        assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
-        retry_run(f"kubectl apply -f ../resources/graph3.json -n {namespace}")
-        r = initial_rest_request("mymodel", namespace, endpoint=api_gateway)
-        assert r.status_code == 200
-        assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
-        i = 0
-        for i in range(100):
-            r = rest_request_ambassador("mymodel", namespace, api_gateway)
-            assert r.status_code == 200
-            res = r.json()
-            assert (res["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]) or (
-                res["data"]["tensor"]["values"] == [5.0, 6.0, 7.0, 8.0]
-            )
-            if (not r.status_code == 200) or (
-                res["data"]["tensor"]["values"] == [5.0, 6.0, 7.0, 8.0]
-            ):
-                break
-            time.sleep(1)
-        assert i < 100
-        logging.warning("Success for test_rolling_update2")
-        run(f"kubectl delete -f ../resources/graph1.json -n {namespace}", shell=True)
-        run(f"kubectl delete -f ../resources/graph3.json -n {namespace}", shell=True)
-
     # Test updating a model with a new resource request but same image
     def test_rolling_update3(self, namespace, api_gateway):
         if api_gateway == API_ISTIO_GATEWAY:
@@ -351,45 +285,40 @@ class TestRollingHttp(object):
 
 
 @pytest.mark.flaky
+@with_api_gateways
 @pytest.mark.parametrize(
     "from_deployment,to_deployment",
     [
+        ("graph1.json", "graph2.json"),  # New image version
+        ("graph1.json", "graph3.json"),  # New image version and new name of container
+        ("graph1.json", "graph4.json"),  # New resource request but same image
         ("graph1.json", "graph8.json"),  # From v1alpha2 to v1
         ("graph7.json", "graph8.json"),  # From v1alpha3 to v1
     ],
 )
-def test_rolling_update_deployment(namespace, from_deployment, to_deployment):
+def test_rolling_update_deployment(
+    namespace, api_gateway, from_deployment, to_deployment
+):
+    if api_gateway == API_ISTIO_GATEWAY:
+        retry_run(f"kubectl create -f ../resources/seldon-gateway.yaml -n {namespace}")
+
     from_file_path = to_resources_path(from_deployment)
     retry_run(f"kubectl apply -f {from_file_path} -n {namespace}")
-    # Note that this is not yet parametrised!
     wait_for_status("mymodel", namespace)
     wait_for_rollout("mymodel", namespace)
-    logging.warning("Initial request")
-    r = initial_rest_request("mymodel", namespace)
-    assert r.status_code == 200
-    assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
+    assert_model("mymodel", namespace, initial=True, endpoint=api_gateway)
 
+    old_deployment_name = get_deployment_names("mymodel", namespace)[0]
     to_file_path = to_resources_path(to_deployment)
-    retry_run(f"kubectl apply -f {to_file_path} -n {namespace}")
-    r = initial_rest_request("mymodel", namespace)
-    assert r.status_code == 200
-    assert r.json()["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]
 
-    i = 0
-    for i in range(100):
-        r = rest_request_ambassador("mymodel", namespace, API_AMBASSADOR)
-        assert r.status_code == 200
-        res = r.json()
-        assert (res["data"]["tensor"]["values"] == [1.0, 2.0, 3.0, 4.0]) or (
-            res["data"]["tensor"]["values"] == [5.0, 6.0, 7.0, 8.0]
-        )
-        if (not r.status_code == 200) or (
-            res["data"]["tensor"]["values"] == [5.0, 6.0, 7.0, 8.0]
-        ):
-            break
-        time.sleep(1)
+    def _update_model():
+        retry_run(f"kubectl apply -f {to_file_path} -n {namespace}")
+        wait_for_shutdown(old_deployment_name, namespace)
+        wait_for_status("mymodel", namespace)
+        wait_for_rollout("mymodel", namespace)
 
-    assert i < 100
+    assert_model_during_op(_update_model, "mymodel", namespace, endpoint=api_gateway)
 
-    run(f"kubectl delete -f {from_file_path} -n {namespace}", shell=True)
-    run(f"kubectl delete -f {to_file_path} -n {namespace}", shell=True)
+    delete_cmd = f"kubectl delete --ignore-not-found -n {namespace}"
+    run(f"{delete_cmd} -f {from_file_path}", shell=True)
+    run(f"{delete_cmd} -f {to_file_path}", shell=True)

--- a/testing/scripts/test_rolling_updates.py
+++ b/testing/scripts/test_rolling_updates.py
@@ -235,7 +235,6 @@ class TestRollingHttp(object):
         ("graph1.json", "graph3.json"),  # New image version and new name of container
         ("graph1.json", "graph4.json"),  # New resource request but same image
         ("graph1.json", "graph5.json"),  # Update with multi-deployment new model
-        ("graph1.json", "graph6.json"),  # Update to multi-predictor model
         ("graph1.json", "graph8.json"),  # From v1alpha2 to v1
         ("graph7.json", "graph8.json"),  # From v1alpha3 to v1
     ],


### PR DESCRIPTION
Fix #1354

## Changelog
- Add `assert_model_during_op` helper to run model assertions during an asynchronous operation.
- Fix some `flake8` linting errors.
- Fix `wait_for_shutdown()` method.
- Parametrise some of the model update tests.