### PR TITLE
Fix chart integration tests

### DIFF
--- a/helm-charts/seldon-single-model/README.md
+++ b/helm-charts/seldon-single-model/README.md
@@ -36,6 +36,7 @@ helm install $MY_MODEL_NAME seldonio/seldon-single-model --namespace $MODELS_NAM
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | annotations | list | `[]` | Annotations applied to the deployment |
+| apiVersion | string | `"machinelearning.seldon.io/v1"` | Version of the SeldonDeployment CRD |
 | hpa.enabled | bool | `false` | Whether to add an HPA spec to the deployment |
 | hpa.maxReplicas | int | `5` | Maximum number of replicas for HPA |
 | hpa.metrics | list | `[{"resource":{"name":"cpu","targetAverageUtilization":10},"type":"Resource"}]` | Metrics that autoscaler should check |

--- a/helm-charts/seldon-single-model/README.md
+++ b/helm-charts/seldon-single-model/README.md
@@ -35,13 +35,13 @@ helm install $MY_MODEL_NAME seldonio/seldon-single-model --namespace $MODELS_NAM
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| annotations | list | `[]` | Annotations applied to the deployment |
+| annotations | object | `{}` | Annotations applied to the deployment |
 | apiVersion | string | `"machinelearning.seldon.io/v1"` | Version of the SeldonDeployment CRD |
 | hpa.enabled | bool | `false` | Whether to add an HPA spec to the deployment |
 | hpa.maxReplicas | int | `5` | Maximum number of replicas for HPA |
 | hpa.metrics | list | `[{"resource":{"name":"cpu","targetAverageUtilization":10},"type":"Resource"}]` | Metrics that autoscaler should check |
 | hpa.minReplicas | int | `1` | Minimum number of replicas for HPA |
-| labels | list | `[]` | Labels applied to the deployment |
+| labels | object | `{}` | Labels applied to the deployment |
 | model.env | object | `{"LOG_LEVEL":"INFO"}` | Environment variables injected into the model's container |
 | model.image | string | `""` | Docker image used by the model |
 | model.logger.enabled | bool | `false` |  |

--- a/helm-charts/seldon-single-model/templates/seldondeployment.json
+++ b/helm-charts/seldon-single-model/templates/seldondeployment.json
@@ -3,20 +3,20 @@
   "apiVersion": "{{ .Values.apiVersion }}",
   "metadata": {
     "name": "{{ .Release.Name }}",
-    "namespace": "{{ .Release.Namespace }}"
-    "labels": [
-      {{- range $label := .Values.labels }}
-        "{{ $label }}"
-      {{- end }}
-    ]
+    "namespace": "{{ .Release.Namespace }}",
+    "labels": {
+      {{- range $name, $val := .Values.labels }}
+        "{{ $name }}": "{{ $val }}"
+      {{ end -}}
+    }
   },
   "spec": {
     "name": "{{ .Release.Name }}",
-    "annotations": [
-      {{- range $annotation := .Values.annotations }}
-        "{{ $annotation }}"
-      {{- end }}
-    ],
+    "annotations": {
+      {{- range $name, $val := .Values.annotations }}
+        "{{ $name }}": "{{ $val }}"
+      {{ end -}}
+    },
     "predictors": [
       {
         "name": "default",
@@ -45,7 +45,7 @@
                         "name": "{{ $var }}",
                         "value": "{{ $val }}"
                       },
-                    {{- end }}
+                    {{ end -}}
                   ],
                   "resources": {{ .Values.model.resources | toJson }},
                 }

