### PR TITLE
Undefined name: import boto3 for lines 49 and 54

### DIFF
--- a/examples/models/openvino_imagenet_ensemble/resources/model/Prediction.py
+++ b/examples/models/openvino_imagenet_ensemble/resources/model/Prediction.py
@@ -3,6 +3,7 @@ import logging
 import datetime
 import os
 import sys
+import boto3
 from urllib.parse import urlparse
 from google.cloud import storage
 from openvino.inference_engine import IENetwork, IEPlugin


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/SeldonIO/seldon-core on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./examples/models/openvino_imagenet_ensemble/resources/model/Prediction.py:48:17: F821 undefined name 'boto3'
    s3_client = boto3.client('s3', endpoint_url=s3_endpoint)
                ^
./examples/models/openvino_imagenet_ensemble/resources/model/Prediction.py:53:19: F821 undefined name 'boto3'
    s3_transfer = boto3.s3.transfer.S3Transfer(s3_client)
                  ^
./examples/models/templates/ModelName.py:1:6: E999 SyntaxError: invalid syntax
from <your_loading_library> import <your_loading_function>
     ^
./util/loadtester/scripts/mnist_grpc_locust.py:148:32: F821 undefined name 'r'
                j = json.loads(r.content)
                               ^
1     E999 SyntaxError: invalid syntax
3     F821 undefined name 'boto3'
4
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.
