### PR TITLE
Move protocol/transport CRD variables

### DIFF
--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/seldon-serving-cert'
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   labels:
     app: seldon
@@ -15,9 +16,11 @@ spec:
   group: machinelearning.seldon.io
   names:
     kind: SeldonDeployment
+    listKind: SeldonDeploymentList
     plural: seldondeployments
     shortNames:
     - sdep
+    singular: seldondeployment
   scope: Namespaced
   subresources:
     status: {}
@@ -26,10 +29,10 @@ spec:
       description: SeldonDeployment is the Schema for the seldondeployments API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -41,6 +44,7 @@ spec:
                 type: string
               type: object
             name:
+              description: Name is Deprecated will be removed in future
               type: string
             oauth_key:
               type: string
@@ -102,11 +106,19 @@ spec:
                                             type: object
                                         type: object
                                       targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
                                         description: targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
-                                        type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                       targetValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
                                         description: targetValue is the target value of the metric (as a quantity). Mutually exclusive with TargetAverageValue.
-                                        type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                     required:
                                     - metricName
                                     type: object
@@ -114,8 +126,12 @@ spec:
                                     description: object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
                                     properties:
                                       averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
                                         description: averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
-                                        type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                       metricName:
                                         description: metricName is the name of the metric in question.
                                         type: string
@@ -156,7 +172,7 @@ spec:
                                             description: API version of the referent
                                             type: string
                                           kind:
-                                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"'
+                                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                             type: string
                                           name:
                                             description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -166,8 +182,12 @@ spec:
                                         - name
                                         type: object
                                       targetValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
                                         description: targetValue is the target value of the metric (as a quantity).
-                                        type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                     required:
                                     - metricName
                                     - target
@@ -210,8 +230,12 @@ spec:
                                             type: object
                                         type: object
                                       targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
                                         description: targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
-                                        type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                     required:
                                     - metricName
                                     - targetAverageValue
@@ -227,8 +251,12 @@ spec:
                                         format: int32
                                         type: integer
                                       targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
                                         description: targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
-                                        type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                     required:
                                     - name
                                     type: object
@@ -637,13 +665,13 @@ spec:
                                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or it's key must be defined
+                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.'
+                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
@@ -661,8 +689,12 @@ spec:
                                                   description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
                                                   description: Specifies the output format of the exposed resources, defaults to "1"
-                                                  type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
                                                 resource:
                                                   description: 'Required: resource to select'
                                                   type: string
@@ -679,7 +711,7 @@ spec:
                                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or it's key must be defined
+                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -788,7 +820,7 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: One and only one of the following should be specified. Exec specifies the action to take.
@@ -906,7 +938,7 @@ spec:
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -955,6 +987,10 @@ spec:
                                       - containerPort
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
                                   readinessProbe:
                                     description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
@@ -1014,7 +1050,7 @@ spec:
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1039,12 +1075,20 @@ spec:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          type: string
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          type: string
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
@@ -1106,6 +1150,104 @@ spec:
                                             description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
                                     type: object
                                   stdin:
                                     description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
@@ -1159,7 +1301,7 @@ spec:
                                           description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is alpha in 1.14.
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1205,6 +1347,718 @@ spec:
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
+                            ephemeralContainers:
+                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+                              items:
+                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Lifecycle is not allowed for ephemeral containers.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: Probes are not allowed for ephemeral containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+                                    type: string
+                                  ports:
+                                    description: Ports are not allowed for ephemeral containers.
+                                    items:
+                                      description: ContainerPort represents a network port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    description: Probes are not allowed for ephemeral containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: SecurityContext is not allowed for ephemeral containers.
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label that applies to the container.
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: Probes are not allowed for ephemeral containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                    type: boolean
+                                  targetContainerName:
+                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+                                    type: string
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
+                                    items:
+                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
                             hostAliases:
                               description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
@@ -1243,7 +2097,7 @@ spec:
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
                                 description: A single application container that you want to run within a pod.
                                 properties:
@@ -1281,13 +2135,13 @@ spec:
                                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or it's key must be defined
