### PR TITLE
Release Pipeline

### DIFF
--- a/ci/create-release
+++ b/ci/create-release
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# add-pr-build-comment
+#
+set -o nounset
+set -o errexit
+set -o pipefail
+set -o noclobber
+set -o noglob
+set -o xtrace
+
+VERSION=$(cat ../version.txt)
+
+# Check if version has trailing -dev otherwise exit
+if [ ${VERSION##*-dev} ]; then
+    echo "Version does not end with -dev"
+    exit 1
+fi
+
+# Remove trailing dev as that will be our release version
+VERSION=${VERSION%"-dev"}
+BRANCH_NAME="release-$VERSION"
+
+# Don't exit on failure so we can test branch exists
+set +o errexit
+    git checkout -b $BRANCH_NAME
+    RETVAL=$?
+    if [[ ${RETVAL} -eq 0 ]]; then
+        echo "Branch already exists"
+        git checkout $BRANCH_NAME
+        git rebase master
+    fi
+set -o errexit
+
+# Perform required actions for release
+(cd ../engine && mvn versions:set -DnewVersion=$(cat ../version.txt))
+(cd ../ && python release.py $(cat version.txt))
+
+# Push updated changes for release
+git add ..
+git commit -m $BRANCH_NAME
+git push origin $BRANCH_NAME
+
+

--- a/ci/create-release
+++ b/ci/create-release
@@ -21,6 +21,10 @@ fi
 VERSION=${VERSION%"-dev"}
 BRANCH_NAME="release-$VERSION"
 
+# Check out master branch to use as base
+git fetch origin master
+git checkout master
+
 # Don't exit on failure so we can test branch exists
 set +o errexit
     git checkout -b $BRANCH_NAME
@@ -38,7 +42,7 @@ set -o errexit
 
 # Push updated changes for release
 git add ..
-git commit -m $BRANCH_NAME
+git commit -m "Updating $BRANCH_NAME"
 git push origin $BRANCH_NAME
 
 

--- a/jenkins-x-createrelease.yml
+++ b/jenkins-x-createrelease.yml
@@ -22,4 +22,4 @@ pipelineConfig:
             steps:
             - name: create-release-step
               dir: ci
-              sh: "./add-pr-build-comment"
+              sh: "./create-release"

--- a/jenkins-x-createrelease.yml
+++ b/jenkins-x-createrelease.yml
@@ -1,0 +1,25 @@
+buildPack: none
+pipelineConfig:
+  pipelines:
+    overrides:
+    - name: changelog
+      pipeline: release
+      stage: promote
+      step:
+        command: echo "skipping promote"
+    release:
+      setVersion:
+        steps:
+        - name: create-version
+          command: cat version.txt > VERSION
+        - name: skip-tag
+          command: echo "skipping tag"
+      pipeline:
+        agent:
+          image: seldonio/core-builder:0.15
+        stages:
+          - name: create-release
+            steps:
+            - name: create-release-step
+              dir: ci
+              sh: "./add-pr-build-comment"


### PR DESCRIPTION
This PR contains functionality to allow us to perform a release with the command:
* `jx pipeline start SeldonIO/seldon-core/createrelease`

What this pipeline will do is:
* Get the VERSION
* Remove the trailing `-dev`
* Run the release scripts
* Push to a branch with the name `release-$VERSION` 

Once the branch is pushed, the usual `release` pipeline will be triggered, which means all containers will be pushed. The key thing is that the only things outstanding will be to do any manual steps such as pushing to the helm charts, and to pypi. However if we want to automate anything else such as the creation of the changelogs, this could be done by adding it to the release script.

For complenetess, the jx scheduler added is the following:
```
    - agent: tekton
      branches:
        entries:
        - createrelease
      name: createrelease
      context: "createrelease"
```

## Disadvantage of current implementation

The pipeline will have to be triggered using the source code of the branch `createrelease`, and this is due to the limitation explained below.

## Explanantion of the pipeline

The current setup is slightly limited due to a constraint in jenkins X, namely that it's not possible to create "release pipelines" that are NOT triggered on every merge.

The `createrelease` pipeline will not be connected in the master branch - that would've been ideal, as that way we can make sure the code executed is always the latest.  However given that if we connect the `createrelease` pipeline to the master branch, it would get triggered every time a new PR is merged, which is not something we want (as we want to trigger it on demand with the command).

Because of this, we have to connect the pipeline to a branch called `createpipeline`, which means that every time we change the CI script or the file `jenkins-x-createpipeline.yml` we'll have to update the branch, which is not as bad given it is quite minimal.
