### PR TITLE
Added CORS headers to enable Front-End inputs on Go Engine

### DIFF
--- a/executor/api/rest/middlewares.go
+++ b/executor/api/rest/middlewares.go
@@ -47,7 +47,10 @@ func (h *CloudeventHeaderMiddleware) Middleware(next http.Handler) http.Handler 
 	})
 }
 
-func corsHeaders(next http.Handler) http.Handler {
+// handleCORSRequests adds CORS-required headers, and during CORS Preflight
+// requests, it will exit the request and the request status will be
+// http.StatusOK
+func handleCORSRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(corsAllowOriginHeader, corsAllowOriginValue)
 		w.Header().Set(corsAllowMethodsHeader, corsAllowMethodsValue)

--- a/executor/api/rest/middlewares.go
+++ b/executor/api/rest/middlewares.go
@@ -5,6 +5,7 @@ import (
 
 	guuid "github.com/google/uuid"
 	"github.com/seldonio/seldon-core/executor/api/payload"
+	"github.com/seldonio/seldon-core/executor/api/util"
 )
 
 const (
@@ -18,12 +19,12 @@ const (
 	contentTypeOptsHeader = "X-Content-Type-Options"
 	contentTypeOptsValue  = "nosniff"
 
-	corsAllowOriginHeader  = "Access-Control-Allow-Origin"
-	corsAllowOriginValue   = "*"
-	corsAllowMethodsHeader = "Access-Control-Allow-Methods"
-	corsAllowMethodsValue  = "GET, OPTIONS, POST"
-	corsAllowHeadersHeader = "Access-Control-Allow-Headers"
-	corsAllowHeadersValue  = "Accept, Accept-Encoding, Authorization, Content-Length, Content-Type, X-CSRF-Token"
+	corsAllowOriginEnvVar        = "CORS_ALLOWED_ORIGINS"
+	corsAllowOriginHeader        = "Access-Control-Allow-Origin"
+	corsAllowOriginValueAll      = "*"
+	corsAllowOriginHeadersVar    = "CORS_ALLOWED_HEADERS"
+	corsAllowHeadersHeader       = "Access-Control-Allow-Headers"
+	corsAllowHeadersValueDefault = "Accept, Accept-Encoding, Authorization, Content-Length, Content-Type, X-CSRF-Token"
 )
 
 type CloudeventHeaderMiddleware struct {
@@ -52,12 +53,12 @@ func (h *CloudeventHeaderMiddleware) Middleware(next http.Handler) http.Handler 
 // http.StatusOK
 func handleCORSRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		corsAllowOriginValue := util.GetEnv(corsAllowOriginEnvVar, corsAllowOriginValueAll)
+		corsAllowHeadersValue := util.GetEnv(corsAllowOriginHeadersVar, corsAllowHeadersValueDefault)
 		w.Header().Set(corsAllowOriginHeader, corsAllowOriginValue)
-		w.Header().Set(corsAllowMethodsHeader, corsAllowMethodsValue)
 		w.Header().Set(corsAllowHeadersHeader, corsAllowHeadersValue)
 		// Don't pass along OPTIONS (CORS Prefetch) Requests
 		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/executor/api/rest/middlewares_test.go
+++ b/executor/api/rest/middlewares_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCORSHeadersGet(t *testing.T) {
+func TestCORSHeadersGetRequest(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	m := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
@@ -31,7 +31,7 @@ func TestCORSHeadersGet(t *testing.T) {
 	g.Expect(headerValAllowMethods).To(Equal(corsAllowMethodsValue))
 }
 
-func TestCORSHeadersOptions(t *testing.T) {
+func TestCORSHeadersOptionsRequest(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	m := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})

--- a/executor/api/rest/middlewares_test.go
+++ b/executor/api/rest/middlewares_test.go
@@ -8,6 +8,55 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestCORSHeadersGet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	m := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	wrapped := corsHeaders(m)
+
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	headerValAllowOrigin := res.Header.Get(corsAllowOriginHeader)
+	g.Expect(headerValAllowOrigin).To(Equal(corsAllowOriginValue))
+
+	headerValAllowHeaders := res.Header.Get(corsAllowHeadersHeader)
+	g.Expect(headerValAllowHeaders).To(Equal(corsAllowHeadersValue))
+
+	headerValAllowMethods := res.Header.Get(corsAllowMethodsHeader)
+	g.Expect(headerValAllowMethods).To(Equal(corsAllowMethodsValue))
+}
+
+func TestCORSHeadersOptions(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	m := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	wrapped := corsHeaders(m)
+
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	headerValAllowOrigin := res.Header.Get(corsAllowOriginHeader)
+	g.Expect(headerValAllowOrigin).To(Equal(corsAllowOriginValue))
+
+	headerValAllowHeaders := res.Header.Get(corsAllowHeadersHeader)
+	g.Expect(headerValAllowHeaders).To(Equal(corsAllowHeadersValue))
+
+	headerValAllowMethods := res.Header.Get(corsAllowMethodsHeader)
+	g.Expect(headerValAllowMethods).To(Equal(corsAllowMethodsValue))
+
+	statusCode := res.StatusCode
+	g.Expect(statusCode).To(Equal(http.StatusOK))
+}
+
 func TestXSSMiddleware(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -127,7 +127,7 @@ func (r *SeldonRestApi) Initialise() {
 		r.Router.Use(puidHeader)
 		r.Router.Use(cloudeventHeaderMiddleware.Middleware)
 		r.Router.Use(xssMiddleware)
-		r.Router.Use(corsHeaders)
+		r.Router.Use(handleCORSRequests)
 
 		switch r.Protocol {
 		case api.ProtocolSeldon:

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -127,6 +127,7 @@ func (r *SeldonRestApi) Initialise() {
 		r.Router.Use(puidHeader)
 		r.Router.Use(cloudeventHeaderMiddleware.Middleware)
 		r.Router.Use(xssMiddleware)
+		r.Router.Use(mux.CORSMethodMiddleware(r.Router))
 		r.Router.Use(handleCORSRequests)
 
 		switch r.Protocol {

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -127,30 +127,31 @@ func (r *SeldonRestApi) Initialise() {
 		r.Router.Use(puidHeader)
 		r.Router.Use(cloudeventHeaderMiddleware.Middleware)
 		r.Router.Use(xssMiddleware)
+		r.Router.Use(corsHeaders)
 
 		switch r.Protocol {
 		case api.ProtocolSeldon:
 			//v0.1 API
-			api01 := r.Router.PathPrefix("/api/v0.1").Methods("POST").Subrouter()
+			api01 := r.Router.PathPrefix("/api/v0.1").Methods("OPTIONS", "POST").Subrouter()
 			api01.Handle("/predictions", r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions))
 			api01.Handle("/feedback", r.wrapMetrics(metric.FeedbackHttpServiceName, r.feedback))
-			r.Router.NewRoute().Path("/api/v0.1/status/{" + ModelHttpPathVariable + "}").Methods("GET").HandlerFunc(r.wrapMetrics(metric.StatusHttpServiceName, r.status))
-			r.Router.NewRoute().Path("/api/v0.1/metadata/{" + ModelHttpPathVariable + "}").Methods("GET").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.metadata))
+			r.Router.NewRoute().Path("/api/v0.1/status/{"+ModelHttpPathVariable+"}").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.StatusHttpServiceName, r.status))
+			r.Router.NewRoute().Path("/api/v0.1/metadata/{"+ModelHttpPathVariable+"}").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.metadata))
 			r.Router.NewRoute().PathPrefix("/api/v0.1/doc/").Handler(http.StripPrefix("/api/v0.1/doc/", http.FileServer(http.Dir("./openapi/"))))
 			//v1.0 API
-			api10 := r.Router.PathPrefix("/api/v1.0").Methods("POST").Subrouter()
+			api10 := r.Router.PathPrefix("/api/v1.0").Methods("OPTIONS", "POST").Subrouter()
 			api10.Handle("/predictions", r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions))
 			api10.Handle("/feedback", r.wrapMetrics(metric.FeedbackHttpServiceName, r.feedback))
-			r.Router.NewRoute().Path("/api/v1.0/status/{" + ModelHttpPathVariable + "}").Methods("GET").HandlerFunc(r.wrapMetrics(metric.StatusHttpServiceName, r.status))
-			r.Router.NewRoute().Path("/api/v1.0/metadata").Methods("GET").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.graphMetadata))
-			r.Router.NewRoute().Path("/api/v1.0/metadata/{" + ModelHttpPathVariable + "}").Methods("GET").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.metadata))
+			r.Router.NewRoute().Path("/api/v1.0/status/{"+ModelHttpPathVariable+"}").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.StatusHttpServiceName, r.status))
+			r.Router.NewRoute().Path("/api/v1.0/metadata").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.graphMetadata))
+			r.Router.NewRoute().Path("/api/v1.0/metadata/{"+ModelHttpPathVariable+"}").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.metadata))
 			r.Router.NewRoute().PathPrefix("/api/v1.0/doc/").Handler(http.StripPrefix("/api/v1.0/doc/", http.FileServer(http.Dir("./openapi/"))))
 
 		case api.ProtocolTensorflow:
-			r.Router.NewRoute().Path("/v1/models/{" + ModelHttpPathVariable + "}/:predict").Methods("POST").HandlerFunc(r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions))
-			r.Router.NewRoute().Path("/v1/models/:predict").Methods("POST").HandlerFunc(r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions)) // Nonstandard path - Seldon extension
-			r.Router.NewRoute().Path("/v1/models/{" + ModelHttpPathVariable + "}").Methods("GET").HandlerFunc(r.wrapMetrics(metric.StatusHttpServiceName, r.status))
-			r.Router.NewRoute().Path("/v1/models/{" + ModelHttpPathVariable + "}/metadata").Methods("GET").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.metadata))
+			r.Router.NewRoute().Path("/v1/models/{"+ModelHttpPathVariable+"}/:predict").Methods("OPTIONS", "POST").HandlerFunc(r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions))
+			r.Router.NewRoute().Path("/v1/models/:predict").Methods("OPTIONS", "POST").HandlerFunc(r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions)) // Nonstandard path - Seldon extension
+			r.Router.NewRoute().Path("/v1/models/{"+ModelHttpPathVariable+"}").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.StatusHttpServiceName, r.status))
+			r.Router.NewRoute().Path("/v1/models/{"+ModelHttpPathVariable+"}/metadata").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.metadata))
 		}
 	}
 }