+                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.'
+                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
@@ -1305,8 +2159,12 @@ spec:
                                                   description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
                                                   description: Specifies the output format of the exposed resources, defaults to "1"
-                                                  type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
                                                 resource:
                                                   description: 'Required: resource to select'
                                                   type: string
@@ -1323,7 +2181,7 @@ spec:
                                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or it's key must be defined
+                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1432,7 +2290,7 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: One and only one of the following should be specified. Exec specifies the action to take.
@@ -1550,7 +2408,7 @@ spec:
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1599,6 +2457,10 @@ spec:
                                       - containerPort
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
                                   readinessProbe:
                                     description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
@@ -1658,7 +2520,7 @@ spec:
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1683,12 +2545,20 @@ spec:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          type: string
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          type: string
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
@@ -1750,6 +2620,104 @@ spec:
                                             description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
                                     type: object
                                   stdin:
                                     description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
@@ -1803,7 +2771,7 @@ spec:
                                           description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is alpha in 1.14.
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1825,6 +2793,18 @@ spec:
                                 type: string
                               description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
+                              type: object
+                            preemptionPolicy:
+                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+                              type: string
                             priority:
                               description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
@@ -1848,7 +2828,7 @@ spec:
                               description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is an alpha feature and may change in the future.'
+                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -1909,6 +2889,19 @@ spec:
                                     - value
                                     type: object
                                   type: array
+                                windowsOptions:
+                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                      type: string
+                                  type: object
                               type: object
                             serviceAccount:
                               description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
@@ -1917,7 +2910,7 @@ spec:
                               description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false. This field is beta-level and may be disabled with the PodShareProcessNamespace feature.'
+                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
@@ -1949,6 +2942,61 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                            topologySpreadConstraints:
+                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is alpha-level and is only honored by clusters that enables the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  maxSkew:
+                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  topologyKey:
+                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
                             volumes:
                               description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
@@ -1964,12 +3012,20 @@ spec:
                     properties:
                       limits:
                         additionalProperties:
-                          type: string
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                       requests:
                         additionalProperties:
-                          type: string
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
@@ -2016,13 +3072,13 @@ spec:
                                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap or it's key must be defined
+                                          description: Specify whether the ConfigMap or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.'
+                                      description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                       properties:
                                         apiVersion:
                                           description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
@@ -2040,8 +3096,12 @@ spec:
                                           description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
                                           description: Specifies the output format of the exposed resources, defaults to "1"
-                                          type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         resource:
                                           description: 'Required: resource to select'
                                           type: string
@@ -2058,7 +3118,7 @@ spec:
                                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or it's key must be defined
+                                          description: Specify whether the Secret or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -2167,7 +3227,7 @@ spec:
                                     type: object
                                 type: object
                               preStop:
-                                description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                 properties:
                                   exec:
                                     description: One and only one of the following should be specified. Exec specifies the action to take.
@@ -2285,7 +3345,7 @@ spec:
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
@@ -2334,6 +3394,10 @@ spec:
                               - containerPort
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
                           readinessProbe:
                             description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
@@ -2393,7 +3457,7 @@ spec:
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
@@ -2418,12 +3482,20 @@ spec:
                             properties:
                               limits:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
-                                  type: string
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
@@ -2485,6 +3557,104 @@ spec:
                                     description: User is a SELinux user label that applies to the container.
                                     type: string
                                 type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                    type: string
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
                             type: object
                           stdin:
                             description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
@@ -2538,7 +3708,7 @@ spec:
                                   description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is alpha in 1.14.
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -2840,8 +4010,6 @@ spec:
                     type: object
                   name:
                     type: string
-                  protocol:
-                    type: string
                   replicas:
                     format: int32
                     type: integer
@@ -2872,13 +4040,13 @@ spec:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or it's key must be defined
+                                      description: Specify whether the ConfigMap or its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.'
+                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
@@ -2896,8 +4064,12 @@ spec:
                                       description: 'Container name: required for volumes, optional for env vars'
                                       type: string
                                     divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of the exposed resources, defaults to "1"
