### PR TITLE
Use production server by default

### DIFF
--- a/doc/source/python/index.rst
+++ b/doc/source/python/index.rst
@@ -17,6 +17,7 @@ You can use the following links to navigate the Python seldon-core module:
    Wrap using S2I <python_wrapping_s2i.md>
    Wrap using Docker <python_wrapping_docker.md>
    Seldon Python Client <seldon_client.md>
+   Seldon Python Server <python_server.md>
    Python API reference <api/modules>
 
 

--- a/doc/source/python/python_component.md
+++ b/doc/source/python/python_component.md
@@ -317,45 +317,33 @@ class UserCustomException(Exception):
 
 ```
 
-### Gunicorn (Alpha Feature)
+## Multi-value numpy arrays
 
-To run your class under gunicorn set the environment variable `GUNICORN_WORKERS` to an integer value > 1.
+By default, when using the data ndarray parameter, the conversion to ndarray (by default) converts all inner types into the same type. With models that may take as input arrays with different value types, you will be able to do so by overriding the `predict_raw` function yourself which gives you access to the raw request, and creating the numpy array as follows:
 
 ```
-apiVersion: machinelearning.seldon.io/v1alpha2
-kind: SeldonDeployment
-metadata:
-  name: gunicorn
-spec:
-  name: worker
-  predictors:
-  - componentSpecs:
-    - spec:
-        containers:
-        - image: seldonio/mock_classifier:1.0
-          name: classifier
-          env:
-          - name: GUNICORN_WORKERS
-            value: '4'
-        terminationGracePeriodSeconds: 1
-    graph:
-      children: []
-      endpoint:
-        type: REST
-      name: classifier
-      type: MODEL
-    labels:
-      version: v1
-    name: example
-    replicas: 1
+import numpy as np
 
+class Model:
+    def predict_raw(self, request):
+        data = request.get("data", {}).get("ndarray")
+        if data:
+            mult_types_array = np.array(data, dtype=object)
+
+        # Handle other data types as required + your logic
 ```
 
 ## Gunicorn and load
 
-If the wrapped python class is run under [gunicorn](https://gunicorn.org/) then as part of initialization of each gunicorn worker a `load` method will be called on your class if it has it. You should use this method to load and initialise your model. This is important for Tensorflow models which need their session created in each worker process. The [Tensorflow MNIST example](../examples/deep_mnist.html) does this.
+If the wrapped python class is [served under Gunicorn](./python_server) then as
+part of initialization of each gunicorn worker a `load` method will be called
+on your class if it has it.
+You should use this method to load and initialise your model.
+This is important for Tensorflow models which need their session created in
+each worker process.
+The [Tensorflow MNIST example](../examples/deep_mnist.html) does this.
 
-```
+```python
 import tensorflow as tf
 import numpy as np
 import os
@@ -381,56 +369,6 @@ class DeepMnist(object):
             self.load()
         predictions = self.sess.run(self.y,feed_dict={self.x:X})
         return predictions.astype(np.float64)
-```
-
-### Single-threaded Flask for REST (experimental)
-
-To run your class single-threaded with Flask set the environment variable `FLASK_SINGLE_THREADED` to 1. This will set the `threaded` parameter of the Flask app to `False`. It is not the optimal setup for most models, but can be useful when your model cannot be made thread-safe like many GPU-based models that deadlock when accessed from multiple threads.
-
-```
-apiVersion: machinelearning.seldon.io/v1alpha2
-kind: SeldonDeployment
-metadata:
-  name: flaskexample
-spec:
-  name: worker
-  predictors:
-  - componentSpecs:
-    - spec:
-        containers:
-        - image: seldonio/mock_classifier:1.0
-          name: classifier
-          env:
-          - name: FLASK_SINGLE_THREADED
-            value: '1'
-        terminationGracePeriodSeconds: 1
-    graph:
-      children: []
-      endpoint:
-        type: REST
-      name: classifier
-      type: MODEL
-    labels:
-      version: v1
-    name: example
-    replicas: 1
-
-```
-
-## Multi-value numpy arrays
-
-By default, when using the data ndarray parameter, the conversion to ndarray (by default) converts all inner types into the same type. With models that may take as input arrays with different value types, you will be able to do so by overriding the `predict_raw` function yourself which gives you access to the raw request, and creating the numpy array as follows:
-
-```
-import numpy as np
-
-class Model:
-    def predict_raw(self, request):
-        data = request.get("data", {}).get("ndarray")
-        if data:
-            mult_types_array = np.array(data, dtype=object)
-
-        # Handle other data types as required + your logic
 ```
 
 ## Integer numbers

