### PR TITLE
Allow non-model specific predict for Tensorflow protocol

### DIFF
--- a/doc/source/graph/protocols.md
+++ b/doc/source/graph/protocols.md
@@ -27,11 +27,15 @@ For Seldon graphs the protocol will work as expected for single model graphs for
  * Sending the response from the first as a request to the second. This will be done automatically when you defined a chain of models as a Seldon graph. It is up to the user to ensure the response of each changed model can be fed a request to the next in the chain.
  * Only Predict calls can be handled in multiple model chaining.
 
+
 General considerations:
 
   * Seldon components marked as MODELS, INPUT_TRANSFORMER and OUTPUT_TRANSFORMERS will allow a PredictionService Predict method to be called.
   * GetModelStatus for any model in the graph is available.
   * GetModelMetadata for any model in the graph is available.
   * Combining and Routing with the Tensorflow protocol is not presently supported.
+  * `status` and `metadata` calls can be asked for any model in the graph
+  * a non-standard Seldon extension is available to call predict on the graph as a whole: `/v1/models/:predict`.
+  * The name of the model in the `graph` section of the SeldonDeployment spec must match the name of the model loaded onto the Tensorflow Server.
 
 

--- a/executor/api/test/seldonmessage_test_client.go
+++ b/executor/api/test/seldonmessage_test_client.go
@@ -6,7 +6,6 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"io"
-	"net/http"
 )
 
 type SeldonMessageTestClient struct {
@@ -19,6 +18,7 @@ type SeldonMessageTestClient struct {
 const (
 	TestClientStatusResponse   = `{"status":"ok"}`
 	TestClientMetadataResponse = `{"metadata":{"name":"mymodel"}}`
+	TestContentType            = "application/json"
 )
 
 func (s SeldonMessageTestClient) Status(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
@@ -34,7 +34,7 @@ func (s SeldonMessageTestClient) Chain(ctx context.Context, modelName string, ms
 }
 
 func (s SeldonMessageTestClient) Unmarshall(msg []byte) (payload.SeldonPayload, error) {
-	reqPayload := payload.BytesPayload{Msg: msg, ContentType: "application/json"}
+	reqPayload := payload.BytesPayload{Msg: msg, ContentType: TestContentType}
 	return &reqPayload, nil
 }
 
@@ -44,9 +44,8 @@ func (s SeldonMessageTestClient) Marshall(out io.Writer, msg payload.SeldonPaylo
 }
 
 func (s SeldonMessageTestClient) CreateErrorPayload(err error) payload.SeldonPayload {
-	respFailed := proto.SeldonMessage{Status: &proto.Status{Code: http.StatusInternalServerError, Info: err.Error()}}
-	res := payload.ProtoPayload{Msg: &respFailed}
-	return &res
+	respFailed := payload.BytesPayload{Msg: []byte(err.Error()), ContentType: TestContentType}
+	return &respFailed
 }
 
 func (s SeldonMessageTestClient) Predict(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {


### PR DESCRIPTION
Fixes #1611

 * Allows `/v1/models/:predict`
 * Fixes error payload handling
 * Adds tests and updates docs