### PR TITLE
fix name of minio_setup notebook in links

### DIFF
--- a/examples/dvc/sklearn_dvc_minio.ipynb
+++ b/examples/dvc/sklearn_dvc_minio.ipynb
@@ -21,8 +21,8 @@
     "\n",
     "## Setup MinIO\n",
     "\n",
-    "Use the provided [notebook](../../../notebooks/setup_minio.ipynb) to install Minio in your cluster and configure `mc` CLI tool. \n",
-    "Instructions [also online](./setup_minio.html)."
+    "Use the provided [notebook](../../../notebooks/minio_setup.ipynb) to install Minio in your cluster and configure `mc` CLI tool. \n",
+    "Instructions [also online](./minio_setup.html)."
    ]
   },
   {

--- a/examples/minio/minio.ipynb
+++ b/examples/minio/minio.ipynb
@@ -18,8 +18,8 @@
     "\n",
     "## Setup MinIO\n",
     "\n",
-    "Use the provided [notebook](../../../notebooks/setup_minio.ipynb) to install Minio in your cluster and configure `mc` CLI tool. \n",
-    "Instructions [also online](./setup_minio.html)."
+    "Use the provided [notebook](../../../notebooks/minio_setup.ipynb) to install Minio in your cluster and configure `mc` CLI tool. \n",
+    "Instructions [also online](./minio_setup.html)."
    ]
   },
   {

--- a/examples/pachyderm/sklearn_pachyderm.ipynb
+++ b/examples/pachyderm/sklearn_pachyderm.ipynb
@@ -21,8 +21,8 @@
     "\n",
     "## Setup MinIO\n",
     "\n",
-    "Use the provided [notebook](../../../notebooks/setup_minio.ipynb) to install Minio in your cluster and configure `mc` CLI tool. \n",
-    "Instructions [also online](./setup_minio.html)."
+    "Use the provided [notebook](../../../notebooks/minio_setup.ipynb) to install Minio in your cluster and configure `mc` CLI tool. \n",
+    "Instructions [also online](./minio_setup.html)."
    ]
   },
   {


### PR DESCRIPTION
A minor fix to the links. Somehow I wrote `setup_minio` instead of `minio_setup`