### PR TITLE
include reward in metrics on wrapper

### DIFF
--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -60,6 +60,7 @@ const (
 	ENV_PREDICTOR_ID                         = "PREDICTOR_ID"
 	ENV_PREDICTOR_LABELS                     = "PREDICTOR_LABELS"
 	ENV_SELDON_DEPLOYMENT_ID                 = "SELDON_DEPLOYMENT_ID"
+	ENV_SELDON_EXECUTOR_ENABLED              = "SELDON_EXECUTOR_ENABLED"
 
 	ANNOTATION_JAVA_OPTS       = "seldon.io/engine-java-opts"
 	ANNOTATION_SEPARATE_ENGINE = "seldon.io/engine-separate-pod"

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -776,6 +776,7 @@ func createContainerService(deploy *appsv1.Deployment,
 		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTOR_ID, Value: p.Name},
 		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTOR_LABELS, Value: string(labels)},
 		corev1.EnvVar{Name: machinelearningv1.ENV_SELDON_DEPLOYMENT_ID, Value: mlDep.ObjectMeta.Name},
+		corev1.EnvVar{Name: machinelearningv1.ENV_SELDON_EXECUTOR_ENABLED, Value: strconv.FormatBool(isExecutorEnabled(mlDep))},
 	}...)
 
 	//Add Metric Env Var

--- a/python/seldon_core/metrics.py
+++ b/python/seldon_core/metrics.py
@@ -27,7 +27,8 @@ ENV_MODEL_IMAGE = "PREDICTIVE_UNIT_IMAGE"
 ENV_PREDICTOR_NAME = "PREDICTOR_ID"
 ENV_PREDICTOR_LABELS = "PREDICTOR_LABELS"
 
-REWARD_KEY = "seldon_api_model_feedback_reward"
+FEEDBACK_KEY = "seldon_api_model_feedback"
+FEEDBACK_REWARD_KEY = "seldon_api_model_feedback_reward"
 
 COUNTER = "COUNTER"
 GAUGE = "GAUGE"
@@ -56,21 +57,28 @@ def split_image_tag(tag: str) -> Tuple[str]:
 
 # Development placeholder
 image = os.environ.get(ENV_MODEL_IMAGE, f"{NONIMPLEMENTED_MSG}:{NONIMPLEMENTED_MSG}")
-image_name, image_version = split_image_tag(image)
+model_image, model_version = split_image_tag(image)
 predictor_version = json.loads(os.environ.get(ENV_PREDICTOR_LABELS, "{}")).get(
     "version", f"{NONIMPLEMENTED_MSG}"
 )
 
