### PR TITLE
Fix for empty explainers

### DIFF
--- a/operator/controllers/ambassador_test.go
+++ b/operator/controllers/ambassador_test.go
@@ -13,7 +13,7 @@ const (
 	TEST_DEFAULT_EXPECTED_RETRIES = 0
 )
 
-func basicAbassadorTests(t *testing.T, mlDep *machinelearningv1.SeldonDeployment, p *machinelearningv1.PredictorSpec, expectedWeight int32, expectedInstanceId string, expectedRetries int) {
+func basicAmbassadorTests(t *testing.T, mlDep *machinelearningv1.SeldonDeployment, p *machinelearningv1.PredictorSpec, expectedWeight int32, expectedInstanceId string, expectedRetries int) {
 	g := NewGomegaWithT(t)
 	s, err := getAmbassadorConfigs(mlDep, p, "myservice", 9000, 5000, "")
 	g.Expect(err).To(BeNil())
@@ -42,7 +42,7 @@ func TestAmbassadorSingle(t *testing.T) {
 			},
 		},
 	}
-	basicAbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
 }
 
 func TestAmbassadorCanary(t *testing.T) {
@@ -56,8 +56,8 @@ func TestAmbassadorCanary(t *testing.T) {
 			},
 		},
 	}
-	basicAbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
-	basicAbassadorTests(t, &mlDep, &p2, 80, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p2, 80, "", TEST_DEFAULT_EXPECTED_RETRIES)
 }
 
 func TestAmbassadorCanaryEqual(t *testing.T) {
@@ -71,8 +71,8 @@ func TestAmbassadorCanaryEqual(t *testing.T) {
 			},
 		},
 	}
-	basicAbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
-	basicAbassadorTests(t, &mlDep, &p2, 50, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p2, 50, "", TEST_DEFAULT_EXPECTED_RETRIES)
 }
 
 func TestAmbassadorCanaryThree(t *testing.T) {
@@ -88,9 +88,9 @@ func TestAmbassadorCanaryThree(t *testing.T) {
 			},
 		},
 	}
-	basicAbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
-	basicAbassadorTests(t, &mlDep, &p2, 20, "", TEST_DEFAULT_EXPECTED_RETRIES)
-	basicAbassadorTests(t, &mlDep, &p3, 20, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p2, 20, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p3, 20, "", TEST_DEFAULT_EXPECTED_RETRIES)
 }
 
 func TestAmbassadorCanaryThreeEqual(t *testing.T) {
@@ -106,9 +106,9 @@ func TestAmbassadorCanaryThreeEqual(t *testing.T) {
 			},
 		},
 	}
-	basicAbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
-	basicAbassadorTests(t, &mlDep, &p2, 33, "", TEST_DEFAULT_EXPECTED_RETRIES)
-	basicAbassadorTests(t, &mlDep, &p3, 33, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p1, 0, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p2, 33, "", TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p3, 33, "", TEST_DEFAULT_EXPECTED_RETRIES)
 }
 
 func TestAmbassadorID(t *testing.T) {
@@ -122,7 +122,7 @@ func TestAmbassadorID(t *testing.T) {
 			},
 		},
 	}
-	basicAbassadorTests(t, &mlDep, &p1, 0, instanceId, TEST_DEFAULT_EXPECTED_RETRIES)
+	basicAmbassadorTests(t, &mlDep, &p1, 0, instanceId, TEST_DEFAULT_EXPECTED_RETRIES)
 }
 
 func TestAmbassadorRetriesAnnotation(t *testing.T) {
@@ -135,5 +135,5 @@ func TestAmbassadorRetriesAnnotation(t *testing.T) {
 			},
 		},
 	}
-	basicAbassadorTests(t, &mlDep, &p, 0, "", 2)
+	basicAmbassadorTests(t, &mlDep, &p, 0, "", 2)
 }

--- a/operator/controllers/controller_utils.go
+++ b/operator/controllers/controller_utils.go
@@ -78,3 +78,9 @@ func getEngineEnvAnnotations(mlDep *machinelearningv1.SeldonDeployment) []corev1
 	}
 	return envVars
 }
+
+// isEmptyExplainer will return true if the explainer can be considered empty
+// (either by being nil or by having unset fields)
+func isEmptyExplainer(explainer *machinelearningv1.Explainer) bool {
+	return explainer == nil || explainer.Type == ""
+}

--- a/operator/controllers/controller_utils_test.go
+++ b/operator/controllers/controller_utils_test.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning/v1"
+)
+
+var _ = Describe("Controller utils", func() {
+	DescribeTable(
+		"isEmptyExplainer",
+		func(explainer *machinelearningv1.Explainer, expected bool) {
+			empty := isEmptyExplainer(explainer)
+			Expect(empty).To(Equal(expected))
+		},
+		Entry("empty if nil", nil, true),
+		Entry("empty if unset type", &machinelearningv1.Explainer{}, true),
+		Entry(
+			"not empty otherwise",
+			&machinelearningv1.Explainer{Type: machinelearningv1.AlibiAnchorsImageExplainer},
+			false,
+		),
+	)
+})

