### PR TITLE
Add operator to dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,3 +16,8 @@ update_configs:
     update_schedule: "weekly"
     default_reviewers:
       - adriangonz
+  - directory: "/operator"
+    package_manager: "go:modules"
+    update_schedule: "weekly"
+    default_reviewers:
+      - adriangonz


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Add `operator`'s dependencies to be tracked by Dependabot.

**Special notes for your reviewer**:
Now that we've upgraded the `operator`'s dependencies manually, it makes sense to start tracking them with Dependabot.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