-                                      type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -2914,7 +4086,7 @@ spec:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or it's key must be defined
+                                      description: Specify whether the Secret or its key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -2929,12 +4101,20 @@ spec:
                         properties:
                           limits:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
@@ -2942,13 +4122,15 @@ spec:
                   traffic:
                     format: int32
                     type: integer
-                  transport:
-                    type: string
                 required:
                 - graph
                 - name
                 type: object
               type: array
+            protocol:
+              type: string
+            transport:
+              type: string
           required:
           - predictors
           type: object

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -104,7 +104,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: '{{ .Values.manager.cpulimit }}'
+            cpu: '{{ .Values.manager.cpuLimit }}'
             memory: '{{ .Values.manager.memoryLimit }}'
           requests:
             cpu: '{{ .Values.manager.cpuRequest }}'

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -104,11 +104,11 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: {{ .Values.manager.cpuLimit }}
-            memory: {{ .Values.manager.memoryLimit }}
+            cpu: '{{ .Values.manager.cpulimit }}'
+            memory: '{{ .Values.manager.memoryLimit }}'
           requests:
-            cpu: {{ .Values.manager.cpuRequest }}
-            memory: {{ .Values.manager.memoryRequest }}
+            cpu: '{{ .Values.manager.cpuRequest }}'
+            memory: '{{ .Values.manager.memoryRequest }}'
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/notebooks/resources/fixed_v1.yaml
+++ b/notebooks/resources/fixed_v1.yaml
@@ -4,10 +4,10 @@ metadata:
   name: fixed
 spec:
   name: fixed
+  protocol: seldon
+  transport: rest
   predictors:
-  - protocol: seldon
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/fixed-model:0.1

--- a/notebooks/resources/fixed_v1_2podspecs.yaml
+++ b/notebooks/resources/fixed_v1_2podspecs.yaml
@@ -4,10 +4,10 @@ metadata:
   name: fixed
 spec:
   name: fixed
+  protocol: seldon
+  transport: rest
   predictors:
-  - protocol: seldon
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/fixed-model:0.1

--- a/notebooks/resources/fixed_v1_sep.yaml
+++ b/notebooks/resources/fixed_v1_sep.yaml
@@ -4,12 +4,12 @@ metadata:
   name: fixed
 spec:
   name: fixed
+  protocol: seldon
+  transport: rest
   annotations:
     seldon.io/engine-separate-pod: "true"
   predictors:
-  - protocol: seldon
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/fixed-model:0.1

--- a/notebooks/resources/fixed_v2.yaml
+++ b/notebooks/resources/fixed_v2.yaml
@@ -4,10 +4,10 @@ metadata:
   name: fixed
 spec:
   name: fixed
+  protocol: seldon
+  transport: rest
   predictors:
-  - protocol: seldon
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/fixed-model:0.2

--- a/notebooks/resources/fixed_v2_2podspecs.yaml
+++ b/notebooks/resources/fixed_v2_2podspecs.yaml
@@ -4,10 +4,10 @@ metadata:
   name: fixed
 spec:
   name: fixed
+  protocol: seldon
+  transport: rest
   predictors:
-  - protocol: seldon
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/fixed-model:0.1

--- a/notebooks/resources/fixed_v2_sep.yaml
+++ b/notebooks/resources/fixed_v2_sep.yaml
@@ -4,12 +4,12 @@ metadata:
   name: fixed
 spec:
   name: fixed
+  protocol: seldon
+  transport: rest
   annotations:
     seldon.io/engine-separate-pod: "true"
   predictors:
-  - protocol: seldon
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/fixed-model:0.2

--- a/notebooks/resources/model_seldon_grpc.yaml
+++ b/notebooks/resources/model_seldon_grpc.yaml
@@ -4,10 +4,10 @@ metadata:
   name: grpc-seldon
 spec:
   name: grpcseldon
+  protocol: seldon
+  transport: grpc
   predictors:
-  - protocol: seldon
-    transport: grpc
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/mock_classifier_grpc:1.3

--- a/notebooks/resources/model_seldon_rest.yaml
+++ b/notebooks/resources/model_seldon_rest.yaml
@@ -4,10 +4,10 @@ metadata:
   name: rest-seldon
 spec:
   name: restseldon
