### PR TITLE
Always set variables for predictive unit and deployment identifiers [Fixes #1449]

### DIFF
--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -678,12 +678,7 @@ func createContainerService(deploy *appsv1.Deployment, p machinelearningv1.Predi
 
 	// Add Environment Variables
 	if !utils.HasEnvVar(con.Env, machinelearningv1.ENV_PREDICTIVE_UNIT_SERVICE_PORT) {
-		con.Env = append(con.Env, []corev1.EnvVar{
-			corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_SERVICE_PORT, Value: strconv.Itoa(int(portNum))},
-			corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_ID, Value: con.Name},
-			corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTOR_ID, Value: p.Name},
-			corev1.EnvVar{Name: machinelearningv1.ENV_SELDON_DEPLOYMENT_ID, Value: mlDep.ObjectMeta.Name},
-		}...)
+		con.Env = append(con.Env, corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_SERVICE_PORT, Value: strconv.Itoa(int(portNum))})
 	}
 
 	if pu != nil && len(pu.Parameters) > 0 {
@@ -691,6 +686,13 @@ func createContainerService(deploy *appsv1.Deployment, p machinelearningv1.Predi
 			con.Env = append(con.Env, corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS, Value: utils.GetPredictiveUnitAsJson(pu.Parameters)})
 		}
 	}
+
+	// Always set the predictive and deployment identifiers
+	con.Env = append(con.Env, []corev1.EnvVar{
+		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_ID, Value: con.Name},
+		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTOR_ID, Value: p.Name},
+		corev1.EnvVar{Name: machinelearningv1.ENV_SELDON_DEPLOYMENT_ID, Value: mlDep.ObjectMeta.Name},
+	}...)
 
 	return svc
 }


### PR DESCRIPTION
Fixes #1449

Ensures the predictive unit and deployment identifier environment variables are always set by the controller.