### PR TITLE
updated histogram buckets

### DIFF
--- a/executor/api/metric/client.go
+++ b/executor/api/metric/client.go
@@ -24,7 +24,7 @@ func NewClientMetrics(spec *v1.PredictorSpec, deploymentName string, modelName s
 		prometheus.HistogramOpts{
 			Name:    ClientRequestsMetricName,
 			Help:    "A histogram of latencies for client calls from executor",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
 		},
 		[]string{DeploymentNameMetric, PredictorNameMetric, PredictorVersionMetric, ServiceMetric, ModelNameMetric, ModelImageMetric, ModelVersionMetric, "method", "code"},
 	)

--- a/executor/api/metric/client.go
+++ b/executor/api/metric/client.go
@@ -24,7 +24,7 @@ func NewClientMetrics(spec *v1.PredictorSpec, deploymentName string, modelName s
 		prometheus.HistogramOpts{
 			Name:    ClientRequestsMetricName,
 			Help:    "A histogram of latencies for client calls from executor",
-			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
+			Buckets: DefBuckets,
 		},
 		[]string{DeploymentNameMetric, PredictorNameMetric, PredictorVersionMetric, ServiceMetric, ModelNameMetric, ModelImageMetric, ModelVersionMetric, "method", "code"},
 	)

--- a/executor/api/metric/constants.go
+++ b/executor/api/metric/constants.go
@@ -19,3 +19,7 @@ const (
 	MetadataHttpServiceName   = "metadata"
 	FeedbackHttpServiceName   = "feedback"
 )
+
+var (
+	DefBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+)

--- a/executor/api/metric/server.go
+++ b/executor/api/metric/server.go
@@ -20,7 +20,7 @@ func NewServerMetrics(spec *v1.PredictorSpec, deploymentName string) *ServerMetr
 		prometheus.HistogramOpts{
 			Name:    ServerRequestsMetricName,
 			Help:    "A histogram of latencies for executor server",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
 		},
 		[]string{DeploymentNameMetric, PredictorNameMetric, PredictorVersionMetric, ServiceMetric, "method", "code"},
 	)

--- a/executor/api/metric/server.go
+++ b/executor/api/metric/server.go
@@ -20,7 +20,7 @@ func NewServerMetrics(spec *v1.PredictorSpec, deploymentName string) *ServerMetr
 		prometheus.HistogramOpts{
 			Name:    ServerRequestsMetricName,
 			Help:    "A histogram of latencies for executor server",
-			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
+			Buckets: DefBuckets,
 		},
 		[]string{DeploymentNameMetric, PredictorNameMetric, PredictorVersionMetric, ServiceMetric, "method", "code"},
 	)


### PR DESCRIPTION
The measured latency is higher than the end to end latency measured by python codes. it is better to use more buckets as python prometheus client.