### PR TITLE
Configurable metrics port names

### DIFF
--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -69,6 +69,8 @@ spec:
           value: '{{ .Values.engine.logMessagesExternally }}'
         - name: PREDICTIVE_UNIT_SERVICE_PORT
           value: '{{ .Values.predictiveUnit.port }}'
+        - name: PREDICTIVE_UNIT_METRICS_PORT_NAME
+          value: '{{ .Values.predictiveUnit.metricsPortName }}'
         - name: PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME
           value: '{{ .Values.predictiveUnit.defaultEnvSecretRefName }}'
         - name: ENGINE_SERVER_GRPC_PORT
@@ -95,6 +97,8 @@ spec:
           value: '{{ .Values.engine.grpc.port }}'
         - name: EXECUTOR_SERVER_PORT
           value: '{{ .Values.executor.port }}'
+        - name: EXECUTOR_SERVER_METRICS_PORT_NAME
+          value: '{{ .Values.executor.metricsPortName }}'
         - name: EXECUTOR_CONTAINER_USER
           value: '{{ .Values.executor.user }}'
         - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -39,6 +39,7 @@ defaultUserID: ""
 executor:
   enabled: true
   port: 8000
+  metricsPortName: metrics
   grpc:
     port: 5001
   image:
@@ -88,6 +89,7 @@ webhook:
 # ## Predictive Unit Values
 predictiveUnit:
   port: 9000
