### PR TITLE
Set user as default reviewer on Dependabot PRs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,6 +4,10 @@ update_configs:
   - package_manager: "python"
     directory: "/python"
     update_schedule: "weekly"
+    default_reviewers:
+      - adriangonz
   - package_manager: "java:maven"
     directory: "/engine"
     update_schedule: "weekly"
+    default_reviewers:
+      - adriangonz


### PR DESCRIPTION
## Changelog
- Set `adriangonz` as the default user on Dependabot PRs