### PR TITLE
Enable operator and executor container build on multi-architecture

### DIFF
--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -18,7 +18,7 @@ COPY logger/ logger/
 COPY k8s/ k8s/
 
 # Build
-RUN go build -a -o executor main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) GO111MODULE=on go build -a -o executor main.go
 
 # Copy OpenAPI folder and change the permissions
 COPY api/rest/openapi/ /openapi/

--- a/executor/Dockerfile.redhat
+++ b/executor/Dockerfile.redhat
@@ -18,8 +18,7 @@ COPY logger/ logger/
 COPY k8s/ k8s/
 
 # Build
-RUN go build -a -o executor main.go
-
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) GO111MODULE=on go build -a -o executor main.go
 # Copy OpenAPI folder and change the permissions
 COPY api/rest/openapi/ /openapi/
 RUN chmod -R 660 /openapi/

--- a/executor/Makefile
+++ b/executor/Makefile
@@ -15,6 +15,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
 # Run go fmt against code
 fmt:
 	go fmt ./...
@@ -26,7 +29,7 @@ vet:
 
 # Build manager binary
 executor: fmt vet
-	go build -o executor main.go
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) GO111MODULE=on go build -o executor main.go
 
 
 .PHONY: copy_protos

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -18,14 +18,14 @@ COPY constants/ constants/
 COPY client/ client/
 
 # Build
-RUN go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY licenses/license.txt licenses/license.txt 
+COPY licenses/license.txt licenses/license.txt
 COPY generated/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_seldon-mutating-webhook-configuration.yaml /tmp/operator-resources/mutate.yaml
 COPY generated/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_seldon-validating-webhook-configuration.yaml /tmp/operator-resources/validate.yaml
 COPY generated/~g_v1_service_seldon-webhook-service.yaml /tmp/operator-resources/service.yaml

--- a/operator/Dockerfile.redhat
+++ b/operator/Dockerfile.redhat
@@ -18,7 +18,7 @@ COPY constants/ constants/
 COPY client/ client/
 
 # Build
-RUN go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) GO111MODULE=on go build -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL name="Seldon Operator" \
@@ -30,7 +30,7 @@ LABEL name="Seldon Operator" \
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY licenses/license.txt licenses/license.txt 
+COPY licenses/license.txt licenses/license.txt
 COPY generated/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_seldon-mutating-webhook-configuration.yaml /tmp/operator-resources/mutate.yaml
 COPY generated/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_seldon-validating-webhook-configuration.yaml /tmp/operator-resources/validate.yaml
 COPY generated/~g_v1_service_seldon-webhook-service.yaml /tmp/operator-resources/service.yaml

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -17,6 +17,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
 .PHONY:show_image
 show_image:
 	echo ${IMG}
@@ -29,7 +32,7 @@ test: generate fmt vet manifests generate-resources
 
 # Build manager binary
 manager: generate fmt vet
-	go build -o bin/manager main.go
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) GO111MODULE=on go build -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests


### PR DESCRIPTION
Since Go compiles completely static binaries and changing the target platform is as simple as changing an environment variable GOARCH. This commit adds multi-architecture building support for operator container image.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>