### PR TITLE
Update requirements.txt and readme file for KerasSpamClassifier

### DIFF
--- a/examples/combiners/spam_clf_combiner/keras-spam-classifier/README.md
+++ b/examples/combiners/spam_clf_combiner/keras-spam-classifier/README.md
@@ -21,7 +21,7 @@ Create a Python virtual environment:
 #### Build
 
 ```
-$ s2i build . seldonio/seldon-core-s2i-python3:0.7 keras-spam-classifier:1.0.0.1
+$ s2i build . seldonio/seldon-core-s2i-python3:1.2.0 keras-spam-classifier:1.0.0.1
 $ docker push <yourdockerhubusername>/keras-spam-classifier:1.0.0.1
 ```
 

--- a/examples/combiners/spam_clf_combiner/keras-spam-classifier/requirements.txt
+++ b/examples/combiners/spam_clf_combiner/keras-spam-classifier/requirements.txt
@@ -1,3 +1,4 @@
+TensorFlow>=2.2.0
 scikit-learn==0.21.2
 numpy>=1.9.2
 keras


### PR DESCRIPTION
Add requirement of Tensorflow 2.2 or higher since keras
requires it.
s2i image should use a newer image than 0.7 since
the current image 'seldonio/seldon-core-s2i-python3:0.7'
does not support Tensorflow version 2.2