### PR TITLE
Added helmchart variable to operator to be able to set a default "global" request logging prefix

### DIFF
--- a/executor/logger/constants.go
+++ b/executor/logger/constants.go
@@ -10,16 +10,15 @@ const (
 )
 
 // Variable to cache the value of ENV default request logger
-var defaultRequestLoggerEndpointPrefix string
+var defaultRequestLoggerEndpointPrefix string = ""
 
 func GetLoggerDefaultUrl(namespace string) string {
-	if defaultRequestLoggerEndpointPrefix != "" {
-		return defaultRequestLoggerEndpointPrefix + namespace
-	}
-	if value, ok := os.LookupEnv("REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX"); ok && value != "" {
-		defaultRequestLoggerEndpointPrefix = value
-	} else {
-		defaultRequestLoggerEndpointPrefix = "http://default-broker."
+	if defaultRequestLoggerEndpointPrefix == "" {
+		if value, ok := os.LookupEnv("REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX"); ok && value != "" {
+			defaultRequestLoggerEndpointPrefix = value
+		} else {
+			defaultRequestLoggerEndpointPrefix = "http://default-broker."
+		}
 	}
 	return defaultRequestLoggerEndpointPrefix + namespace
 }

--- a/executor/logger/constants.go
+++ b/executor/logger/constants.go
@@ -1,5 +1,7 @@
 package logger
 
+import "os"
+
 const (
 	LoggerWorkerQueueSize = 100
 	CloudEventsIdHeader   = "Ce-Id"
@@ -7,6 +9,17 @@ const (
 	CloudEventsTypeSource = "Ce-source"
 )
 
+// Variable to cache the value of ENV default request logger
+var defaultRequestLoggerEndpointPrefix string
+
 func GetLoggerDefaultUrl(namespace string) string {
-	return "http://default-broker." + namespace
+	if defaultRequestLoggerEndpointPrefix != "" {
+		return defaultRequestLoggerEndpointPrefix + namespace
+	}
+	if value, ok := os.LookupEnv("REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX"); ok && value != "" {
+		defaultRequestLoggerEndpointPrefix = value
+	} else {
+		defaultRequestLoggerEndpointPrefix = "http://default-broker."
+	}
+	return defaultRequestLoggerEndpointPrefix + namespace
 }

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -88,6 +88,8 @@ spec:
           value: '{{ .Values.executor.user }}'
         - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
           value: '{{ .Values.executor.serviceAccount.name }}'
+        - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX
+          value: '{{ .Values.executor.defaultRequestLoggerEndpointPrefix }}'
         image: '{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         name: manager

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -42,6 +42,7 @@ executor:
   serviceAccount:
     name: default
   user: 8888
+  defaultRequestLoggerEndpointPrefix: 'http://default-broker.'
 image:
   pullPolicy: IfNotPresent
   registry: docker.io

--- a/operator/apis/machinelearning/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning/v1/seldondeployment_types.go
@@ -19,10 +19,11 @@ package v1
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"strconv"
+
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 const (

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -68,6 +68,8 @@ spec:
           value: ""
         - name: USE_EXECUTOR
           value: "true"
+        - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT
+          value: ""
         - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
           value: seldonio/seldon-core-executor:1.0.3-SNAPSHOT
         - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY

--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -226,6 +226,7 @@ func createExecutorContainer(mlDep *machinelearningv1.SeldonDeployment, p *machi
 		},
 		Env: []corev1.EnvVar{
 			{Name: "ENGINE_PREDICTOR", Value: predictorB64},
+			{Name: "REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX", Value: GetEnv("EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX", "")},
 		},
 		Ports: []corev1.ContainerPort{
 			{ContainerPort: int32(http_port), Protocol: corev1.ProtocolTCP},

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -4,26 +4,28 @@ import re
 import yaml
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--prefix', default="xx", help='find files matching prefix')
-parser.add_argument('--folder', required=True, help='Output folder')
+parser.add_argument("--prefix", default="xx", help="find files matching prefix")
+parser.add_argument("--folder", required=True, help="Output folder")
 args, _ = parser.parse_known_args()
 
-HELM_SPARTAKUS_IF_START = '{{- if .Values.usageMetrics.enabled }}\n'
-HELM_CRD_IF_START = '{{- if .Values.crd.create }}\n'
-HELM_NOT_SINGLE_NAMESPACE_IF_START = '{{- if not .Values.singleNamespace }}\n'
-HELM_SINGLE_NAMESPACE_IF_START = '{{- if .Values.singleNamespace }}\n'
-HELM_CONTROLLERID_IF_START = '{{- if .Values.controllerId }}\n'
-HELM_NOT_CONTROLLERID_IF_START = '{{- if not .Values.controllerId }}\n'
-HELM_RBAC_IF_START = '{{- if .Values.rbac.create }}\n'
-HELM_RBAC_CSS_IF_START = '{{- if .Values.rbac.configmap.create }}\n'
-HELM_SA_IF_START = '{{- if .Values.serviceAccount.create -}}\n'
-HELM_CERTMANAGER_IF_START = '{{- if .Values.certManager.enabled -}}\n'
-HELM_NOT_CERTMANAGER_IF_START = '{{- if not .Values.certManager.enabled -}}\n'
-HELM_VERSION_IF_START= '{{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}\n'
-HELM_KUBEFLOW_IF_START='{{- if .Values.kubeflow }}\n'
-HELM_KUBEFLOW_IF_NOT_START='{{- if not .Values.kubeflow }}\n'
-#HELM_SECRET_IF_START = '{{- if .Values.webhook.secretProvided -}}\n'
-HELM_IF_END = '{{- end }}\n'
+HELM_SPARTAKUS_IF_START = "{{- if .Values.usageMetrics.enabled }}\n"
+HELM_CRD_IF_START = "{{- if .Values.crd.create }}\n"
+HELM_NOT_SINGLE_NAMESPACE_IF_START = "{{- if not .Values.singleNamespace }}\n"
+HELM_SINGLE_NAMESPACE_IF_START = "{{- if .Values.singleNamespace }}\n"
+HELM_CONTROLLERID_IF_START = "{{- if .Values.controllerId }}\n"
+HELM_NOT_CONTROLLERID_IF_START = "{{- if not .Values.controllerId }}\n"
+HELM_RBAC_IF_START = "{{- if .Values.rbac.create }}\n"
+HELM_RBAC_CSS_IF_START = "{{- if .Values.rbac.configmap.create }}\n"
+HELM_SA_IF_START = "{{- if .Values.serviceAccount.create -}}\n"
+HELM_CERTMANAGER_IF_START = "{{- if .Values.certManager.enabled -}}\n"
+HELM_NOT_CERTMANAGER_IF_START = "{{- if not .Values.certManager.enabled -}}\n"
+HELM_VERSION_IF_START = (
+    '{{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}\n'
+)
+HELM_KUBEFLOW_IF_START = "{{- if .Values.kubeflow }}\n"
+HELM_KUBEFLOW_IF_NOT_START = "{{- if not .Values.kubeflow }}\n"
+# HELM_SECRET_IF_START = '{{- if .Values.webhook.secretProvided -}}\n'
+HELM_IF_END = "{{- end }}\n"
 
 HELM_ENV_SUBST = {
     "AMBASSADOR_ENABLED": "ambassador.enabled",
@@ -35,11 +37,11 @@ HELM_ENV_SUBST = {
     "ENGINE_PROMETHEUS_PATH": "engine.prometheus.path",
     "ENGINE_CONTAINER_USER": "engine.user",
     "ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME": "engine.serviceAccount.name",
-    "ISTIO_ENABLED":"istio.enabled",
-    "ISTIO_GATEWAY":"istio.gateway",
-    "ISTIO_TLS_MODE":"istio.tlsMode",
-    "PREDICTIVE_UNIT_SERVICE_PORT":"predictiveUnit.port",
-    "USE_EXECUTOR":"executor.enabled",
+    "ISTIO_ENABLED": "istio.enabled",
+    "ISTIO_GATEWAY": "istio.gateway",
+    "ISTIO_TLS_MODE": "istio.tlsMode",
+    "PREDICTIVE_UNIT_SERVICE_PORT": "predictiveUnit.port",
+    "USE_EXECUTOR": "executor.enabled",
     "EXECUTOR_SERVER_GRPC_PORT": "engine.grpc.port",
     "EXECUTOR_CONTAINER_IMAGE_PULL_POLICY": "executor.image.pullPolicy",
     "EXECUTOR_SERVER_PORT": "executor.port",
@@ -47,88 +49,130 @@ HELM_ENV_SUBST = {
     "EXECUTOR_CONTAINER_USER": "executor.user",
     "EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME": "executor.serviceAccount.name",
 }
-HELM_VALUES_IMAGE_PULL_POLICY = '{{ .Values.image.pullPolicy }}'
+HELM_VALUES_IMAGE_PULL_POLICY = "{{ .Values.image.pullPolicy }}"
 
 
 def helm_value(value: str):
-    return '{{ .Values.' + value + ' }}'
+    return "{{ .Values." + value + " }}"
+
 
 def helm_value_json(value: str):
-    return '{{ .Values.' + value + ' | toJson }}'
+    return "{{ .Values." + value + " | toJson }}"
+
 
 def helm_release(value: str):
-    return '{{ .Release.' + value + ' }}'
+    return "{{ .Release." + value + " }}"
+
 
 if __name__ == "__main__":
     exp = args.prefix + "*"
     files = glob.glob(exp)
     webhookData = '{{- $altNames := list ( printf "seldon-webhook-service.%s" .Release.Namespace ) ( printf "seldon-webhook-service.%s.svc" .Release.Namespace ) -}}\n'
     webhookData = webhookData + '{{- $ca := genCA "custom-metrics-ca" 365 -}}\n'
-    webhookData = webhookData + '{{- $cert := genSignedCert "seldon-webhook-service" nil $altNames 365 $ca -}}\n'
+    webhookData = (
+        webhookData
+        + '{{- $cert := genSignedCert "seldon-webhook-service" nil $altNames 365 $ca -}}\n'
+    )
 
     for file in files:
-        with open(file, 'r') as stream:
+        with open(file, "r") as stream:
             res = yaml.safe_load(stream)
             kind = res["kind"].lower()
             name = res["metadata"]["name"].lower()
             filename = args.folder + "/" + (kind + "_" + name).lower() + ".yaml"
 
-            print("Processing ",file)
+            print("Processing ", file)
             # Update common labels
             if "metadata" in res and "labels" in res["metadata"]:
-                res["metadata"]["labels"]["app.kubernetes.io/instance"] = '{{ .Release.Name }}'
                 res["metadata"]["labels"][
-                    "app.kubernetes.io/name"] = '{{ include "seldon.name" . }}'
+                    "app.kubernetes.io/instance"
+                ] = "{{ .Release.Name }}"
                 res["metadata"]["labels"][
-                    "app.kubernetes.io/version"] = '{{ .Chart.Version }}'
+                    "app.kubernetes.io/name"
+                ] = '{{ include "seldon.name" . }}'
+                res["metadata"]["labels"][
+                    "app.kubernetes.io/version"
+                ] = "{{ .Chart.Version }}"
 
             # Update namespace to be helm var only if we are deploying into seldon-system
             if "metadata" in res and "namespace" in res["metadata"]:
-                if res["metadata"]["namespace"] == "seldon-system" or res["metadata"]["namespace"] == "seldon1-system":
-                    res["metadata"]["namespace"] = '{{ .Release.Namespace }}'
+                if (
+                    res["metadata"]["namespace"] == "seldon-system"
+                    or res["metadata"]["namespace"] == "seldon1-system"
+                ):
+                    res["metadata"]["namespace"] = "{{ .Release.Namespace }}"
 
             # controller manager
             if kind == "deployment" and name == "seldon-controller-manager":
-                res["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = helm_value(
-                    'image.pullPolicy')
                 res["spec"]["template"]["spec"]["containers"][0][
-                    "image"] = "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+                    "imagePullPolicy"
+                ] = helm_value("image.pullPolicy")
+                res["spec"]["template"]["spec"]["containers"][0][
+                    "image"
+                ] = "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 
                 for env in res["spec"]["template"]["spec"]["containers"][0]["env"]:
                     if env["name"] in HELM_ENV_SUBST:
                         env["value"] = helm_value(HELM_ENV_SUBST[env["name"]])
                     elif env["name"] == "ENGINE_CONTAINER_IMAGE_AND_VERSION":
-                        env["value"] = '{{ .Values.engine.image.registry }}/{{ .Values.engine.image.repository }}:{{ .Values.engine.image.tag }}'
+                        env[
+                            "value"
+                        ] = "{{ .Values.engine.image.registry }}/{{ .Values.engine.image.repository }}:{{ .Values.engine.image.tag }}"
                     elif env["name"] == "EXECUTOR_CONTAINER_IMAGE_AND_VERSION":
-                        env["value"] = '{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}'
+                        env[
+                            "value"
+                        ] = "{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}"
                     elif env["name"] == "CONTROLLER_ID":
                         env["value"] = "{{ .Values.controllerId }}"
+                    elif (
+                        env["name"] == "EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX"
+                    ):
+                        env[
+                            "value"
+                        ] = "{{ .Values.executor.defaultRequestLoggerEndpointPrefix }}"
                 # Update webhook port
-                for portSpec in res["spec"]["template"]["spec"]["containers"][0]["ports"]:
+                for portSpec in res["spec"]["template"]["spec"]["containers"][0][
+                    "ports"
+                ]:
                     if portSpec["name"] == "webhook-server":
                         portSpec["containerPort"] = helm_value("webhook.port")
-                for argIdx in range(0, len(res["spec"]["template"]["spec"]["containers"][0]["args"])):
-                    if res["spec"]["template"]["spec"]["containers"][0]["args"][argIdx] == "--webhook-port=443":
+                for argIdx in range(
+                    0, len(res["spec"]["template"]["spec"]["containers"][0]["args"])
+                ):
+                    if (
+                        res["spec"]["template"]["spec"]["containers"][0]["args"][argIdx]
+                        == "--webhook-port=443"
+                    ):
                         res["spec"]["template"]["spec"]["containers"][0]["args"][
-                            argIdx] = "--webhook-port=" + helm_value("webhook.port")
-                res["spec"]["template"]["spec"]["containers"][0]["args"].append("{{- if .Values.singleNamespace }}--namespace={{ .Release.Namespace }}{{- end }}")
-
+                            argIdx
+                        ] = "--webhook-port=" + helm_value("webhook.port")
+                res["spec"]["template"]["spec"]["containers"][0]["args"].append(
+                    "{{- if .Values.singleNamespace }}--namespace={{ .Release.Namespace }}{{- end }}"
+                )
 
             if kind == "configmap" and name == "seldon-config":
                 res["data"]["credentials"] = helm_value_json("credentials")
                 res["data"]["predictor_servers"] = helm_value_json("predictor_servers")
-                res["data"]["storageInitializer"] = helm_value_json("storageInitializer")
+                res["data"]["storageInitializer"] = helm_value_json(
+                    "storageInitializer"
+                )
 
             if kind == "serviceaccount" and name == "seldon-manager":
                 res["metadata"]["name"] = helm_value("serviceAccount.name")
 
             if kind == "clusterrole":
-                res["metadata"]["name"] = res["metadata"]["name"] + "-" + helm_release("Namespace")
+                res["metadata"]["name"] = (
+                    res["metadata"]["name"] + "-" + helm_release("Namespace")
+                )
 
             # Update cluster role bindings
             if kind == "clusterrolebinding":
-                res["metadata"]["name"] = res["metadata"]["name"] + "-" + helm_release("Namespace")
-                res["roleRef"]["name"] = res["roleRef"]["name"] + "-" + helm_release("Namespace")
+                res["metadata"]["name"] = (
+                    res["metadata"]["name"] + "-" + helm_release("Namespace")
+                )
+                res["roleRef"]["name"] = (
+                    res["roleRef"]["name"] + "-" + helm_release("Namespace")
+                )
                 if name == "seldon-manager-rolebinding":
                     res["subjects"][0]["name"] = helm_value("serviceAccount.name")
                     res["subjects"][0]["namespace"] = helm_release("Namespace")
@@ -138,10 +182,12 @@ if __name__ == "__main__":
             # Update role bindings
             if kind == "rolebinding":
                 res["subjects"][0]["namespace"] = helm_release("Namespace")
-                if  name == "seldon1-manager-rolebinding" or name == "seldon1-manager-sas-rolebinding":
+                if (
+                    name == "seldon1-manager-rolebinding"
+                    or name == "seldon1-manager-sas-rolebinding"
+                ):
                     res["subjects"][0]["name"] = helm_value("serviceAccount.name")
                     res["subjects"][0]["namespace"] = helm_release("Namespace")
-
 
             # Update webhook certificates
             if name == "seldon-webhook-server-cert" and kind == "secret":
@@ -149,83 +195,206 @@ if __name__ == "__main__":
                 res["data"]["tls.crt"] = "{{ $cert.Cert | b64enc }}"
                 res["data"]["tls.key"] = "{{ $cert.Key | b64enc }}"
 
-            if kind == "mutatingwebhookconfiguration" or kind == "validatingwebhookconfiguration":
-                res["metadata"]["name"] = res["metadata"]["name"] + "-" + helm_release("Namespace")
-                res["webhooks"][0]["clientConfig"]["caBundle"] = "{{ $ca.Cert | b64enc }}"
-                res["webhooks"][0]["clientConfig"]["service"]["namespace"] = helm_release("Namespace")
-                res["webhooks"][1]["clientConfig"]["caBundle"] = "{{ $ca.Cert | b64enc }}"
-                res["webhooks"][1]["clientConfig"]["service"]["namespace"] = helm_release("Namespace")
-                res["webhooks"][2]["clientConfig"]["caBundle"] = "{{ $ca.Cert | b64enc }}"
-                res["webhooks"][2]["clientConfig"]["service"]["namespace"] = helm_release("Namespace")
+            if (
+                kind == "mutatingwebhookconfiguration"
+                or kind == "validatingwebhookconfiguration"
+            ):
+                res["metadata"]["name"] = (
+                    res["metadata"]["name"] + "-" + helm_release("Namespace")
+                )
+                res["webhooks"][0]["clientConfig"][
+                    "caBundle"
+                ] = "{{ $ca.Cert | b64enc }}"
+                res["webhooks"][0]["clientConfig"]["service"][
+                    "namespace"
+                ] = helm_release("Namespace")
+                res["webhooks"][1]["clientConfig"][
+                    "caBundle"
+                ] = "{{ $ca.Cert | b64enc }}"
+                res["webhooks"][1]["clientConfig"]["service"][
+                    "namespace"
+                ] = helm_release("Namespace")
+                res["webhooks"][2]["clientConfig"][
+                    "caBundle"
+                ] = "{{ $ca.Cert | b64enc }}"
+                res["webhooks"][2]["clientConfig"]["service"][
+                    "namespace"
+                ] = helm_release("Namespace")
                 if "cert-manager.io/inject-ca-from" in res["metadata"]["annotations"]:
-                    res["metadata"]["annotations"]["cert-manager.io/inject-ca-from"] = helm_release("Namespace") + "/seldon-serving-cert"
-
+                    res["metadata"]["annotations"]["cert-manager.io/inject-ca-from"] = (
+                        helm_release("Namespace") + "/seldon-serving-cert"
+                    )
 
             if kind == "certificate":
-                res["spec"]["commonName"] = '{{- printf "seldon-webhook-service.%s.svc" .Release.Namespace -}}'
-                res["spec"]["dnsNames"][0] = '{{- printf "seldon-webhook-service.%s.svc.cluster.local" .Release.Namespace -}}'
-                res["spec"]["dnsNames"][1] = '{{- printf "seldon-webhook-service.%s.svc" .Release.Namespace -}}'
+                res["spec"][
+                    "commonName"
+                ] = '{{- printf "seldon-webhook-service.%s.svc" .Release.Namespace -}}'
+                res["spec"]["dnsNames"][
+                    0
+                ] = '{{- printf "seldon-webhook-service.%s.svc.cluster.local" .Release.Namespace -}}'
+                res["spec"]["dnsNames"][
+                    1
+                ] = '{{- printf "seldon-webhook-service.%s.svc" .Release.Namespace -}}'
 
-            if kind == "customresourcedefinition"and name == "seldondeployments.machinelearning.seldon.io":
+            if (
+                kind == "customresourcedefinition"
+                and name == "seldondeployments.machinelearning.seldon.io"
+            ):
                 # Will only work for cert-manager at present as caBundle would need to be generated in same file as secrets above
                 if "conversion" in res["spec"]:
                     res["spec"]["conversion"]["webhookClientConfig"]["caBundle"] = "=="
                 if "cert-manager.io/inject-ca-from" in res["metadata"]["annotations"]:
-                    res["metadata"]["annotations"]["cert-manager.io/inject-ca-from"] = helm_release("Namespace") + "/seldon-serving-cert"
+                    res["metadata"]["annotations"]["cert-manager.io/inject-ca-from"] = (
+                        helm_release("Namespace") + "/seldon-serving-cert"
+                    )
 
             # Update webhook service port
             if kind == "service" and name == "seldon-webhook-service":
                 res["spec"]["ports"][0]["targetPort"] = helm_value("webhook.port")
 
-
             fdata = yaml.dump(res, width=1000)
 
             # Spartatkus
             if name.find("spartakus") > -1:
-                fdata =  HELM_SPARTAKUS_IF_START + fdata + HELM_IF_END
+                fdata = HELM_SPARTAKUS_IF_START + fdata + HELM_IF_END
             # cluster roles for single namespace
             elif name == "seldon-manager-rolebinding" or name == "seldon-manager-role":
-                fdata = HELM_NOT_SINGLE_NAMESPACE_IF_START + HELM_RBAC_IF_START + fdata + HELM_IF_END + HELM_IF_END
-            elif name == "seldon-manager-sas-rolebinding" or name == "seldon-manager-sas-role":
-                fdata = HELM_NOT_SINGLE_NAMESPACE_IF_START + HELM_RBAC_IF_START + HELM_RBAC_CSS_IF_START + fdata + HELM_IF_END + HELM_IF_END + HELM_IF_END
+                fdata = (
+                    HELM_NOT_SINGLE_NAMESPACE_IF_START
+                    + HELM_RBAC_IF_START
+                    + fdata
+                    + HELM_IF_END
+                    + HELM_IF_END
+                )
+            elif (
+                name == "seldon-manager-sas-rolebinding"
+                or name == "seldon-manager-sas-role"
+            ):
+                fdata = (
+                    HELM_NOT_SINGLE_NAMESPACE_IF_START
+                    + HELM_RBAC_IF_START
+                    + HELM_RBAC_CSS_IF_START
+                    + fdata
+                    + HELM_IF_END
+                    + HELM_IF_END
+                    + HELM_IF_END
+                )
             # roles/rolebindings for single namespace
-            elif name == "seldon1-manager-rolebinding" or name == "seldon1-manager-role":
-                fdata = HELM_SINGLE_NAMESPACE_IF_START + HELM_RBAC_IF_START + fdata + HELM_IF_END + HELM_IF_END
-            elif name == "seldon1-manager-sas-role" or name == "seldon1-manager-sas-rolebinding":
-                fdata = HELM_SINGLE_NAMESPACE_IF_START + HELM_RBAC_IF_START  + HELM_RBAC_CSS_IF_START + fdata + HELM_IF_END + HELM_IF_END + HELM_IF_END
+            elif (
+                name == "seldon1-manager-rolebinding" or name == "seldon1-manager-role"
+            ):
+                fdata = (
+                    HELM_SINGLE_NAMESPACE_IF_START
+                    + HELM_RBAC_IF_START
+                    + fdata
+                    + HELM_IF_END
+                    + HELM_IF_END
+                )
+            elif (
+                name == "seldon1-manager-sas-role"
+                or name == "seldon1-manager-sas-rolebinding"
+            ):
+                fdata = (
+                    HELM_SINGLE_NAMESPACE_IF_START
+                    + HELM_RBAC_IF_START
+                    + HELM_RBAC_CSS_IF_START
+                    + fdata
+                    + HELM_IF_END
+                    + HELM_IF_END
+                    + HELM_IF_END
+                )
             # manager role binding
-            elif name == "seldon-manager-cm-rolebinding" or name == "seldon-manager-cm-role":
-                fdata = HELM_RBAC_IF_START + HELM_RBAC_CSS_IF_START + fdata + HELM_IF_END + HELM_IF_END
+            elif (
+                name == "seldon-manager-cm-rolebinding"
+                or name == "seldon-manager-cm-role"
+            ):
+                fdata = (
+                    HELM_RBAC_IF_START
+                    + HELM_RBAC_CSS_IF_START
+                    + fdata
+                    + HELM_IF_END
+                    + HELM_IF_END
+                )
             elif name == "seldon-manager" and kind == "serviceaccount":
                 fdata = HELM_SA_IF_START + fdata + HELM_IF_END
-            elif kind == "issuer"or kind == "certificate":
+            elif kind == "issuer" or kind == "certificate":
                 fdata = HELM_CERTMANAGER_IF_START + fdata + HELM_IF_END
             elif name == "seldon-webhook-server-cert" and kind == "secret":
                 fdata = HELM_NOT_CERTMANAGER_IF_START + fdata + HELM_IF_END
             elif name == "seldondeployments.machinelearning.seldon.io":
-                fdata =HELM_CRD_IF_START + fdata + HELM_IF_END
+                fdata = HELM_CRD_IF_START + fdata + HELM_IF_END
 
             # make sure webhook is not quoted as its an int
-            fdata = fdata.replace("'{{ .Values.webhook.port }}'","{{ .Values.webhook.port }}")
+            fdata = fdata.replace(
+                "'{{ .Values.webhook.port }}'", "{{ .Values.webhook.port }}"
+            )
 
             if not kind == "namespace":
-                if "seldon1" in name and name != "seldon1-manager-rolebinding" and name != "seldon1-manager-role" and \
-                    name != "seldon1-manager-sas-role" and name != "seldon1-manager-sas-rolebinding":
-                    print("Ignore ",name)
+                if (
+                    "seldon1" in name
+                    and name != "seldon1-manager-rolebinding"
+                    and name != "seldon1-manager-role"
+                    and name != "seldon1-manager-sas-role"
+                    and name != "seldon1-manager-sas-rolebinding"
+                ):
+                    print("Ignore ", name)
                     continue
-                elif name == "seldon-webhook-server-cert" and kind == "secret" or \
-                        kind == "mutatingwebhookconfiguration" or kind == "validatingwebhookconfiguration":
+                elif (
+                    name == "seldon-webhook-server-cert"
+                    and kind == "secret"
+                    or kind == "mutatingwebhookconfiguration"
+                    or kind == "validatingwebhookconfiguration"
+                ):
                     webhookData = webhookData + "---\n\n" + fdata
                 else:
-                    with open(filename, 'w') as outfile:
+                    with open(filename, "w") as outfile:
                         outfile.write(fdata)
     # Write webhook related data in 1 file
-    namespaceSelector = "  namespaceSelector:\n    matchLabels:\n      seldon.io/controller-id: " + helm_release("Namespace") + "\n"
-    objectSelector = "  objectSelector:\n    matchLabels:\n      seldon.io/controller-id: " + helm_value("controllerId") + "\n"
-    kubeflowSelector = "    matchLabels:\n      serving.kubeflow.org/inferenceservice: enabled\n"
-    webhookData = re.sub(r"(.*namespaceSelector:\n.*matchExpressions:\n.*\n.*\n)",HELM_VERSION_IF_START+HELM_NOT_SINGLE_NAMESPACE_IF_START+r"\1"+HELM_KUBEFLOW_IF_START+kubeflowSelector+HELM_IF_END+HELM_IF_END+HELM_IF_END+HELM_SINGLE_NAMESPACE_IF_START+namespaceSelector+HELM_IF_END,webhookData, re.M)
-    webhookData = re.sub(r"(.*objectSelector:\n.*matchExpressions:\n.*\n.*\n)",HELM_KUBEFLOW_IF_NOT_START+HELM_VERSION_IF_START+HELM_NOT_CONTROLLERID_IF_START+r"\1"+HELM_IF_END+HELM_IF_END+HELM_CONTROLLERID_IF_START+objectSelector+HELM_IF_END+HELM_IF_END,webhookData, re.M)
+    namespaceSelector = (
+        "  namespaceSelector:\n    matchLabels:\n      seldon.io/controller-id: "
+        + helm_release("Namespace")
+        + "\n"
+    )
+    objectSelector = (
+        "  objectSelector:\n    matchLabels:\n      seldon.io/controller-id: "
+        + helm_value("controllerId")
+        + "\n"
+    )
+    kubeflowSelector = (
+        "    matchLabels:\n      serving.kubeflow.org/inferenceservice: enabled\n"
+    )
+    webhookData = re.sub(
+        r"(.*namespaceSelector:\n.*matchExpressions:\n.*\n.*\n)",
+        HELM_VERSION_IF_START
+        + HELM_NOT_SINGLE_NAMESPACE_IF_START
+        + r"\1"
+        + HELM_KUBEFLOW_IF_START
+        + kubeflowSelector
+        + HELM_IF_END
+        + HELM_IF_END
+        + HELM_IF_END
+        + HELM_SINGLE_NAMESPACE_IF_START
+        + namespaceSelector
+        + HELM_IF_END,
+        webhookData,
+        re.M,
+    )
+    webhookData = re.sub(
+        r"(.*objectSelector:\n.*matchExpressions:\n.*\n.*\n)",
+        HELM_KUBEFLOW_IF_NOT_START
+        + HELM_VERSION_IF_START
+        + HELM_NOT_CONTROLLERID_IF_START
+        + r"\1"
+        + HELM_IF_END
+        + HELM_IF_END
+        + HELM_CONTROLLERID_IF_START
+        + objectSelector
+        + HELM_IF_END
+        + HELM_IF_END,
+        webhookData,
+        re.M,
+    )
 
     filename = args.folder + "/" + "webhook.yaml"
-    with open(filename, 'w') as outfile:
+    with open(filename, "w") as outfile:
         outfile.write(webhookData)


### PR DESCRIPTION
Fixes #1510

This PR includes:
* Added extra env variable to executor to add a default request logging prefix
* Added changes in executor to use this as default variable
* Default env var is cached in executor code with variable to avoid accessing getenv [for efficiency](https://dinolai.com/notes/golang/golang-benchmark-reading-config-from-os-env-and-file.html)
* Helmchart resources python file also has the extra env variable for helmchart generation
* Helmchart resources python file was edited by formatter (hence why all file is updated)

Things to consider:
* Currently it allows for the prefix to be overriden, which still assumes that there will be one request logger per namespace. If we think it's best to make it a REQUEST_LOGGER_ENDPOINT instead of REQUEST_LOGGER_ENDPOINT_PREFIX then we'd just need to make sure it reflects this. 
* Currently the changes made the ENV variable to be optional as there is a "default" value in `executor/logger/constants.go`, however if we add this value as the default when the executor container is being created in the operator we would be abel to have that default there instead.

Further questions:
* Currently the way to enable request logging needs to be set on every deployment, for every predictor. It could also be possible to enable request logging on a global level, with the ability to enable/disable on a per-deployment level. If this is something desirable, then we would look at adding another variable and ensuring that it's checked in the executor's predictor_process `Predict` method.