+  metricsPortName: metrics
   # If you would like to add extra environment variables to the init container to make available
   #   secrets such as cloud credentials, you can provide a default secret name that will be loaded
   #   to all the containers. You can then override this using the envSecretRefName in SeldonDeployments

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -19,11 +19,12 @@ package v1
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"strconv"
+
 	"github.com/seldonio/seldon-core/operator/constants"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 const (
@@ -49,6 +50,7 @@ const (
 	ENV_PREDICTIVE_UNIT_SERVICE_PORT         = "PREDICTIVE_UNIT_SERVICE_PORT"
 	ENV_PREDICTIVE_UNIT_SERVICE_PORT_METRICS = "PREDICTIVE_UNIT_METRICS_SERVICE_PORT"
 	ENV_PREDICTIVE_UNIT_METRICS_ENDPOINT     = "PREDICTIVE_UNIT_METRICS_ENDPOINT"
+	ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME    = "PREDICTIVE_UNIT_METRICS_PORT_NAME"
 	ENV_PREDICTIVE_UNIT_PARAMETERS           = "PREDICTIVE_UNIT_PARAMETERS"
 	ENV_PREDICTIVE_UNIT_IMAGE                = "PREDICTIVE_UNIT_IMAGE"
 	ENV_PREDICTIVE_UNIT_ID                   = "PREDICTIVE_UNIT_ID"

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
@@ -45,7 +45,7 @@ var (
 	C                                   client.Client
 	envPredictiveUnitServicePort        = os.Getenv(ENV_PREDICTIVE_UNIT_SERVICE_PORT)
 	envPredictiveUnitServicePortMetrics = os.Getenv(ENV_PREDICTIVE_UNIT_SERVICE_PORT_METRICS)
-	predictiveUnitMetricsPortName       = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_ENDPOINT, constants.DefaultMetricsPortName)
+	predictiveUnitMetricsPortName       = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
 )
 
 const PredictorServerConfigMapKeyName = "predictor_servers"
@@ -189,6 +189,7 @@ func getUpdatePortNumMap(name string, nextPortNum *int32, portMap map[string]int
 
 func addMetricsPortAndIncrement(nextMetricsPortNum *int32, con *corev1.Container) {
 	existingMetricPort := GetPort(predictiveUnitMetricsPortName, con.Ports)
+	predictiveUnitMetricsPortName = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
 	if existingMetricPort == nil {
 		con.Ports = append(con.Ports, corev1.ContainerPort{
 			Name:          predictiveUnitMetricsPortName,

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
@@ -45,7 +45,7 @@ var (
 	C                                   client.Client
 	envPredictiveUnitServicePort        = os.Getenv(ENV_PREDICTIVE_UNIT_SERVICE_PORT)
 	envPredictiveUnitServicePortMetrics = os.Getenv(ENV_PREDICTIVE_UNIT_SERVICE_PORT_METRICS)
-	predictiveUnitMetricsPortName       = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
+	envPredictiveUnitMetricsPortName    = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
 )
 
 const PredictorServerConfigMapKeyName = "predictor_servers"
@@ -188,11 +188,10 @@ func getUpdatePortNumMap(name string, nextPortNum *int32, portMap map[string]int
 }
 
 func addMetricsPortAndIncrement(nextMetricsPortNum *int32, con *corev1.Container) {
-	existingMetricPort := GetPort(predictiveUnitMetricsPortName, con.Ports)
-	predictiveUnitMetricsPortName = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
+	existingMetricPort := GetPort(envPredictiveUnitMetricsPortName, con.Ports)
 	if existingMetricPort == nil {
 		con.Ports = append(con.Ports, corev1.ContainerPort{
-			Name:          predictiveUnitMetricsPortName,
+			Name:          envPredictiveUnitMetricsPortName,
 			ContainerPort: *nextMetricsPortNum,
 			Protocol:      corev1.ProtocolTCP,
 		})

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
+
 	"github.com/seldonio/seldon-core/operator/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,12 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"strconv"
 )
 
 var (
@@ -44,6 +45,7 @@ var (
 	C                                   client.Client
 	envPredictiveUnitServicePort        = os.Getenv(ENV_PREDICTIVE_UNIT_SERVICE_PORT)
 	envPredictiveUnitServicePortMetrics = os.Getenv(ENV_PREDICTIVE_UNIT_SERVICE_PORT_METRICS)
+	predictiveUnitMetricsPortName       = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_ENDPOINT, constants.DefaultMetricsPortName)
 )
 
 const PredictorServerConfigMapKeyName = "predictor_servers"
@@ -186,10 +188,10 @@ func getUpdatePortNumMap(name string, nextPortNum *int32, portMap map[string]int
 }
 
 func addMetricsPortAndIncrement(nextMetricsPortNum *int32, con *corev1.Container) {
-	existingMetricPort := GetPort(constants.MetricsPortName, con.Ports)
+	existingMetricPort := GetPort(predictiveUnitMetricsPortName, con.Ports)
 	if existingMetricPort == nil {
 		con.Ports = append(con.Ports, corev1.ContainerPort{
-			Name:          constants.MetricsPortName,
+			Name:          predictiveUnitMetricsPortName,
 			ContainerPort: *nextMetricsPortNum,
 			Protocol:      corev1.ProtocolTCP,
 		})

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -210,7 +209,7 @@ func TestDefaultSingleContainer(t *testing.T) {
 	spec.DefaultSeldonDeployment("mydep", "default")
 
 	// Test Metric Ports
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
 
@@ -267,11 +266,11 @@ func TestMetricsPortAddedTwoContainers(t *testing.T) {
 
 	//Metrics
 	spec.DefaultSeldonDeployment("mydep", "default")
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
 
-	metricPort = GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[1].Ports)
+	metricPort = GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[1].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber + 1))
 
@@ -351,10 +350,10 @@ func TestMetricsPortAddedTwoComponentSpecsTwoContainers(t *testing.T) {
 	spec.DefaultSeldonDeployment(name, namespace)
 
 	// Metrics
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
-	metricPort = GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[1].Spec.Containers[0].Ports)
+	metricPort = GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[1].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber + 1))
 
@@ -392,8 +391,6 @@ func TestMetricsPortAddedTwoComponentSpecsTwoContainers(t *testing.T) {
 }
 
 func TestOverrideMetricsPortName(t *testing.T) {
-	os.Setenv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, "myMetricsPort")
-	defer os.Unsetenv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME)
 	g := NewGomegaWithT(t)
 	scheme := runtime.NewScheme()
 	C = fake.NewFakeClientWithScheme(scheme)
@@ -410,11 +407,12 @@ func TestOverrideMetricsPortName(t *testing.T) {
 		},
 	}
 
+	envPredictiveUnitMetricsPortName = "myMetricsPort"
 	spec.DefaultSeldonDeployment("mydep", "default")
 	// Metrics
-	metricPort := GetPort("myMetricsPort", spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
-	g.Expect(metricPort).NotTo(BeNil())
-	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
+	customMetricsPort := GetPort("myMetricsPort", spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	g.Expect(customMetricsPort).NotTo(BeNil())
+	g.Expect(customMetricsPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
 
 	defaultMetricsPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(defaultMetricsPort).To(BeNil())
@@ -456,7 +454,7 @@ func TestPortUseExisting(t *testing.T) {
 	}
 
 	spec.DefaultSeldonDeployment("mydep", "default")
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(containerPortMetrics))
 

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
@@ -439,7 +439,7 @@ func TestPortUseExisting(t *testing.T) {
 								{
 									Image: "seldonio/mock_classifier:1.0",
 									Name:  "classifier",
-									Ports: []v1.ContainerPort{{Name: constants.DefaultMetricsPortName, ContainerPort: containerPortMetrics},
+									Ports: []v1.ContainerPort{{Name: envPredictiveUnitMetricsPortName, ContainerPort: containerPortMetrics},
 										{Name: constants.HttpPortName, ContainerPort: containerPortAPI}},
 								},
 							},
@@ -487,7 +487,7 @@ func TestMetricsPortAddedToPrepacked(t *testing.T) {
 	}
 
 	spec.DefaultSeldonDeployment("mydep", "default")
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
 
@@ -518,7 +518,7 @@ func TestPredictorProtocolGrpc(t *testing.T) {
 	}
 
 	spec.DefaultSeldonDeployment("mydep", "default")
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
 
@@ -560,7 +560,7 @@ func TestPrepackedWithExistingContainer(t *testing.T) {
 	}
 
 	spec.DefaultSeldonDeployment("mydep", "default")
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
 
@@ -599,11 +599,11 @@ func TestMetricsPortAddedToTwoPrepacked(t *testing.T) {
 	}
 
 	spec.DefaultSeldonDeployment("mydep", "default")
-	metricPort := GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
+	metricPort := GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[0].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber))
 
-	metricPort = GetPort(constants.DefaultMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[1].Ports)
+	metricPort = GetPort(envPredictiveUnitMetricsPortName, spec.Predictors[0].ComponentSpecs[0].Spec.Containers[1].Ports)
 	g.Expect(metricPort).NotTo(BeNil())
 	g.Expect(metricPort.ContainerPort).To(Equal(constants.FirstMetricsPortNumber + 1))
 

--- a/operator/constants/constants.go
+++ b/operator/constants/constants.go
@@ -22,9 +22,10 @@ const (
 	HttpPortName          = "http"
 )
 
+// Metrics-related constants
 const (
-	MetricsPortName        = "metrics"
 	FirstMetricsPortNumber = int32(6000)
+	DefaultMetricsPortName = "metrics"
 )
 
 const (

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -762,7 +762,8 @@ func createContainerService(deploy *appsv1.Deployment,
 	}...)
 
 	//Add Metric Env Var
-	metricPort := getPort(constants.MetricsPortName, con.Ports)
+	predictiveUnitMetricsPortName := GetEnv(machinelearningv1.ENV_PREDICTIVE_UNIT_METRICS_ENDPOINT, constants.DefaultMetricsPortName)
+	metricPort := getPort(predictiveUnitMetricsPortName, con.Ports)
 	if metricPort != nil {
 		con.Env = append(con.Env, []corev1.EnvVar{
 			corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_SERVICE_PORT_METRICS, Value: strconv.Itoa(int(metricPort.ContainerPort))},

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -762,7 +762,7 @@ func createContainerService(deploy *appsv1.Deployment,
 	}...)
 
 	//Add Metric Env Var
-	predictiveUnitMetricsPortName := GetEnv(machinelearningv1.ENV_PREDICTIVE_UNIT_METRICS_ENDPOINT, constants.DefaultMetricsPortName)
+	predictiveUnitMetricsPortName := GetEnv(machinelearningv1.ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
 	metricPort := getPort(predictiveUnitMetricsPortName, con.Ports)
 	if metricPort != nil {
 		con.Env = append(con.Env, []corev1.EnvVar{

--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -18,6 +18,10 @@ package controllers
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"github.com/seldonio/seldon-core/operator/constants"
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,14 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"os"
-	"strconv"
-	"strings"
 )
 
 const (
 	ENV_DEFAULT_EXECUTOR_SERVER_PORT      = "EXECUTOR_SERVER_PORT"
 	ENV_DEFAULT_EXECUTOR_SERVER_GRPC_PORT = "EXECUTOR_SERVER_GRPC_PORT"
+	ENV_EXECUTOR_METRICS_PORT_NAME        = "EXECUTOR_SERVER_METRICS_PORT_NAME"
 	ENV_EXECUTOR_PROMETHEUS_PATH          = "EXECUTOR_PROMETHEUS_PATH"
 	ENV_ENGINE_PROMETHEUS_PATH            = "ENGINE_PROMETHEUS_PATH"
 	ENV_EXECUTOR_USER                     = "EXECUTOR_CONTAINER_USER"
@@ -57,6 +59,8 @@ var (
 	envEngineUser           = os.Getenv(ENV_ENGINE_USER)
 	envExecutorUser         = os.Getenv(ENV_EXECUTOR_USER)
 	envUseExecutor          = os.Getenv(ENV_USE_EXECUTOR)
+
+	executorMetricsPortName = GetEnv(ENV_EXECUTOR_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
 )
 
 func addEngineToDeployment(mlDep *machinelearningv1.SeldonDeployment, p *machinelearningv1.PredictorSpec, engine_http_port int, engine_grpc_port int, pSvcName string, deploy *appsv1.Deployment) error {
@@ -251,9 +255,9 @@ func createExecutorContainer(mlDep *machinelearningv1.SeldonDeployment, p *machi
 			{Name: "REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX", Value: GetEnv("EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT_PREFIX", "")},
 		},
 		Ports: []corev1.ContainerPort{
-			{ContainerPort: int32(http_port), Protocol: corev1.ProtocolTCP},
-			{ContainerPort: int32(http_port), Protocol: corev1.ProtocolTCP, Name: constants.MetricsPortName},
-			{ContainerPort: int32(grpc_port), Protocol: corev1.ProtocolTCP},
+			{ContainerPort: int32(http_port), Protocol: corev1.ProtocolTCP, Name: constants.HttpPortName},
+			{ContainerPort: int32(http_port), Protocol: corev1.ProtocolTCP, Name: executorMetricsPortName},
+			{ContainerPort: int32(grpc_port), Protocol: corev1.ProtocolTCP, Name: constants.GrpcPortName},
 		},
 		ReadinessProbe: &corev1.Probe{Handler: corev1.Handler{HTTPGet: &corev1.HTTPGetAction{Port: intstr.FromInt(http_port), Path: "/ready", Scheme: corev1.URISchemeHTTP}},
 			InitialDelaySeconds: 20,
@@ -302,9 +306,9 @@ func createEngineContainerSpec(mlDep *machinelearningv1.SeldonDeployment, p *mac
 			{Name: "JAVA_OPTS", Value: getAnnotation(mlDep, machinelearningv1.ANNOTATION_JAVA_OPTS, "-server")},
 		},
 		Ports: []corev1.ContainerPort{
-			{ContainerPort: int32(engine_http_port), Protocol: corev1.ProtocolTCP},
-			{ContainerPort: int32(engine_http_port), Protocol: corev1.ProtocolTCP, Name: constants.MetricsPortName},
-			{ContainerPort: int32(engine_grpc_port), Protocol: corev1.ProtocolTCP},
+			{ContainerPort: int32(engine_http_port), Protocol: corev1.ProtocolTCP, Name: constants.HttpPortName},
+			{ContainerPort: int32(engine_http_port), Protocol: corev1.ProtocolTCP, Name: executorMetricsPortName},
+			{ContainerPort: int32(engine_grpc_port), Protocol: corev1.ProtocolTCP, Name: constants.GrpcPortName},
 			{ContainerPort: 8082, Name: "admin", Protocol: corev1.ProtocolTCP},
 			{ContainerPort: 9090, Name: "jmx", Protocol: corev1.ProtocolTCP},
 		},


### PR DESCRIPTION
Fixes #1798 and addresses #1799 (option multiple metrics ports)

Metrics ports names can be configured with environment variables and through the helm chart.