### PR TITLE
fix issues with test_upgrade notebook

### DIFF
--- a/notebooks/operator_upgrade.ipynb
+++ b/notebooks/operator_upgrade.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!helm upgrade seldon-core seldon-core-operator --repo https://storage.googleapis.com/seldon-charts --namespace seldon-system --set istio.enabled=true --wait"
+    "!helm upgrade seldon seldon-core-operator --repo https://storage.googleapis.com/seldon-charts --namespace seldon-system --set istio.enabled=true --wait"
    ]
   },
   {
@@ -282,7 +282,7 @@
    "outputs": [],
    "source": [
     "def waitStatus(desired):\n",
-    "    for i in range(120):\n",
+    "    for i in range(360):\n",
     "        allAvailable = True\n",
     "        failedGet = False\n",
     "        state=!kubectl get sdep -o json\n",
@@ -366,7 +366,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!helm upgrade seldon-core ../helm-charts/seldon-core-operator --namespace seldon-system --set istio.enabled=true --wait"
+    "!helm upgrade seldon ../helm-charts/seldon-core-operator --namespace seldon-system --set istio.enabled=true --wait"
    ]
   },
   {
@@ -415,13 +415,6 @@
    "source": [
     "!kubectl delete sdep --all"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/python/licenses/license.txt
+++ b/python/licenses/license.txt
@@ -1029,7 +1029,7 @@ Apache Software License
 
 
 google-auth
-1.19.0
+1.19.1
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004

--- a/python/licenses/license_info.csv
+++ b/python/licenses/license_info.csv
@@ -24,7 +24,7 @@
 "flatbuffers","1.12","Apache Software License"
 "gast","0.3.3","BSD License"
 "google-api-core","1.21.0","Apache Software License"
-"google-auth","1.19.0","Apache Software License"
+"google-auth","1.19.1","Apache Software License"
 "google-auth-oauthlib","0.4.1","Apache Software License"
 "google-cloud-core","1.3.0","Apache Software License"
 "google-cloud-storage","1.29.0","Apache Software License"

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -73,6 +73,7 @@ install_cert_manager:
 
 install_seldon: install_cert_manager
 	kubectl create namespace seldon-system || echo "namespace seldon-system exists"
+	helm delete seldon --namespace seldon-system || echo "seldon-core not installed"
 	helm install seldon \
 		../../helm-charts/seldon-core-operator \
 		--namespace seldon-system \

--- a/testing/scripts/test_notebooks.py
+++ b/testing/scripts/test_notebooks.py
@@ -177,3 +177,4 @@ class TestNotebooks(object):
             create_and_run_script("../../notebooks", "operator_upgrade")
         except:
             run("make install_seldon", shell=True, check=False)
+            raise


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

It fixes problems with notebook that tests seldon-core upgrades.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Closes https://github.com/SeldonIO/seldon-core/issues/2119

**Special notes for your reviewer**:

- increased timeout in `waitStatus` helper function (defined inside notebook)
- fixed re-raising exception if notebook fails
- fixed helm-target for upgrade command (makefile installs `seldon`, notebook was trying to upgrade `seldon-core`)
- `install_seldon` target in testing Makefile can be re-executed now as it will first attempt to remove currently installed seldon-core

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