+  protocol: seldon
+  transport: rest  
   predictors:
-  - protocol: seldon
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - image: seldonio/mock_classifier_rest:1.3

--- a/notebooks/resources/model_tfserving_grpc.yaml
+++ b/notebooks/resources/model_tfserving_grpc.yaml
@@ -4,10 +4,10 @@ metadata:
   name: grpc-tfserving
 spec:
   name: grpctfserving
+  protocol: tensorflow
+  transport: grpc
   predictors:
-  - protocol: tensorflow
-    transport: grpc
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - args: 

--- a/notebooks/resources/model_tfserving_rest.yaml
+++ b/notebooks/resources/model_tfserving_rest.yaml
@@ -4,10 +4,10 @@ metadata:
   name: rest-tfserving
 spec:
   name: resttfserving
+  protocol: tensorflow
+  transport: rest
   predictors:
-  - protocol: tensorflow
-    transport: rest
-    componentSpecs:
+  - componentSpecs:
     - spec:
         containers:
         - args: 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -19,7 +19,7 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests generate-resources
-	go test ./controllers/...  -coverprofile cover.out
+	go test ./controllers/... ./apis/...  -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet

--- a/operator/apis/machinelearning/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning/v1/seldondeployment_types.go
@@ -171,6 +171,8 @@ type SeldonDeploymentSpec struct {
 	OauthKey    string            `json:"oauth_key,omitempty" protobuf:"string,3,opt,name=oauth_key"`
 	OauthSecret string            `json:"oauth_secret,omitempty" protobuf:"string,4,opt,name=oauth_secret"`
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,5,opt,name=annotations"`
+	Protocol    Protocol          `json:"protocol,omitempty" protobuf:"bytes,6,opt,name=protocol"`
+	Transport   Transport         `json:"transport,omitempty" protobuf:"bytes,7,opt,name=transport"`
 }
 
 type PredictorSpec struct {
@@ -185,8 +187,6 @@ type PredictorSpec struct {
 	Traffic         int32                   `json:"traffic,omitempty" protobuf:"bytes,9,opt,name=traffic"`
 	Explainer       *Explainer              `json:"explainer,omitempty" protobuf:"bytes,10,opt,name=explainer"`
 	Shadow          bool                    `json:"shadow,omitempty" protobuf:"bytes,11,opt,name=shadow"`
-	Protocol        Protocol                `json:"protocol,omitempty" protobuf:"bytes,12,opt,name=protocol"`
-	Transport       Transport               `json:"transport,omitempty" protobuf:"bytes,13,opt,name=transport"`
 }
 
 type Protocol string

--- a/operator/apis/machinelearning/v1/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning/v1/seldondeployment_webhook.go
@@ -453,6 +453,15 @@ func sizeOfGraph(p *PredictiveUnit) int {
 	return count + 1
 }
 
+func collectTransports(pu *PredictiveUnit, transportsFound map[EndpointType]bool) {
+	if pu.Endpoint != nil && pu.Endpoint.Type != "" {
+		transportsFound[pu.Endpoint.Type] = true
+	}
+	for _, c := range pu.Children {
+		collectTransports(&c, transportsFound)
+	}
+}
+
 func (r *SeldonDeploymentSpec) ValidateSeldonDeployment() error {
 	var allErrs field.ErrorList
 
@@ -466,8 +475,12 @@ func (r *SeldonDeploymentSpec) ValidateSeldonDeployment() error {
 		allErrs = append(allErrs, field.Invalid(fldPath, r.Transport, "Invalid transport"))
 	}
 
+	transports := make(map[EndpointType]bool)
+
 	predictorNames := make(map[string]bool)
 	for i, p := range r.Predictors {
+
+		collectTransports(p.Graph, transports)
 
 		_, noEngine := p.Annotations[ANNOTATION_NO_ENGINE]
 		if noEngine && sizeOfGraph(p.Graph) > 1 {
@@ -481,6 +494,18 @@ func (r *SeldonDeploymentSpec) ValidateSeldonDeployment() error {
 		}
 		predictorNames[p.Name] = true
 		allErrs = checkPredictiveUnits(p.Graph, &p, field.NewPath("spec").Child("predictors").Index(i).Child("graph"), allErrs)
+	}
+
+	if len(transports) > 1 {
+		fldPath := field.NewPath("spec")
+		allErrs = append(allErrs, field.Invalid(fldPath, "", "Multiple endpoint.types found - can only have 1 type in graph. Please use spec.transport"))
+	} else if len(transports) == 1 && r.Transport != "" {
+		for k := range transports {
+			if (k == REST && r.Transport != TransportRest) || (k == GRPC && r.Transport != TransportGrpc) {
+				fldPath := field.NewPath("spec")
+				allErrs = append(allErrs, field.Invalid(fldPath, "", "Mixed transport types found. Remove graph endpoint.types if transport set at deployment level"))
+			}
+		}
 	}
 
 	allErrs = checkTraffic(r, field.NewPath("spec"), allErrs)

--- a/operator/apis/machinelearning/v1/seldondeployment_webhook_test.go
+++ b/operator/apis/machinelearning/v1/seldondeployment_webhook_test.go
@@ -1,0 +1,178 @@
+package v1
+
+import (
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestValidateBadProtocol(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := &SeldonDeploymentSpec{
+		Protocol: "abc",
+		Predictors: []PredictorSpec{
+			{
+				Name: "p1",
+				ComponentSpecs: []*SeldonPodSpec{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Image: "seldonio/mock_classifier:1.0",
+									Name:  "classifier",
+								},
+							},
+						},
+					},
+				},
+				Graph: &PredictiveUnit{
+					Name: "classifier",
+				},
+			},
+		},
+	}
+
+	spec.DefaultSeldonDeployment("mydep", "default")
+	err := spec.ValidateSeldonDeployment()
+	g.Expect(err).ToNot(BeNil())
+	serr := err.(*errors.StatusError)
+	g.Expect(serr.Status().Code).To(Equal(int32(422)))
+	g.Expect(len(serr.Status().Details.Causes)).To(Equal(2))
+	g.Expect(serr.Status().Details.Causes[0].Type).To(Equal(v12.CauseTypeFieldValueInvalid))
+	g.Expect(serr.Status().Details.Causes[0].Field).To(Equal("spec"))
+}
+
+func TestValidateBadTransport(t *testing.T) {
+	g := NewGomegaWithT(t)
+	impl := MODEL
+	spec := &SeldonDeploymentSpec{
+		Transport: "abc",
+		Predictors: []PredictorSpec{
+			{
+				Name: "p1",
+				ComponentSpecs: []*SeldonPodSpec{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Image: "seldonio/mock_classifier:1.0",
+									Name:  "classifier",
+								},
+							},
+						},
+					},
+				},
+				Graph: &PredictiveUnit{
+					Name: "classifier",
+					Type: &impl,
+				},
+			},
+		},
+	}
+
+	spec.DefaultSeldonDeployment("mydep", "default")
+	err := spec.ValidateSeldonDeployment()
+	g.Expect(err).ToNot(BeNil())
+	serr := err.(*errors.StatusError)
+	g.Expect(serr.Status().Code).To(Equal(int32(422)))
+	g.Expect(len(serr.Status().Details.Causes)).To(Equal(2))
+	g.Expect(serr.Status().Details.Causes[0].Type).To(Equal(v12.CauseTypeFieldValueInvalid))
+	g.Expect(serr.Status().Details.Causes[0].Field).To(Equal("spec"))
+}
+
+func TestValidateMixedTransport(t *testing.T) {
+	g := NewGomegaWithT(t)
+	impl := MODEL
+	spec := &SeldonDeploymentSpec{
+		Transport: TransportRest,
+		Predictors: []PredictorSpec{
+			{
+				Name: "p1",
+				ComponentSpecs: []*SeldonPodSpec{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Image: "seldonio/mock_classifier:1.0",
+									Name:  "classifier",
+								},
+								{
+									Image: "seldonio/mock_classifier:1.0",
+									Name:  "classifier2",
+								},
+							},
+						},
+					},
+				},
+				Graph: &PredictiveUnit{
+					Name: "classifier",
+					Type: &impl,
+					Endpoint: &Endpoint{
+						Type: GRPC,
+					},
+					Children: []PredictiveUnit{
+						{
+							Name: "classifier2",
+							Type: &impl,
+							Endpoint: &Endpoint{
+								Type: REST,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	spec.DefaultSeldonDeployment("mydep", "default")
+	err := spec.ValidateSeldonDeployment()
+	g.Expect(err).ToNot(BeNil())
+	serr := err.(*errors.StatusError)
+	g.Expect(serr.Status().Code).To(Equal(int32(422)))
+	g.Expect(len(serr.Status().Details.Causes)).To(Equal(1))
+	g.Expect(serr.Status().Details.Causes[0].Type).To(Equal(v12.CauseTypeFieldValueInvalid))
+	g.Expect(serr.Status().Details.Causes[0].Field).To(Equal("spec"))
+}
+
+func TestValidateMixedMultipleTransport(t *testing.T) {
+	g := NewGomegaWithT(t)
+	impl := MODEL
+	spec := &SeldonDeploymentSpec{
+		Transport: TransportRest,
+		Predictors: []PredictorSpec{
+			{
+				Name: "p1",
+				ComponentSpecs: []*SeldonPodSpec{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Image: "seldonio/mock_classifier:1.0",
+									Name:  "classifier",
+								},
+							},
+						},
+					},
+				},
+				Graph: &PredictiveUnit{
+					Name: "classifier",
+					Type: &impl,
+					Endpoint: &Endpoint{
+						Type: GRPC,
+					},
+				},
+			},
+		},
+	}
+
+	spec.DefaultSeldonDeployment("mydep", "default")
+	err := spec.ValidateSeldonDeployment()
+	g.Expect(err).NotTo(BeNil())
+	serr := err.(*errors.StatusError)
+	g.Expect(serr.Status().Code).To(Equal(int32(422)))
+	g.Expect(len(serr.Status().Details.Causes)).To(Equal(1))
+	g.Expect(serr.Status().Details.Causes[0].Type).To(Equal(v12.CauseTypeFieldValueInvalid))
+	g.Expect(serr.Status().Details.Causes[0].Field).To(Equal("spec"))
+}