--- a/doc/source/python/python_server.md
+++ b/doc/source/python/python_server.md
@@ -1,0 +1,168 @@
+# Seldon Python Server
+
+To serve your component, Seldon's Python wrapper will use
+[Gunicorn](https://gunicorn.org/) under the hood by default.
+Gunicorn is a high-performing HTTP server for Unix which allows you to easily
+scale your model across multiple worker processes and threads.
+
+.. Note:: 
+  Gunicorn will only handle the horizontal scaling of your model **within the
+  same pod and container**.
+  To learn more about how to scale your model across multiple pod replicas see
+  the :doc:`../graph/scaling` section of the docs.
+
+## Workers
+
+By default, Seldon will only use a **single worker process**.
+However, it's possible to increase this number through the `GUNICORN_WORKERS`
+environment variable.
+This variable can be controlled directly through the `SeldonDeployment` CRD.
+
+For example, to run your model under 4 workers, you could do:
+
+```yaml
+apiVersion: machinelearning.seldon.io/v1
+kind: SeldonDeployment
+metadata:
+  name: gunicorn
+spec:
+  name: worker
+  predictors:
+  - componentSpecs:
+    - spec:
+        containers:
+        - image: seldonio/mock_classifier:1.0
+          name: classifier
+          env:
+          - name: GUNICORN_WORKERS
+            value: '4'
+        terminationGracePeriodSeconds: 1
+    graph:
+      children: []
+      endpoint:
+        type: REST
+      name: classifier
+      type: MODEL
+    labels:
+      version: v1
+    name: example
+    replicas: 1
+
+```
+
+## Threads
+
+By default, Seldon will process your model's incoming requests using a pool of
+**10 threads per worker process**.
+You can increase this number through the `GUNICORN_THREADS` environment
+variable.
+This variable can be controlled directly through the `SeldonDeployment` CRD.
+
+For example, to run your model with 5 threads per worker, you could do:
+
+```yaml
+apiVersion: machinelearning.seldon.io/v1
+kind: SeldonDeployment
+metadata:
+  name: gunicorn
+spec:
+  name: worker
+  predictors:
+  - componentSpecs:
+    - spec:
+        containers:
+        - image: seldonio/mock_classifier:1.0
+          name: classifier
+          env:
+          - name: GUNICORN_THREADS
+            value: '5'
+        terminationGracePeriodSeconds: 1
+    graph:
+      children: []
+      endpoint:
+        type: REST
+      name: classifier
+      type: MODEL
+    labels:
+      version: v1
+    name: example
+    replicas: 1
+
+```
+
+### Disable multithreading
+
+In some cases, you may want to completely disable multithreading.
+To serve your model within a single thread, set the environment variable
+`FLASK_SINGLE_THREADED` to 1.
+This is not the most optimal setup for most models, but can be useful when your
+model cannot be made thread-safe like many GPU-based models that deadlock when
+accessed from multiple threads.
+
+
+```yaml
+apiVersion: machinelearning.seldon.io/v1alpha2
+kind: SeldonDeployment
+metadata:
+  name: flaskexample
+spec:
+  name: worker
+  predictors:
+  - componentSpecs:
+    - spec:
+        containers:
+        - image: seldonio/mock_classifier:1.0
+          name: classifier
+          env:
+          - name: FLASK_SINGLE_THREADED
+            value: '1'
+        terminationGracePeriodSeconds: 1
+    graph:
+      children: []
+      endpoint:
+        type: REST
+      name: classifier
+      type: MODEL
+    labels:
+      version: v1
+    name: example
+    replicas: 1
+
+```
+
+## Development server
+
+While Gunicorn is recommended for production workloads, it's also possible to
+use Flask's built-in development server.
+To enable the development server, you can set the `SELDON_DEBUG` variable to
+`1`.
+
+```yaml
+apiVersion: machinelearning.seldon.io/v1
+kind: SeldonDeployment
+metadata:
+  name: flask-development-server
+spec:
+  name: worker
+  predictors:
+  - componentSpecs:
+    - spec:
+        containers:
+        - image: seldonio/mock_classifier:1.0
+          name: classifier
+          env:
+          - name: SELDON_DEBUG
+            value: '1'
+        terminationGracePeriodSeconds: 1
+    graph:
+      children: []
+      endpoint:
+        type: REST
+      name: classifier
+      type: MODEL
+    labels:
+      version: v1
+    name: example
+    replicas: 1
+
+```

--- a/python/seldon_core/app.py
+++ b/python/seldon_core/app.py
@@ -18,6 +18,18 @@ def accesslog(log_level: str) -> Union[str, None]:
     return "-"
 
 
+def worker_class(single_threaded: bool) -> str:
+    """
+    Use gthread workers to run every request on a separate thread (unless we
+    explicitly force the code on a single thread).
+    """
+
+    if single_threaded:
+        return "sync"
+
+    return "gthread"
+
+
 class StandaloneApplication(BaseApplication):
     """
     Standalone Application to run a Flask app in Gunicorn.

--- a/python/seldon_core/app.py
+++ b/python/seldon_core/app.py
@@ -1,10 +1,21 @@
 import os
 import logging
 
-from typing import Dict
+from typing import Dict, Union
 from gunicorn.app.base import BaseApplication
 
 logger = logging.getLogger(__name__)
+
+
+def accesslog(log_level: str) -> Union[str, None]:
+    """
+    Enable / disable access log in Gunicorn depending on the log level.
+    """
+
+    if log_level in ["WARNING", "ERROR", "CRITICAL"]:
+        return None
+
+    return "-"
 
 
 class StandaloneApplication(BaseApplication):

--- a/python/seldon_core/app.py
+++ b/python/seldon_core/app.py
@@ -18,16 +18,15 @@ def accesslog(log_level: str) -> Union[str, None]:
     return "-"
 
 
-def worker_class(single_threaded: bool) -> str:
+def threads(threads: int, single_threaded: bool) -> int:
     """
-    Use gthread workers to run every request on a separate thread (unless we
-    explicitly force the code on a single thread).
+    Number of threads to run in each Gunicorn worker.
     """
 
     if single_threaded:
-        return "sync"
+        return 1
 
-    return "gthread"
+    return threads
 
 
 class StandaloneApplication(BaseApplication):

--- a/python/seldon_core/app.py
+++ b/python/seldon_core/app.py
@@ -1,0 +1,52 @@
+import os
+import logging
+
+from typing import Dict
+from gunicorn.app.base import BaseApplication
+
+logger = logging.getLogger(__name__)
+
+
+class StandaloneApplication(BaseApplication):
+    """
+    Standalone Application to run a Flask app in Gunicorn.
+    """
+
+    def __init__(self, app, options: Dict = None):
+        self.application = app
+        self.options = options
+        super().__init__()
+
+    def load_config(self):
+        config = dict(
+            [
+                (key, value)
+                for key, value in self.options.items()
+                if key in self.cfg.settings and value is not None
+            ]
+        )
+        for key, value in config.items():
+            self.cfg.set(key.lower(), value)
+
+    def load(self):
+        return self.application
+
+
+class UserModelApplication(StandaloneApplication):
+    """
+    Gunicorn application to run a Flask app in Gunicorn loading first the
+    user's model.
+    """
+
+    def __init__(self, app, user_object, options: Dict = None):
+        self.user_object = user_object
+        super().__init__(app, options)
+
+    def load(self):
+        logger.debug("LOADING APP %d", os.getpid())
+        try:
+            logger.debug("Calling user load method")
+            self.user_object.load()
+        except (NotImplementedError, AttributeError):
+            logger.debug("No load method in user model")
+        return self.application

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -15,7 +15,7 @@ from seldon_core import persistence, __version__, wrapper as seldon_microservice
 from seldon_core.metrics import SeldonMetrics
 from seldon_core.flask_utils import ANNOTATIONS_FILE, SeldonMicroserviceException
 from seldon_core.utils import getenv_as_bool
-from seldon_core.app import StandaloneApplication, UserModelApplication
+from seldon_core.app import StandaloneApplication, UserModelApplication, accesslog
 
 logger = logging.getLogger(__name__)
 
@@ -327,8 +327,8 @@ def main():
             def rest_prediction_server():
                 options = {
                     "bind": "%s:%s" % ("0.0.0.0", port),
-                    "access_logfile": "-",
-                    "loglevel": args.log_level,
+                    "accesslog": accesslog(args.log_level),
+                    "loglevel": args.log_level.lower(),
                     "timeout": 5000,
                     "workers": args.workers,
                     "max_requests": args.max_requests,
@@ -389,13 +389,12 @@ def main():
         else:
             options = {
                 "bind": "%s:%s" % ("0.0.0.0", metrics_port),
-                "access_logfile": "-",
-                "loglevel": args.log_level,
+                "accesslog": accesslog(args.log_level),
+                "loglevel": args.log_level.lower(),
                 "timeout": 5000,
                 "max_requests": args.max_requests,
                 "max_requests_jitter": args.max_requests_jitter,
             }
-            app = seldon_microservice.get_rest_microservice(seldon_metrics)
             StandaloneApplication(app, options=options).run()
 
     logger.info("REST metrics microservice running on port %i", metrics_port)

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -224,7 +224,12 @@ def main():
         "--log-level", type=str, default=os.environ.get(LOG_LEVEL_ENV, "INFO")
     )
     parser.add_argument(
-        "--debug", type=bool, default=getenv_as_bool(DEBUG_ENV, default=False)
+        "--debug",
+        nargs="?",
+        type=bool,
+        default=getenv_as_bool(DEBUG_ENV, default=False),
+        const=True,
+        help="Enable debug mode.",
     )
     parser.add_argument(
         "--tracing",

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -15,7 +15,12 @@ from seldon_core import persistence, __version__, wrapper as seldon_microservice
 from seldon_core.metrics import SeldonMetrics
 from seldon_core.flask_utils import ANNOTATIONS_FILE, SeldonMicroserviceException
 from seldon_core.utils import getenv_as_bool
-from seldon_core.app import StandaloneApplication, UserModelApplication, accesslog
+from seldon_core.app import (
+    StandaloneApplication,
+    UserModelApplication,
+    accesslog,
+    worker_class,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +335,7 @@ def main():
                     "accesslog": accesslog(args.log_level),
                     "loglevel": args.log_level.lower(),
                     "timeout": 5000,
+                    "worker_class": worker_class(args.single_threaded),
                     "workers": args.workers,
                     "max_requests": args.max_requests,
                     "max_requests_jitter": args.max_requests_jitter,
@@ -392,6 +398,7 @@ def main():
                 "accesslog": accesslog(args.log_level),
                 "loglevel": args.log_level.lower(),
                 "timeout": 5000,
+                "worker_class": worker_class(args.single_threaded),
                 "max_requests": args.max_requests,
                 "max_requests_jitter": args.max_requests_jitter,
             }

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -357,7 +357,7 @@ def main():
                 options = {
                     "bind": "%s:%s" % ("0.0.0.0", port),
                     "access_logfile": "-",
-                    "loglevel": "info",
+                    "loglevel": args.log_level,
                     "timeout": 5000,
                     "workers": args.workers,
                     "max_requests": args.max_requests,

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -644,3 +644,16 @@ def getenv(*env_vars, default=None):
             return os.environ.get(env_var)
 
     return default
+
+
+def getenv_as_bool(*env_vars, default=False):
+    """
+    Read environment variable, parsing it to a boolean.
+    """
+
+    val = getenv(*env_vars)
+
+    if val is None:
+        return default
+
+    return val.lower() in ["1", "true", "t"]

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -442,3 +442,27 @@ def test_getenv(monkeypatch, env, expected):
 
     value = scu.getenv("FOO1", "FOO2", "FOO3", default="DEF")
     assert value == expected
+
+
+@pytest.mark.parametrize(
+    "env_val,expected",
+    [
+        ("TRUE", True),
+        ("true", True),
+        ("t", True),
+        ("1", True),
+        ("FALSE", False),
+        ("false", False),
+        ("f", False),
+        ("0", False),
+        (None, False),
+    ],
+)
+def test_getenv_as_bool(monkeypatch, env_val, expected):
+    env_var = "MY_BOOL_VAR"
+
+    if env_val is not None:
+        monkeypatch.setenv(env_var, env_val)
+
+    value = scu.getenv_as_bool(env_var, default=False)
+    assert value == expected


### PR DESCRIPTION
Fixes #1993 

## Changelog

- Run Gunicorn by default with 1 worker and 10 threads
- Add `--threads` / `GUNICORN_THREADS` flags to control number of threads
- Add `--debug` / `SELDON_DEBUG` flags to enable Flask's development server
- Apply the same above to the metrics server
- Update docs
