### PR TITLE
Make copy of locals()

### DIFF
--- a/python/seldon_core/seldon_client.py
+++ b/python/seldon_core/seldon_client.py
@@ -206,7 +206,7 @@ class SeldonClient(object):
         if debug:
             logger.setLevel(logging.DEBUG)
             http_client.HTTPConnection.debuglevel = 1
-        self.config = locals()
+        self.config = locals().copy()
         del self.config["self"]
         logger.debug("Configuration:" + str(self.config))
 


### PR DESCRIPTION
Fixes #1499

## Changelog
- Don't use `locals()` directly. Instead, make a copy.