### PR TITLE
Document custom inference servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ Below are some of the core components together with link to the logs that provid
 * [Metrics with Prometheus ](https://docs.seldon.io/projects/seldon-core/en/latest/analytics/analytics.html)
 * [Payload Logging with ELK ](https://docs.seldon.io/projects/seldon-core/en/latest/analytics/logging.html)
 * [Distributed Tracing with Jaeger ](https://docs.seldon.io/projects/seldon-core/en/latest/graph/distributed-tracing.html)
-* [Autoscaling in Kubernetes ](https://docs.seldon.io/projects/seldon-core/en/latest/graph/autoscaling.html)
+* [Replica Scaling ](https://docs.seldon.io/projects/seldon-core/en/latest/graph/scaling.html)
+* [Custom Inference Servers](https://docs.seldon.io/projects/seldon-core/en/latest/servers/custom.html)
       
 ### Advanced Inference
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -94,7 +94,7 @@ Documentation Index
    Metrics with Prometheus <analytics/analytics.md>
    Payload Logging with ELK <analytics/logging.md>
    Distributed Tracing with Jaeger <graph/distributed-tracing.md>
-   Replica scaling  <graph/scaling.md>
+   Replica Scaling  <graph/scaling.md>
    Custom Inference Servers <servers/custom.md>
       
 .. toctree::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -95,6 +95,7 @@ Documentation Index
    Payload Logging with ELK <analytics/logging.md>
    Distributed Tracing with Jaeger <graph/distributed-tracing.md>
    Replica scaling  <graph/scaling.md>
+   Custom Inference Servers <servers/custom.md>
       
 .. toctree::
    :maxdepth: 1

--- a/doc/source/python/index.rst
+++ b/doc/source/python/index.rst
@@ -14,7 +14,8 @@ You can use the following links to navigate the Python seldon-core module:
 
    Seldon Core Python Module <python_module.md>
    Your python class <python_component.md>
-   Wrap using S2I <python_wrapping_s2i.md> or Docker <python_wrapping_docker.md>
+   Wrap using S2I <python_wrapping_s2i.md>
+   Wrap using Docker <python_wrapping_docker.md>
    Seldon Python Client <seldon_client.md>
    Python API reference <api/modules>
 

--- a/doc/source/servers/custom.md
+++ b/doc/source/servers/custom.md
@@ -1,0 +1,106 @@
+# Custom inference servers
+
+Out of the box, Seldon offers support for several [pre-packaged inference
+servers](./overview.md).
+However, there may be cases where it makes sense to rollout your own re-usable
+inference server.
+For example, you may need particular dependencies, specific versions, a custom
+process to download your model weights, etc.
+
+To support these use cases, Seldon allows you to easily build your own
+inference servers, which can then be configured to be used as you would do the
+pre-packaged ones.
+That is, by using the `implementation` key and passing through model parameters
+(e.g. `modelUri`).
+
+```yaml
+apiVersion: machinelearning.seldon.io/v1alpha2
+kind: SeldonDeployment
+metadata:
+  name: nlp-model
+spec:
+  predictors:
+    - graph:
+        children: []
+        implementation: CUSTOM_INFERENCE_SERVER
+        modelUri: s3://our-custom-models/nlp-model
+        name: model
+      name: default
+      replicas: 1
+```
+
+## Building a new inference server
+
+To build a new custom inference server you can follow the same instructions as
+the ones on [how to wrap a model](../wrappers/language_wrappers.md).
+The only difference is that the server will now receive a set of model
+parameters, like `modelUri`.
+
+As inspiration, you can see how the [SKLearn
+server](https://github.com/SeldonIO/seldon-core/blob/d84b97431c49602d25f6f5397ba540769ec695d9/servers/sklearnserver/sklearnserver/SKLearnServer.py#L16-L23)
+and the [other pre-packaged inference servers](./overview.md) handle these as
+part of their `__init__()` method:
+
+```python
+def __init__(self, model_uri: str = None,  method: str = "predict_proba"):
+        super().__init__()
+        self.model_uri = model_uri
+        self.method = method
+        self.ready = False
+        self.load()
+```
+
+## Adding a new inference server
+
+The list of available inference servers in Seldon Core is maintained in the
+`seldon-config` configmap, which lives in the same namespace as your Seldon
+Core operator.
+In particular, the `predictor_servers` key holds the JSON config for each
+inference server.
+
+The `predictor_servers` key will hold a JSON dictionary similar to the one
+below:
+
+```json
+{
+  "SKLEARN_SERVER": {
+    "grpc": {
+      "defaultImageVersion": "0.2",
+      "image": "seldonio/sklearnserver_grpc"
+    },
+    "rest": {
+      "defaultImageVersion": "0.2",
+      "image": "seldonio/sklearnserver_rest"
+    }
+  }
+}
+```
+
+Adding a new inference server is just a matter of adding a new key to the dict
+above.
+For example:
+
+```json
+{
+  "CUSTOM_INFERENCE_SERVER": {
+    "grpc": {
+      "defaultImageVersion": "1.0",
+      "image": "org/custom-server-grpc"
+    },
+    "rest": {
+      "defaultImageVersion": "1.0",
+      "image": "org/custom-server-rest"
+    }
+  },
+  "SKLEARN_SERVER": {
+    "grpc": {
+      "defaultImageVersion": "0.2",
+      "image": "seldonio/sklearnserver_grpc"
+    },
+    "rest": {
+      "defaultImageVersion": "0.2",
+      "image": "seldonio/sklearnserver_rest"
+    }
+  }
+}
+```

--- a/doc/source/servers/mlflow.md
+++ b/doc/source/servers/mlflow.md
@@ -24,10 +24,8 @@ The MLflow built-in server will create the Conda environment specified on your
 Note that this approach may slow down your Kubernetes `SeldonDeployment`
 startup time considerably.
 
-In some cases, it may be worth consider creating your own custom reusable
-server using
-[s2i](https://docs.seldon.io/projects/seldon-core/en/latest/python/python_wrapping_s2i.html)
-with the `seldonio/seldon-core-s2i-conda` template image.
+In some cases, it may be worth to consider [creating your own custom reusable
+server](./custom.md).
 For example, when the Conda environment can be considered stable, you can
 create your own image with a fixed set of dependencies.
 This image can then be re-used across different model versions using the same

--- a/doc/source/servers/overview.md
+++ b/doc/source/servers/overview.md
@@ -17,13 +17,13 @@ metadata:
 spec:
   name: iris
   predictors:
-  - graph:
-      children: []
-      implementation: SKLEARN_SERVER
-      modelUri: gs://seldon-models/sklearn/iris
-      name: classifier
-    name: default
-    replicas: 1
+    - graph:
+        children: []
+        implementation: SKLEARN_SERVER
+        modelUri: gs://seldon-models/sklearn/iris
+        name: classifier
+      name: default
+      replicas: 1
 ```
 
 The `modelUri` specifies the bucket containing the saved model, in this case `gs://seldon-models/sklearn/iris`.
@@ -34,7 +34,6 @@ The `modelUri` specifies the bucket containing the saved model, in this case `gs
 - S3-compatible (using `s3://`)
 - Minio-compatible (using `s3://`)
 - Azure Blob storage (using `https://(.+?).blob.core.windows.net/(.+)`)
-
 
 The download is handled by an initContainer that runs before your predictor loads. This initContainer image uses our [Storage.py library](https://github.com/SeldonIO/seldon-core/blob/master/python/seldon_core/storage.py) to download the files. However it is also possible for you to override the initContainer with your own custom container to download any files from custom resources.
 
@@ -79,7 +78,8 @@ Next steps:
 - [Tensorflow Serving](tensorflow.html)
 - [MLflow Server](mlflow.html)
 
-Custom serving images or versions of images can also be added or overridden in the operator's `seldon-config` configmap.
+You can also build and add your own [custom inference servers](./custom.md),
+which can then be used in a similar way as the pre-packaged ones.
 
 If your use case does not fit for a reusable standard server then you can create your own component using our wrappers.
 
@@ -97,24 +97,24 @@ In order to understand what are the environment variables required, you can have
 
 #### AWS Required Variables
 
-* AWS_ACCESS_KEY_ID
-* AWS_SECRET_ACCESS_KEY
-* AWS_ENDPOINT_URL
-* USE_SSL
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- AWS_ENDPOINT_URL
+- USE_SSL
 
 #### Minio Required Variables
 
-* AWS_ACCESS_KEY_ID
-* AWS_SECRET_ACCESS_KEY
-* AWS_ENDPOINT_URL
-* USE_SSL
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- AWS_ENDPOINT_URL
+- USE_SSL
 
 #### Azure Required Variables
 
-* AZ_TENANT_ID
-* AZ_CLIENT_ID
-* AZ_CLIENT_SECRET
-* AZ_SUBSCRIPTION_ID
+- AZ_TENANT_ID
+- AZ_CLIENT_ID
+- AZ_CLIENT_SECRET
+- AZ_SUBSCRIPTION_ID
 
 #### Google Cloud Required Variables
 
@@ -164,7 +164,7 @@ You can set a global default when you install Seldon Core through the Helm chart
 ```yaml
 # ... other variables
 executor:
-    defaultEnvSecretRefName: seldon-core-init-container-secret
+  defaultEnvSecretRefName: seldon-core-init-container-secret
 # ... other variables
 ```
 
@@ -234,4 +234,3 @@ spec:
     name: default
     replicas: 1
 ```
-


### PR DESCRIPTION
Fixes #1416 

## Changelog

- Add new page on building and adding "Custom Inference Servers".
- Split S2I + Docker link to wrapping your own model in 2 separate lines.