--- a/helm-charts/seldon-single-model/templates/seldondeployment.json
+++ b/helm-charts/seldon-single-model/templates/seldondeployment.json
@@ -1,6 +1,6 @@
 {
   "kind": "SeldonDeployment",
-  "apiVersion": "machinelearning.seldon.io/v1",
+  "apiVersion": "{{ .Values.apiVersion }}",
   "metadata": {
     "name": "{{ .Release.Name }}",
     "namespace": "{{ .Release.Namespace }}"

--- a/helm-charts/seldon-single-model/values.yaml
+++ b/helm-charts/seldon-single-model/values.yaml
@@ -21,10 +21,10 @@ model:
 replicas: 1
 
 # labels -- Labels applied to the deployment
-labels: []
+labels: {}
 
 # annotations -- Annotations applied to the deployment
-annotations: []
+annotations: {}
 
 hpa:
   # hpa.enabled -- Whether to add an HPA spec to the deployment

--- a/helm-charts/seldon-single-model/values.yaml
+++ b/helm-charts/seldon-single-model/values.yaml
@@ -1,3 +1,6 @@
+# apiVersion -- Version of the SeldonDeployment CRD
+apiVersion: machinelearning.seldon.io/v1
+
 model:
   # model.image -- Docker image used by the model
   image: ""

--- a/testing/scripts/test_api_version.py
+++ b/testing/scripts/test_api_version.py
@@ -34,4 +34,4 @@ def test_api_version(namespace, apiVersion):
     assert r.status_code == 200
     assert len(r.json()["data"]["tensor"]["values"]) == 1
 
-    run(f"helm delete mymodel", shell=True)
+    run("helm delete mymodel", shell=True)

--- a/testing/scripts/test_helm_charts_clusterwide.py
+++ b/testing/scripts/test_helm_charts_clusterwide.py
@@ -2,41 +2,40 @@ from seldon_e2e_utils import (
     wait_for_rollout,
     wait_for_status,
     initial_rest_request,
-    initial_grpc_request,
     rest_request_ambassador,
-    grpc_request_ambassador2,
     API_AMBASSADOR,
+    assert_model,
 )
 from subprocess import run
 import logging
-import time
 
 
 class TestClusterWide(object):
 
     # Test singe model helm script with 4 API methods
     def test_single_model(self, namespace):
-        run(
-            f"helm install mymodel ../../helm-charts/seldon-single-model --namespace {namespace}",
-            shell=True,
-            check=True,
+        command = (
+            "helm install mymodel ../../helm-charts/seldon-single-model "
+            f"--set model.image=seldonio/fixed-model:0.1 "
+            f"--namespace {namespace}"
         )
+        run(command, shell=True, check=True)
+
         wait_for_status("mymodel", namespace)
         wait_for_rollout("mymodel", namespace)
-        initial_rest_request("mymodel", namespace)
-        logging.warning("Test Ambassador REST gateway")
-        r = rest_request_ambassador("mymodel", namespace, API_AMBASSADOR)
-        logging.warning(r.json())
-        assert r.status_code == 200
-        assert len(r.json()["data"]["tensor"]["values"]) == 1
-        run(f"helm delete mymodel", shell=True)
+
+        assert_model("mymodel", namespace, initial=True)
+
+        run("helm delete mymodel", shell=True)
 
     # Test AB Test model helm script with 4 API methods
     def test_abtest_model(self, namespace):
+        command = (
+            "helm install myabtest ../../helm-charts/seldon-abtest "
+            f"--namespace {namespace}"
+        )
         run(
-            f"helm install myabtest ../../helm-charts/seldon-abtest --namespace {namespace}",
-            shell=True,
-            check=True,
+            command, shell=True, check=True,
         )
         wait_for_status("myabtest", namespace)
         wait_for_rollout("myabtest", namespace, expected_deployments=2)
@@ -50,7 +49,7 @@ class TestClusterWide(object):
         logging.warning(
             "WARNING SKIPPING FLAKY AMBASSADOR TEST UNTIL AMBASSADOR GRPC ISSUE FIXED.."
         )
-        run(f"helm delete myabtest", shell=True)
+        run("helm delete myabtest", shell=True)
 
     # Test MAB Test model helm script with 4 API methods
     def test_mab_model(self, namespace):
@@ -71,4 +70,4 @@ class TestClusterWide(object):
         logging.warning(
             "WARNING SKIPPING FLAKY AMBASSADOR TEST UNTIL AMBASSADOR GRPC ISSUE FIXED.."
         )
-        run(f"helm delete mymab", shell=True)
+        run("helm delete mymab", shell=True)

--- a/testing/scripts/test_rolling_updates.py
+++ b/testing/scripts/test_rolling_updates.py
@@ -1,4 +1,3 @@
-import os
 import time
 import logging
 import pytest


### PR DESCRIPTION
Fix issue introduced by #1906, which broke the `seldon-single-model` chart and some of the integration tests.

## Changelog

- Use right type for `labels` and `annotations` in chart
- Use `seldonio/fixed-model:0.1` on tests using `seldon-single-model` chart