### PR TITLE
Fix: Parse image name and version from env

### DIFF
--- a/python/seldon_core/metadata.py
+++ b/python/seldon_core/metadata.py
@@ -3,6 +3,8 @@ import logging
 
 from typing import Union, List, Dict
 
+from seldon_core.metrics import split_image_tag
+
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +158,7 @@ def validate_model_metadata(data: Dict) -> Dict:
     a correct type for specific components.
     """
     if MODEL_IMAGE is not None:
-        image_name, image_version = MODEL_IMAGE.split(":")
+        image_name, image_version = split_image_tag(MODEL_IMAGE)
     else:
         image_name, image_version = "", ""
     name = data.get("name", image_name)

--- a/python/seldon_core/metrics.py
+++ b/python/seldon_core/metrics.py
@@ -48,8 +48,8 @@ def split_image_tag(tag: str) -> Tuple[str]:
     -------
         Image name, image version tuple
     """
-    *name_parts, version = tag.split(':')
-    return ':'.join(name_parts), version
+    *name_parts, version = tag.split(":")
+    return ":".join(name_parts), version
 
 
 # Development placeholder

--- a/python/seldon_core/metrics.py
+++ b/python/seldon_core/metrics.py
@@ -11,7 +11,7 @@ from multiprocessing import Manager
 
 import numpy as np
 
-from typing import List, Dict
+from typing import List, Dict, Tuple
 import logging
 import json
 import os
@@ -34,9 +34,27 @@ TIMER = "TIMER"
 # This sets the bins spread logarithmically between 0.001 and 30
 BINS = [0] + list(np.logspace(-3, np.log10(30), 50)) + [np.inf]
 
+
+def split_image_tag(tag: str) -> Tuple[str]:
+    """
+    Extract image name and version from an image tag.
+
+    Parameters
+    ----------
+    tag
+        Fully qualified docker image tag. Eg. seldonio/sklearn-iris:0.1
+
+    Returns
+    -------
+        Image name, image version tuple
+    """
+    *name_parts, version = tag.split(':')
+    return ':'.join(name_parts), version
+
+
 # Development placeholder
 image = os.environ.get(ENV_MODEL_IMAGE, f"{NONIMPLEMENTED_MSG}:{NONIMPLEMENTED_MSG}")
-image_name, image_version = image.split(":")
+image_name, image_version = split_image_tag(image)
 predictor_version = json.loads(os.environ.get(ENV_PREDICTOR_LABELS, "{}")).get(
     "version", f"{NONIMPLEMENTED_MSG}"
 )

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -2,6 +2,8 @@ import logging
 import json
 import pytest
 
+from unittest.mock import patch
+
 from seldon_core.metrics import SeldonMetrics
 from seldon_core.wrapper import get_rest_microservice
 from seldon_core.metadata import (
@@ -96,7 +98,38 @@ def test_validate_model_metadata():
         "inputs": [{"name": "input", "datatype": "BYTES", "shape": [1]}],
         "outputs": [{"name": "output", "datatype": "BYTES", "shape": [1]}],
     }
-    assert meta == validate_model_metadata(meta)
+    with patch(
+        'seldon_core.metadata.MODEL_IMAGE', None
+    ):
+        assert meta == validate_model_metadata(meta)
+
+
+def test_validate_model_metadata_with_env():
+    meta = {
+        "name": "my-model-name",
+        "versions": ["model-version"],
+        "platform": "model-platform",
+        "inputs": [{"name": "input", "datatype": "BYTES", "shape": [1]}],
+        "outputs": [{"name": "output", "datatype": "BYTES", "shape": [1]}],
+    }
+    with patch(
+        'seldon_core.metadata.MODEL_IMAGE', 'seldonio/sklearn-iris:0.1'
+    ):
+        assert meta == validate_model_metadata(meta)
+
+
+def test_validate_model_metadata_with_colon_in_env():
+    meta = {
+        "name": "my-model-name",
+        "versions": ["model-version"],
+        "platform": "model-platform",
+        "inputs": [{"name": "input", "datatype": "BYTES", "shape": [1]}],
+        "outputs": [{"name": "output", "datatype": "BYTES", "shape": [1]}],
+    }
+    with patch(
+        'seldon_core.metadata.MODEL_IMAGE', 'localhost:32000/sklearn-iris:0.1'
+    ):
+        assert meta == validate_model_metadata(meta)
 
 
 @pytest.mark.parametrize("invalid_versions", ["v1", [1], "[v]", "[1]", 1, 1.1])

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -98,9 +98,7 @@ def test_validate_model_metadata():
         "inputs": [{"name": "input", "datatype": "BYTES", "shape": [1]}],
         "outputs": [{"name": "output", "datatype": "BYTES", "shape": [1]}],
     }
