### PR TITLE
Added option to force REST Flask app to run single-threaded

### DIFF
--- a/doc/source/python/python_component.md
+++ b/doc/source/python/python_component.md
@@ -383,6 +383,40 @@ class DeepMnist(object):
         return predictions.astype(np.float64)
 ```
 
+### Single-threaded Flask for REST (experimental)
+
+To run your class single-threaded with Flask set the environment variable `FLASK_SINGLE_THREADED` to 1. This will set the `threaded` parameter of the Flask app to `False`. It is not the optimal setup for most models, but can be useful when your model cannot be made thread-safe like many GPU-based models that deadlock when accessed from multiple threads.
+
+```
+apiVersion: machinelearning.seldon.io/v1alpha2
+kind: SeldonDeployment
+metadata:
+  name: flaskexample
+spec:
+  name: worker
+  predictors:
+  - componentSpecs:
+    - spec:
+        containers:
+        - image: seldonio/mock_classifier:1.0
+          name: classifier
+          env:
+          - name: FLASK_SINGLE_THREADED
+            value: '1'
+        terminationGracePeriodSeconds: 1
+    graph:
+      children: []
+      endpoint:
+        type: REST
+      name: classifier
+      type: MODEL
+    labels:
+      version: v1
+    name: example
+    replicas: 1
+
+```
+
 ## Multi-value numpy arrays
 
 By default, when using the data ndarray parameter, the conversion to ndarray (by default) converts all inner types into the same type. With models that may take as input arrays with different value types, you will be able to do so by overriding the `predict_raw` function yourself which gives you access to the raw request, and creating the numpy array as follows:

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -348,12 +348,16 @@ def main():
                     logger.info("Set JAEGER_EXTRA_TAGS %s", jaeger_extra_tags)
                     tracing = FlaskTracing(tracer, True, app, jaeger_extra_tags)
 
-                app.run(host="0.0.0.0", port=port, threaded=False if args.single_threaded else True)
+                app.run(
+                    host="0.0.0.0",
+                    port=port,
+                    threaded=False if args.single_threaded else True,
+                )
 
             logger.info(
                 "REST gunicorn microservice running on port %i single-threaded=%s",
                 port,
-                args.single_threaded
+                args.single_threaded,
             )
             server1_func = rest_prediction_server
 

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -245,6 +245,12 @@ def main():
         default=int(os.environ.get("GUNICORN_MAX_REQUESTS_JITTER", "0")),
         help="Maximum random jitter to add to max-requests.",
     )
+    parser.add_argument(
+        "--single-threaded",
+        type=int,
+        default=int(os.environ.get("FLASK_SINGLE_THREADED", "0")),
+        help="Force the Flask app to run single-threaded",
+    )
 
     args = parser.parse_args()
 
@@ -322,7 +328,7 @@ def main():
                 )
                 StandaloneApplication(app, user_object, options=options).run()
 
-            logger.info("REST gunicorn microservice running on port %i", port)
+            logger.info("REST microservice running on port %i", port)
             server1_func = rest_prediction_server
 
         else:
@@ -342,9 +348,13 @@ def main():
                     logger.info("Set JAEGER_EXTRA_TAGS %s", jaeger_extra_tags)
                     tracing = FlaskTracing(tracer, True, app, jaeger_extra_tags)
 
-                app.run(host="0.0.0.0", port=port)
+                app.run(host="0.0.0.0", port=port, threaded=False if args.single_threaded else True)
 
-            logger.info("REST microservice running on port %i", port)
+            logger.info(
+                "REST gunicorn microservice running on port %i single-threaded=%s",
+                port,
+                args.single_threaded
+            )
             server1_func = rest_prediction_server
 
     elif args.api_type == "GRPC":

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -355,7 +355,7 @@ def main():
                 )
 
             logger.info(
-                "REST gunicorn microservice running on port %i single-threaded=%s",
+                "REST microservice running on port %i single-threaded=%s",
                 port,
                 args.single_threaded,
             )

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -328,7 +328,7 @@ def main():
                 )
                 StandaloneApplication(app, user_object, options=options).run()
 
-            logger.info("REST microservice running on port %i", port)
+            logger.info("REST gunicorn microservice running on port %i", port)
             server1_func = rest_prediction_server
 
         else:


### PR DESCRIPTION
This is to avoid deadlocks with GPU models, especially Pytorch ones.