### PR TITLE
allow independent installation of grafana and prometheus

### DIFF
--- a/helm-charts/seldon-core-analytics/templates/grafana/grafana-net-2115-dashboard-configmap.yaml
+++ b/helm-charts/seldon-core-analytics/templates/grafana/grafana-net-2115-dashboard-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enabled }}
 apiVersion: v1
 data:
 {{ (.Files.Glob "files/grafana/configs/grafana-net-2115-dashboard.json").AsConfig | indent 2 }}
@@ -8,3 +9,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     seldon_dashboard: "1"
+{{- end }}

--- a/helm-charts/seldon-core-analytics/templates/grafana/metrics-test-dashboard-configmap.yaml
+++ b/helm-charts/seldon-core-analytics/templates/grafana/metrics-test-dashboard-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enabled }}
 apiVersion: v1
 data:
 {{ (.Files.Glob "files/grafana/configs/metrics-test-dashboard.json").AsConfig | indent 2 }}
@@ -8,3 +9,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     seldon_dashboard: "1"
+{{- end }}

--- a/helm-charts/seldon-core-analytics/templates/grafana/newdb.yaml
+++ b/helm-charts/seldon-core-analytics/templates/grafana/newdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enabled }}
 apiVersion: v1
 data:
 {{ (.Files.Glob "files/grafana/configs/newdb.json").AsConfig | indent 2 }}
@@ -8,3 +9,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     seldon_dashboard: "1"
+{{- end }}

--- a/helm-charts/seldon-core-analytics/templates/grafana/prediction-analytics-dashboard-configmap.yaml
+++ b/helm-charts/seldon-core-analytics/templates/grafana/prediction-analytics-dashboard-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enabled }}
 apiVersion: v1
 data:
 {{ (.Files.Glob "files/grafana/configs/predictions-analytics-dashboard.json").AsConfig | indent 2 }}
@@ -8,3 +9,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     seldon_dashboard: "1"
+{{- end }}

--- a/helm-charts/seldon-core-analytics/templates/prometheus/alertmanager-config-configmap.yaml
+++ b/helm-charts/seldon-core-analytics/templates/prometheus/alertmanager-config-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prometheus.enabled }}
 apiVersion: v1
 data:
 {{- if .Values.alertmanager.config.enabled }}
@@ -19,3 +20,4 @@ metadata:
   creationTimestamp: null
   name: alertmanager-server-conf
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm-charts/seldon-core-analytics/templates/prometheus/prometheus-rules-configmap.yaml
+++ b/helm-charts/seldon-core-analytics/templates/prometheus/prometheus-rules-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prometheus.enabled }}
 apiVersion: v1
 data:
 {{ (.Files.Glob "files/prometheus/rules/*.rules").AsConfig | indent 2 }}
@@ -6,3 +7,4 @@ metadata:
   creationTimestamp: null
   name: prometheus-rules
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm-charts/seldon-core-analytics/templates/prometheus/prometheus-server-conf-configmap.yaml
+++ b/helm-charts/seldon-core-analytics/templates/prometheus/prometheus-server-conf-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prometheus.enabled }}
 apiVersion: v1
 data:
 {{ (.Files.Glob "files/prometheus/prometheus-config.yaml").AsConfig | indent 2 }}
@@ -6,3 +7,4 @@ metadata:
   creationTimestamp: null
   name: prometheus-server-conf
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm-charts/seldon-core-analytics/values.yaml
+++ b/helm-charts/seldon-core-analytics/values.yaml
@@ -1,4 +1,5 @@
 grafana:
+  enabled: true
   adminUser: admin
   adminPassword: password
   sidecar:
@@ -19,6 +20,7 @@ alertmanager:
 rbac:
   enabled: true
 prometheus:
+  enabled: true
   service_type: ClusterIP
   server:
     name: seldon


### PR DESCRIPTION
This PR allows installing Grafana without installing Prometheus. 
This is useful if you are already have a Prometheus installation, but you want to use this chart to install Grafana with Seldon dashboards.  

To install just Grafana or just Prometheus, you can set `.enabled` to `false`.



