### PR TITLE
Leave timeouts as default

### DIFF
--- a/doc/source/graph/annotations.md
+++ b/doc/source/graph/annotations.md
@@ -18,10 +18,17 @@ You can configure aspects of Seldon Core via annotations in the SeldonDeployment
 
 ### REST API Control
 
- * ```seldon.io/rest-timeout``` : REST timeout (msecs)
-   * Locations : SeldonDeployment.spec.annotations
-   * Default is no overall timeout but will use GoLang's default transport settings which include a 30 sec connection timeout.
-   * [REST timeout example](model_rest_grpc_settings.md)
+.. Note:: 
+   When using REST APIs, timeouts will only apply to each node and not to the
+   full inference graph.
+   Therefore, each sub-request for each individual node in the graph will be
+   able to take up to ``seldon.io/rest-timeout`` milliseconds.
+
+* ```seldon.io/rest-timeout``` : REST timeout (msecs)
+  * Locations : SeldonDeployment.spec.annotations
+  * Default is no overall timeout but will use GoLang's default transport settings which include a 30 sec connection timeout.
+  * [REST timeout example](model_rest_grpc_settings.md)
+
 
 ### Service Orchestrator
 

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/url"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"time"
 )
 
 const (
@@ -71,12 +70,12 @@ func (r *SeldonRestApi) CreateHttpServer(port int) *http.Server {
 	address := fmt.Sprintf("0.0.0.0:%d", port)
 	r.Log.Info("Listening", "Address", address)
 
+	// Note that we leave the Server timeouts to 0. This means that the server
+	// will apply no timeout at all. Instead, we control that through the
+	// http.Client instance making requests to the underlying node graph servers.
 	return &http.Server{
 		Handler: r.Router,
 		Addr:    address,
-		// Good practice: enforce timeouts for servers you create!
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Fixes #1691

## Changelog
- Use default of `0` for `executor`'s server timeouts, since that is controlled through the underlying `http.Client`.