### PR TITLE
Fix for ensuring old clusterwide webhook is deleted

### DIFF
--- a/executor/go.sum
+++ b/executor/go.sum
@@ -380,6 +380,7 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0 h1:ElTg5tNp4DqfV7UQjDqv2+RJlNzsDtvNAWccbItceIE=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e h1:n/3MEhJQjQxrOUCzh1Y3Re6aJUUWRp2M9+Oc3eVn/54=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -661,6 +662,7 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/helm-charts/seldon-core-operator/templates/clusterrole_seldon-webhook-role.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrole_seldon-webhook-role.yaml
@@ -19,6 +19,7 @@ rules:
   - get
   - list
   - create
+  - delete
   - update
 - apiGroups:
   - apps

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -115,8 +115,6 @@ spec:
           value: '{{ .Values.executor.image.pullPolicy }}'
         - name: EXECUTOR_PROMETHEUS_PATH
           value: '{{ .Values.executor.prometheus.path }}'
-        - name: EXECUTOR_SERVER_GRPC_PORT
-          value: '{{ .Values.engine.grpc.port }}'
         - name: EXECUTOR_SERVER_PORT
           value: '{{ .Values.executor.port }}'
         - name: EXECUTOR_CONTAINER_USER

--- a/operator/config/lite/role_webhook.yaml
+++ b/operator/config/lite/role_webhook.yaml
@@ -13,6 +13,7 @@ rules:
   - get
   - list
   - create
+  - delete
   - update
 - apiGroups:
   - apps

--- a/operator/seldon-operator/Makefile
+++ b/operator/seldon-operator/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 VERSION ?= $(shell cat ../../version.txt)
-PREV_VERSION=1.1.0
+PREV_VERSION=1.2.0
 COMMUNITY_OPERATORS_BASE=/home/clive/work/seldon-core/redhat/community-operators
 
 .PHONY: recreate-generated

--- a/operator/seldon-operator/deploy/cluster_role.yaml
+++ b/operator/seldon-operator/deploy/cluster_role.yaml
@@ -42,6 +42,7 @@ rules:
   - get
   - list
   - create
+  - delete
   - update
 - apiGroups:
   - apps

--- a/operator/seldon-operator/deploy/operator.yaml
+++ b/operator/seldon-operator/deploy/operator.yaml
@@ -78,7 +78,7 @@ spec:
         - name: AMBASSADOR_SINGLE_NAMESPACE
           value: 'false'
         - name: ENGINE_CONTAINER_IMAGE_AND_VERSION
-          value: docker.io/seldonio/engine:1.2.0
+          value: docker.io/seldonio/engine:1.2.1-dev
         - name: ENGINE_CONTAINER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
@@ -108,7 +108,7 @@ spec:
         - name: USE_EXECUTOR
           value: 'true'
         - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
-          value: seldonio/seldon-core-executor:1.2.0
+          value: seldonio/seldon-core-executor:1.2.1-dev
         - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
           value: IfNotPresent
         - name: EXECUTOR_PROMETHEUS_PATH
@@ -125,7 +125,7 @@ spec:
           value: http://default-broker
         - name: DEFAULT_USER_ID
           value: ''
-        image: seldonio/seldon-core-operator:1.2.0
+        image: seldonio/seldon-core-operator:1.2.1-dev
         name: manager
         ports:
         - containerPort: 8443

--- a/operator/seldon-operator/deploy/role.yaml
+++ b/operator/seldon-operator/deploy/role.yaml
@@ -42,6 +42,7 @@ rules:
   - get
   - list
   - create
+  - delete
   - update
 - apiGroups:
   - apps

--- a/operator/seldon-operator/testing/k8s/README.md
+++ b/operator/seldon-operator/testing/k8s/README.md
@@ -4,3 +4,4 @@ Follow https://github.com/operator-framework/community-operators/blob/master/doc
 
 Using resource in this folder.
 
+We set `startingCSV` to allow us to test auto upgrades by OLM. It should cycle through all operators from 1.1.0 onwards.

--- a/operator/seldon-operator/testing/k8s/operator-subscription.yaml
+++ b/operator/seldon-operator/testing/k8s/operator-subscription.yaml
@@ -8,3 +8,4 @@ spec:
   name: seldon-operator
   source: seldon-operators
   sourceNamespace: marketplace
+  startingCSV: seldon-operator.v1.1.0

--- a/operator/utils/k8s/webhook.go
+++ b/operator/utils/k8s/webhook.go
@@ -66,7 +66,21 @@ func (wc *WebhookCreator) CreateMutatingWebhookConfigurationFromFile(rawYaml []b
 		return err
 	}
 
+	// create or update via client
+	client := wc.clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
+
 	if watchNamespace {
+		// Try to delete clusterwide webhook config if available
+		_, err := client.Get(mwc.Name, v1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			wc.logger.Info("existing clusterwide mwc not found", "name", mwc.Name)
+		} else {
+			client.Delete(mwc.Name, &v1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+			wc.logger.Info("Deleted clusterwide mwc", "name", mwc.Name)
+		}
 		mwc.Name = mwc.Name + "-" + namespace
 	}
 
@@ -94,9 +108,6 @@ func (wc *WebhookCreator) CreateMutatingWebhookConfigurationFromFile(rawYaml []b
 		return err
 	}
 
-	// create or update via client
-	client := wc.clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
-
 	found, err := client.Get(mwc.Name, v1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		wc.logger.Info("Creating mutating webhook")
@@ -117,7 +128,21 @@ func (wc *WebhookCreator) CreateValidatingWebhookConfigurationFromFile(rawYaml [
 		return err
 	}
 
+	// create or update via client
+	client := wc.clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
+
 	if watchNamespace {
+		// Try to delete clusterwide webhook config if available
+		_, err := client.Get(vwc.Name, v1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			wc.logger.Info("existing clusterwide vwc not found", "name", vwc.Name)
+		} else {
+			client.Delete(vwc.Name, &v1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+			wc.logger.Info("Deleted clusterwide vwc", "name", vwc.Name)
+		}
 		vwc.Name = vwc.Name + "-" + namespace
 	}
 
@@ -139,9 +164,6 @@ func (wc *WebhookCreator) CreateValidatingWebhookConfigurationFromFile(rawYaml [
 	if err != nil {
 		return err
 	}
-
-	// create or update via client
-	client := wc.clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 
 	found, err := client.Get(vwc.Name, v1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {


### PR DESCRIPTION
Fixes #2009 

 * Delete the webhook clusterwide configurations if they exist when installing by namespace
