### PR TITLE
Propagate non-default ServiceAccount same way as in separate executor

### DIFF
--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -829,10 +829,13 @@ func createDeploymentWithoutEngine(depName string, seldonId string, seldonPodSpe
 		}
 	}
 
-	// Add a particular service account rather than default for the engine
-	svcAccountName := getSvcOrchSvcAccountName(mlDep)
-	deploy.Spec.Template.Spec.ServiceAccountName = svcAccountName
-	deploy.Spec.Template.Spec.DeprecatedServiceAccount = svcAccountName
+	// Check if ServiceAccount is not set in PodSpec
+	if (seldonPodSpec.Spec.ServiceAccountName == "") || (seldonPodSpec.Spec.DeprecatedServiceAccount == "") {
+		// Get Deployment ServiceAccount from environment or use default
+		svcAccountName := getSvcOrchSvcAccountName(mlDep)
+		deploy.Spec.Template.Spec.ServiceAccountName = svcAccountName
+		deploy.Spec.Template.Spec.DeprecatedServiceAccount = svcAccountName
+	}
 
 	// Add Pod Security Context
 	deploy.Spec.Template.Spec.SecurityContext = podSecurityContext

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -829,6 +829,11 @@ func createDeploymentWithoutEngine(depName string, seldonId string, seldonPodSpe
 		}
 	}
 
+	// Add a particular service account rather than default for the engine
+	svcAccountName := getSvcOrchSvcAccountName(mlDep)
+	deploy.Spec.Template.Spec.ServiceAccountName = svcAccountName
+	deploy.Spec.Template.Spec.DeprecatedServiceAccount = svcAccountName
+
 	// Add Pod Security Context
 	deploy.Spec.Template.Spec.SecurityContext = podSecurityContext
 


### PR DESCRIPTION
Propagate non-default ServiceAccount using Environment Variables in Seldon Controller Manager deployment. Namely `EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME` and `ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME`.
It's still could be overridden by PodSpec within sdep.
