### PR TITLE
Add support to add ambassador circuit-breaker in seldon deployment

### DIFF
--- a/doc/source/ingress/ambassador.md
+++ b/doc/source/ingress/ambassador.md
@@ -39,6 +39,10 @@ curl -v 0.0.0.0:8003/seldon/mymodel/api/v1.0/predictions -d '{"data":{"names":["
 |`seldon.io/ambassador-shadow:true` | Activate shadowing for this deployment |
 |`seldon.io/grpc-read-timeout: <gRPC read timeout (msecs)>` | gRPC read timeout |
 |`seldon.io/rest-read-timeout:<REST read timeout (msecs)>` | REST read timeout |
+|`seldon.io/ambassador-circuit-breakers-max-connections:<maximum number of connections>` | The maximum number of connections will make to the Seldon Deployment |
+|`seldon.io/ambassador-circuit-breakers-max-pending-requests:<maximum number of queued requests>` | The maximum number of requests that will be queued while waiting for a connection |
+|`seldon.io/ambassador-circuit-breakers-max-requests:<maximum number of parallel outstanding requests>` | The maximum number of parallel outstanding requests to the Seldon Deployment |
+|`seldon.io/ambassador-circuit-breakers-max-retries:<maximum number of parallel retries>` | The maximum number of parallel retries allowed to the Seldon Deployment |
 
 All annotations should be placed in `spec.annotations`.
 
@@ -118,6 +122,24 @@ You simply need to add some annotations to your Seldon Deployment resource.
 A worked example for [header based routing](../examples/ambassador_headers.html) is provided.
 
 To understand more about the Ambassador configuration for this see [their docs on header based routing](https://www.getambassador.io/reference/headers).
+
+### Circuit Breakers
+By preventing additional connections or requests to an overloaded Seldon Deployment, circuit breakers help improve resilience of your system. 
+
+You simply need to add some annotations to your Seldon Deployment resource.
+
+  * `seldon.io/ambassador-circuit-breakers-max-connections:<maximum number of connections>` : The maximum number of connections will make to the Seldon Deployment
+     * Example:  `"seldon.io/ambassador-circuit-breakers-max-connections":"200"`
+  * `seldon.io/ambassador-circuit-breakers-max-pending-requests:<maximum number of queued requests>` : The maximum number of requests that will be queued while waiting for a connection
+     * Example:  `"seldon.io/ambassador-circuit-breakers-max-pending-requests":"100"`
+  * `seldon.io/ambassador-circuit-breakers-max-requests:<maximum number of parallel outstanding requests>` : The maximum number of parallel outstanding requests to the Seldon Deployment
+     * Example: `"seldon.io/ambassador-circuit-breakers-max-requests":"200"`
+  * `seldon.io/ambassador-circuit-breakers-max-retries:<maximum number of parallel retries>` : The maximum number of parallel retries allowed to the Seldon Deployment
+     * Example: `"seldon.io/ambassador-circuit-breakers-max-retries":"3"`
+
+A worked example for [circuit breakers](../examples/ambassador_circuit_breakers.html) is provided.
+
+To understand more about the Ambassador configuration for this see [their docs on circuit breakers](https://www.getambassador.io/docs/latest/topics/using/circuit-breakers/).
 
 ## Multiple Ambassadors in the same cluster
 

--- a/examples/ambassador/README.md
+++ b/examples/ambassador/README.md
@@ -3,4 +3,5 @@
  * [Canary deployments](./canary)
  * [Shadow deployments](./shadow)
  * [Header based routing](./headers)
+ * [Circuit Breakers](./circuit_breakers)
  * [Custom configuration](./custom)

--- a/examples/ambassador/circuit_breakers/README.md
+++ b/examples/ambassador/circuit_breakers/README.md
@@ -1,0 +1,4 @@
+# Circuit Breakers with Seldon and Ambassador
+
+Follow the [notebook](ambassador_circuit_breakers.ipynb) to show how you can deploy Seldon Deployments with circuit breakers.
+

--- a/examples/ambassador/circuit_breakers/ambassador_circuit_breakers.ipynb
+++ b/examples/ambassador/circuit_breakers/ambassador_circuit_breakers.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Custom URL prefix with Seldon and Ambassador\n",
+    "# Circuit Breakers with Seldon and Ambassador\n",
     "\n",
-    "This notebook shows how you can deploy Seldon Deployments with custom Ambassador configuration."
+    "This notebook shows how you can deploy Seldon Deployments which can have circuit breakers via Ambassador's circuit breakers configuration.\n"
    ]
   },
   {
@@ -15,7 +15,25 @@
    "source": [
     "## Setup Seldon Core\n",
     "\n",
-    "Uset the setup notebook to [Setup Cluster](../../seldon_core_setup.ipynb#Setup-Cluster) with [Ambassador Ingress](../../seldon_core_setup.ipynb#Ambassador) and [Install Seldon Core](../../seldon_core_setup.ipynb#Install-Seldon-Core). Instructions [also online](./seldon_core_setup.html)."
+    "Use the setup notebook to [Setup Cluster](../../seldon_core_setup.ipynb#Setup-Cluster) with [Ambassador Ingress](../../seldon_core_setup.ipynb#Ambassador) and [Install Seldon Core](../../seldon_core_setup.ipynb#Install-Seldon-Core). Instructions [also online](./seldon_core_setup.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl create namespace seldon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl config set-context $(kubectl config current-context) --namespace=seldon"
    ]
   },
   {
@@ -24,25 +42,21 @@
    "source": [
     "## Launch main model\n",
     "\n",
-    "We will create a very simple Seldon Deployment with a dummy model image `seldonio/mock_classifier:1.0`. This deployment is named `example`. We will add custom Ambassador config which sets the Ambassador prefix to `/mycompany/ml`\n",
+    "We will create a very simple Seldon Deployment with a dummy model image `seldonio/mock_classifier:1.0`. This deployment is named `example`. We will add following circuit breakers configurations.\n",
     "\n",
-    "We must ensure we set the correct service endpoint. Seldon Core creates an endpoint of the form:\n",
-    " \n",
-    "`<spec.name>-<predictor.name>.<namespace>:<port>`\n",
+    "```\n",
+    "    \"seldon.io/ambassador-circuit-breakers-max-connections\":\"200\",\n",
+    "    \"seldon.io/ambassador-circuit-breakers-max-pending-requests\":\"100\",\n",
+    "    \"seldon.io/ambassador-circuit-breakers-max-requests\":\"200\",\n",
+    "    \"seldon.io/ambassador-circuit-breakers-max-retries\":\"3\"\n",
+    "```\n",
     "\n",
     "Where\n",
     "\n",
-    "  * `<spec-name>` is the name you give to the Seldon Deployment spec: `example` below\n",
-    "  * `<predcitor.name>` is the predictor name in the Seldon Deployment: `single` below\n",
-    "  * `<namespace>` is the namespace your Seldon Deployment is deployed to\n",
-    "  * `<port>` is the port either 8000 for REST or 5000 for gRPC\n",
-    "  \n",
-    "This will allow you to set the `service` value in the Ambassador config you create. So for the example below we have:\n",
-    "\n",
-    "```\n",
-    "service: production-model-example.seldon:8000\n",
-    "```\n",
-    "  \n",
+    "  * `\"seldon.io/ambassador-circuit-breakers-max-connections\":\"200\"` is the maximum number of connections will make to the Seldon Deployment\n",
+    "  * `\"seldon.io/ambassador-circuit-breakers-max-pending-requests\":\"100\"` is the maximum number of requests that will be queued while waiting for a connection\n",
+    "  * `\"seldon.io/ambassador-circuit-breakers-max-requests\":\"200\"` is the maximum number of parallel outstanding requests to the Seldon Deployment\n",
+    "  * `\"seldon.io/ambassador-circuit-breakers-max-retries\":\"3\"` the maximum number of parallel retries allowed to the Seldon Deployment\n",
     "  "
    ]
   },
