### PR TITLE
add 2 args to seldon-core-microservice

### DIFF
--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -279,6 +279,22 @@ def main():
         help="Force the Flask app to run single-threaded. Also applies to Gunicorn.",
     )
 
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get(SERVICE_PORT_ENV_NAME, DEFAULT_PORT)),
+        help="Set port of seldon service",
+    )
+
+    parser.add_argument(
+        "--metrics_port",
+        type=int,
+        default=int(
+            os.environ.get(METRICS_SERVICE_PORT_ENV_NAME, DEFAULT_METRICS_PORT)
+        ),
+        help="Set port of seldon service",
+    )
+
     args = parser.parse_args()
     parameters = parse_parameters(json.loads(args.parameters))
 
@@ -313,10 +329,8 @@ def main():
     else:
         user_object = user_class(**parameters)
 
-    port = int(os.environ.get(SERVICE_PORT_ENV_NAME, DEFAULT_PORT))
-    metrics_port = int(
-        os.environ.get(METRICS_SERVICE_PORT_ENV_NAME, DEFAULT_METRICS_PORT)
-    )
+    port = args.port
+    metrics_port = args.metrics_port
 
     if args.tracing:
         tracer = setup_tracing(args.interface_name)

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -287,12 +287,12 @@ def main():
     )
 
     parser.add_argument(
-        "--metrics_port",
+        "--metrics-port",
         type=int,
         default=int(
             os.environ.get(METRICS_SERVICE_PORT_ENV_NAME, DEFAULT_METRICS_PORT)
         ),
-        help="Set port of seldon service",
+        help="Set metrics port of seldon service",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR adds two arguments to `seldon_core_microservice` command line tool. The arguments are `port` and `metrics_port`. 
This addition is necessary to allow multiple endpoints launched with `seldon_core_microservice` to run simultaneously. The current use for this is to parallelize the test of multiple components before building docker images or deploying to kubernetes. 
**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
No issue submitted for this. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Added the arguments `port` and `metrics_port` to `seldon_core_microservice` command line tool. 
```



