### PR TITLE
Fixed bug: PUUID Header is now set on resoponse instead of request

### DIFF
--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -142,8 +142,9 @@ func (r *SeldonRestApi) Initialise() {
 func puidHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if puid := r.Header.Get(payload.SeldonPUIDHeader); puid == "" {
-			r.Header.Set(payload.SeldonPUIDHeader, guuid.New().String())
+			w.Header().Set(payload.SeldonPUIDHeader, guuid.New().String())
 		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -146,7 +146,7 @@ func puidHeader(next http.Handler) http.Handler {
 			puid = guuid.New().String()
 			r.Header.Set(payload.SeldonPUIDHeader, puid)
 		}
-		if req_puid := w.Header().Get(payload.SeldonPUIDHeader); len(req_puid) == 0 {
+		if res_puid := w.Header().Get(payload.SeldonPUIDHeader); len(res_puid) == 0 {
 			w.Header().Set(payload.SeldonPUIDHeader, puid)
 		}
 

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -142,6 +142,7 @@ func (r *SeldonRestApi) Initialise() {
 func puidHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if puid := r.Header.Get(payload.SeldonPUIDHeader); puid == "" {
+			r.Header.Set(payload.SeldonPUIDHeader, guuid.New().String())
 			w.Header().Set(payload.SeldonPUIDHeader, guuid.New().String())
 		}
 

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -141,9 +141,13 @@ func (r *SeldonRestApi) Initialise() {
 
 func puidHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if puid := r.Header.Get(payload.SeldonPUIDHeader); puid == "" {
-			r.Header.Set(payload.SeldonPUIDHeader, guuid.New().String())
-			w.Header().Set(payload.SeldonPUIDHeader, guuid.New().String())
+		puid := r.Header.Get(payload.SeldonPUIDHeader)
+		if len(puid) == 0 {
+			puid = guuid.New().String()
+			r.Header.Set(payload.SeldonPUIDHeader, puid)
+		}
+		if req_puid := w.Header().Get(payload.SeldonPUIDHeader); len(req_puid) == 0 {
+			w.Header().Set(payload.SeldonPUIDHeader, puid)
 		}
 
 		next.ServeHTTP(w, r)

--- a/executor/api/rest/server_test.go
+++ b/executor/api/rest/server_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	guuid "github.com/google/uuid"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/expfmt"
 	"github.com/seldonio/seldon-core/executor/api"
@@ -63,6 +64,38 @@ func TestSimpleModel(t *testing.T) {
 	res := httptest.NewRecorder()
 	r.Router.ServeHTTP(res, req)
 	g.Expect(res.Code).To(Equal(200))
+}
+
+func TestHeaderResponsePuuid(t *testing.T) {
+	t.Logf("Started")
+	g := NewGomegaWithT(t)
+
+	model := v1.MODEL
+	p := v1.PredictorSpec{
+		Name: "p",
+		Graph: &v1.PredictiveUnit{
+			Type: &model,
+			Endpoint: &v1.Endpoint{
+				ServiceHost: "foo",
+				ServicePort: 9000,
+				Type:        v1.REST,
+			},
+		},
+	}
+
+	url, _ := url.Parse("http://localhost")
+	r := NewServerRestApi(&p, test.NewSeldonMessageTestClient(t, 0, nil, nil), false, url, "default", api.ProtocolSeldon, "test", "/metrics")
+	r.Initialise()
+	var data = ` {"data":{"ndarray":[1.1,2.0]}}`
+
+	req, _ := http.NewRequest("POST", "/api/v0.1/predictions", strings.NewReader(data))
+	req.Header = map[string][]string{"Content-Type": []string{"application/json"}}
+	res := httptest.NewRecorder()
+	r.Router.ServeHTTP(res, req)
+	g.Expect(res.Code).To(Equal(200))
+	// Check that the SeldonPUUIDHeader is set
+	g.Expect(len(res.Header().Get(payload.SeldonPUIDHeader))).ShouldNot(BeZero())
+	g.Expect(len(res.Header().Get(payload.SeldonPUIDHeader))).To(Equal(len(guuid.New().String())))
 }
 
 func TestModelWithServer(t *testing.T) {

--- a/executor/api/rest/server_test.go
+++ b/executor/api/rest/server_test.go
@@ -66,7 +66,7 @@ func TestSimpleModel(t *testing.T) {
 	g.Expect(res.Code).To(Equal(200))
 }
 
-func TestRequestPuuidIsSet(t *testing.T) {
+func TestReponsePuuidIsSet(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)
 

--- a/executor/api/rest/server_test.go
+++ b/executor/api/rest/server_test.go
@@ -66,7 +66,7 @@ func TestSimpleModel(t *testing.T) {
 	g.Expect(res.Code).To(Equal(200))
 }
 
-func TestHeaderResponsePuuid(t *testing.T) {
+func TestRequestPuuidIsSet(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)
 
@@ -96,6 +96,53 @@ func TestHeaderResponsePuuid(t *testing.T) {
 	// Check that the SeldonPUUIDHeader is set
 	g.Expect(len(res.Header().Get(payload.SeldonPUIDHeader))).ShouldNot(BeZero())
 	g.Expect(len(res.Header().Get(payload.SeldonPUIDHeader))).To(Equal(len(guuid.New().String())))
+}
+
+func TestRequestPuuidIsSet(t *testing.T) {
+	t.Logf("Started")
+	g := NewGomegaWithT(t)
+	called := false
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := ioutil.ReadAll(r.Body)
+		g.Expect(err).To(BeNil())
+		g.Expect(len(r.Header.Get(payload.SeldonPUIDHeader))).To(Equal(len(guuid.New().String())))
+		called = true
+		w.Write([]byte(bodyBytes))
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	url, err := url.Parse(server.URL)
+	g.Expect(err).Should(BeNil())
+	urlParts := strings.Split(url.Host, ":")
+	port, err := strconv.Atoi(urlParts[1])
+	g.Expect(err).Should(BeNil())
+
+	model := v1.MODEL
+	p := v1.PredictorSpec{
+		Name: "p",
+		Graph: &v1.PredictiveUnit{
+			Type: &model,
+			Endpoint: &v1.Endpoint{
+				ServiceHost: urlParts[0],
+				ServicePort: int32(port),
+				Type:        v1.REST,
+			},
+		},
+	}
+
+	client, err := NewJSONRestClient(api.ProtocolSeldon, "dep", &p, nil)
+	g.Expect(err).To(BeNil())
+	r := NewServerRestApi(&p, client, false, url, "default", api.ProtocolSeldon, "test", "/metrics")
+	r.Initialise()
+	var data = ` {"data":{"ndarray":[1.1,2.0]}}`
+
+	req, _ := http.NewRequest("POST", "/api/v0.1/predictions", strings.NewReader(data))
+	req.Header = map[string][]string{"Content-Type": []string{"application/json"}}
+	res := httptest.NewRecorder()
+	r.Router.ServeHTTP(res, req)
+	g.Expect(res.Code).To(Equal(200))
+	g.Expect(called).To(Equal(true))
 }
 
 func TestModelWithServer(t *testing.T) {


### PR DESCRIPTION
The PUUID Header is set manually in the client logic of the code, but the middleware that was added with mux which is intended to add headers on response was adding the header on the request instead of the response, and hence the UUID wasn't being returned on the header. With this change the header is now returned. 

Test is confirmed to fail in the previous implementation and it now ensures that the request header is set on the response.