### PR TITLE
Enable production settings in loggers

### DIFF
--- a/doc/source/analytics/log_level.md
+++ b/doc/source/analytics/log_level.md
@@ -7,7 +7,7 @@ level (or the equivalent less verbose settings).
 The verbosity level can be increased to also log `DEBUG` and `INFO` messages by
 following these instructions.
 
-## Log level in Python Wrapper
+## Log level in Python inference servers
 
 .. Note:: 
    Setting the ``SELDON_LOG_LEVEL`` to ``WARNING`` and above in the Python

--- a/doc/source/analytics/log_level.md
+++ b/doc/source/analytics/log_level.md
@@ -1,48 +1,72 @@
 # Logging and log level
 
-Seldon core metrics containers are able to provide different log levels. 
-By default the containers come out of the box with `WARNING` as default log
-level (or the equivalent less verbose settings).
+Out of the box, your Seldon deployments will be pre-configured to a sane set of
+defaults when it comes to logging.
+These settings involve both the logging level and the structure of the log
+messages.
 
-The verbosity level can be increased to also log `DEBUG` and `INFO` messages by
-following these instructions.
+These settings can be changed on a per-component basis.
 
-## Log level in Python inference servers
+## Log level
+
+By default, all the components in your Seldon deployment will come out of the
+box with `INFO` as the default log level.
+
+To change the log level you can use the `SELDON_LOG_LEVEL` environment
+variable.
+In general, this variable can be set to the following log levels (from more to
+less verbose):
+
+- `DEBUG`
+- `INFO`
+- `WARNING` 
+- `ERROR`
+
+### Python inference servers
 
 .. Note:: 
    Setting the ``SELDON_LOG_LEVEL`` to ``WARNING`` and above in the Python
-   wrapper will disable the server's access logs.
+   wrapper will disable the server's access logs, which are considered
+   ``INFO``-level logs.
 
 When using the [Python wrapper](../python) (including the
 [MLflow](../servers/mlflow), [SKLearn](../servers/sklearn) and
 [XGBoost](../servers/xgboost) pre-package servers), you can control the log
 level using the `SELDON_LOG_LEVEL` environment variable.
-This variable can be set to `DEBUG`, `INFO`, `WARNING` or `ERROR` to adjust the
-log level accordingly.
-Note that this has to be set in the **respective container** within your
-inference graph.
+Note that the `SELDON_LOG_LEVEL` variable has to be set in the **respective
+container** within your inference graph.
 
 For example, to set it in each container running with the python wrapper, you
 would do it as follows by adding the environment variable `SELDON_LOG_LEVEL` to
 the containers running images wrapped by the python wrapper:
 
 ```jsonc
-// ...
 "spec": {
-  "containers": [
-      { 
-          "name": "mymodel",
-          "image": "x.y:123",
-          "env": [
-              {
-                  "name": SELDON_LOG_LEVEL,
-                  "value": DEBUG
-              }
-          ]
-      }
+  // ...
+  "predictors": [
+    {
+      "componentSpecs": [
+        {
+          "spec": {
+            "containers": [
+                { 
+                    "name": "mymodel",
+                    "image": "x.y:123",
+                    "env": [
+                        {
+                            "name": "SELDON_LOG_LEVEL",
+                            "value": "DEBUG"
+                        }
+                    ]
+                }
+            ]
+          }
+        }
+      ]
+    }
   ]
+  // ...
 }
-// ...
 ```
 
 Once this has been set, it's possible to use the log in your wrapper code as follows:
