### PR TITLE
Reduce flakiness on tracing tests

### DIFF
--- a/testing/scripts/jaeger_utils.py
+++ b/testing/scripts/jaeger_utils.py
@@ -15,7 +15,7 @@ def _is_empty(result):
     wait=wait_exponential(max=5),
     retry=retry_if_result(_is_empty),
 )
-def get_traces(pod_name, service, operation):
+def get_traces(pod_name, service, operation, _should_retry=lambda x: False):
     """
     Fetch traces for a given pod, service and operation.
 
@@ -51,4 +51,8 @@ def get_traces(pod_name, service, operation):
     response = requests.get(endpoint, params=params)
     payload = response.json()
     traces = payload["data"]
+
+    if _should_retry(traces):
+        return None
+
     return traces


### PR DESCRIPTION
## Context

Jaeger processes the tracing spans asynchronously, so there is a slight delay between an action happening and Jaeger reporting the full trace. Because of this, the integration tests introduced in #1464 may fail some times (when we fetch the requests while not all of them have been processed yet).

## Changelog
- Retry Jaeger tracing request if the trace seems incomplete.