### PR TITLE
Allow predictor replica changes to not cause rolling update

### DIFF
--- a/executor/go.sum
+++ b/executor/go.sum
@@ -380,6 +380,7 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0 h1:ElTg5tNp4DqfV7UQjDqv2+RJlNzsDtvNAWccbItceIE=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e h1:n/3MEhJQjQxrOUCzh1Y3Re6aJUUWRp2M9+Oc3eVn/54=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -661,6 +662,7 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/notebooks/resources/.gitignore
+++ b/notebooks/resources/.gitignore
@@ -1,0 +1,6 @@
+fixed_v1_2predictors.yaml
+fixed_v1_rep.yaml
+fixed_v1_rep2.yaml
+fixed_v1_rep4.yaml
+fixed_v2_2predictors.yaml
+fixed_v2_rep.yaml

--- a/notebooks/rolling_updates.ipynb
+++ b/notebooks/rolling_updates.ipynb
@@ -150,9 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "Now we can modify the model by providing a new image name, using the following config file:"
    ]
@@ -239,9 +237,239 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Change Replicas (no rolling update)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll want to try modifying number of replicas and no rolling update is needed.\n",
+    "\n",
+    "We'll first create the following model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile resources/fixed_v1_rep2.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  name: fixed\n",
+    "spec:\n",
+    "  name: fixed\n",
+    "  protocol: seldon\n",
+    "  transport: rest\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier\n",
+    "    graph:\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: default\n",
+    "    replicas: 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can run that model and wait until it's released"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl apply -f resources/fixed_v1_rep2.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl rollout status deploy/$(kubectl get deploy -l seldon-deployment-id=fixed \\\n",
+    "                                 -o jsonpath='{.items[0].metadata.name}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's confirm that the state of the model is Available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(60):\n",
+    "    state=!kubectl get sdep fixed -o jsonpath='{.status.state}'\n",
+    "    state=state[0]\n",
+    "    print(state)\n",
+    "    if state==\"Available\":\n",
+    "        break\n",
+    "    time.sleep(1)\n",
+    "assert(state==\"Available\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0]]}}' \\\n",
+    "   -X POST http://localhost:8003/seldon/seldon/fixed/api/v1.0/predictions \\\n",
+    "   -H \"Content-Type: application/json\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can modify the model by providing a new image name, using the following config file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile resources/fixed_v1_rep4.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  name: fixed\n",
+    "spec:\n",
+    "  name: fixed\n",
+    "  protocol: seldon\n",
+    "  transport: rest\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier\n",
+    "    graph:\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: default\n",
+    "    replicas: 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl apply -f resources/fixed_v1_rep4.yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's actually send a couple of requests to make sure that there are no failed requests as the rolling update is performed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time.sleep(5) # To allow operator to start the update\n",
+    "for i in range(120):\n",
+    "    responseRaw=!curl -s -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0]]}}' -X POST http://localhost:8003/seldon/seldon/fixed/api/v1.0/predictions -H \"Content-Type: application/json\"\n",
+    "    try:\n",
+    "        response = json.loads(responseRaw[0])\n",
+    "    except:\n",
+    "        print(\"Failed to parse json\",responseRaw)\n",
+    "        continue\n",
+    "    assert(response['data']['ndarray'][0]==1 or response['data']['ndarray'][0]==5)\n",
+    "    jsonRaw=!kubectl get deploy -l seldon-deployment-id=fixed -o json\n",
+    "    data=\"\".join(jsonRaw)\n",
+    "    resources = json.loads(data)\n",
+    "    numReplicas = int(resources[\"items\"][0][\"status\"][\"replicas\"])\n",
+    "    if numReplicas == 4:\n",
+    "        break\n",
+    "    time.sleep(1)\n",
+    "print(\"Rollout Success\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now downsize back to 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl apply -f resources/fixed_v1_rep2.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time.sleep(5) # To allow operator to start the update\n",
+    "for i in range(120):\n",
+    "    responseRaw=!curl -s -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0]]}}' -X POST http://localhost:8003/seldon/seldon/fixed/api/v1.0/predictions -H \"Content-Type: application/json\"\n",
+    "    try:\n",
+    "        response = json.loads(responseRaw[0])\n",
+    "    except:\n",
+    "        print(\"Failed to parse json\",responseRaw)\n",
+    "        continue\n",
+    "    assert(response['data']['ndarray'][0]==1 or response['data']['ndarray'][0]==5)\n",
+    "    jsonRaw=!kubectl get deploy -l seldon-deployment-id=fixed -o json\n",
+    "    data=\"\".join(jsonRaw)\n",
+    "    resources = json.loads(data)\n",
+    "    numReplicas = int(resources[\"items\"][0][\"status\"][\"replicas\"])\n",
+    "    if numReplicas == 2:\n",
+    "        break\n",
+    "    time.sleep(1)\n",
+    "print(\"Rollout Success\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl delete -f resources/fixed_v1_rep2.yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Separate Service Orchestrator\n",
     "\n",
-    "We can test that the rolling update works when we use the annotation that allows us to have the service orchestrator on a separate pod, namely `seldon.io/engine-separate-pod: \"true\"`, as per the config file below:"
+    "We can test that the rolling update works when we use the annotation that allows us to have the service orchestrator on a separate pod, namely `seldon.io/engine-separate-pod: \"true\"`, as per the config file below. Though in this case both the service orchestrator and model pod will be recreated."
    ]
   },
   {
@@ -425,7 +653,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can test that the rolling update works when we have multiple podSpecs in our deployment."
+    "We can test that the rolling update works when we have multiple podSpecs in our deployment and only does a rolling update the the first pod (which also contains the service orchestrator)"
    ]
   },
   {
@@ -797,6 +1025,225 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Two Predictors\n",
+    "\n",
+    "We can test that the rolling update works when we have two predictors in our deployment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile resources/fixed_v1_2predictors.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  name: fixed\n",
+    "spec:\n",
+    "  name: fixed\n",
+    "  protocol: seldon\n",
+    "  transport: rest\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier2\n",
+    "    graph:\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "      children:\n",
+    "      - name: classifier2\n",
+    "        type: MODEL\n",
+    "    name: a\n",
+    "    replicas: 3\n",
+    "    traffic: 50\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier2\n",
+    "    graph:\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "      children:\n",
+    "      - name: classifier2\n",
+    "        type: MODEL\n",
+    "    name: b\n",
+    "    replicas: 1\n",
+    "    traffic: 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl apply -f resources/fixed_v1_2predictors.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl rollout status deploy/$(kubectl get deploy -l seldon-deployment-id=fixed \\\n",
+    "                                 -o jsonpath='{.items[0].metadata.name}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can wait until the pod is available before starting the rolling update."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(60):\n",
+    "    state=!kubectl get sdep fixed -o jsonpath='{.status.state}'\n",
+    "    state=state[0]\n",
+    "    print(state)\n",
+    "    if state==\"Available\":\n",
+    "        break\n",
+    "    time.sleep(1)\n",
+    "assert(state==\"Available\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0]]}}' \\\n",
+    "   -X POST http://localhost:8003/seldon/seldon/fixed/api/v1.0/predictions \\\n",
+    "   -H \"Content-Type: application/json\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can make a rolling update by changing the version of the docker image we will be updating it for."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile resources/fixed_v2_2predictors.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  name: fixed\n",
+    "spec:\n",
+    "  name: fixed\n",
+    "  protocol: seldon\n",
+    "  transport: rest\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/fixed-model:0.2\n",
+    "          name: classifier\n",
+    "        - image: seldonio/fixed-model:0.2\n",
+    "          name: classifier2\n",
+    "    graph:\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "      children:\n",
+    "      - name: classifier2\n",
+    "        type: MODEL\n",
+    "    name: a\n",
+    "    replicas: 3\n",
+    "    traffic: 50\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier\n",
+    "        - image: seldonio/fixed-model:0.1\n",
+    "          name: classifier2\n",
+    "    graph:\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "      children:\n",
+    "      - name: classifier2\n",
+    "        type: MODEL\n",
+    "    name: b\n",
+    "    replicas: 1\n",
+    "    traffic: 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl apply -f resources/fixed_v2_2predictors.yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can send requests to confirm that the rolling update is performed without interruptions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time.sleep(5) # To allow operator to start the update\n",
+    "for i in range(120):\n",
+    "    responseRaw=!curl -s -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0]]}}' -X POST http://localhost:8003/seldon/seldon/fixed/api/v1.0/predictions -H \"Content-Type: application/json\"\n",
+    "    try:\n",
+    "        response = json.loads(responseRaw[0])\n",
+    "    except:\n",
+    "        print(\"Failed to parse json\",responseRaw)\n",
+    "        continue\n",
+    "    assert(response['data']['ndarray'][0]==1 or response['data']['ndarray'][0]==5)\n",
+    "    jsonRaw=!kubectl get deploy -l seldon-deployment-id=fixed -o json\n",
+    "    data=\"\".join(jsonRaw)\n",
+    "    resources = json.loads(data)\n",
+    "    numReplicas = int(resources[\"items\"][0][\"status\"][\"replicas\"])\n",
+    "    if numReplicas == 3:\n",
+    "        break\n",
+    "    time.sleep(1)\n",
+    "print(\"Rollout Success\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl delete -f resources/fixed_v2_2predictors.yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Model name changes\n",
     "\n",
     "This will not do a rolling update but create a new deployment."
@@ -985,7 +1432,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -318,6 +318,9 @@ func createEngineContainer(mlDep *machinelearningv1.SeldonDeployment, p *machine
 	pCopy := p.DeepCopy()
 	// Set traffic to zero to ensure this doesn't cause a diff in the resulting  deployment created
 	pCopy.Traffic = 0
+	// Set replicas to zero to ensure this doesn't cause a diff in the resulting deployment created
+	var replicasCopy int32 = 0
+	pCopy.Replicas = &replicasCopy
 	predictorB64, err := getEngineVarJson(pCopy)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #2008 

 * Ensure predictor.replicas is zeroed when taking bas64 representation for executor. This ensure pod does not change just for this reason.
 * Adds test in rolling_updates notebook

