### PR TITLE
Add mock classifier to related images for RedHat

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -61,6 +61,8 @@ spec:
           value: ""          
         - name: RELATED_IMAGE_EXPLAINER
           value: ""          
+        - name: RELATED_IMAGE_MOCK_CLASSIFIER
+          value: ""          
         - name: MANAGER_CREATE_RESOURCES          
           value: "false"
         - name: POD_NAMESPACE

--- a/operator/seldon-operator/bundle/create_bundle.sh
+++ b/operator/seldon-operator/bundle/create_bundle.sh
@@ -7,7 +7,8 @@ STARTUP_DIR="$( cd "$( dirname "$0" )" && pwd )"
 OPERATOR_IMAGE=registry.connect.redhat.com/seldonio/seldon-core-operator
 EXECUTOR_IMAGE=registry.connect.redhat.com/seldonio/seldon-core-executor
 ENGINE_IMAGE=registry.connect.redhat.com/seldonio/seldon-engine
-MOCK_IMAGE=registry.connect.redhat.com/seldonio/mock-classifier@sha256:482ee477c344badcaa80e850f4339db41957f9c2396ae24f9e398b67bd5c184e
+MOCK_IMAGE_SHA=registry.connect.redhat.com/seldonio/mock-classifier@sha256:482ee477c344badcaa80e850f4339db41957f9c2396ae24f9e398b67bd5c184e
+MOCK_IMAGE=registry.connect.redhat.com/seldonio/mock-classifier
 STORAGE_INITIALIZER_IMAGE=registry.connect.redhat.com/seldonio/storage-initializer
 SKLEARNSERVER_REST_IMAGE=registry.connect.redhat.com/seldonio/sklearnserver-rest
 SKLEARNSERVER_GRPC_IMAGE=registry.connect.redhat.com/seldonio/sklearnserver-grpc
@@ -34,7 +35,7 @@ function update_images {
     sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_ENGINE$\)#\1\2\n\1  value: '${ENGINE_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
     sed -i 's#\(^.*image: \)seldonio/seldon-core-operator:.*$#\1'${OPERATOR_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
     sed -i 's#\(^.*containerImage: \)seldonio/seldon-core-operator:.*$#\1'${OPERATOR_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
-    sed -i 's#seldonio/mock_classifier_rest:1.3#'${MOCK_IMAGE}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
+    sed -i 's#seldonio/mock_classifier_rest:1.3#'${MOCK_IMAGE_SHA}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
     sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_STORAGE_INITIALIZER$\)#\1\2\n\1  value: '${STORAGE_INITIALIZER_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
     sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_SKLEARNSERVER_REST$\)#\1\2\n\1  value: '${SKLEARNSERVER_REST_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
     sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_SKLEARNSERVER_GRPC$\)#\1\2\n\1  value: '${SKLEARNSERVER_GRPC_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
@@ -46,6 +47,7 @@ function update_images {
     sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_TFPROXY_GRPC$\)#\1\2\n\1  value: '${TFPROXY_GRPC_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
     sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_TENSORFLOW$\)#\1\2\n\1  value: '${TENSORFLOW_IMAGE}:2.1.0'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
     sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_EXPLAINER$\)#\1\2\n\1  value: '${EXPLAINER_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml
+    sed -i 's#\(^.*\)\(- name: RELATED_IMAGE_MOCK_CLASSIFIER$\)#\1\2\n\1  value: '${MOCK_IMAGE}:${VERSION}'#' certified/${VERSION}/seldon-operator.v${VERSION}.clusterserviceversion.yaml    
 }
 
 function update_package {


### PR DESCRIPTION
Fixes #2118 

 * Adds mock-classifier to RELATED_IMAGE section of manager.