--- a/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -7919,8 +7919,6 @@ spec:
                     type: object
                   name:
                     type: string
-                  protocol:
-                    type: string
                   replicas:
                     format: int32
                     type: integer
@@ -8071,13 +8069,15 @@ spec:
                   traffic:
                     format: int32
                     type: integer
-                  transport:
-                    type: string
                 required:
                 - graph
                 - name
                 type: object
               type: array
+            protocol:
+              type: string
+            transport:
+              type: string
           required:
           - predictors
           type: object

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -70,8 +70,6 @@ spec:
           value: ""
         - name: USE_EXECUTOR
           value: "true"
-        - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT
-          value: ""
         - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
           value: seldonio/seldon-core-executor:1.0.3-SNAPSHOT
         - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
@@ -86,6 +84,8 @@ spec:
           value: "8888"          
         - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
           value: default
+        - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX
+          value: "http://default-broker."
         image: controller:latest
         name: manager
         resources:

--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -188,7 +188,7 @@ func getSvcOrchUser(mlDep *machinelearningv1.SeldonDeployment) (int64, error) {
 }
 
 func createExecutorContainer(mlDep *machinelearningv1.SeldonDeployment, p *machinelearningv1.PredictorSpec, predictorB64 string, http_port int, grpc_port int, resources *corev1.ResourceRequirements) corev1.Container {
-	transport := p.Transport
+	transport := mlDep.Spec.Transport
 	//Backwards compatible with older resources
 	if transport == "" {
 		if p.Graph.Endpoint.Type == machinelearningv1.GRPC {
@@ -197,7 +197,7 @@ func createExecutorContainer(mlDep *machinelearningv1.SeldonDeployment, p *machi
 			transport = machinelearningv1.TransportRest
 		}
 	}
-	protocol := p.Protocol
+	protocol := mlDep.Spec.Protocol
 	//Backwards compatibility for older resources
 	if protocol == "" {
 		protocol = machinelearningv1.ProtocolSeldon

--- a/operator/controllers/seldondeployment_prepackaged_servers.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers.go
@@ -90,7 +90,7 @@ func createTensorflowServingContainer(pu *machinelearningv1.PredictiveUnit, useP
 	}
 }
 
-func addTFServerContainer(r *SeldonDeploymentReconciler, pu *machinelearningv1.PredictiveUnit, p *machinelearningv1.PredictorSpec, deploy *appsv1.Deployment, serverConfig machinelearningv1.PredictorServerConfig) error {
+func addTFServerContainer(mlDep *machinelearningv1.SeldonDeployment, r *SeldonDeploymentReconciler, pu *machinelearningv1.PredictiveUnit, p *machinelearningv1.PredictorSpec, deploy *appsv1.Deployment, serverConfig machinelearningv1.PredictorServerConfig) error {
 
 	if len(*pu.Implementation) > 0 && (serverConfig.Tensorflow || serverConfig.TensorflowImage != "") {
 
@@ -100,7 +100,7 @@ func addTFServerContainer(r *SeldonDeploymentReconciler, pu *machinelearningv1.P
 		c := utils.GetContainerForDeployment(deploy, pu.Name)
 
 		var tfServingContainer *v1.Container
-		if p.Protocol == machinelearningv1.ProtocolTensorflow {
+		if mlDep.Spec.Protocol == machinelearningv1.ProtocolTensorflow {
 			tfServingContainer = createTensorflowServingContainer(pu, true)
 			containers := make([]v1.Container, len(deploy.Spec.Template.Spec.Containers))
 			for i, ctmp := range deploy.Spec.Template.Spec.Containers {
@@ -287,7 +287,7 @@ func createStandaloneModelServers(r *SeldonDeploymentReconciler, mlDep *machinel
 		if err := addModelDefaultServers(r, pu, p, deploy, ServerConfig); err != nil {
 			return err
 		}
-		if err := addTFServerContainer(r, pu, p, deploy, ServerConfig); err != nil {
+		if err := addTFServerContainer(mlDep, r, pu, p, deploy, ServerConfig); err != nil {
 			return err
 		}
 	}

--- a/operator/controllers/seldondeployment_prepackaged_servers_test.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers_test.go
@@ -198,11 +198,11 @@ var _ = Describe("Create a prepacked tfserving server for tensorflow protocol an
 				Namespace: key.Namespace,
 			},
 			Spec: machinelearningv1.SeldonDeploymentSpec{
-				Name: name,
+				Name:     name,
+				Protocol: machinelearningv1.ProtocolTensorflow,
 				Predictors: []machinelearningv1.PredictorSpec{
 					{
-						Name:     "p1",
-						Protocol: machinelearningv1.ProtocolTensorflow,
+						Name: "p1",
 						Graph: &machinelearningv1.PredictiveUnit{
 							Name:           modelName,
 							Type:           &modelType,
@@ -324,12 +324,12 @@ var _ = Describe("Create a prepacked tfserving server for tensorflow protocol an
 				Namespace: key.Namespace,
 			},
 			Spec: machinelearningv1.SeldonDeploymentSpec{
-				Name: name,
+				Name:      name,
+				Protocol:  machinelearningv1.ProtocolTensorflow,
+				Transport: machinelearningv1.TransportGrpc,
 				Predictors: []machinelearningv1.PredictorSpec{
 					{
-						Name:      "p1",
-						Protocol:  machinelearningv1.ProtocolTensorflow,
-						Transport: machinelearningv1.TransportGrpc,
+						Name: "p1",
 						Graph: &machinelearningv1.PredictiveUnit{
 							Name:           modelName,
 							Type:           &modelType,

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
                 res["spec"]["template"]["spec"]["containers"][0]["resources"]["requests"][
                     "memory"] = helm_value("manager.memoryRequest")
                 res["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"][
-                    "cpu"] = helm_value("manager.cpulimit")
+                    "cpu"] = helm_value("manager.cpuLimit")
                 res["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"][
                     "memory"] = helm_value("manager.memoryLimit")
 

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -41,6 +41,7 @@ HELM_ENV_SUBST = {
     "ISTIO_GATEWAY": "istio.gateway",
     "ISTIO_TLS_MODE": "istio.tlsMode",
     "PREDICTIVE_UNIT_SERVICE_PORT": "predictiveUnit.port",
+    "PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME": "predictiveUnit.defaultEnvSecretRefName",
     "USE_EXECUTOR": "executor.enabled",
     "EXECUTOR_SERVER_GRPC_PORT": "engine.grpc.port",
     "EXECUTOR_CONTAINER_IMAGE_PULL_POLICY": "executor.image.pullPolicy",
@@ -48,6 +49,7 @@ HELM_ENV_SUBST = {
     "EXECUTOR_PROMETHEUS_PATH": "executor.prometheus.path",
     "EXECUTOR_CONTAINER_USER": "executor.user",
     "EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME": "executor.serviceAccount.name",
+    "EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX": "executor.defaultRequestLoggerEndpointPrefix",
 }
 HELM_VALUES_IMAGE_PULL_POLICY = "{{ .Values.image.pullPolicy }}"
 
@@ -111,6 +113,16 @@ if __name__ == "__main__":
                     "image"
                 ] = "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 
+                # Resource requests
+                res["spec"]["template"]["spec"]["containers"][0]["resources"]["requests"][
+                    "cpu"] = helm_value("manager.cpuRequest")
+                res["spec"]["template"]["spec"]["containers"][0]["resources"]["requests"][
+                    "memory"] = helm_value("manager.memoryRequest")
+                res["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"][
+                    "cpu"] = helm_value("manager.cpulimit")
+                res["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"][
+                    "memory"] = helm_value("manager.memoryLimit")
+
                 for env in res["spec"]["template"]["spec"]["containers"][0]["env"]:
                     if env["name"] in HELM_ENV_SUBST:
                         env["value"] = helm_value(HELM_ENV_SUBST[env["name"]])
@@ -124,12 +136,7 @@ if __name__ == "__main__":
                         ] = "{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}"
                     elif env["name"] == "CONTROLLER_ID":
                         env["value"] = "{{ .Values.controllerId }}"
-                    elif (
-                        env["name"] == "EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX"
-                    ):
-                        env[
-                            "value"
-                        ] = "{{ .Values.executor.defaultRequestLoggerEndpointPrefix }}"
+
                 # Update webhook port
                 for portSpec in res["spec"]["template"]["spec"]["containers"][0][
                     "ports"

--- a/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
@@ -6684,8 +6684,6 @@ spec:
                     type: object
                   name:
                     type: string
-                  protocol:
-                    type: string
                   replicas:
                     format: int32
                     type: integer
@@ -6836,13 +6834,15 @@ spec:
                   traffic:
                     format: int32
                     type: integer
-                  transport:
-                    type: string
                 required:
                 - graph
                 - name
                 type: object
               type: array
+            protocol:
+              type: string
+            transport:
+              type: string
           required:
           - predictors
           type: object

--- a/servers/tfserving/samples/halfplustwo_rest.yaml
+++ b/servers/tfserving/samples/halfplustwo_rest.yaml
@@ -4,6 +4,8 @@ metadata:
   name: hpt
 spec:
   name: hpt
+  protocol: tensorflow
+  transport: rest
   predictors:
   - graph:
       children: []
@@ -16,6 +18,4 @@ spec:
           value: halfplustwo
     name: default
     replicas: 1
-    protocol: tensorflow
-    transport: rest
     


### PR DESCRIPTION
Fixes #1552 

 * Move protocol and transport CRD variables from predictor to deploymentSpec as they should be global to the deployed graph.
 
Also fixes some small bugs:

 * Ensures the cpu/memory resource requests/limits for manager are generated for helm template from the kustomize in `split_resources.py`
 * Removes `EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT` and adds `EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX` to kustomize and updates `split_resources.py` to ensure they are generated in Helm template