### PR TITLE
first expand test for upgrade status

### DIFF
--- a/testing/scripts/seldon_e2e_utils.py
+++ b/testing/scripts/seldon_e2e_utils.py
@@ -565,11 +565,12 @@ def assert_model(sdep_name, namespace, initial=False, endpoint=API_AMBASSADOR):
     # a Kubernetes resource. This covers cases where some resources (e.g. CRD
     # versions or webhooks) may get inadvertently removed between versions.
     ret = run(
-        f"kubectl get -n {namespace} sdep {sdep_name}",
-        stdout=subprocess.DEVNULL,
+        f"kubectl get -n {namespace} sdep {sdep_name} -o=jsonpath='{.status.state}'",
+        stdout=subprocess.PIPE,
         shell=True,
     )
     assert ret.returncode == 0
+    assert ret.stdout != "Failed"
 
 
 def to_resources_path(file_name):


### PR DESCRIPTION
for https://github.com/SeldonIO/seldon-core/issues/2017
Hoping to see this fail as this is expanding the check to catch failed sdeps during an operator upgrade. Should fail during upgrade of 1.1.0 to master