+legacy_mode = os.environ.get("SELDON_EXECUTOR_ENABLED", "true").lower() == "false"
+
 DEFAULT_LABELS = {
-    "seldon_deployment_name": os.environ.get(
+    "deployment_name": os.environ.get(
         ENV_SELDON_DEPLOYMENT_NAME, f"{NONIMPLEMENTED_MSG}"
     ),
     "model_name": os.environ.get(ENV_MODEL_NAME, f"{NONIMPLEMENTED_MSG}"),
-    "image_name": image_name,
-    "image_version": image_version,
+    "model_image": model_image,
+    "model_version": model_version,
     "predictor_name": os.environ.get(ENV_PREDICTOR_NAME, f"{NONIMPLEMENTED_MSG}"),
     "predictor_version": predictor_version,
 }
+
+# Compatibility layer of tags until Seldon-Core 1.3
+DEFAULT_LABELS["seldon_deployment_name"] = DEFAULT_LABELS["deployment_name"]
+DEFAULT_LABELS["image_name"] = DEFAULT_LABELS["model_image"]
+DEFAULT_LABELS["image_version"] = DEFAULT_LABELS["model_version"]
 
 
 class SeldonMetrics:
@@ -88,9 +96,10 @@ class SeldonMetrics:
 
     def update_reward(self, reward: float):
         """"Update metrics key corresponding to feedback reward counter."""
-        if not reward:
+        if not reward or legacy_mode:
             return
-        self.update([{"type": "COUNTER", "key": REWARD_KEY, "value": reward}])
+        self.update([{"type": "COUNTER", "key": FEEDBACK_KEY, "value": 1}])
+        self.update([{"type": "COUNTER", "key": FEEDBACK_REWARD_KEY, "value": reward}])
 
     def update(self, custom_metrics):
         # Read a corresponding worker's metric data with lock as Proxy objects

--- a/python/seldon_core/metrics.py
+++ b/python/seldon_core/metrics.py
@@ -27,6 +27,8 @@ ENV_MODEL_IMAGE = "PREDICTIVE_UNIT_IMAGE"
 ENV_PREDICTOR_NAME = "PREDICTOR_ID"
 ENV_PREDICTOR_LABELS = "PREDICTOR_LABELS"
 
+REWARD_KEY = "seldon_api_model_feedback_reward"
+
 COUNTER = "COUNTER"
 GAUGE = "GAUGE"
 TIMER = "TIMER"
@@ -83,6 +85,12 @@ class SeldonMetrics:
 
     def __del__(self):
         self._manager.shutdown()
+
+    def update_reward(self, reward: float):
+        """"Update metrics key corresponding to feedback reward counter."""
+        if not reward:
+            return
+        self.update([{"type": "COUNTER", "key": REWARD_KEY, "value": reward}])
 
     def update(self, custom_metrics):
         # Read a corresponding worker's metric data with lock as Proxy objects

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -116,7 +116,10 @@ def predict(
 
 
 def send_feedback(
-    user_model: Any, request: prediction_pb2.Feedback, predictive_unit_id: str
+    user_model: Any,
+    request: prediction_pb2.Feedback,
+    predictive_unit_id: str,
+    seldon_metrics: SeldonMetrics,
 ) -> prediction_pb2.SeldonMessage:
     """
 
@@ -133,6 +136,8 @@ def send_feedback(
     -------
 
     """
+    seldon_metrics.update_reward(request.reward)
+
     if hasattr(user_model, "send_feedback_rest"):
         logger.warning("send_feedback_rest is deprecated. Please use send_feedback_raw")
         request_json = json_format.MessageToJson(request)

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -74,7 +74,7 @@ def get_rest_microservice(user_model, seldon_metrics):
         requestProto = json_to_feedback(requestJson)
         logger.debug("Proto Request: %s", requestProto)
         responseProto = seldon_core.seldon_methods.send_feedback(
-            user_model, requestProto, PRED_UNIT_ID
+            user_model, requestProto, PRED_UNIT_ID, seldon_metrics
         )
         jsonDict = seldon_message_to_json(responseProto)
         return jsonify(jsonDict)
@@ -203,7 +203,7 @@ class SeldonModelGRPC(object):
 
     def SendFeedback(self, feedback_grpc, context):
         return seldon_core.seldon_methods.send_feedback(
-            self.user_model, feedback_grpc, PRED_UNIT_ID
+            self.user_model, feedback_grpc, PRED_UNIT_ID, self.seldon_metrics
         )
 
     def TransformInput(self, request_grpc, context):

--- a/python/tests/test_metrics.py
+++ b/python/tests/test_metrics.py
@@ -353,6 +353,35 @@ def test_seldon_metrics_predict(cls, client_gets_metrics):
 
 
 @pytest.mark.parametrize("cls", [UserObject, UserObjectLowLevel])
+def test_seldon_metrics_send_feedback(cls):
+    user_object = cls()
+    seldon_metrics = SeldonMetrics()
+
+    app = get_rest_microservice(user_object, seldon_metrics)
+    client = app.test_client()
+
+    rv = client.get('/send-feedback?json={"reward": 42}')
+    assert rv.status_code == 200
+
+    data = seldon_metrics.data[os.getpid()]
+
+    assert data["COUNTER", "seldon_api_model_feedback_reward"] == {
+        "value": 42.0,
+        "tags": {},
+    }
+
+    rv = client.get('/send-feedback?json={"reward": 42}')
+    assert rv.status_code == 200
+
+    data = seldon_metrics.data[os.getpid()]
+
+    assert data["COUNTER", "seldon_api_model_feedback_reward"] == {
+        "value": 84.0,
+        "tags": {},
+    }
+
+
+@pytest.mark.parametrize("cls", [UserObject, UserObjectLowLevel])
 def test_seldon_metrics_aggregate(cls, client_gets_metrics):
     user_object = cls()
     seldon_metrics = SeldonMetrics()

--- a/python/tests/test_model_microservice.py
+++ b/python/tests/test_model_microservice.py
@@ -58,6 +58,8 @@ class UserObject(SeldonComponent):
         self.nparray = np.array([1, 2, 3])
         self.ret_meta = ret_meta
 
+        self.rewards = []
+
     def predict(self, X, features_names, **kwargs):
         """
         Return a prediction.
@@ -76,7 +78,8 @@ class UserObject(SeldonComponent):
             logging.info(X)
             return X
 
-    def feedback(self, features, feature_names, reward, truth):
+    def send_feedback(self, features, feature_names, reward, truth, routing=None):
+        self.rewards.append(reward)
         logging.info("Feedback called")
 
     def tags(self):
@@ -435,6 +438,7 @@ def test_model_feedback_ok():
     j = json.loads(rv.data)
     logging.info(j)
     assert rv.status_code == 200
+    assert user_object.rewards[-1] == 1.0
 
 
 def test_feedback_v10_ok():


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

It makes sure that `reward metrics` is recorded when model's `send-feedback` is hit.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/SeldonIO/seldon-core/issues/2115

**Special notes for your reviewer**:

- adds `SELDON_EXECUTOR_ENABLED` environmental variable on the wrapper
- fixes custom metrics tags (keep wrong ones until 1.3 for compatibility reasons)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