--- a/operator/controllers/labels.go
+++ b/operator/controllers/labels.go
@@ -28,7 +28,7 @@ func addLabelsToService(svc *corev1.Service, pu *machinelearningv1.PredictiveUni
 	if p.Traffic < 50 && p.Traffic > 0 {
 		svc.Labels[machinelearningv1.Label_canary] = "true"
 	}
-	if p.Explainer != nil {
+	if !isEmptyExplainer(p.Explainer) {
 		svc.Labels[machinelearningv1.Label_explainer] = "true"
 	}
 }

--- a/operator/controllers/labels_test.go
+++ b/operator/controllers/labels_test.go
@@ -3,11 +3,13 @@ package controllers
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,97 +38,119 @@ func TestAddLabelsToDeployment(t *testing.T) {
 	})
 }
 
-func TestAddLabelsToService(t *testing.T) {
-	g := NewGomegaWithT(t)
-	cases1 := []struct {
-		puType machinelearningv1.PredictiveUnitType
-		result string
-	}{
-		{
-			puType: machinelearningv1.ROUTER,
-			result: machinelearningv1.Label_router,
-		},
-		{
-			puType: machinelearningv1.COMBINER,
-			result: machinelearningv1.Label_combiner,
-		},
-		{
-			puType: machinelearningv1.MODEL,
-			result: machinelearningv1.Label_model,
-		},
-		{
-			puType: machinelearningv1.TRANSFORMER,
-			result: machinelearningv1.Label_transformer,
-		},
-		{
-			puType: machinelearningv1.OUTPUT_TRANSFORMER,
-			result: machinelearningv1.Label_output_transformer,
-		},
-	}
-	cases2 := []struct {
-		shadow    bool
-		explainer *machinelearningv1.Explainer
-		traffic   int32
-		result    string
-	}{
-		{
-			shadow:    false,
-			explainer: nil,
-			traffic:   0,
-			result:    machinelearningv1.Label_default,
-		},
-		{
-			shadow:    false,
-			explainer: nil,
-			traffic:   50,
-			result:    machinelearningv1.Label_default,
-		},
-		{
-			shadow:    false,
-			explainer: nil,
-			traffic:   75,
-			result:    machinelearningv1.Label_default,
-		},
-		{
-			shadow:    true,
-			explainer: nil,
-			traffic:   0,
-			result:    machinelearningv1.Label_shadow,
-		},
-		{
-			shadow:    false,
-			explainer: nil,
-			traffic:   49,
-			result:    machinelearningv1.Label_canary,
-		},
-		{
-			shadow:    false,
-			explainer: &machinelearningv1.Explainer{},
-			traffic:   0,
-			result:    machinelearningv1.Label_explainer,
-		},
-	}
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{},
-		},
-	}
-	p := machinelearningv1.PredictorSpec{}
-	pu := &machinelearningv1.PredictiveUnit{}
-	t.Run("adds correct label to Service from Predictive Unit Type", func(t *testing.T) {
-		for _, c := range cases1 {
-			pu.Type = &c.puType
-			addLabelsToService(svc, pu, p)
-			g.Expect(svc.Labels[c.result]).To(Equal("true"))
+var _ = Describe("addLabelsToService", func() {
+
+	var svc *corev1.Service
+	var p machinelearningv1.PredictorSpec
+	var pu *machinelearningv1.PredictiveUnit
+
+	BeforeEach(func() {
+		svc = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
 		}
+		p = machinelearningv1.PredictorSpec{}
+		pu = &machinelearningv1.PredictiveUnit{}
 	})
-	t.Run("adds correct label to Service for Default, Shadow, Canary & Explainer from Predictor Spec", func(t *testing.T) {
-		for _, c := range cases2 {
-			p.Shadow = c.shadow
-			p.Explainer = c.explainer
-			p.Traffic = c.traffic
+
+	DescribeTable(
+		"Adds correct label to Service from Predictive Unit Type",
+		func(puType machinelearningv1.PredictiveUnitType, result string) {
+			pu.Type = &puType
 			addLabelsToService(svc, pu, p)
-			g.Expect(svc.Labels[c.result]).To(Equal("true"))
-		}
-	})
-}
+
+			Expect(svc.Labels[result]).To(Equal("true"))
+		},
+		Entry("router", machinelearningv1.ROUTER, machinelearningv1.Label_router),
+		Entry("combiner", machinelearningv1.COMBINER, machinelearningv1.Label_combiner),
+		Entry("model", machinelearningv1.MODEL, machinelearningv1.Label_model),
+		Entry("transformer", machinelearningv1.TRANSFORMER, machinelearningv1.Label_transformer),
+		Entry("output transformer", machinelearningv1.OUTPUT_TRANSFORMER, machinelearningv1.Label_output_transformer),
+	)
+
+	DescribeTable(
+		"Adds correct label to Service from Predictor Spec",
+		func(shadow bool, explainer *machinelearningv1.Explainer, traffic int, result string, missing []string) {
+			p.Shadow = shadow
+			p.Explainer = explainer
+			p.Traffic = int32(traffic)
+
+			// Required until https://github.com/SeldonIO/seldon-core/pull/1600 is
+			// merged. We should remove afterwards.
+			puType := machinelearningv1.MODEL
+			pu.Type = &puType
+
+			addLabelsToService(svc, pu, p)
+
+			Expect(svc.Labels[result]).To(Equal("true"))
+			for _, m := range missing {
+				Expect(svc.Labels).ToNot(HaveKey(m))
+			}
+		},
+		Entry(
+			"default",
+			false,
+			nil,
+			0,
+			machinelearningv1.Label_default,
+			[]string{machinelearningv1.Label_explainer},
+		),
+		Entry(
+			"default with 50%% traffic",
+			false,
+			nil,
+			50,
+			machinelearningv1.Label_default,
+			[]string{machinelearningv1.Label_explainer},
+		),
+		Entry(
+			"default with 75%% traffic",
+			false,
+			nil,
+			50,
+			machinelearningv1.Label_default,
+			[]string{machinelearningv1.Label_explainer},
+		),
+		Entry(
+			"default with empty explainer",
+			false,
+			&machinelearningv1.Explainer{},
+			0,
+			machinelearningv1.Label_default,
+			[]string{machinelearningv1.Label_explainer},
+		),
+		Entry(
+			"shadow",
+			true,
+			nil,
+			0,
+			machinelearningv1.Label_shadow,
+			[]string{
+				machinelearningv1.Label_explainer,
+				machinelearningv1.Label_default,
+			},
+		),
+		Entry(
+			"canary",
+			false,
+			nil,
+			48,
+			machinelearningv1.Label_canary,
+			[]string{
+				machinelearningv1.Label_explainer,
+				machinelearningv1.Label_default,
+			},
+		),
+		Entry(
+			"explainer",
+			false,
+			&machinelearningv1.Explainer{
+				Type: machinelearningv1.AlibiAnchorsImageExplainer,
+			},
+			0,
+			machinelearningv1.Label_explainer,
+			[]string{},
+		),
+	)
+})

--- a/operator/controllers/seldondeployment_explainers.go
+++ b/operator/controllers/seldondeployment_explainers.go
@@ -32,7 +32,7 @@ import (
 
 func createExplainer(r *SeldonDeploymentReconciler, mlDep *machinelearningv1.SeldonDeployment, p *machinelearningv1.PredictorSpec, c *components, pSvcName string, log logr.Logger) error {
 
-	if p.Explainer != nil {
+	if !isEmptyExplainer(p.Explainer) {
 
 		seldonId := machinelearningv1.GetSeldonDeploymentName(mlDep)
 

--- a/operator/controllers/seldondeployment_explainers_test.go
+++ b/operator/controllers/seldondeployment_explainers_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Seldon Team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning/v1"
+	"github.com/seldonio/seldon-core/operator/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("createExplainer", func() {
+	var r *SeldonDeploymentReconciler
+	var mlDep *machinelearningv1.SeldonDeployment
+	var p *machinelearningv1.PredictorSpec
+	var c *components
+	var pSvcName string
+
+	BeforeEach(func() {
+		p = &machinelearningv1.PredictorSpec{
+			Name: "main",
+		}
+
+		mlDep = &machinelearningv1.SeldonDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-model",
+			},
+			Spec: machinelearningv1.SeldonDeploymentSpec{
+				Predictors: []machinelearningv1.PredictorSpec{*p},
+			},
+		}
+
+		c = &components{}
+
+		pSvcName = machinelearningv1.GetPredictorKey(mlDep, p)
+
+		r = &SeldonDeploymentReconciler{
+			Client:   k8sManager.GetClient(),
+			Log:      ctrl.Log.WithName("controllers").WithName("SeldonDeployment"),
+			Scheme:   k8sManager.GetScheme(),
+			Recorder: k8sManager.GetEventRecorderFor(constants.ControllerName),
+		}
+	})
+
+	DescribeTable(
+		"Empty explainers should not create any component",
+		func(explainer *machinelearningv1.Explainer) {
+			p.Explainer = explainer
+			err := createExplainer(r, mlDep, p, c, pSvcName, r.Log)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.deployments).To(BeEmpty())
+		},
+		Entry("nil explainer", nil),
+		Entry("empty explainer", &machinelearningv1.Explainer{}),
+	)
+})

--- a/operator/controllers/seldondeployment_explainers_test.go
+++ b/operator/controllers/seldondeployment_explainers_test.go
@@ -69,7 +69,7 @@ var _ = Describe("createExplainer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.deployments).To(BeEmpty())
 		},
-		Entry("nil explainer", nil),
-		Entry("empty explainer", &machinelearningv1.Explainer{}),
+		Entry("nil", nil),
+		Entry("empty type", &machinelearningv1.Explainer{}),
 	)
 })


### PR DESCRIPTION
Fixes #1593 

## Changelog
- Fix typo on `basicAmbassadorTest` function.
- Add helper `isEmptyExplainer()`.
- Use helper to check if we should create an explainer deployment and/or add an `explainer` label.
- Migrate `operator/controller/labels_test.go` to Gomega. Apparently they weren't running with `t.Run()`.  
- Add empty explainer tests for `controllers.createExplainer()`.