@@ -54,86 +78,57 @@ log = logging.getLogger()
 log.debug(...)
 ```
 
-## Log level in the service orchestrator
+### Log level in the service orchestrator
 
-.. Note:: 
-   When using the Go implementation, setting the ``SELDON_LOG_LEVEL`` to
-   ``WARNING`` and above in the service orchestrator will also change the
-   structure of the log messages, which will be logged as JSON, and will enable
-   log sampling.
+To change the log level in the service orchestrator, you can set the
+`SELDON_LOG_LEVEL`  environment variable on the `svcOrchSpec` section of the
+`SeldonDeployment` CRD:
 
-In order to set the log level in the Seldon engine this can be done by
-providing the env option to the svcOrchSpec, as follows:
-
-```json
-"svcOrchSpec": {
-    "env": [
-        {
-            "name": "SELDON_LOG_LEVEL",
-            "value": "DEBUG"
-        }
-    ]
-}
-```
-
-Here is a full example configuration file with a loglevel selection.
-
-```json
-{    
-    "apiVersion": "machinelearning.seldon.io/v1",
-    "kind": "SeldonDeployment",
-    "metadata": {
-        "labels": {
-            "app": "seldon"
-        },
-        "name": "seldon-model"
-    },
-    "spec": {
-        "predictors": [
-            {
-                "componentSpecs": [
-                    {
-                        "spec": {
-                            "containers": [
-                                {
-                                    "image": "seldonio/mock_classifier:1.0",
-                                    "imagePullPolicy": "IfNotPresent",
-                                    "name": "classifier",
-                                    "resources": {
-                                        "requests": {
-                                            "memory": "1Mi"
-                                        }
-                                    }
-                                }
-                            ],
-                            "terminationGracePeriodSeconds": 1
-                        }
-                    }
-                ],
-                "graph": {
-                    "children": [],
-                    "endpoint": {
-                        "type": "REST"
-                    },
-                    "name": "classifier",
-                    "type": "MODEL"
-                },
-                "labels": {
-                    "version": "v1"
-                },
-                "name": "example",
-                "replicas": 1,
-                "svcOrchSpec": {
-                    "env": [
-                        {
-                            "name": "SELDON_LOG_LEVEL",
-                            "value": "DEBUG"
-                        }
-                    ]
-                }
-            }
-        ]
+```jsonc
+"spec": {
+  // ...
+  "predictors": [
+    {
+      "svcOrchSpec": {
+          "env": [
+              {
+                  "name": "SELDON_LOG_LEVEL",
+                  "value": "DEBUG"
+              }
+          ]
+      }
     }
+  ]
+  // ...
 }
 ```
 
+## Log format and sampling
+
+By default, Seldon's service orchestrator and operator will serialise the log
+messages as JSON and will enable log sampling.
+This behaviour can be disabled by setting the `SELDON_DEBUG` variable to
+`true`.
+Note that this will **enable "debug mode"**, which can also have other side
+effects.
+
+For example, to change this on the service orchestrator, you would do:
+
+```jsonc
+"spec": {
+  // ...
+  "predictors": [
+    {
+      "svcOrchSpec": {
+          "env": [
+              {
+                  "name": "SELDON_DEBUG",
+                  "value": "true"
+              }
+          ]
+      }
+    }
+  ]
+  // ...
+}
+```

--- a/doc/source/analytics/log_level.md
+++ b/doc/source/analytics/log_level.md
@@ -1,21 +1,33 @@
-# Seldon Core Analytics
+# Logging and log level
 
 Seldon core metrics containers are able to provide different log levels. 
+By default the containers come out of the box with `WARNING` as default log
+level (or the equivalent less verbose settings).
 
-By default the containers come out of the box with WARNING as default log level.
+The verbosity level can be increased to also log `DEBUG` and `INFO` messages by
+following these instructions.
 
-This can be changed into DEBUG, INFO, WARNING and ERROR by following the following instructions.
+## Log level in Python Wrapper
 
-## Setting the environment variable
+.. Note:: 
+   Setting the ``SELDON_LOG_LEVEL`` to ``WARNING`` and above in the Python
+   wrapper will disable the server's access logs.
 
-### Setting log level in a Python Wrapper
+When using the [Python wrapper](../python) (including the
+[MLflow](../servers/mlflow), [SKLearn](../servers/sklearn) and
+[XGBoost](../servers/xgboost) pre-package servers), you can control the log
+level using the `SELDON_LOG_LEVEL` environment variable.
+This variable can be set to `DEBUG`, `INFO`, `WARNING` or `ERROR` to adjust the
+log level accordingly.
+Note that this has to be set in the **respective container** within your
+inference graph.
 
-The change can be done by setting the `SELDON_LOG_LEVEL` environment variable in the respective container.
+For example, to set it in each container running with the python wrapper, you
+would do it as follows by adding the environment variable `SELDON_LOG_LEVEL` to
+the containers running images wrapped by the python wrapper:
 
-For example, to set it in each container running with the python wrapper, you would do it as follows by adding the environment variable SELDON_LOG_LEVEL to the containers running images wrapped by the python wrapper:
-
-```
-...
+```jsonc
+// ...
 "spec": {
   "containers": [
       { 
@@ -30,24 +42,30 @@ For example, to set it in each container running with the python wrapper, you wo
       }
   ]
 }
-...
+// ...
 ```
 
 Once this has been set, it's possible to use the log in your wrapper code as follows:
 
-```
+```python
 import logging
 
 log = logging.getLogger()
-
 log.debug(...)
 ```
 
-### Setting log level in the Seldon Engine
+## Log level in the service orchestrator
 
-In order to set the log level in the SeldonEngine this can be done by providing the env option to the svcOrchSpec, as follows:
+.. Note:: 
+   When using the Go implementation, setting the ``SELDON_LOG_LEVEL`` to
+   ``WARNING`` and above in the service orchestrator will also change the
+   structure of the log messages, which will be logged as JSON, and will enable
+   log sampling.
 
-```
+In order to set the log level in the Seldon engine this can be done by
+providing the env option to the svcOrchSpec, as follows:
+
+```json
 "svcOrchSpec": {
     "env": [
         {
@@ -60,9 +78,9 @@ In order to set the log level in the SeldonEngine this can be done by providing 
 
 Here is a full example configuration file with a loglevel selection.
 
-```
+```json
 {    
-    "apiVersion": "machinelearning.seldon.io/v1alpha2",
+    "apiVersion": "machinelearning.seldon.io/v1",
     "kind": "SeldonDeployment",
     "metadata": {
         "labels": {
@@ -71,9 +89,6 @@ Here is a full example configuration file with a loglevel selection.
         "name": "seldon-model"
     },
     "spec": {
-        "name": "test-deployment",
-        "oauth_key": "oauth-key",
-        "oauth_secret": "oauth-secret",
         "predictors": [
             {
                 "componentSpecs": [
@@ -121,5 +136,4 @@ Here is a full example configuration file with a loglevel selection.
     }
 }
 ```
-
 

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jmx.enabled = false
 
 logging.file=
 logging.level.root=WARN
-logging.level.io.seldon=${SELDON_LOG_LEVEL:INFO}
+logging.level.io.seldon=${SELDON_LOG_LEVEL:WARN}
 
 #logging of raw requests in-engine
 log.requests=${SELDON_LOG_REQUESTS:false}

--- a/executor/api/grpc/tensorflow/client.go
+++ b/executor/api/grpc/tensorflow/client.go
@@ -66,10 +66,10 @@ func (s *TensorflowGrpcClient) getConnection(host string, port int32, modelName 
 func (s *TensorflowGrpcClient) Chain(ctx context.Context, modelName string, msg payload.SeldonPayload) (payload.SeldonPayload, error) {
 	switch v := msg.GetPayload().(type) {
 	case *serving.PredictRequest, *serving.ClassificationRequest, *serving.MultiInferenceRequest:
-		s.Log.Info("Identity chain")
+		s.Log.V(1).Info("Identity chain")
 		return msg, nil
 	case *serving.PredictResponse:
-		s.Log.Info("Chain!")
+		s.Log.V(1).Info("Chain!")
 		pr := serving.PredictRequest{
 			ModelSpec: &serving.ModelSpec{
 				Name: modelName,

--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -151,7 +151,7 @@ func (smc *JSONRestClient) addHeaders(req *http.Request, m map[string][]string) 
 }
 
 func (smc *JSONRestClient) doHttp(ctx context.Context, modelName string, method string, url *url.URL, msg []byte, meta map[string][]string, contentType string) ([]byte, string, error) {
-	smc.Log.Info("Calling HTTP", "URL", url)
+	smc.Log.V(1).Info("Calling HTTP", "URL", url)
 
 	var req *http.Request
 	var err error

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -256,7 +256,7 @@ func (r *SeldonRestApi) feedback(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *SeldonRestApi) predictions(w http.ResponseWriter, req *http.Request) {
-	r.Log.Info("Predictions called")
+	r.Log.V(1).Info("Predictions called")
 
 	ctx := req.Context()
 	// Add Seldon Puid to Context
@@ -307,7 +307,7 @@ func (r *SeldonRestApi) predictions(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *SeldonRestApi) graphMetadata(w http.ResponseWriter, req *http.Request) {
-	r.Log.Info("Graph Metadata called.")
+	r.Log.V(1).Info("Graph Metadata called.")
 
 	ctx := req.Context()
 

--- a/executor/api/util/utils.go
+++ b/executor/api/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 )
@@ -42,5 +43,17 @@ func GetEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}
+	return fallback
+}
+
+// Get an environment variable given by key or return the fallback.
+func GetEnvAsBool(key string, fallback bool) bool {
+	if raw, ok := os.LookupEnv(key); ok {
+		val, err := strconv.ParseBool(raw)
+		if err == nil {
+			return val
+		}
+	}
+
 	return fallback
 }

--- a/executor/api/util/utils_test.go
+++ b/executor/api/util/utils_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"os"
 	"testing"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -43,5 +44,58 @@ func TestExtractRouteFromSeldonMessage(t *testing.T) {
 		routes := ExtractRouteFromSeldonMessage(&sm)
 
 		g.Expect(routes).To(Equal(c.expected))
+	}
+}
+
+func TestGetEnvAsBool(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		raw      string
+		expected bool
+	}{
+		{
+			raw:      "true",
+			expected: true,
+		},
+		{
+			raw:      "TRUE",
+			expected: true,
+		},
+		{
+			raw:      "1",
+			expected: true,
+		},
+		{
+			raw:      "false",
+			expected: false,
+		},
+		{
+			raw:      "FALSE",
+			expected: false,
+		},
+		{
+			raw:      "0",
+			expected: false,
+		},
+		{
+			raw:      "foo",
+			expected: false,
+		},
+		{
+			raw:      "",
+			expected: false,
+		},
+		{
+			raw:      "345",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		os.Setenv("TEST_FOO", test.raw)
+		val := GetEnvAsBool("TEST_FOO", false)
+
+		g.Expect(val).To(Equal(test.expected))
 	}
 }

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/tensorflow/tensorflow/tensorflow/go/core v0.0.0-00010101000000-000000000000
 	github.com/uber/jaeger-client-go v2.24.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
+	go.uber.org/zap v1.10.0
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/grpc v1.30.0
 	gotest.tools v2.2.0+incompatible

--- a/executor/main.go
+++ b/executor/main.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	logLevelEnvVar  = "SELDON_LOG_LEVEL"
-	logLevelDefault = "WARNING"
+	logLevelDefault = "INFO"
 	debugEnvVar     = "SELDON_DEBUG"
 )
 
@@ -171,7 +171,7 @@ func runGrpcServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 }
 
 func setupLogger(debug bool) {
-	level := zap.WarnLevel
+	level := zap.InfoLevel
 	switch *logLevel {
 	case "DEBUG":
 		level = zap.DebugLevel

--- a/executor/main.go
+++ b/executor/main.go
@@ -46,6 +46,7 @@ var (
 	hostname       = flag.String("hostname", "localhost", "The hostname of the running server")
 	logWorkers     = flag.Int("logger_workers", 5, "Number of workers handling payload logging")
 	prometheusPath = flag.String("prometheus_path", "/metrics", "The prometheus metrics path")
+	debug          = flag.Bool("debug", false, "Enable debug mode. Logs will be more verbose, and not structured.")
 )
 
 func getPredictorFromEnv() (*v1.PredictorSpec, error) {
@@ -173,7 +174,7 @@ func main() {
 		log.Fatal("Failed to create server url from", *hostname, *port)
 	}
 
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(logf.ZapLogger(*debug))
 	logger := logf.Log.WithName("entrypoint")
 
 	var predictor *v1.PredictorSpec

--- a/executor/main.go
+++ b/executor/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/grpc/tensorflow"
 	"github.com/seldonio/seldon-core/executor/api/rest"
 	"github.com/seldonio/seldon-core/executor/api/tracing"
+	"github.com/seldonio/seldon-core/executor/api/util"
 	"github.com/seldonio/seldon-core/executor/k8s"
 	loghandler "github.com/seldonio/seldon-core/executor/logger"
 	"github.com/seldonio/seldon-core/executor/proto/tensorflow/serving"
@@ -34,7 +35,15 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
+const (
+	logLevelEnvVar  = "SELDON_LOG_LEVEL"
+	logLevelDefault = "WARNING"
+	debugEnvVar     = "SELDON_DEBUG"
+)
+
 var (
+	debugDefault = false
+
 	configPath     = flag.String("config", "", "Path to kubconfig")
 	sdepName       = flag.String("sdep", "", "Seldon deployment name")
 	namespace      = flag.String("namespace", "", "Namespace")
@@ -46,7 +55,16 @@ var (
 	hostname       = flag.String("hostname", "localhost", "The hostname of the running server")
 	logWorkers     = flag.Int("logger_workers", 5, "Number of workers handling payload logging")
 	prometheusPath = flag.String("prometheus_path", "/metrics", "The prometheus metrics path")
-	debug          = flag.Bool("debug", false, "Enable debug mode. Logs will be more verbose, and not structured.")
+	debug          = flag.Bool(
+		"debug",
+		util.GetEnvAsBool(debugEnvVar, debugDefault),
+		"Enable debug mode. Logs will be sampled and less structured.",
+	)
+	logLevel = flag.String(
+		"log_level",
+		util.GetEnv(logLevelEnvVar, logLevelDefault),
+		"Log level.",
+	)
 )
 
 func getPredictorFromEnv() (*v1.PredictorSpec, error) {

--- a/executor/main.go
+++ b/executor/main.go
@@ -150,6 +150,20 @@ func runGrpcServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 	}
 }
 
+func setupLogger(debug bool) {
+	// NOTE: The Go logger doesn't use `DEBUG`, `WARNING`, etc.  but we can mimic
+	// it to maintain compatibility.
+	logLevel := os.Getenv("SELDON_LOG_LEVEL")
+
+	if logLevel == "DEBUG" || logLevel == "INFO" {
+		debug = true
+	} else if logLevel == "WARN" || logLevel == "WARNING" || logLevel == "ERROR" {
+		debug = false
+	}
+
+	logf.SetLogger(logf.ZapLogger(debug))
+}
+
 func main() {
 	flag.Parse()
 
@@ -174,7 +188,7 @@ func main() {
 		log.Fatal("Failed to create server url from", *hostname, *port)
 	}
 
-	logf.SetLogger(logf.ZapLogger(*debug))
+	setupLogger(*debug)
 	logger := logf.Log.WithName("entrypoint")
 
 	var predictor *v1.PredictorSpec

--- a/executor/main.go
+++ b/executor/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/url"
 	"os"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
-	"github.com/prometheus/common/log"
 	"github.com/seldonio/seldon-core/executor/api"
 	seldonclient "github.com/seldonio/seldon-core/executor/api/client"
 	"github.com/seldonio/seldon-core/executor/api/grpc"
@@ -133,7 +133,7 @@ func runHttpServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 func runGrpcServer(lis net.Listener, logger logr.Logger, predictor *v1.PredictorSpec, client seldonclient.SeldonApiClient, port int, serverUrl *url.URL, namespace string, protocol string, deploymentName string, annotations map[string]string) {
 	grpcServer, err := grpc.CreateGrpcServer(predictor, deploymentName, annotations, logger)
 	if err != nil {
-		log.Fatalf("Failed to create grpc server: %v", err)
+		log.Fatalf("Failed to create gRPC server: %v", err)
 	}
 	if protocol == api.ProtocolSeldon {
 		seldonGrpcServer := seldon.NewGrpcSeldonServer(predictor, client, serverUrl, namespace)
@@ -145,7 +145,7 @@ func runGrpcServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 	}
 	err = grpcServer.Serve(lis)
 	if err != nil {
-		log.Errorf("Grpc server error: %v", err)
+		logger.Error(err, "gRPC server error")
 	}
 }
 
@@ -204,12 +204,12 @@ func main() {
 	// Ensure standard OpenAPI seldon API file has this deployment's values
 	err = rest.EmbedSeldonDeploymentValuesInSwaggerFile(*namespace, *sdepName)
 	if err != nil {
-		log.Error(err, "Failed to embed variables on OpenAPI template")
+		logger.Error(err, "Failed to embed variables on OpenAPI template")
 	}
 
 	annotations, err := k8s.GetAnnotations()
 	if err != nil {
-		log.Error(err, "Failed to load annotations")
+		logger.Error(err, "Failed to load annotations")
 	}
 
 	//Start Logger Dispacther

--- a/executor/main.go
+++ b/executor/main.go
@@ -170,7 +170,7 @@ func runGrpcServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 	}
 }
 
-func setupLogger(debug bool) {
+func setupLogger() {
 	level := zap.InfoLevel
 	switch *logLevel {
 	case "DEBUG":
@@ -189,7 +189,7 @@ func setupLogger(debug bool) {
 	atomicLevel := zap.NewAtomicLevelAt(level)
 
 	logger := zapf.New(
-		zapf.UseDevMode(debug),
+		zapf.UseDevMode(*debug),
 		zapf.Level(&atomicLevel),
 	)
 
@@ -220,7 +220,7 @@ func main() {
 		log.Fatal("Failed to create server url from", *hostname, *port)
 	}
 
-	setupLogger(*debug)
+	setupLogger()
 	logger := logf.Log.WithName("entrypoint")
 
 	var predictor *v1.PredictorSpec

--- a/operator/controllers/ambassador.go
+++ b/operator/controllers/ambassador.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/seldonio/seldon-core/operator/constants"
+	"github.com/seldonio/seldon-core/operator/utils"
 
 	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"gopkg.in/yaml.v2"
@@ -371,19 +372,19 @@ func getAmbassadorConfigs(mlDep *machinelearningv1.SeldonDeployment, p *machinel
 
 		// Return the appropriate set of config based on whether http and/or grpc is active
 		if engine_http_port > 0 && engine_grpc_port > 0 {
-			if GetEnv("AMBASSADOR_SINGLE_NAMESPACE", "false") == "true" {
+			if utils.GetEnv("AMBASSADOR_SINGLE_NAMESPACE", "false") == "true" {
 				return YAML_SEP + cRestGlobal + YAML_SEP + cGrpcGlobal + YAML_SEP + cRestNamespaced + YAML_SEP + cGrpcNamespaced, nil
 			} else {
 				return YAML_SEP + cRestGlobal + YAML_SEP + cGrpcGlobal, nil
 			}
 		} else if engine_http_port > 0 {
-			if GetEnv("AMBASSADOR_SINGLE_NAMESPACE", "false") == "true" {
+			if utils.GetEnv("AMBASSADOR_SINGLE_NAMESPACE", "false") == "true" {
 				return YAML_SEP + cRestGlobal + YAML_SEP + cRestNamespaced, nil
 			} else {
 				return YAML_SEP + cRestGlobal, nil
 			}
 		} else if engine_grpc_port > 0 {
-			if GetEnv("AMBASSADOR_SINGLE_NAMESPACE", "false") == "true" {
+			if utils.GetEnv("AMBASSADOR_SINGLE_NAMESPACE", "false") == "true" {
 				return YAML_SEP + cGrpcGlobal + YAML_SEP + cGrpcNamespaced, nil
 			} else {
 				return YAML_SEP + cGrpcGlobal, nil

--- a/operator/controllers/controller_utils.go
+++ b/operator/controllers/controller_utils.go
@@ -39,14 +39,6 @@ func getEngineVarJson(p *machinelearningv1.PredictorSpec) (string, error) {
 	return base64.StdEncoding.EncodeToString(str), nil
 }
 
-// Get an environment variable given by key or return the fallback.
-func GetEnv(key, fallback string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
-	}
-	return fallback
-}
-
 // Get an annotation from the Seldon Deployment given by annotationKey or return the fallback.
 func getAnnotation(mlDep *machinelearningv1.SeldonDeployment, annotationKey string, fallback string) string {
 	if annotation, hasAnnotation := mlDep.Spec.Annotations[annotationKey]; hasAnnotation {

--- a/operator/controllers/controller_utils.go
+++ b/operator/controllers/controller_utils.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"encoding/base64"
 	"encoding/json"
-	"os"
 	"sort"
 	"strings"
 

--- a/operator/controllers/model_initializer_injector.go
+++ b/operator/controllers/model_initializer_injector.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	ControllerNamespace        = GetEnv("POD_NAMESPACE", "seldon-system")
+	ControllerNamespace        = utils.GetEnv("POD_NAMESPACE", "seldon-system")
 	ControllerConfigMapName    = "seldon-config"
 	envStorageInitializerImage = os.Getenv(EnvStorageInitializerImageRelated)
 )

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -144,8 +144,8 @@ func createIstioResources(mlDep *machinelearningv1.SeldonDeployment,
 	httpAllowed bool,
 	grpcAllowed bool) ([]*istio.VirtualService, []*istio.DestinationRule, error) {
 
-	istio_gateway := GetEnv(ENV_ISTIO_GATEWAY, "seldon-gateway")
-	istioTLSMode := GetEnv(ENV_ISTIO_TLS_MODE, "")
+	istio_gateway := utils.GetEnv(ENV_ISTIO_GATEWAY, "seldon-gateway")
+	istioTLSMode := utils.GetEnv(ENV_ISTIO_TLS_MODE, "")
 	istioRetriesAnnotation := getAnnotation(mlDep, ANNOTATION_ISTIO_RETRIES, "")
 	istioRetriesTimeoutAnnotation := getAnnotation(mlDep, ANNOTATION_ISTIO_RETRIES_TIMEOUT, "1")
 	istioRetries := 0
@@ -328,7 +328,7 @@ func createIstioResources(mlDep *machinelearningv1.SeldonDeployment,
 func getEngineHttpPort() (engine_http_port int, err error) {
 	// Get engine http port from environment or use default
 	engine_http_port = DEFAULT_ENGINE_CONTAINER_PORT
-	var env_engine_http_port = GetEnv(ENV_DEFAULT_ENGINE_SERVER_PORT, "")
+	var env_engine_http_port = utils.GetEnv(ENV_DEFAULT_ENGINE_SERVER_PORT, "")
 	if env_engine_http_port != "" {
 		engine_http_port, err = strconv.Atoi(env_engine_http_port)
 		if err != nil {
@@ -341,7 +341,7 @@ func getEngineHttpPort() (engine_http_port int, err error) {
 func getEngineGrpcPort() (engine_grpc_port int, err error) {
 	// Get engine grpc port from environment or use default
 	engine_grpc_port = DEFAULT_ENGINE_GRPC_PORT
-	var env_engine_grpc_port = GetEnv(ENV_DEFAULT_ENGINE_SERVER_GRPC_PORT, "")
+	var env_engine_grpc_port = utils.GetEnv(ENV_DEFAULT_ENGINE_SERVER_GRPC_PORT, "")
 	if env_engine_grpc_port != "" {
 		engine_grpc_port, err = strconv.Atoi(env_engine_grpc_port)
 		if err != nil {
@@ -592,7 +592,7 @@ func (r *SeldonDeploymentReconciler) createComponents(mlDep *machinelearningv1.S
 	}
 
 	//TODO Fixme - not changed to handle per predictor scenario
-	if GetEnv(ENV_ISTIO_ENABLED, "false") == "true" {
+	if utils.GetEnv(ENV_ISTIO_ENABLED, "false") == "true" {
 		vsvcs, dstRule, err := createIstioResources(mlDep, seldonId, namespace, externalPorts, httpAllowed, grpcAllowed)
 		if err != nil {
 			return nil, err
@@ -644,7 +644,7 @@ func createPredictorService(pSvcName string, seldonId string, p *machinelearning
 		}
 	}
 
-	if GetEnv("AMBASSADOR_ENABLED", "false") == "true" {
+	if utils.GetEnv("AMBASSADOR_ENABLED", "false") == "true" {
 		psvc.Annotations = make(map[string]string)
 		//Create top level Service
 		ambassadorConfig, err := getAmbassadorConfigs(mlDep, p, pSvcName, engine_http_port, engine_grpc_port, isExplainer)
@@ -778,7 +778,7 @@ func createContainerService(deploy *appsv1.Deployment,
 	}...)
 
 	//Add Metric Env Var
-	predictiveUnitMetricsPortName := GetEnv(machinelearningv1.ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
+	predictiveUnitMetricsPortName := utils.GetEnv(machinelearningv1.ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
 	metricPort := getPort(predictiveUnitMetricsPortName, con.Ports)
 	if metricPort != nil {
 		con.Env = append(con.Env, []corev1.EnvVar{
@@ -1434,7 +1434,7 @@ func (r *SeldonDeploymentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	}
 
 	// Check we should reconcile this by matching controller-id
-	controllerId := GetEnv(ENV_CONTROLLER_ID, "")
+	controllerId := utils.GetEnv(ENV_CONTROLLER_ID, "")
 	desiredControllerId := instance.Labels[LABEL_CONTROLLER_ID]
 	if desiredControllerId != controllerId {
 		log.Info("Skipping reconcile of deployment.", "Our controller ID form Env", controllerId, " desired controller ID from label", desiredControllerId)
@@ -1588,7 +1588,7 @@ func (r *SeldonDeploymentReconciler) SetupWithManager(mgr ctrl.Manager, name str
 		return err
 	}
 
-	if GetEnv(ENV_ISTIO_ENABLED, "false") == "true" {
+	if utils.GetEnv(ENV_ISTIO_ENABLED, "false") == "true" {
 		if err := mgr.GetFieldIndexer().IndexField(&istio.VirtualService{}, ownerKey, func(rawObj runtime.Object) []string {
 			// grab the deployment object, extract the owner...
 			vsvc := rawObj.(*istio.VirtualService)

--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -24,6 +24,7 @@ import (
 
 	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"github.com/seldonio/seldon-core/operator/constants"
+	"github.com/seldonio/seldon-core/operator/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -58,7 +59,7 @@ var (
 	envExecutorUser         = os.Getenv(ENV_EXECUTOR_USER)
 	envUseExecutor          = os.Getenv(ENV_USE_EXECUTOR)
 
-	executorMetricsPortName = GetEnv(ENV_EXECUTOR_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
+	executorMetricsPortName = utils.GetEnv(ENV_EXECUTOR_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
 )
 
 func addEngineToDeployment(mlDep *machinelearningv1.SeldonDeployment, p *machinelearningv1.PredictorSpec, engine_http_port int, engine_grpc_port int, pSvcName string, deploy *appsv1.Deployment) error {
@@ -123,7 +124,7 @@ func addEngineToDeployment(mlDep *machinelearningv1.SeldonDeployment, p *machine
 func getExecutorHttpPort() (engine_http_port int, err error) {
 	// Get engine http port from environment or use default
 	engine_http_port = DEFAULT_EXECUTOR_CONTAINER_PORT
-	var env_engine_http_port = GetEnv(ENV_DEFAULT_EXECUTOR_SERVER_PORT, "")
+	var env_engine_http_port = utils.GetEnv(ENV_DEFAULT_EXECUTOR_SERVER_PORT, "")
 	if env_engine_http_port != "" {
 		engine_http_port, err = strconv.Atoi(env_engine_http_port)
 		if err != nil {
@@ -142,9 +143,9 @@ func isExecutorEnabled(mlDep *machinelearningv1.SeldonDeployment) bool {
 func getPrometheusPath(mlDep *machinelearningv1.SeldonDeployment) string {
 	prometheusPath := "/prometheus"
 	if isExecutorEnabled(mlDep) {
-		prometheusPath = GetEnv(ENV_EXECUTOR_PROMETHEUS_PATH, prometheusPath)
+		prometheusPath = utils.GetEnv(ENV_EXECUTOR_PROMETHEUS_PATH, prometheusPath)
 	} else {
-		prometheusPath = GetEnv(ENV_ENGINE_PROMETHEUS_PATH, prometheusPath)
+		prometheusPath = utils.GetEnv(ENV_ENGINE_PROMETHEUS_PATH, prometheusPath)
 	}
 	return prometheusPath
 }
@@ -216,7 +217,7 @@ func createExecutorContainer(mlDep *machinelearningv1.SeldonDeployment, p *machi
 			"--protocol", string(protocol),
 			"--prometheus_path", getPrometheusPath(mlDep),
 		},
-		ImagePullPolicy:          corev1.PullPolicy(GetEnv("EXECUTOR_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")),
+		ImagePullPolicy:          corev1.PullPolicy(utils.GetEnv("EXECUTOR_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")),
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		VolumeMounts: []corev1.VolumeMount{
@@ -227,7 +228,7 @@ func createExecutorContainer(mlDep *machinelearningv1.SeldonDeployment, p *machi
 		},
 		Env: []corev1.EnvVar{
 			{Name: "ENGINE_PREDICTOR", Value: predictorB64},
-			{Name: "REQUEST_LOGGER_DEFAULT_ENDPOINT", Value: GetEnv("EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT", "http://default-broker")},
+			{Name: "REQUEST_LOGGER_DEFAULT_ENDPOINT", Value: utils.GetEnv("EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT", "http://default-broker")},
 		},
 		Ports: []corev1.ContainerPort{
 			{ContainerPort: int32(port), Protocol: corev1.ProtocolTCP},
@@ -262,7 +263,7 @@ func createEngineContainerSpec(mlDep *machinelearningv1.SeldonDeployment, p *mac
 	return &corev1.Container{
 		Name:                     EngineContainerName,
 		Image:                    engineImage,
-		ImagePullPolicy:          corev1.PullPolicy(GetEnv("ENGINE_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")),
+		ImagePullPolicy:          corev1.PullPolicy(utils.GetEnv("ENGINE_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")),
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		VolumeMounts: []corev1.VolumeMount{
@@ -383,7 +384,7 @@ func createEngineContainer(mlDep *machinelearningv1.SeldonDeployment, p *machine
 	if _, ok := svcOrchEnvMap["SELDON_LOG_MESSAGES_EXTERNALLY"]; ok {
 		//this env var is set already so no need to set a default
 	} else {
-		c.Env = append(c.Env, corev1.EnvVar{Name: "SELDON_LOG_MESSAGES_EXTERNALLY", Value: GetEnv("ENGINE_LOG_MESSAGES_EXTERNALLY", "false")})
+		c.Env = append(c.Env, corev1.EnvVar{Name: "SELDON_LOG_MESSAGES_EXTERNALLY", Value: utils.GetEnv("ENGINE_LOG_MESSAGES_EXTERNALLY", "false")})
 	}
 	return c, nil
 }

--- a/operator/controllers/seldondeployment_explainers.go
+++ b/operator/controllers/seldondeployment_explainers.go
@@ -235,7 +235,7 @@ func (ei *ExplainerInitialiser) createExplainer(mlDep *machinelearningv1.SeldonD
 		if grpcPort > 0 {
 			c.serviceDetails[eSvcName].GrpcEndpoint = eSvcName + "." + eSvc.Namespace + ":" + strconv.Itoa(grpcPort)
 		}
-		if GetEnv(ENV_ISTIO_ENABLED, "false") == "true" {
+		if utils.GetEnv(ENV_ISTIO_ENABLED, "false") == "true" {
 			vsvcs, dstRule := createExplainerIstioResources(eSvcName, p, mlDep, seldonId, getNamespace(mlDep), httpPort, grpcPort)
 			c.virtualServices = append(c.virtualServices, vsvcs...)
 			c.destinationRules = append(c.destinationRules, dstRule...)
@@ -266,7 +266,7 @@ func createExplainerIstioResources(pSvcName string, p *machinelearningv1.Predict
 		vsNameGrpc = strings.TrimSuffix(vsNameGrpc, "-")
 	}
 
-	istio_gateway := GetEnv(ENV_ISTIO_GATEWAY, "seldon-gateway")
+	istio_gateway := utils.GetEnv(ENV_ISTIO_GATEWAY, "seldon-gateway")
 	httpVsvc := &istio.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vsNameHttp,

--- a/operator/controllers/seldondeployment_prepackaged_servers.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers.go
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	PredictiveUnitDefaultEnvSecretRefName = GetEnv(ENV_PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME, "")
+	PredictiveUnitDefaultEnvSecretRefName = utils.GetEnv(ENV_PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME, "")
 )
 
 type PrePackedInitialiser struct {

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/google/go-cmp v0.5.0
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	gopkg.in/yaml.v2 v2.3.0
 	go.uber.org/zap v1.10.0
+	gopkg.in/yaml.v2 v2.3.0
 	istio.io/api v0.0.0-20191115173247-e1a1952e5b81
 	istio.io/client-go v0.0.0-20191120150049-26c62a04cdbc
 	k8s.io/api v0.17.8

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	gopkg.in/yaml.v2 v2.3.0
+	go.uber.org/zap v1.10.0
 	istio.io/api v0.0.0-20191115173247-e1a1952e5b81
 	istio.io/client-go v0.0.0-20191120150049-26c62a04cdbc
 	k8s.io/api v0.17.8

--- a/operator/main.go
+++ b/operator/main.go
@@ -67,6 +67,7 @@ func main() {
 	var namespace string
 	var operatorNamespace string
 	var createResources bool
+	var debug bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
@@ -74,9 +75,10 @@ func main() {
 	flag.StringVar(&namespace, "namespace", "", "The namespace to restrict the operator.")
 	flag.StringVar(&operatorNamespace, "operator-namespace", "default", "The namespace of the running operator")
 	flag.BoolVar(&createResources, "create-resources", false, "Create resources such as webhooks and configmaps on startup")
+	flag.BoolVar(&debug, "debug", false, "Enable debug mode. Logs will be more verbose, and not structured.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.Logger(true))
+	ctrl.SetLogger(zap.Logger(debug))
 
 	config := ctrl.GetConfigOrDie()
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -60,6 +60,20 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+func setupLogger(debug bool) {
+	// NOTE: The Go logger doesn't use `DEBUG`, `WARNING`, etc.  but we can mimic
+	// it to maintain compatibility.
+	logLevel := os.Getenv("SELDON_LOG_LEVEL")
+
+	if logLevel == "DEBUG" || logLevel == "INFO" {
+		debug = true
+	} else if logLevel == "WARN" || logLevel == "WARNING" || logLevel == "ERROR" {
+		debug = false
+	}
+
+	ctrl.SetLogger(zap.Logger(debug))
+}
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -68,6 +82,7 @@ func main() {
 	var operatorNamespace string
 	var createResources bool
 	var debug bool
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
@@ -78,7 +93,7 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "Enable debug mode. Logs will be more verbose, and not structured.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.Logger(debug))
+	setupLogger(debug)
 
 	config := ctrl.GetConfigOrDie()
 

--- a/operator/utils/utils.go
+++ b/operator/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"encoding/json"
+	"os"
+	"strconv"
 	"strings"
 
 	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
@@ -81,4 +83,24 @@ func SetEnvVar(envVars []v1.EnvVar, newVar v1.EnvVar) (newEnvVars []v1.EnvVar) {
 		newEnvVars = append(newEnvVars, newVar)
 	}
 	return newEnvVars
+}
+
+// Get an environment variable given by key or return the fallback.
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+// Get an environment variable given by key or return the fallback.
+func GetEnvAsBool(key string, fallback bool) bool {
+	if raw, ok := os.LookupEnv(key); ok {
+		val, err := strconv.ParseBool(raw)
+		if err == nil {
+			return val
+		}
+	}
+
+	return fallback
 }

--- a/operator/utils/utils_test.go
+++ b/operator/utils/utils_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetEnvAsBool(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		raw      string
+		expected bool
+	}{
+		{
+			raw:      "true",
+			expected: true,
+		},
+		{
+			raw:      "TRUE",
+			expected: true,
+		},
+		{
+			raw:      "1",
+			expected: true,
+		},
+		{
+			raw:      "false",
+			expected: false,
+		},
+		{
+			raw:      "FALSE",
+			expected: false,
+		},
+		{
+			raw:      "0",
+			expected: false,
+		},
+		{
+			raw:      "foo",
+			expected: false,
+		},
+		{
+			raw:      "",
+			expected: false,
+		},
+		{
+			raw:      "345",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		os.Setenv("TEST_FOO", test.raw)
+		val := GetEnvAsBool("TEST_FOO", false)
+
+		g.Expect(val).To(Equal(test.expected))
+	}
+}

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -197,7 +197,11 @@ def main():
         "--parameters", type=str, default=os.environ.get(PARAMETERS_ENV_NAME, "[]")
     )
     parser.add_argument(
-        "--log-level", type=str, default=os.environ.get(LOG_LEVEL_ENV, "INFO")
+        "--log-level",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="WARNING",
+        help="Log level of the inference server",
     )
     parser.add_argument(
         "--debug",

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -29,6 +29,8 @@ SERVICE_PORT_ENV_NAME = "PREDICTIVE_UNIT_SERVICE_PORT"
 METRICS_SERVICE_PORT_ENV_NAME = "PREDICTIVE_UNIT_METRICS_SERVICE_PORT"
 
 LOG_LEVEL_ENV = "SELDON_LOG_LEVEL"
+DEFAULT_LOG_LEVEL = "INFO"
+
 DEFAULT_PORT = 5000
 DEFAULT_METRICS_PORT = 6000
 
@@ -224,7 +226,7 @@ def main():
         "--log-level",
         type=str,
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="WARNING",
+        default=DEFAULT_LOG_LEVEL,
         help="Log level of the inference server",
     )
     parser.add_argument(

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -227,7 +227,7 @@ def main():
         type=str,
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default=DEFAULT_LOG_LEVEL,
-        help="Log level of the inference server",
+        help="Log level of the inference server.",
     )
     parser.add_argument(
         "--debug",


### PR DESCRIPTION
Fixes #1737 

## Changelog

- Use `WARNING` (or equivalent) as default on Python wrapper, engine, operator and executor.
- Move some logs on operator and executor to `V(1)` (which is equivalent to `DEBUG`)
- Add `--debug` flag and read `SELDON_LOG_LEVEL` to operator and executor
- Update docs on log levels

## Notes

The `executor` and `operator` use [Kubernetes' convention for logging](https://github.com/kubernetes-sigs/controller-runtime/blob/master/TMP-LOGGING.md), which moves away from the usual `WARNING`, `DEBUG`, etc. into arbitrary verbosity levels (identified as integers).

Following their guidelines, we will treat level `1` as `DEBUG` and `0` as important information.

## TODO

- [ ] Allow to change log level in `seldon-core-operator` chart (can be left to a future PR)