### PR TITLE
Don't specify version in Tox

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -3,7 +3,7 @@ test=pytest
 
 [tox:tox]
 envlist =
-  py37
+  py
   tensorflow
   gcs
   all


### PR DESCRIPTION
Fixes #1247 

## Changelog
- Run `tox` with whatever Python version is present