-    with patch(
-        'seldon_core.metadata.MODEL_IMAGE', None
-    ):
+    with patch("seldon_core.metadata.MODEL_IMAGE", None):
         assert meta == validate_model_metadata(meta)
 
 
@@ -112,9 +110,7 @@ def test_validate_model_metadata_with_env():
         "inputs": [{"name": "input", "datatype": "BYTES", "shape": [1]}],
         "outputs": [{"name": "output", "datatype": "BYTES", "shape": [1]}],
     }
-    with patch(
-        'seldon_core.metadata.MODEL_IMAGE', 'seldonio/sklearn-iris:0.1'
-    ):
+    with patch("seldon_core.metadata.MODEL_IMAGE", "seldonio/sklearn-iris:0.1"):
         assert meta == validate_model_metadata(meta)
 
 
@@ -126,9 +122,7 @@ def test_validate_model_metadata_with_colon_in_env():
         "inputs": [{"name": "input", "datatype": "BYTES", "shape": [1]}],
         "outputs": [{"name": "output", "datatype": "BYTES", "shape": [1]}],
     }
-    with patch(
-        'seldon_core.metadata.MODEL_IMAGE', 'localhost:32000/sklearn-iris:0.1'
-    ):
+    with patch("seldon_core.metadata.MODEL_IMAGE", "localhost:32000/sklearn-iris:0.1"):
         assert meta == validate_model_metadata(meta)
 
 

--- a/python/tests/test_metrics.py
+++ b/python/tests/test_metrics.py
@@ -26,18 +26,18 @@ from seldon_core.user_model import client_custom_metrics
 
 
 def test_split_image_tag():
-    image = 'seldonio/sklearn-iris:0.1'
-    expected_name = 'seldonio/sklearn-iris'
-    expected_version = '0.1'
+    image = "seldonio/sklearn-iris:0.1"
+    expected_name = "seldonio/sklearn-iris"
+    expected_version = "0.1"
     name, version = split_image_tag(image)
     assert name == expected_name
     assert version == expected_version
 
 
 def test_split_image_tag_with_colon():
-    image = 'localhost:32000/sklearn-iris:0.1'
-    expected_name = 'localhost:32000/sklearn-iris'
-    expected_version = '0.1'
+    image = "localhost:32000/sklearn-iris:0.1"
+    expected_name = "localhost:32000/sklearn-iris"
+    expected_version = "0.1"
     name, version = split_image_tag(image)
     assert name == expected_name
     assert version == expected_version

--- a/python/tests/test_metrics.py
+++ b/python/tests/test_metrics.py
@@ -17,11 +17,30 @@ from seldon_core.metrics import (
     create_counter,
     create_gauge,
     create_timer,
+    split_image_tag,
     validate_metrics,
     COUNTER,
     BINS,
 )
 from seldon_core.user_model import client_custom_metrics
+
+
+def test_split_image_tag():
+    image = 'seldonio/sklearn-iris:0.1'
+    expected_name = 'seldonio/sklearn-iris'
+    expected_version = '0.1'
+    name, version = split_image_tag(image)
+    assert name == expected_name
+    assert version == expected_version
+
+
+def test_split_image_tag_with_colon():
+    image = 'localhost:32000/sklearn-iris:0.1'
+    expected_name = 'localhost:32000/sklearn-iris'
+    expected_version = '0.1'
+    name, version = split_image_tag(image)
+    assert name == expected_name
+    assert version == expected_version
 
 
 def test_create_counter():


### PR DESCRIPTION
Came across this bug, thought it would be helpful if I could fix it. Open to feedback on implementation, testing, naming, etc. I would have put the function in utils, but that would have caused a circular dependency.

![seldon_core](https://user-images.githubusercontent.com/6689770/80411755-9e5bb800-88c4-11ea-8827-f23eb7c24340.png)

Also seems like there's some duplication in the `metadata` and `metrics` modules, but I didn't want to overstep.

Fixes seldonio/seldon-core#1756