### PR TITLE
Mlflowserver use mlflow predict signature

### DIFF
--- a/doc/source/servers/mlflow.md
+++ b/doc/source/servers/mlflow.md
@@ -52,6 +52,32 @@ spec:
       replicas: 1
 ```
 
+## MLFlow xtype
+
+By default the server will call your loaded model's predict function with a `numpy.ndarray`. If you wish for it to call it with `pandas.DataFrame` instead, you can pass a parameter `X_type` and set it to `DataFrame`. For example:   
+
+```yaml
+apiVersion: machinelearning.seldon.io/v1alpha2
+kind: SeldonDeployment
+metadata:
+  name: mlflow
+spec:
+  name: wines
+  predictors:
+    - graph:
+        children: []
+        implementation: MLFLOW_SERVER
+        modelUri: gs://seldon-models/mlflow/elasticnet_wine
+        name: classifier
+      parameters:
+        - name: xtype
+          type: STRING
+          value: DataFrame
+      name: default
+      replicas: 1
+```
+
+```
 You can also try out a [worked
 notebook](../examples/server_examples.html#Serve-MLflow-Elasticnet-Wines-Model)
 or check our [talk at the Spark + AI Summit

--- a/doc/source/servers/mlflow.md
+++ b/doc/source/servers/mlflow.md
@@ -54,7 +54,7 @@ spec:
 
 ## MLFlow xtype
 
-By default the server will call your loaded model's predict function with a `numpy.ndarray`. If you wish for it to call it with `pandas.DataFrame` instead, you can pass a parameter `X_type` and set it to `DataFrame`. For example:   
+By default the server will call your loaded model's predict function with a `numpy.ndarray`. If you wish for it to call it with `pandas.DataFrame` instead, you can pass a parameter `xtype` and set it to `DataFrame`. For example:   
 
 ```yaml
 apiVersion: machinelearning.seldon.io/v1alpha2

--- a/servers/mlflowserver/mlflowserver/MLFlowServer.py
+++ b/servers/mlflowserver/mlflowserver/MLFlowServer.py
@@ -15,10 +15,12 @@ MLFLOW_SERVER = "model"
 
 
 class MLFlowServer(SeldonComponent):
-    def __init__(self, model_uri: str):
+    def __init__(self, model_uri: str, xtype: str = 'ndarray'):
         super().__init__()
         logger.info(f"Creating MLFLow server with URI {model_uri}")
+        logger.info(f"xtype: {xtype}")
         self.model_uri = model_uri
+        self.xtype = xtype
         self.ready = False
 
     def load(self):
@@ -34,11 +36,15 @@ class MLFlowServer(SeldonComponent):
 
         if not self.ready:
             raise requests.HTTPError("Model not loaded yet")
-        if feature_names is not None and len(feature_names) > 0:
-            df = pd.DataFrame(data=X, columns=feature_names)
+
+        if self.xtype == "ndarray":
+            result = self._model.predict(X)
         else:
-            df = pd.DataFrame(data=X)
-        result = self._model.predict(df)
+            if feature_names is not None and len(feature_names) > 0:
+                df = pd.DataFrame(data=X, columns=feature_names)
+            else:
+                df = pd.DataFrame(data=X)
+            result = self._model.predict(df)
         logger.info(f"Prediction result: {result}")
         return result
 

--- a/servers/mlflowserver/mlflowserver/MLFlowServer.py
+++ b/servers/mlflowserver/mlflowserver/MLFlowServer.py
@@ -1,6 +1,7 @@
 import numpy as np
 import logging
 import requests
+import pandas as pd
 from mlflow import pyfunc
 from seldon_core import Storage
 from seldon_core.user_model import SeldonComponent
@@ -33,8 +34,11 @@ class MLFlowServer(SeldonComponent):
 
         if not self.ready:
             raise requests.HTTPError("Model not loaded yet")
-
-        result = self._model.predict(X)
+        if feature_names is not None and len(feature_names) > 0:
+            df = pd.DataFrame(data=X, columns=feature_names)
+        else:
+            df = pd.DataFrame(data=X)
+        result = self._model.predict(df)
         logger.info(f"Prediction result: {result}")
         return result
 

--- a/servers/mlflowserver/mlflowserver/requirements.txt
+++ b/servers/mlflowserver/mlflowserver/requirements.txt
@@ -1,6 +1,7 @@
 pyyaml==5.1.2
 requests==2.22.0
 mlflow>=1.4.0,<1.9.0
+pandas
 
 # local seldon-core inside the s2i image
 /microservice/python


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Fixes MLFlowServer predict function to call MLFlow's original predict function with pandas.DataFrame instead of numpy.ndarray. This is according MLFlow's [documentation](https://www.mlflow.org/docs/latest/models.html#python-function-python-function) 
This includes using the feature_names parameter as well.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2113 

**Special notes for your reviewer**:
This issue was discussed on the #general slack channel with @cliveseldon 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
This will allow MLFlow_Server users to send the data.names parameter, and connect it with the DataFrame's columns property. Shouldn't break existing functionality, just extend it.
```

