### PR TITLE
Push dated SNAPSHOT images with respective branches containing helm charts

### DIFF
--- a/ci_build_and_push_images.sh
+++ b/ci_build_and_push_images.sh
@@ -26,63 +26,31 @@ done
 set +o errexit
 
 
-echo "Files changed in python folder:"
-git --no-pager diff --exit-code --name-only origin/master python
-PYTHON_MODIFIED=$?
-if [[ $PYTHON_MODIFIED -gt 0 ]]; then
-    (cd wrappers/s2i/python/build_scripts \
-        && ./build_all_local.sh \
-        && ./push_all.sh)
-    PYTHON_EXIT_VALUE=$?
-else
-    echo "SKIPPING PYTHON IMAGE BUILD..."
-    PYTHON_EXIT_VALUE=0
-fi
+(cd wrappers/s2i/python/build_scripts \
+    && ./build_all_local.sh \
+    && ./push_all.sh)
+PYTHON_EXIT_VALUE=$?
 
-echo "Files changed in operator folder:"
-git --no-pager diff --exit-code --name-only origin/master operator
-OPERATOR_MODIFIED=$?
-if [[ $OPERATOR_MODIFIED -gt 0 ]]; then
-    make \
-        -C operator \
-        docker-build \
-        docker-push
-    OPERATOR_EXIT_VALUE=$?
-else
-    echo "SKIPPING OPERATOR IMAGE BUILD..."
-    OPERATOR_EXIT_VALUE=0
-fi
+make \
+    -C operator \
+    docker-build \
+    docker-push
+OPERATOR_EXIT_VALUE=$?
 
-echo "Files changed in executor folder:"
-git --no-pager diff --exit-code --name-only origin/master executor
-EXECUTOR_MODIFIED=$?
-if [[ $EXECUTOR_MODIFIED -gt 0 ]]; then
-    make \
-        -C executor \
-        docker-build \
-        docker-push
-    EXECUTOR_EXIT_VALUE=$?
-else
-    echo "SKIPPING EXECUTOR IMAGE BUILD..."
-    EXECUTOR_EXIT_VALUE=0
-fi
+make \
+    -C executor \
+    docker-build \
+    docker-push
+EXECUTOR_EXIT_VALUE=$?
 
-echo "Files changed in engine folder:"
-git --no-pager diff --exit-code --name-only origin/master engine
-ENGINE_MODIFIED=$?
-if [[ $ENGINE_MODIFIED -gt 0 ]]; then
-    make \
-        -C testing/scripts \
-        build_protos
-    make \
-        -C engine \
-        build_image \
-        push_to_registry
-    ENGINE_EXIT_VALUE=$?
-else
-    echo "SKIPPING ENGINE IMAGE BUILD..."
-    ENGINE_EXIT_VALUE=0
-fi
+make \
+    -C testing/scripts \
+    build_protos
+make \
+    -C engine \
+    build_image \
+    push_to_registry
+ENGINE_EXIT_VALUE=$?
 
 
 

--- a/ci_build_and_push_images.sh
+++ b/ci_build_and_push_images.sh
@@ -53,7 +53,6 @@ make \
 ENGINE_EXIT_VALUE=$?
 
 
-
 #######################################
 # EXIT STOPS COMMANDS FROM HERE ONWARDS
 set -o errexit
@@ -63,8 +62,14 @@ docker ps -aq | xargs -r docker rm -f || true
 service docker stop || true
 
 # NOW THAT WE'VE CLEANED WE CAN EXIT ON TEST EXIT VALUE
+echo "Python exit value: $PYTHON_EXIT_VALUE"
+echo "Operator exit value: $OPERATOR_EXIT_VALUE"
+echo "Engine exit value: $ENGINE_EXIT_VALUE"
+echo "Executor exit value: $EXECUTOR_EXIT_VALUE"
+
 exit $((${PYTHON_EXIT_VALUE} \
     + ${OPERATOR_EXIT_VALUE} \
-    + ${ENGINE_EXIT_VALUE})) \
+    + ${ENGINE_EXIT_VALUE} \
     + ${EXECUTOR_EXIT_VALUE}))
+
 

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -76,10 +76,23 @@ pipelineConfig:
               command: bash
               args:
               - ./ci_build_and_push_images.sh
-            - name: exit-with-error-to-avoid-auto-changelog
-              command: exit
+            - name: create-dated-version
+              command: echo $(cat version.txt)_$(date +"%Y%m%d%H%M%S") > version.txt
+            - name: create-new-branch
+              command: git checkout -b v$(cat version.txt)
+            # This is necessary as the python release.py has a known bug which hangs if the JARs are not downloaded first
+            - name: update-release-tags
+              command: (cd engine && mvn versions:set -DnewVersion=$(cat ../version.txt)) && python release.py $(cat version.txt)
+            - name: add-changes-to-branch
+              command: git add .
+            - name: commit-changes-to-branch
+              command: git commit -m "Added changes for branch"
+            - name: build-and-push-dated-images
+              command: bash
               args:
-              - "1"
+              - ./ci_build_and_push_images.sh
+            - name: push-new-branch
+              command: git push origin v$(cat version.txt) 
             options:
               containerOptions:
                 volumeMounts:

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,5 +1,5 @@
 SELDON_CORE_DIR=..
-VERSION=1.0.2
+VERSION := $(shell cat ../version.txt)
 
 .PHONY: get_apis
 get_apis:

--- a/wrappers/s2i/python/Makefile
+++ b/wrappers/s2i/python/Makefile
@@ -1,10 +1,10 @@
+VERSION := $(shell cat ../version.txt)
 SHELL:=/bin/bash
 
 PYTHON_VERSION=3.7
 CONDA_VERSION=4.7.12
 IMAGE_PYTHON_VERSION=`echo -n $(PYTHON_VERSION) | sed 's/\.//g'`
 BASE_IMAGE_PYTHON_VERSION=`echo -n $(PYTHON_VERSION) | cut -d. -f1`
-IMAGE_VERSION=0.19-SNAPSHOT
 IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python${IMAGE_PYTHON_VERSION}
 BASE_IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python${BASE_IMAGE_PYTHON_VERSION}
 GPU_IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python3-tf-gpu

--- a/wrappers/s2i/python/build_scripts/build_all_local.sh
+++ b/wrappers/s2i/python/build_scripts/build_all_local.sh
@@ -1,2 +1,3 @@
 ./build_local_python3.6.sh
 ./build_local_python3.7.sh
+./build_python_gpu.sh


### PR DESCRIPTION
Fixes #1605 and includes:
* Working push of dated snapshots as tested in https://github.com/SeldonIO/jenkins-x-seldon-core-sandbox/
* Updated CI script to push all images always (to ensure all images are pushed dated)
* Added Jenkins X command to push dated SNAPSHOT with branch (didn't make it a tag)
* Helm charts are updated on the branch so will be pointing to relevant dated images
* Fixed python version so it uses main image
* Updated wrapper version and fixed issue for Python image builder

Note: We need to make sure the PR tests actualyl run all the tests that are run when creating the images as if one image fails on build it will not be pushed