### PR TITLE
Add error handler for R

### DIFF
--- a/incubating/wrappers/s2i/R/microservice.R
+++ b/incubating/wrappers/s2i/R/microservice.R
@@ -308,7 +308,7 @@ error_handler <- function(req, res, err) {
     res$status <- 500
     list(error = "500 - Internal server error")
   } else {
-    res$status <- err$status
+    res$status <- err$status_code
     list(
       status = list(
         status=jsonlite::unbox("FAILURE"),

--- a/incubating/wrappers/s2i/R/microservice.R
+++ b/incubating/wrappers/s2i/R/microservice.R
@@ -12,31 +12,31 @@ parseQS <- function(qs){
   if (stri_startswith_fixed(qs, "?")) {
     qs <- substr(qs, 2, nchar(qs))
   }
-  
+
   parts <- strsplit(qs, "&", fixed = TRUE)[[1]]
   kv <- strsplit(parts, "=", fixed = TRUE)
   kv <- kv[sapply(kv, length) == 2] # Ignore incompletes
-  
+
   keys <- sapply(kv, "[[", 1)
   keys <- unname(sapply(keys, url_decode))
-  
+
   vals <- sapply(kv, "[[", 2)
   vals[is.na(vals)] <- ""
   vals <- unname(sapply(vals, url_decode))
-  
+
   ret <- as.list(vals)
   names(ret) <- keys
-  
+
   # If duplicates, combine
   combine_elements <- function(name){
     unname(unlist(ret[names(ret)==name]))
   }
-  
+
   unique_names <- unique(names(ret))
-  
+
   ret <- lapply(unique_names, combine_elements)
   names(ret) <- unique_names
-  
+
   ret
 }
 
@@ -127,8 +127,8 @@ parse_data <- function(req){
 }
 
 predict_endpoint <- function(req,res,json=NULL,isDefault=NULL) {
-  #for ( obj in ls(req) ) { 
-  #  print(c(obj,get(obj,envir = req))) 
+  #for ( obj in ls(req) ) {
+  #  print(c(obj,get(obj,envir = req)))
   #}
   json <- parse_data(req) # Hack as Plumber using URLDecode which doesn't decode +
   jdf <- fromJSON(json)
@@ -229,15 +229,15 @@ parse_commandline <- function() {
                        help="Persistence", metavar = "persistence", default = 0)
   args <- parse_args(parser, args = commandArgs(trailingOnly = TRUE),
                      convert_hyphens_to_underscores = TRUE)
-  
+
   if (is.null(args$parameters)){
     args$parameters <- Sys.getenv("PREDICTIVE_UNIT_PARAMETERS")
   }
-  
+
   if (args$parameters == ''){
     args$parameters = "[]"
   }
-  
+
   args
 }
 
@@ -301,7 +301,27 @@ route <- function(x,...) UseMethod("route",x)
 transform_input <- function(x,...) UseMethod("transform_input",x)
 transform_output <- function(x,...) UseMethod("transform_output",x)
 
+error_handler <- function(req, res, err) {
+  if (!inherits(err, "seldon_microservice_error")) {
+    print(err)
+
+    res$status <- 500
+    list(error = "500 - Internal server error")
+  } else {
+    res$status <- err$status
+    list(
+      status = list(
+        status=jsonlite::unbox("FAILURE"),
+        info=jsonlite::unbox(err$message),
+        code=jsonlite::unbox(err$status_code),
+        reason=jsonlite::unbox(err$reason)
+      )
+    )
+  }
+}
+
 serve_model <- plumber$new()
+serve_model$setErrorHandler(error_handler)
 if (args$service == "MODEL") {
   serve_model$handle("POST", "/predict",predict_endpoint)
   serve_model$handle("GET", "/predict",predict_endpoint)
@@ -312,12 +332,12 @@ if (args$service == "MODEL") {
   serve_model$handle("GET", "/route",route_endpoint)
   serve_model$handle("POST", "/send-feedback",send_feedback_endpoint)
   serve_model$handle("GET", "/send-feedback",send_feedback_endpoint)
-}  else if (args$service == "TRANSFORMER") {  
+}  else if (args$service == "TRANSFORMER") {
   serve_model$handle("POST", "/transform-output",transform_output_endpoint)
   serve_model$handle("GET", "/transform-output",transform_output_endpoint)
   serve_model$handle("POST", "/transform-input",transform_input_endpoint)
   serve_model$handle("GET", "/transform-input",transform_input_endpoint)
-  
+
 } else
 {
   v("Unknown service type [%s]\n",args$service)

--- a/incubating/wrappers/s2i/R/seldon_microservice_error.R
+++ b/incubating/wrappers/s2i/R/seldon_microservice_error.R
@@ -1,0 +1,7 @@
+seldon_microservice_error <- function(message, status_code, reason="MICROSERVICE_BAD_DATA") {
+  err <- structure(
+    list(message = message, status_code = status_code, reason = reason),
+    class = c("seldon_microservice_error", "error", "condition")
+  )
+  signalCondition(err)
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
raise an error in R code, can not get the message we create

response now:
<img width="526" alt="螢幕快照 2020-07-17 下午4 17 14" src="https://user-images.githubusercontent.com/43433325/87773651-07185800-c856-11ea-96a2-1f403e47d8fa.png">

expect response:
<img width="345" alt="螢幕快照 2020-07-17 下午4 20 10" src="https://user-images.githubusercontent.com/43433325/87773751-316a1580-c856-11ea-99fe-c912b20b90fe.png">

so add an error handler to catch `seldon_microservice_error` which is used to create a custom error

usage:
```R
source("seldon_microservice_error.R")

predict.model_f <- function() {
  seldon_microservice_error("param X wrong", 400)
}
```

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Added custom error for R
```