--- a/executor/api/util/utils.go
+++ b/executor/api/util/utils.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"os"
+
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 )
 
@@ -33,4 +35,12 @@ func ExtractRouteFromSeldonMessage(msg *proto.SeldonMessage) []int {
 		return routeArr
 	}
 	return []int{-1}
+}
+
+// Get an environment variable given by key or return the fallback.
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -23,8 +23,7 @@ require (
 	github.com/tensorflow/tensorflow/tensorflow/go/core v0.0.0-00010101000000-000000000000
 	github.com/uber/jaeger-client-go v2.21.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
-	google.golang.org/appengine v1.6.5
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/grpc v1.28.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.2

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/uber/jaeger-client-go v2.21.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
+	google.golang.org/appengine v1.6.5
 	google.golang.org/grpc v1.28.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.2


### PR DESCRIPTION
# Description

* Added CORS headers to all requests
  * All front-end web requests were getting rejected
* Added OPTIONS Request type, which is done via CORS Preflight
  * All OPTIONS requests, typical in CORS Preflight, were being rejected

Fixes # [CORS issue in Slack](https://seldondev.slack.com/archives/C8Y9A8G0Y/p1591802505468300)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Unit Tests
- [ ] Integration Tests
- [x] Production deployment (at MLB)

**Test Configuration**:

- Go version: `go version go1.14.3 darwin/amd64`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