@@ -52,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pygmentize model_custom_ambassador.json"
+    "!pygmentize model_circuit_breakers_ambassador.json"
    ]
   },
   {
@@ -61,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl create -f model_custom_ambassador.json"
+    "!kubectl create -f model_circuit_breakers_ambassador.json"
    ]
   },
   {
@@ -103,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r = sc.predict(gateway=\"ambassador\",transport=\"rest\",gateway_prefix=\"/mycompany/ml\")\n",
+    "r = sc.predict(gateway=\"ambassador\",transport=\"rest\")\n",
     "assert(r.success==True)\n",
     "print(r)"
    ]
@@ -114,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl delete -f model_custom_ambassador.json"
+    "!kubectl delete -f model_circuit_breakers_ambassador.json"
    ]
   },
   {
@@ -142,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.4"
   },
   "varInspector": {
    "cols": {

--- a/examples/ambassador/circuit_breakers/model_circuit_breakers_ambassador.json
+++ b/examples/ambassador/circuit_breakers/model_circuit_breakers_ambassador.json
@@ -1,0 +1,46 @@
+{
+    "apiVersion": "machinelearning.seldon.io/v1alpha2",
+    "kind": "SeldonDeployment",
+    "metadata": {
+        "labels": {
+            "app": "seldon"
+        },
+        "name": "example"
+    },
+    "spec": {	
+        "name": "production-model",
+    "annotations": {
+        "seldon.io/ambassador-circuit-breakers-max-connections":"200",
+        "seldon.io/ambassador-circuit-breakers-max-pending-requests":"100",
+        "seldon.io/ambassador-circuit-breakers-max-requests":"200",
+        "seldon.io/ambassador-circuit-breakers-max-retries":"3"
+    },
+        "predictors": [
+            {
+                "componentSpecs": [{
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "seldonio/mock_classifier_rest:1.4",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "classifier"
+                            }
+                        ],
+                        "terminationGracePeriodSeconds": 1
+                    }}
+                                  ],
+                "graph":
+                {
+                    "children": [],
+                    "name": "classifier",
+                    "type": "MODEL",
+                    "endpoint": {
+                        "type": "REST"
+                    }},
+                "name": "single",
+                "replicas": 1
+            }
+        ]
+    }
+}
+


### PR DESCRIPTION
Trying to fix https://github.com/SeldonIO/seldon-core/issues/1556
With this PR, users will be able to add ambassador circuit breakers from model deployment annotations.