### PR TITLE
remove wrapper metadata entry from 1.1 docs

### DIFF
--- a/doc/source/python/python_component.md
+++ b/doc/source/python/python_component.md
@@ -148,9 +148,6 @@ class ModelWithMetrics(object):
     	return {"system":"production"}
 ```
 
-## REST Metadata Endpoint
-The python wrapper will automatically expose a `/metadata` endpoint to return metadata about the loaded model. It is up to the developer to implement a `metadata` method in their class to provide an arbitrary Dict back containing the model metadata.\
-
 ## REST Health Endpoint
 If you wish to add a REST health point, you can implement the `health_status` method with signature as shown below:
 ```python
@@ -426,6 +423,18 @@ class Model:
 
         # Make predictions using float_array
 ```
+
+
+## Incubating features
+
+
+### REST Metadata Endpoint
+The python wrapper will automatically expose a `/metadata` endpoint to return metadata about the loaded model.
+It is up to the developer to implement a `metadata` method in their class to provide an arbitrary `dict` back containing the model metadata.
+
+Note: future work will most likely standardize `/metadata` endpoint and change behaviour of this method. See [this](https://github.com/SeldonIO/seldon-core/issues/1638) GitHub issue for details.
+
+
 
 ## Next Steps
 


### PR DESCRIPTION
Remove metadata from 1.1 documentation as this will be rapidly evolving now in most-likely backward incompatible way.

May point is that right now we seemed to allow user to return from `metadata` method anything as long as it is `dict` and serve it on `/metadata` whereas model metadata will be very well structured in context of https://github.com/SeldonIO/seldon-core/issues/1638