### PR TITLE
fix the loop length from parmeters count

### DIFF
--- a/incubating/wrappers/s2i/R/microservice.R
+++ b/incubating/wrappers/s2i/R/microservice.R
@@ -246,7 +246,7 @@ extract_parmeters <- function(params) {
   j = fromJSON(params)
   values <- list()
   names <- list()
-  for (i in seq_along(j))
+  for (i in seq_len(NROW(j)))
   {
     name <- j[i,"name"]
     value <- j[i,"value"]


### PR DESCRIPTION
Fixed error when using parameters in deployment yaml.

When I set the following parameters:
```yml
predictors:
    - name: sample-graph
      graph:
        name: image-transformer-input
        type: TRANSFORMER
        endpoint:
          type: REST
        parameters:
        - name: env
          value: dev
          type: STRING
        children: []
```

The parameters in yaml would convert to json format:
```json
[{"name":"env", "value":"dev", "type":"STRING"}]
```

When using `seq_along`, it would return `1 2 3`
But in this case, I expect to return `1`, because the json string just have `1` row not `3` rows.
```R
> library(jsonlite)
> params <- '[{"name":"env", "value":"dev", "type":"STRING"}]'
> j = fromJSON(params)
> seq_along(j)
[1] 1 2 3
```