### PR TITLE
Add k8s folder to executor build

### DIFF
--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -15,6 +15,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY predictor/ predictor/
 COPY logger/ logger/
+COPY k8s/ k8s/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o executor main.go

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cloudevents/sdk-go v0.10.2
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3

--- a/executor/logger/worker.go
+++ b/executor/logger/worker.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	CEInferenceRequest       = "io.seldon.serving.inference.request"
-	CEInferenceResponse      = "io.seldon.serving.inference.response"
+	CEInferenceRequest  = "io.seldon.serving.inference.request"
+	CEInferenceResponse = "io.seldon.serving.inference.response"
 	// cloud events extension attributes have to be lowercase alphanumeric
 	RequestIdAttr            = "requestid"
 	ModelIdAttr              = "modelid"


### PR DESCRIPTION
## Changelog
- Add missing `k8s` folder to `Dockerfile`. Otherwise, `make docker-build` was complaining without it.
- Add some changes coming from `fmt` and `go mod`.
