### PR TITLE
info-log seldon-core version on microservice start

### DIFF
--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -14,6 +14,7 @@ from seldon_core.flask_utils import ANNOTATIONS_FILE
 import seldon_core.wrapper as seldon_microservice
 from typing import Dict, Callable
 from seldon_core.flask_utils import SeldonMicroserviceException
+from seldon_core import __version__
 import gunicorn.app.base
 
 logger = logging.getLogger(__name__)
@@ -202,6 +203,7 @@ def main():
     )
     logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
     logger.info("Starting microservice.py:main")
+    logger.info(f"Seldon Core version: {__version__}")
 
     sys.path.append(os.getcwd())
     parser = argparse.ArgumentParser()

--- a/python/seldon_core/version.py
+++ b/python/seldon_core/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.1-SNAPSHOT"
+__version__ = "1.1.1-rc"

--- a/python/tests/test_microservice.py
+++ b/python/tests/test_microservice.py
@@ -3,11 +3,11 @@ import requests
 import pytest
 import grpc
 import numpy as np
-import signal
 
 from os.path import dirname, join
 from unittest import mock
 from tenacity import Retrying, stop_after_attempt, wait_exponential
+from seldon_core import __version__
 from seldon_core.proto import prediction_pb2
 from seldon_core.proto import prediction_pb2_grpc
 from seldon_core import microservice
@@ -26,6 +26,13 @@ def retry_method(method, args=(), kwargs={}, stop_after=5, max_sleep=10):
         with attempt:
             logging.info(f"Calling method... try: {attempt.retry_state.attempt_number}")
             return method(*args, **kwargs)
+
+
+def test_microservice_version():
+    fname = join(dirname(__file__), "..", "..", "version.txt")
+    with open(fname, "r") as f:
+        version = f.readline().strip()
+    assert version == __version__
 
 
 def test_model_template_app_rest(microservice):

--- a/release.py
+++ b/release.py
@@ -191,10 +191,17 @@ def update_operator_kustomize_prepackaged_images(fpath, seldon_core_version, deb
         print("error updating operator kustomize yaml for prepackaged server images".format(**locals()))
         print(err)
 
+
 def update_versions_txt(seldon_core_version, debug=False):
     with open("version.txt", "w") as f:
         f.write("{seldon_core_version}\n".format(**locals()))
     print("Updated version.txt")
+
+
+def update_versions_py(seldon_core_version, debug=False):
+    with open("python/seldon_core/version.py", "w") as f:
+        f.write('__version__ = "{seldon_core_version}"\n'.format(**locals()))
+    print("Updated python/seldon_core/version.py")
 
 
 def update_kustomize_engine_version(seldon_core_version, debug=False):
@@ -346,6 +353,9 @@ def set_version(
     #
     # Update top level versions.txt
     update_versions_txt(seldon_core_version, debug)
+    #
+    # Update version.py in python/seldon_core
+    update_versions_py(seldon_core_version, debug)
     #
     # update the pom files
     for fpath in pom_files_realpaths:


### PR DESCRIPTION
Fixes #1718
Closes https://github.com/SeldonIO/seldon-core/issues/1704

But I wonder if maybe we could also log the git commit hash additionally to have it 100% clear what version are users running when they submit logs.

EDIT: actually we only have problem in distinguishing different `1.1.0-SNAPSHOT` for example. 
If someone will use dated build we will have a clear version. Still my preference would be to version using git hashes but this will correctly leverage existing mechanism.

Edit 2: test added in this PR  will also avoid in future problems reported in https://github.com/SeldonIO/seldon-core/issues/1718