### PR TITLE
featt(http2): Update service endpoints

### DIFF
--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -634,7 +634,7 @@ func createPredictorService(pSvcName string, seldonId string, p *machinelearning
 		},
 	}
 	if isExecutorEnabled(mlDep) {
-		psvc.Spec.Ports = append(psvc.Spec.Ports, corev1.ServicePort{Protocol: corev1.ProtocolTCP, Port: int32(engine_http_port), TargetPort: intstr.FromInt(engine_http_port), Name: "http2"})
+		psvc.Spec.Ports = append(psvc.Spec.Ports, corev1.ServicePort{Protocol: corev1.ProtocolTCP, Port: int32(engine_http_port), TargetPort: intstr.FromInt(engine_http_port), Name: "executor"})
 	} else {
 		if engine_http_port != 0 && len(psvc.Spec.Ports) == 0 {
 			psvc.Spec.Ports = append(psvc.Spec.Ports, corev1.ServicePort{Protocol: corev1.ProtocolTCP, Port: int32(engine_http_port), TargetPort: intstr.FromInt(engine_http_port), Name: "http"})

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -212,9 +212,11 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -262,6 +264,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -302,6 +305,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -464,6 +468,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: seldon-system/seldon-serving-cert
     controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
   labels:
     app: seldon
     app.kubernetes.io/instance: seldon1
@@ -30,10 +31,14 @@ spec:
       description: SeldonDeployment is the Schema for the seldondeployments API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -68,30 +73,56 @@ spec:
                               type: integer
                             metrics:
                               items:
-                                description: MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+                                description: MetricSpec specifies how to scale based
+                                  on a single metric (only `type` and one other matching
+                                  field should be set at once).
                                 properties:
                                   external:
-                                    description: external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+                                    description: external refers to a global metric
+                                      that is not associated with any Kubernetes object.
+                                      It allows autoscaling based on information coming
+                                      from components running outside of cluster (for
+                                      example length of queue in cloud messaging service,
+                                      or QPS from loadbalancer running outside of
+                                      cluster).
                                     properties:
                                       metricName:
-                                        description: metricName is the name of the metric in question.
+                                        description: metricName is the name of the
+                                          metric in question.
                                         type: string
                                       metricSelector:
-                                        description: metricSelector is used to identify a specific time series within a given metric.
+                                        description: metricSelector is used to identify
+                                          a specific time series within a given metric.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -103,55 +134,91 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       targetAverageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
+                                        description: targetAverageValue is the target
+                                          per-pod value of global metric (as a quantity).
+                                          Mutually exclusive with TargetValue.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       targetValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetValue is the target value of the metric (as a quantity). Mutually exclusive with TargetAverageValue.
+                                        description: targetValue is the target value
+                                          of the metric (as a quantity). Mutually
+                                          exclusive with TargetAverageValue.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - metricName
                                     type: object
                                   object:
-                                    description: object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+                                    description: object refers to a metric describing
+                                      a single kubernetes object (for example, hits-per-second
+                                      on an Ingress object).
                                     properties:
                                       averageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       metricName:
-                                        description: metricName is the name of the metric in question.
+                                        description: metricName is the name of the
+                                          metric in question.
                                         type: string
                                       selector:
-                                        description: selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -163,20 +230,28 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       target:
-                                        description: target is the described Kubernetes object.
+                                        description: target is the described Kubernetes
+                                          object.
                                         properties:
                                           apiVersion:
                                             description: API version of the referent
                                             type: string
                                           kind:
-                                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                            description: 'Kind of the referent; More
+                                              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            description: 'Name of the referent; More
+                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         required:
                                         - kind
@@ -186,7 +261,8 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetValue is the target value of the metric (as a quantity).
+                                        description: targetValue is the target value
+                                          of the metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -195,27 +271,54 @@ spec:
                                     - targetValue
                                     type: object
                                   pods:
-                                    description: pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+                                    description: pods refers to a metric describing
+                                      each pod in the current scale target (for example,
+                                      transactions-processed-per-second).  The values
+                                      will be averaged together before being compared
+                                      to the target value.
                                     properties:
                                       metricName:
-                                        description: metricName is the name of the metric in question
+                                        description: metricName is the name of the
+                                          metric in question
                                         type: string
                                       selector:
-                                        description: selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
-                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key that the selector applies to.
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -227,14 +330,21 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       targetAverageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+                                        description: targetAverageValue is the target
+                                          value of the average of the metric across
+                                          all relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -242,27 +352,44 @@ spec:
                                     - targetAverageValue
                                     type: object
                                   resource:
-                                    description: resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+                                    description: resource refers to a resource metric
+                                      (such as those specified in requests and limits)
+                                      known to Kubernetes describing each pod in the
+                                      current scale target (e.g. CPU or memory). Such
+                                      metrics are built in to Kubernetes, and have
+                                      special scaling options on top of those available
+                                      to normal per-pod metrics using the "pods" source.
                                     properties:
                                       name:
-                                        description: name is the name of the resource in question.
+                                        description: name is the name of the resource
+                                          in question.
                                         type: string
                                       targetAverageUtilization:
-                                        description: targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+                                        description: targetAverageUtilization is the
+                                          target value of the average of the resource
+                                          metric across all relevant pods, represented
+                                          as a percentage of the requested value of
+                                          the resource for the pods.
                                         format: int32
                                         type: integer
                                       targetAverageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
+                                        description: targetAverageValue is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, as a raw value
+                                          (instead of as a percentage of the request),
+                                          similar to the "pods" metric source type.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - name
                                     type: object
                                   type:
-                                    description: type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+                                    description: type is the type of metric source.  It
+                                      should be one of "Object", "Pods" or "Resource",
+                                      each mapping to a matching field in the object.
                                     type: string
                                 required:
                                 - type
@@ -283,36 +410,79 @@ spec:
                           description: PodSpec is a description of a pod.
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
+                              description: Optional duration in seconds the pod may
+                                be active on the node relative to StartTime before
+                                the system will actively try to mark it failed and
+                                kill associated containers. Value must be a positive
+                                integer.
                               format: int64
                               type: integer
                             affinity:
                               description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node matches the corresponding matchExpressions;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                        description: An empty preferred scheduling
+                                          term matches all objects with implicit weight
+                                          0 (i.e. it's a no-op). A null preferred
+                                          scheduling term matches no objects (i.e.
+                                          is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
+                                                description: A list of node selector
+                                                  requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -322,18 +492,38 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
+                                                description: A list of node selector
+                                                  requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -344,7 +534,9 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -353,26 +545,57 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                            description: A null or empty node selector
+                                              term matches no objects. The requirements
+                                              of them are ANDed. The TopologySelectorTerm
+                                              type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
+                                                description: A list of node selector
+                                                  requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -382,18 +605,38 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
+                                                description: A list of node selector
+                                                  requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -409,32 +652,74 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node has pods which matches the corresponding
+                                        podAffinityTerm; the node(s) with the highest
+                                        sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -446,22 +731,45 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -470,26 +778,64 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node. When there are
+                                        multiple elements, the lists of nodes corresponding
+                                        to each podAffinityTerm are intersected, i.e.
+                                        all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
+                                            description: A label query over a set
+                                              of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -501,16 +847,34 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty
+                                              list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -518,32 +882,75 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g. avoid putting this pod in the same
+                                    node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the anti-affinity
+                                        expressions specified by this field, but it
+                                        may choose a node that violates one or more
+                                        of the expressions. The node that is most
+                                        preferred is the one with the greatest sum
+                                        of weights, i.e. for each node that meets
+                                        all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity
+                                        expressions, etc.), compute a sum by iterating
+                                        through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which
+                                        matches the corresponding podAffinityTerm;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -555,22 +962,45 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -579,26 +1009,64 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      description: If the anti-affinity requirements
+                                        specified by this field are not met at scheduling
+                                        time, the pod will not be scheduled onto the
+                                        node. If the anti-affinity requirements specified
+                                        by this field cease to be met at some point
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node. When
+                                        there are multiple elements, the lists of
+                                        nodes corresponding to each podAffinityTerm
+                                        are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
+                                            description: A label query over a set
+                                              of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -610,16 +1078,34 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty
+                                              list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -628,36 +1114,76 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                              description: AutomountServiceAccountToken indicates
+                                whether a service account token should be automatically
+                                mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
+                              description: List of containers belonging to the pod.
+                                Containers cannot currently be added or removed. There
+                                must be at least one container in a Pod. Cannot be
+                                updated.
                               items:
-                                description: A single application container that you want to run within a pod.
+                                description: A single application container that you
+                                  want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -666,56 +1192,84 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -726,72 +1280,127 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -799,58 +1408,108 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -858,25 +1517,38 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -884,31 +1556,53 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -922,70 +1616,115 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                    description: List of ports to expose from the
+                                      container. Exposing a port here gives the system
+                                      additional information about the network connections
+                                      a container uses, but is primarily informational.
+                                      Not specifying a port here DOES NOT prevent
+                                      that port from being exposed. Any port which
+                                      is listening on the default "0.0.0.0" address
+                                      inside a container will be accessible from the
+                                      network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
+                                      description: ContainerPort represents a network
+                                        port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
+                                          description: What host IP to bind the external
+                                            port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
                                           type: string
                                         protocol:
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -996,31 +1735,54 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -1034,48 +1796,71 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1084,7 +1869,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1093,107 +1880,219 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
+                                            description: Level is SELinux level label
+                                              that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
+                                            description: User is a SELinux user label
+                                              that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. This is an alpha feature
+                                      enabled by the StartupProbe feature flag. More
+                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -1207,77 +2106,140 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1285,27 +2247,46 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1313,24 +2294,37 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+                              description: Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated
+                                DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+                                  description: A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers
+                                    generated from DNSPolicy. Duplicated nameservers
+                                    will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+                                  description: A list of DNS resolver options. This
+                                    will be merged with the base options generated
+                                    from DNSPolicy. Duplicated entries will be removed.
+                                    Resolution options given in Options will override
+                                    those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                    description: PodDNSConfigOption defines DNS resolver
+                                      options of a pod.
                                     properties:
                                       name:
                                         description: Required.
@@ -1340,45 +2334,112 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+                                  description: A list of DNS search domains for host-name
+                                    lookup. This will be appended to the base search
+                                    paths generated from DNSPolicy. Duplicated search
+                                    paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                              description: Set DNS policy for the pod. Defaults to
+                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
+                                'ClusterFirst', 'Default' or 'None'. DNS parameters
+                                given in DNSConfig will be merged with the policy
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                              description: 'EnableServiceLinks indicates whether information
+                                about services should be injected into pod''s environment
+                                variables, matching the syntax of Docker links. Optional:
+                                Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+                              description: List of ephemeral containers run in this
+                                pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging.
+                                This list cannot be specified when creating a pod,
+                                and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
+                                This field is alpha-level and is only honored by servers
+                                that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+                                description: An EphemeralContainer is a container
+                                  that may be added temporarily to an existing pod
+                                  for user-initiated activities such as debugging.
+                                  Ephemeral containers have no resource or scheduling
+                                  guarantees, and they will not be restarted when
+                                  they exit or when a pod is removed or restarted.
+                                  If an ephemeral container causes a pod to exceed
+                                  its resource allocation, the pod may be evicted.
+                                  Ephemeral containers may not be added by directly
+                                  updating the pod spec. They must be added via the
+                                  pod's ephemeralcontainers subresource, and they
+                                  will appear in the pod spec once added. This is
+                                  an alpha feature enabled by the EphemeralContainers
+                                  feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -1387,56 +2448,84 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1447,31 +2536,50 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                       type: object
@@ -1480,39 +2588,70 @@ spec:
                                     description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
+                                    description: Lifecycle is not allowed for ephemeral
+                                      containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -1520,64 +2659,114 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -1585,31 +2774,44 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1617,31 +2819,52 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -1655,107 +2878,167 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+                                    description: Name of the ephemeral container specified
+                                      as a DNS_LABEL. This name must be unique among
+                                      all containers, init containers and ephemeral
+                                      containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
+                                    description: Ports are not allowed for ephemeral
+                                      containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
+                                      description: ContainerPort represents a network
+                                        port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
+                                          description: What host IP to bind the external
+                                            port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
                                           type: string
                                         protocol:
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -1769,54 +3052,78 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+                                    description: Resources are not allowed for ephemeral
+                                      containers. Ephemeral containers use spare resources
+                                      already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1825,7 +3132,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1834,107 +3143,208 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
+                                    description: SecurityContext is not allowed for
+                                      ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
+                                            description: Level is SELinux level label
+                                              that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
+                                            description: User is a SELinux user label
+                                              that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -1948,80 +3358,149 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+                                    description: If set, the name of the container
+                                      from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces
+                                      (IPC, PID, etc) of this container. If not set
+                                      then the ephemeral container is run in whatever
+                                      namespaces are shared for the pod. Note that
+                                      the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2029,27 +3508,46 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2057,16 +3555,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
+                              description: HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork
+                                pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                                description: HostAlias holds the mapping between IP
+                                  and hostnames that will be injected as an entry
+                                  in the pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -2079,55 +3585,123 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
+                              description: 'Use the host''s ipc namespace. Optional:
+                                Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
+                              description: Host networking requested for this pod.
+                                Use the host's network namespace. If this option is
+                                set, the ports that will be used must be specified.
+                                Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
+                              description: 'Use the host''s pid namespace. Optional:
+                                Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
+                              description: Specifies the hostname of the Pod If not
+                                specified, the pod's hostname will be set to a system-defined
+                                value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: 'ImagePullSecrets is an optional list of
+                                references to secrets in the same namespace to use
+                                for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual
+                                puller implementations for them to use. For example,
+                                in the case of docker, only DockerConfig type secrets
+                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                description: LocalObjectReference contains enough
+                                  information to let you locate the referenced object
+                                  inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              description: 'List of initialization containers belonging
+                                to the pod. Init containers are executed in order
+                                prior to containers being started. If any init container
+                                fails, the pod is considered to have failed and is
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers. Init containers may not have
+                                Lifecycle actions, Readiness probes, Liveness probes,
+                                or Startup probes. The resourceRequirements of an
+                                init container are taken into account during scheduling
+                                by finding the highest request/limit for each resource
+                                type, and then using the max of of that value or the
+                                sum of the normal containers. Limits are applied to
+                                init containers in a similar fashion. Init containers
+                                cannot currently be added or removed. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
+                                description: A single application container that you
+                                  want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -2136,56 +3710,84 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2196,72 +3798,127 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -2269,58 +3926,108 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -2328,25 +4035,38 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2354,31 +4074,53 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -2392,70 +4134,115 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                    description: List of ports to expose from the
+                                      container. Exposing a port here gives the system
+                                      additional information about the network connections
+                                      a container uses, but is primarily informational.
+                                      Not specifying a port here DOES NOT prevent
+                                      that port from being exposed. Any port which
+                                      is listening on the default "0.0.0.0" address
+                                      inside a container will be accessible from the
+                                      network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
+                                      description: ContainerPort represents a network
+                                        port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
+                                          description: What host IP to bind the external
+                                            port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
                                           type: string
                                         protocol:
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2466,31 +4253,54 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -2504,48 +4314,71 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2554,7 +4387,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2563,107 +4398,219 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
+                                            description: Level is SELinux level label
+                                              that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
+                                            description: User is a SELinux user label
+                                              that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. This is an alpha feature
+                                      enabled by the StartupProbe feature flag. More
+                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -2677,77 +4624,140 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2755,27 +4765,46 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2783,19 +4812,28 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+                              description: NodeName is a request to schedule this
+                                pod onto a specific node. If it is non-empty, the
+                                scheduler simply schedules this pod onto that node,
+                                assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: 'NodeSelector is a selector which must
+                                be true for the pod to fit on a node. Selector which
+                                must match a node''s labels for the pod to be scheduled
+                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2804,83 +4842,175 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
+                              description: 'Overhead represents the resource overhead
+                                associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time
+                                by the RuntimeClass admission controller. If the RuntimeClass
+                                admission controller is enabled, overhead must not
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set. If RuntimeClass is configured
+                                and selected in the PodSpec, Overhead will be set
+                                to the value defined in the corresponding RuntimeClass,
+                                otherwise it will remain unset and treated as zero.
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                                This field is alpha-level as of Kubernetes v1.16,
+                                and is only honored by servers that enable the PodOverhead
+                                feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+                              description: PreemptionPolicy is the Policy for preempting
+                                pods with lower priority. One of Never, PreemptLowerPriority.
+                                Defaults to PreemptLowerPriority if unset. This field
+                                is alpha-level and is only honored by servers that
+                                enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
+                              description: The priority value. Various system components
+                                use this field to find the priority of the pod. When
+                                Priority Admission Controller is enabled, it prevents
+                                users from setting this field. The admission controller
+                                populates this field from PriorityClassName. The higher
+                                the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                              description: 'If specified, all readiness gates will
+                                be evaluated for pod readiness. A pod is ready when
+                                all its containers are ready AND all conditions specified
+                                in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
+                                description: PodReadinessGate contains the reference
+                                  to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
+                                    description: ConditionType refers to a condition
+                                      in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: 'Restart policy for all containers within
+                                the pod. One of Always, OnFailure, Never. Default
+                                to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
+                              description: 'RuntimeClassName refers to a RuntimeClass
+                                object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                                This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
+                              description: If specified, the pod will be dispatched
+                                by specified scheduler. If not specified, the pod
+                                will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
+                              description: 'SecurityContext holds pod-level security
+                                attributes and common container settings. Optional:
+                                Defaults to empty.  See type description for default
+                                values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
+                                  description: "A special supplemental group that
+                                    applies to all containers in a pod. Some volume
+                                    types allow the Kubelet to change the ownership
+                                    of that volume to be owned by the pod: \n 1. The
+                                    owning GID will be the FSGroup 2. The setgid bit
+                                    is set (new files created in the volume will be
+                                    owned by FSGroup) 3. The permission bits are OR'd
+                                    with rw-rw---- \n If unset, the Kubelet will not
+                                    modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the
+                                    value specified in SecurityContext takes precedence
+                                    for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                  description: The SELinux context to be applied to
+                                    all containers. If unspecified, the container
+                                    runtime will allocate a random SELinux context
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
+                                      description: Level is SELinux level label that
+                                        applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
+                                      description: User is a SELinux user label that
+                                        applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+                                  description: A list of groups applied to the first
+                                    process run in each container, in addition to
+                                    the container's primary GID.  If unspecified,
+                                    no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+                                  description: Sysctls hold a list of namespaced sysctls
+                                    used for the pod. Pods with unsupported sysctls
+                                    (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
                                     properties:
                                       name:
                                         description: Name of a property to set
@@ -2894,79 +5024,168 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                              description: 'DeprecatedServiceAccount is a depreciated
+                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: 'ServiceAccountName is the name of the
+                                ServiceAccount to use to run this pod. More info:
+                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
+                              description: 'Share a single process namespace between
+                                all of the containers in a pod. When this is set containers
+                                will be able to view and signal processes from other
+                                containers in the same pod, and the first process
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
+                              description: If specified, the fully qualified Pod hostname
+                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                domain>". If not specified, the pod will not have
+                                a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully. May be decreased in delete
+                                request. Value must be non-negative integer. The value
+                                zero indicates delete immediately. If this value is
+                                nil, the default grace period will be used instead.
+                                The grace period is the duration in seconds after
+                                the processes running in the pod are sent a termination
+                                signal and the time when the processes are forcibly
+                                halted with a kill signal. Set this value longer than
+                                the expected cleanup time for your process. Defaults
+                                to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                description: The pod this Toleration is attached to
+                                  tolerates any taint that matches the triple <key,value,effect>
+                                  using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    description: Effect indicates the taint effect
+                                      to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule,
+                                      PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    description: Key is the taint key that the toleration
+                                      applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists;
+                                      this combination means to match all values and
+                                      all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                    description: Operator represents a key's relationship
+                                      to the value. Valid operators are Exists and
+                                      Equal. Defaults to Equal. Exists is equivalent
+                                      to wildcard for value, so that a pod can tolerate
+                                      all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                    description: TolerationSeconds represents the
+                                      period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is
+                                      ignored) tolerates the taint. By default, it
+                                      is not set, which means tolerate the taint forever
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    description: Value is the taint value the toleration
+                                      matches to. If the operator is Exists, the value
+                                      should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is alpha-level and is only honored by clusters that enables the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
+                              description: TopologySpreadConstraints describes how
+                                a group of pods ought to spread across topology domains.
+                                Scheduler will schedule pods in a way which abides
+                                by the constraints. This field is alpha-level and
+                                is only honored by clusters that enables the EvenPodsSpread
+                                feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                    description: LabelSelector is used to find matching
+                                      pods. Pods that match this label selector are
+                                      counted to determine the number of pods in their
+                                      corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2978,18 +5197,58 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                    description: 'MaxSkew describes the degree to
+                                      which pods may be unevenly distributed. It''s
+                                      the maximum permitted difference between the
+                                      number of matching pods in any two topology
+                                      domains of a given topology type. For example,
+                                      in a 3-zone cluster, MaxSkew is set to 1, and
+                                      pods with the same labelSelector spread as 1/1/0:
+                                      | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                      - if MaxSkew is 1, incoming pod can only be
+                                      scheduled to zone3 to become 1/1/1; scheduling
+                                      it onto zone1(zone2) would make the ActualSkew(2-0)
+                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
+                                      is 2, incoming pod can be scheduled onto any
+                                      zone. It''s a required field. Default value
+                                      is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                                    description: TopologyKey is the key of node labels.
+                                      Nodes that have a label with this key and identical
+                                      values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket",
+                                      and try to put balanced number of pods into
+                                      each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                    description: 'WhenUnsatisfiable indicates how
+                                      to deal with a pod if it doesn''t satisfy the
+                                      spread constraint. - DoNotSchedule (default)
+                                      tells the scheduler not to schedule it - ScheduleAnyway
+                                      tells the scheduler to still schedule it It''s
+                                      considered as "Unsatisfiable" if and only if
+                                      placing incoming pod on any topology violates
+                                      "MaxSkew". For example, in a 3-zone cluster,
+                                      MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1: | zone1 | zone2
+                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                                      is set to DoNotSchedule, incoming pod can only
+                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                                      as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can
+                                      still be imbalanced, but scheduler won''t make
+                                      it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -3002,7 +5261,8 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: 'List of volumes that can be mounted by
+                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
                                 type: object
                               type: array
@@ -3012,7 +5272,8 @@ spec:
                       type: object
                     type: array
                   engineResources:
-                    description: ResourceRequirements describes the compute resource requirements.
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
                     properties:
                       limits:
                         additionalProperties:
@@ -3021,7 +5282,8 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                       requests:
                         additionalProperties:
@@ -3030,7 +5292,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
                   explainer:
@@ -3040,31 +5305,60 @@ spec:
                           type: string
                         type: object
                       containerSpec:
-                        description: A single application container that you want to run within a pod.
+                        description: A single application container that you want
+                          to run within a pod.
                         properties:
                           args:
-                            description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            description: 'Arguments to the entrypoint. The docker
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. The $(VAR_NAME)
+                              syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                              Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                             items:
                               type: string
                             type: array
                           command:
-                            description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The docker image''s ENTRYPOINT is used if this
+                              is not provided. Variable references $(VAR_NAME) are
+                              expanded using the container''s environment. If a variable
+                              cannot be resolved, the reference in the input string
+                              will be unchanged. The $(VAR_NAME) syntax can be escaped
+                              with a double $$, ie: $$(VAR_NAME). Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the container. Cannot be updated.
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
                             items:
-                              description: EnvVar represents an environment variable present in a Container.
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previous defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    The $(VAR_NAME) syntax can be escaped with a double
+                                    $$, ie: $$(VAR_NAME). Escaped references will
+                                    never be expanded, regardless of whether the variable
+                                    exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
                                       description: Selects a key of a ConfigMap.
@@ -3073,37 +5367,53 @@ spec:
                                           description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap or its key must be defined
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, metadata.labels,
+                                        metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                        status.hostIP, status.podIP, status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in the specified API version.
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for volumes, optional for env vars'
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
@@ -3113,16 +5423,22 @@ spec:
                                       - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the pod's namespace
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or its key must be defined
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -3133,66 +5449,111 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
                             items:
-                              description: EnvFromSource represents the source of a set of ConfigMaps
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must be defined
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be defined
+                                      description: Specify whether the Secret must
+                                        be defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                            description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
                             type: string
                           imagePullPolicy:
-                            description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                            description: 'Image pull policy. One of Always, Never,
+                              IfNotPresent. Defaults to Always if :latest tag is specified,
+                              or IfNotPresent otherwise. Cannot be updated. More info:
+                              https://kubernetes.io/docs/concepts/containers/images#updating-images'
                             type: string
                           lifecycle:
-                            description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
                             properties:
                               postStart:
-                                description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request to perform.
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
-                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
                                         items:
-                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
                                               description: The header field name
@@ -3209,49 +5570,87 @@ spec:
                                         description: Path to access on the HTTP server.
                                         type: string
                                       port:
-                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
                                         type: string
                                     required:
                                     - port
                                     type: object
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: 'TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported TODO:
+                                      implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
-                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
                                         type: string
                                       port:
-                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - port
                                     type: object
                                 type: object
                               preStop:
-                                description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The reason for termination is passed to the
+                                  handler. The Pod''s termination grace period countdown
+                                  begins before the PreStop hooked is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period. Other management of the container
+                                  blocks until the hook completes or until the termination
+                                  grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request to perform.
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
-                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
                                         items:
-                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
                                               description: The header field name
@@ -3268,22 +5667,32 @@ spec:
                                         description: Path to access on the HTTP server.
                                         type: string
                                       port:
-                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
                                         type: string
                                     required:
                                     - port
                                     type: object
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: 'TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported TODO:
+                                      implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
-                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
                                         type: string
                                       port:
-                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - port
@@ -3291,31 +5700,49 @@ spec:
                                 type: object
                             type: object
                           livenessProbe:
-                            description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies the http request to
+                                  perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
                                           description: The header field name
@@ -3332,67 +5759,104 @@ spec:
                                     description: Path to access on the HTTP server.
                                     type: string
                                   port:
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                 - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
                                     type: string
                                   port:
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
                             type: string
                           ports:
-                            description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                            description: List of ports to expose from the container.
+                              Exposing a port here gives the system additional information
+                              about the network connections a container uses, but
+                              is primarily informational. Not specifying a port here
+                              DOES NOT prevent that port from being exposed. Any port
+                              which is listening on the default "0.0.0.0" address
+                              inside a container will be accessible from the network.
+                              Cannot be updated.
                             items:
-                              description: ContainerPort represents a network port in a single container.
+                              description: ContainerPort represents a network port
+                                in a single container.
                               properties:
                                 containerPort:
-                                  description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
                                   format: int32
                                   type: integer
                                 hostIP:
-                                  description: What host IP to bind the external port to.
+                                  description: What host IP to bind the external port
+                                    to.
                                   type: string
                                 hostPort:
-                                  description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
                                   format: int32
                                   type: integer
                                 name:
-                                  description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
                                   type: string
                                 protocol:
-                                  description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                  description: Protocol for port. Must be UDP, TCP,
+                                    or SCTP. Defaults to "TCP".
                                   type: string
                               required:
                               - containerPort
@@ -3403,31 +5867,49 @@ spec:
                             - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies the http request to
+                                  perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
                                           description: The header field name
@@ -3444,45 +5926,62 @@ spec:
                                     description: Path to access on the HTTP server.
                                     type: string
                                   port:
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                 - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
                                     type: string
                                   port:
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             properties:
                               limits:
                                 additionalProperties:
@@ -3491,7 +5990,8 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3500,107 +6000,200 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           securityContext:
-                            description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            description: 'Security options the pod should run with.
+                              More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                             properties:
                               allowPrivilegeEscalation:
-                                description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN'
                                 type: boolean
                               capabilities:
-                                description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime.
                                 properties:
                                   add:
                                     description: Added capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities type
+                                      description: Capability represent POSIX capabilities
+                                        type
                                       type: string
                                     type: array
                                   drop:
                                     description: Removed capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities type
+                                      description: Capability represent POSIX capabilities
+                                        type
                                       type: string
                                     type: array
                                 type: object
                               privileged:
-                                description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false.
                                 type: boolean
                               procMount:
-                                description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled.
                                 type: string
                               readOnlyRootFilesystem:
-                                description: Whether this container has a read-only root filesystem. Default is false.
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false.
                                 type: boolean
                               runAsGroup:
-                                description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
-                                description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
                                 properties:
                                   level:
-                                    description: Level is SELinux level label that applies to the container.
+                                    description: Level is SELinux level label that
+                                      applies to the container.
                                     type: string
                                   role:
-                                    description: Role is a SELinux role label that applies to the container.
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
                                     type: string
                                   type:
-                                    description: Type is a SELinux type label that applies to the container.
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
                                     type: string
                                   user:
-                                    description: User is a SELinux user label that applies to the container.
+                                    description: User is a SELinux user label that
+                                      applies to the container.
                                     type: string
                                 type: object
                               windowsOptions:
-                                description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                      This field is alpha-level and is only honored
+                                      by servers that enable the WindowsGMSA feature
+                                      flag.
                                     type: string
                                   gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use. This field
+                                      is alpha-level and is only honored by servers
+                                      that enable the WindowsGMSA feature flag.
                                     type: string
                                   runAsUserName:
-                                    description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. This field is beta-level and may
+                                      be disabled with the WindowsRunAsUserName feature
+                                      flag.
                                     type: string
                                 type: object
                             type: object
                           startupProbe:
-                            description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. This is an alpha feature enabled by the
+                              StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should be specified. Exec specifies the action to take.
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies the http request to
+                                  perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
                                           description: The header field name
@@ -3620,71 +6213,120 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                 - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           stdin:
-                            description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
                             type: boolean
                           stdinOnce:
-                            description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
                             type: boolean
                           terminationMessagePath:
-                            description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
                             type: string
                           terminationMessagePolicy:
-                            description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                            description: Indicate how the termination message should
+                              be populated. File will use the contents of terminationMessagePath
+                              to populate the container status message on both success
+                              and failure. FallbackToLogsOnError will use the last
+                              chunk of container log output if the termination message
+                              file is empty and the container exited with an error.
+                              The log output is limited to 2048 bytes or 80 lines,
+                              whichever is smaller. Defaults to File. Cannot be updated.
                             type: string
                           tty:
-                            description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
                             type: boolean
                           volumeDevices:
-                            description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
+                            description: volumeDevices is the list of block devices
+                              to be used by the container. This is a beta feature.
                             items:
-                              description: volumeDevice describes a mapping of a raw block device within a container.
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
                               properties:
                                 devicePath:
-                                  description: devicePath is the path inside of the container that the device will be mapped to.
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
                                   type: string
                                 name:
-                                  description: name must match the name of a persistentVolumeClaim in the pod
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
                                   type: string
                               required:
                               - devicePath
@@ -3692,27 +6334,43 @@ spec:
                               type: object
                             type: array
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
                             items:
-                              description: VolumeMount describes a mounting of a Volume within a container.
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
                                   description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -3720,7 +6378,10 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
                             type: string
                         required:
                         - name
@@ -3773,13 +6434,18 @@ spec:
                                               implementation:
                                                 type: string
                                               logger:
-                                                description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
+                                                description: Request/response  payload
+                                                  logging. v2alpha1 feature that is
+                                                  added to v1 for backwards compatibility
+                                                  while v1 is the storage version.
                                                 properties:
                                                   mode:
-                                                    description: What payloads to log
+                                                    description: What payloads to
+                                                      log
                                                     type: string
                                                   url:
-                                                    description: URL to send request logging CloudEvents
+                                                    description: URL to send request
+                                                      logging CloudEvents
                                                     type: string
                                                 type: object
                                               methods:
@@ -3822,13 +6488,17 @@ spec:
                                         implementation:
                                           type: string
                                         logger:
-                                          description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
+                                          description: Request/response  payload logging.
+                                            v2alpha1 feature that is added to v1 for
+                                            backwards compatibility while v1 is the
+                                            storage version.
                                           properties:
                                             mode:
                                               description: What payloads to log
                                               type: string
                                             url:
-                                              description: URL to send request logging CloudEvents
+                                              description: URL to send request logging
+                                                CloudEvents
                                               type: string
                                           type: object
                                         methods:
@@ -3871,7 +6541,9 @@ spec:
                                   implementation:
                                     type: string
                                   logger:
-                                    description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
+                                    description: Request/response  payload logging.
+                                      v2alpha1 feature that is added to v1 for backwards
+                                      compatibility while v1 is the storage version.
                                     properties:
                                       mode:
                                         description: What payloads to log
@@ -3920,7 +6592,9 @@ spec:
                             implementation:
                               type: string
                             logger:
-                              description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
+                              description: Request/response  payload logging. v2alpha1
+                                feature that is added to v1 for backwards compatibility
+                                while v1 is the storage version.
                               properties:
                                 mode:
                                   description: What payloads to log
@@ -3969,7 +6643,9 @@ spec:
                       implementation:
                         type: string
                       logger:
-                        description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
+                        description: Request/response  payload logging. v2alpha1 feature
+                          that is added to v1 for backwards compatibility while v1
+                          is the storage version.
                         properties:
                           mode:
                             description: What payloads to log
@@ -4023,16 +6699,27 @@ spec:
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present in a Container.
+                          description: EnvVar represents an environment variable present
+                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
                                   description: Selects a key of a ConfigMap.
@@ -4041,37 +6728,52 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or its key must be defined
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, metadata.labels,
+                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                    status.hostIP, status.podIP, status.podIPs.'
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in the specified API version.
+                                      description: Path of the field to select in
+                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes, optional for env vars'
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
@@ -4081,16 +6783,22 @@ spec:
                                   - resource
                                   type: object
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's namespace
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its key must be defined
+                                      description: Specify whether the Secret or its
+                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -4104,7 +6812,8 @@ spec:
                         format: int32
                         type: integer
                       resources:
-                        description: ResourceRequirements describes the compute resource requirements.
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
                         properties:
                           limits:
                             additionalProperties:
@@ -4113,7 +6822,8 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
@@ -4122,7 +6832,11 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
                     type: object

--- a/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: seldon-system/seldon-serving-cert
     controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
   labels:
     app: seldon
     app.kubernetes.io/instance: seldon1
@@ -31,14 +30,10 @@ spec:
       description: SeldonDeployment is the Schema for the seldondeployments API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -73,56 +68,30 @@ spec:
                               type: integer
                             metrics:
                               items:
-                                description: MetricSpec specifies how to scale based
-                                  on a single metric (only `type` and one other matching
-                                  field should be set at once).
+                                description: MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
                                 properties:
                                   external:
-                                    description: external refers to a global metric
-                                      that is not associated with any Kubernetes object.
-                                      It allows autoscaling based on information coming
-                                      from components running outside of cluster (for
-                                      example length of queue in cloud messaging service,
-                                      or QPS from loadbalancer running outside of
-                                      cluster).
+                                    description: external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
                                     properties:
                                       metricName:
-                                        description: metricName is the name of the
-                                          metric in question.
+                                        description: metricName is the name of the metric in question.
                                         type: string
                                       metricSelector:
-                                        description: metricSelector is used to identify
-                                          a specific time series within a given metric.
+                                        description: metricSelector is used to identify a specific time series within a given metric.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
+                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -134,91 +103,55 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       targetAverageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetAverageValue is the target
-                                          per-pod value of global metric (as a quantity).
-                                          Mutually exclusive with TargetValue.
+                                        description: targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       targetValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetValue is the target value
-                                          of the metric (as a quantity). Mutually
-                                          exclusive with TargetAverageValue.
+                                        description: targetValue is the target value of the metric (as a quantity). Mutually exclusive with TargetAverageValue.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - metricName
                                     type: object
                                   object:
-                                    description: object refers to a metric describing
-                                      a single kubernetes object (for example, hits-per-second
-                                      on an Ingress object).
+                                    description: object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
                                     properties:
                                       averageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: averageValue is the target value
-                                          of the average of the metric across all
-                                          relevant pods (as a quantity)
+                                        description: averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       metricName:
-                                        description: metricName is the name of the
-                                          metric in question.
+                                        description: metricName is the name of the metric in question.
                                         type: string
                                       selector:
-                                        description: selector is the string-encoded
-                                          form of a standard kubernetes label selector
-                                          for the given metric When set, it is passed
-                                          as an additional parameter to the metrics
-                                          server for more specific metrics scoping
-                                          When unset, just the metricName will be
-                                          used to gather metrics.
+                                        description: selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
+                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -230,28 +163,20 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       target:
-                                        description: target is the described Kubernetes
-                                          object.
+                                        description: target is the described Kubernetes object.
                                         properties:
                                           apiVersion:
                                             description: API version of the referent
                                             type: string
                                           kind:
-                                            description: 'Kind of the referent; More
-                                              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         required:
                                         - kind
@@ -261,8 +186,7 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetValue is the target value
-                                          of the metric (as a quantity).
+                                        description: targetValue is the target value of the metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -271,54 +195,27 @@ spec:
                                     - targetValue
                                     type: object
                                   pods:
-                                    description: pods refers to a metric describing
-                                      each pod in the current scale target (for example,
-                                      transactions-processed-per-second).  The values
-                                      will be averaged together before being compared
-                                      to the target value.
+                                    description: pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
                                     properties:
                                       metricName:
-                                        description: metricName is the name of the
-                                          metric in question
+                                        description: metricName is the name of the metric in question
                                         type: string
                                       selector:
-                                        description: selector is the string-encoded
-                                          form of a standard kubernetes label selector
-                                          for the given metric When set, it is passed
-                                          as an additional parameter to the metrics
-                                          server for more specific metrics scoping
-                                          When unset, just the metricName will be
-                                          used to gather metrics.
+                                        description: selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
+                                                  description: key is the label key that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -330,21 +227,14 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       targetAverageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetAverageValue is the target
-                                          value of the average of the metric across
-                                          all relevant pods (as a quantity)
+                                        description: targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -352,44 +242,27 @@ spec:
                                     - targetAverageValue
                                     type: object
                                   resource:
-                                    description: resource refers to a resource metric
-                                      (such as those specified in requests and limits)
-                                      known to Kubernetes describing each pod in the
-                                      current scale target (e.g. CPU or memory). Such
-                                      metrics are built in to Kubernetes, and have
-                                      special scaling options on top of those available
-                                      to normal per-pod metrics using the "pods" source.
+                                    description: resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
                                     properties:
                                       name:
-                                        description: name is the name of the resource
-                                          in question.
+                                        description: name is the name of the resource in question.
                                         type: string
                                       targetAverageUtilization:
-                                        description: targetAverageUtilization is the
-                                          target value of the average of the resource
-                                          metric across all relevant pods, represented
-                                          as a percentage of the requested value of
-                                          the resource for the pods.
+                                        description: targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
                                         format: int32
                                         type: integer
                                       targetAverageValue:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: targetAverageValue is the target
-                                          value of the average of the resource metric
-                                          across all relevant pods, as a raw value
-                                          (instead of as a percentage of the request),
-                                          similar to the "pods" metric source type.
+                                        description: targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - name
                                     type: object
                                   type:
-                                    description: type is the type of metric source.  It
-                                      should be one of "Object", "Pods" or "Resource",
-                                      each mapping to a matching field in the object.
+                                    description: type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
                                     type: string
                                 required:
                                 - type
@@ -410,79 +283,36 @@ spec:
                           description: PodSpec is a description of a pod.
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may
-                                be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
                               description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling
-                                    rules for the pod.
+                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated
-                                              with the corresponding weight.
+                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector
-                                                  requirements by node's labels.
+                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
+                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -492,38 +322,18 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector
-                                                  requirements by node's fields.
+                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
+                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -534,9 +344,7 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching
-                                              the corresponding nodeSelectorTerm,
-                                              in the range 1-100.
+                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -545,57 +353,26 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector
-                                            terms. The terms are ORed.
+                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector
-                                                  requirements by node's labels.
+                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
+                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -605,38 +382,18 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector
-                                                  requirements by node's fields.
+                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that
-                                                        the selector applies to.
+                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -652,74 +409,32 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules
-                                    (e.g. co-locate this pod in the same node, zone,
-                                    etc. as some other pod(s)).
+                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched
-                                          WeightedPodAffinityTerm fields are added
-                                          per-node to find the most preferred node(s)
+                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity
-                                              term, associated with the corresponding
-                                              weight.
+                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
+                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
+                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -731,45 +446,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -778,64 +470,26 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
+                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
+                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -847,34 +501,16 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -882,75 +518,32 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling
-                                    rules (e.g. avoid putting this pod in the same
-                                    node, zone, etc. as some other pod(s)).
+                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched
-                                          WeightedPodAffinityTerm fields are added
-                                          per-node to find the most preferred node(s)
+                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity
-                                              term, associated with the corresponding
-                                              weight.
+                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
+                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
+                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -962,45 +555,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -1009,64 +579,26 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set
-                                              of resources, in this case pods.
+                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
+                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
-                                                        merge patch.
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1078,34 +610,16 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1114,76 +628,36 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates
-                                whether a service account token should be automatically
-                                mounted.
+                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you
-                                  want to run within a pod.
+                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment
-                                        variable present in a Container.
+                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable.
-                                            Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment
-                                            variable's value. Cannot be used if value
-                                            is not empty.
+                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -1192,84 +666,56 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its key must be defined
+                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                metadata.labels, metadata.annotations,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema
-                                                    the FieldPath is written in terms
-                                                    of, defaults to "v1".
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to
-                                                    select in the specified API version.
+                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required
-                                                    for volumes, optional for env
-                                                    vars'
+                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output
-                                                    format of the exposed resources,
-                                                    defaults to "1"
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource
-                                                    to select'
+                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret
-                                                in the pod's namespace
+                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret
-                                                    to select from.  Must be a valid
-                                                    secret key.
+                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1280,127 +726,72 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap
-                                                must be defined
+                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret
-                                                must be defined
+                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
-                                              request to perform.
+                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set
-                                                  in the request. HTTP allows repeated
-                                                  headers.
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes
-                                                    a custom header to be used in
-                                                    HTTP probes
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name
+                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field
-                                                        value
+                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1408,108 +799,58 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the
-                                                  HTTP server.
+                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name
-                                                  to connect to, defaults to the pod
-                                                  IP.'
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
-                                              request to perform.
+                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set
-                                                  in the request. HTTP allows repeated
-                                                  headers.
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes
-                                                    a custom header to be used in
-                                                    HTTP probes
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name
+                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field
-                                                        value
+                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1517,38 +858,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the
-                                                  HTTP server.
+                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name
-                                                  to connect to, defaults to the pod
-                                                  IP.'
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1556,53 +884,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
-                                      Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -1616,115 +922,70 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network
-                                        port in a single container.
+                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external
-                                            port to.
+                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
-                                            Most containers do not need this.
+                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -1735,54 +996,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -1796,71 +1034,48 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1869,9 +1084,7 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1880,219 +1093,107 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime.
+                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX
-                                                capabilities type
+                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX
-                                                capabilities type
+                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false.
+                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
+                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
+                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label
-                                              that applies to the container.
+                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label
-                                              that applies to the container.
+                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label
-                                              that applies to the container.
+                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label
-                                              that applies to the container.
+                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field. This field is alpha-level and
-                                              is only honored by servers that enable
-                                              the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is
-                                              the name of the GMSA credential spec
-                                              to use. This field is alpha-level and
-                                              is only honored by servers that enable
-                                              the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence. This field is beta-level
-                                              and may be disabled with the WindowsRunAsUserName
-                                              feature flag.
+                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is an alpha feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -2106,140 +1207,77 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
+                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block
-                                      devices to be used by the container. This is
-                                      a beta feature.
+                                    description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
                                     items:
-                                      description: volumeDevice describes a mapping
-                                        of a raw block device within a container.
+                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside
-                                            of the container that the device will
-                                            be mapped to.
+                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of
-                                            a persistentVolumeClaim in the pod
+                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2247,46 +1285,27 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting
-                                        of a Volume within a container.
+                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
-                                            not contain ':'.
+                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
-                                            to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of
-                                            a Volume.
+                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
-                                            Defaults to false.
+                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2294,37 +1313,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
+                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
+                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver
-                                      options of a pod.
+                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
                                         description: Required.
@@ -2334,112 +1340,45 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
-                                This field is alpha-level and is only honored by servers
-                                that enable the EphemeralContainers feature.
+                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container
-                                  that may be added temporarily to an existing pod
-                                  for user-initiated activities such as debugging.
-                                  Ephemeral containers have no resource or scheduling
-                                  guarantees, and they will not be restarted when
-                                  they exit or when a pod is removed or restarted.
-                                  If an ephemeral container causes a pod to exceed
-                                  its resource allocation, the pod may be evicted.
-                                  Ephemeral containers may not be added by directly
-                                  updating the pod spec. They must be added via the
-                                  pod's ephemeralcontainers subresource, and they
-                                  will appear in the pod spec once added. This is
-                                  an alpha feature enabled by the EphemeralContainers
-                                  feature flag.
+                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment
-                                        variable present in a Container.
+                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable.
-                                            Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment
-                                            variable's value. Cannot be used if value
-                                            is not empty.
+                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -2448,84 +1387,56 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its key must be defined
+                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                metadata.labels, metadata.annotations,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema
-                                                    the FieldPath is written in terms
-                                                    of, defaults to "v1".
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to
-                                                    select in the specified API version.
+                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required
-                                                    for volumes, optional for env
-                                                    vars'
+                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output
-                                                    format of the exposed resources,
-                                                    defaults to "1"
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource
-                                                    to select'
+                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret
-                                                in the pod's namespace
+                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret
-                                                    to select from.  Must be a valid
-                                                    secret key.
+                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2536,50 +1447,31 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap
-                                                must be defined
+                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret
-                                                must be defined
+                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
@@ -2588,70 +1480,39 @@ spec:
                                     description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral
-                                      containers.
+                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
-                                              request to perform.
+                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set
-                                                  in the request. HTTP allows repeated
-                                                  headers.
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes
-                                                    a custom header to be used in
-                                                    HTTP probes
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name
+                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field
-                                                        value
+                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2659,114 +1520,64 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the
-                                                  HTTP server.
+                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name
-                                                  to connect to, defaults to the pod
-                                                  IP.'
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
-                                              request to perform.
+                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set
-                                                  in the request. HTTP allows repeated
-                                                  headers.
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes
-                                                    a custom header to be used in
-                                                    HTTP probes
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name
+                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field
-                                                        value
+                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2774,44 +1585,31 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the
-                                                  HTTP server.
+                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name
-                                                  to connect to, defaults to the pod
-                                                  IP.'
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2819,52 +1617,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral
-                                      containers.
+                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -2878,167 +1655,107 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral
-                                      containers.
+                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network
-                                        port in a single container.
+                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external
-                                            port to.
+                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
-                                            Most containers do not need this.
+                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral
-                                      containers.
+                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -3052,78 +1769,54 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
-                                      already allocated to the pod.
+                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -3132,9 +1825,7 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3143,208 +1834,107 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for
-                                      ephemeral containers.
+                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime.
+                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX
-                                                capabilities type
+                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX
-                                                capabilities type
+                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false.
+                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
+                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
+                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label
-                                              that applies to the container.
+                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label
-                                              that applies to the container.
+                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label
-                                              that applies to the container.
+                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label
-                                              that applies to the container.
+                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field. This field is alpha-level and
-                                              is only honored by servers that enable
-                                              the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is
-                                              the name of the GMSA credential spec
-                                              to use. This field is alpha-level and
-                                              is only honored by servers that enable
-                                              the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence. This field is beta-level
-                                              and may be disabled with the WindowsRunAsUserName
-                                              feature flag.
+                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral
-                                      containers.
+                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -3358,149 +1948,80 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
-                                      from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container is run in whatever
-                                      namespaces are shared for the pod. Note that
-                                      the container runtime must support this feature.
+                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
+                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block
-                                      devices to be used by the container. This is
-                                      a beta feature.
+                                    description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
                                     items:
-                                      description: volumeDevice describes a mapping
-                                        of a raw block device within a container.
+                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside
-                                            of the container that the device will
-                                            be mapped to.
+                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of
-                                            a persistentVolumeClaim in the pod
+                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -3508,46 +2029,27 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting
-                                        of a Volume within a container.
+                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
-                                            not contain ':'.
+                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
-                                            to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of
-                                            a Volume.
+                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
-                                            Defaults to false.
+                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -3555,24 +2057,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -3585,123 +2079,55 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional:
-                                Default to false.'
+                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
-                                Default to false.
+                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional:
-                                Default to false.'
+                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
-                                references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. For example,
-                                in the case of docker, only DockerConfig type secrets
-                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough
-                                  information to let you locate the referenced object
-                                  inside the same namespace.
+                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you
-                                  want to run within a pod.
+                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment
-                                        variable present in a Container.
+                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable.
-                                            Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment
-                                            variable's value. Cannot be used if value
-                                            is not empty.
+                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -3710,84 +2136,56 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its key must be defined
+                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                metadata.labels, metadata.annotations,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema
-                                                    the FieldPath is written in terms
-                                                    of, defaults to "v1".
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to
-                                                    select in the specified API version.
+                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required
-                                                    for volumes, optional for env
-                                                    vars'
+                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output
-                                                    format of the exposed resources,
-                                                    defaults to "1"
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource
-                                                    to select'
+                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret
-                                                in the pod's namespace
+                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret
-                                                    to select from.  Must be a valid
-                                                    secret key.
+                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -3798,127 +2196,72 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap
-                                                must be defined
+                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret
-                                                must be defined
+                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
-                                              request to perform.
+                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set
-                                                  in the request. HTTP allows repeated
-                                                  headers.
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes
-                                                    a custom header to be used in
-                                                    HTTP probes
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name
+                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field
-                                                        value
+                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -3926,108 +2269,58 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the
-                                                  HTTP server.
+                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name
-                                                  to connect to, defaults to the pod
-                                                  IP.'
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http
-                                              request to perform.
+                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set
-                                                  in the request. HTTP allows repeated
-                                                  headers.
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes
-                                                    a custom header to be used in
-                                                    HTTP probes
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name
+                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field
-                                                        value
+                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -4035,38 +2328,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the
-                                                  HTTP server.
+                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name
-                                                  to connect to, defaults to the pod
-                                                  IP.'
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4074,53 +2354,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
-                                      Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -4134,115 +2392,70 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network
-                                        port in a single container.
+                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external
-                                            port to.
+                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
-                                            Most containers do not need this.
+                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -4253,54 +2466,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -4314,71 +2504,48 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -4387,9 +2554,7 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4398,219 +2563,107 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime.
+                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX
-                                                capabilities type
+                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX
-                                                capabilities type
+                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false.
+                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
+                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
+                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label
-                                              that applies to the container.
+                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label
-                                              that applies to the container.
+                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label
-                                              that applies to the container.
+                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label
-                                              that applies to the container.
+                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field. This field is alpha-level and
-                                              is only honored by servers that enable
-                                              the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is
-                                              the name of the GMSA credential spec
-                                              to use. This field is alpha-level and
-                                              is only honored by servers that enable
-                                              the WindowsGMSA feature flag.
+                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence. This field is beta-level
-                                              and may be disabled with the WindowsRunAsUserName
-                                              feature flag.
+                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is an alpha feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request
-                                          to perform.
+                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in
-                                              the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a
-                                                custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -4624,140 +2677,77 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP
-                                              server.
+                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect
-                                              to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
+                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block
-                                      devices to be used by the container. This is
-                                      a beta feature.
+                                    description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
                                     items:
-                                      description: volumeDevice describes a mapping
-                                        of a raw block device within a container.
+                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside
-                                            of the container that the device will
-                                            be mapped to.
+                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of
-                                            a persistentVolumeClaim in the pod
+                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -4765,46 +2755,27 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting
-                                        of a Volume within a container.
+                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
-                                            not contain ':'.
+                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
-                                            to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of
-                                            a Volume.
+                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
-                                            Defaults to false.
+                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -4812,28 +2783,19 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -4842,175 +2804,83 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
-                                associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                This field is alpha-level as of Kubernetes v1.16,
-                                and is only honored by servers that enable the PodOverhead
-                                feature.'
+                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
-                                Defaults to PreemptLowerPriority if unset. This field
-                                is alpha-level and is only honored by servers that
-                                enable the NonPreemptingPriority feature.
+                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference
-                                  to a pod condition
+                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition
-                                      in the pod's condition list with matching type.
+                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. Default
-                                to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                This is a beta feature as of Kubernetes v1.14.'
+                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container.
+                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
+                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container.
+                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that
-                                        applies to the container.
+                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that
-                                        applies to the container.
+                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that
-                                        applies to the container.
+                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that
-                                        applies to the container.
+                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
+                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter
-                                      to be set
+                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
                                         description: Name of a property to set
@@ -5024,168 +2894,79 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
+                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
-                                        This field is alpha-level and is only honored
-                                        by servers that enable the WindowsGMSA feature
-                                        flag.
+                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name
-                                        of the GMSA credential spec to use. This field
-                                        is alpha-level and is only honored by servers
-                                        that enable the WindowsGMSA feature flag.
+                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence. This field is beta-level and may
-                                        be disabled with the WindowsRunAsUserName
-                                        feature flag.
+                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates delete immediately. If this value is
-                                nil, the default grace period will be used instead.
-                                The grace period is the duration in seconds after
-                                the processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. This field is alpha-level and
-                                is only honored by clusters that enables the EvenPodsSpread
-                                feature. All topologySpreadConstraints are ANDed.
+                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is alpha-level and is only honored by clusters that enables the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how
-                                  to spread matching pods among the given topology.
+                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -5197,58 +2978,18 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. It''s
-                                      the maximum permitted difference between the
-                                      number of matching pods in any two topology
-                                      domains of a given topology type. For example,
-                                      in a 3-zone cluster, MaxSkew is set to 1, and
-                                      pods with the same labelSelector spread as 1/1/0:
-                                      | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                                      - if MaxSkew is 1, incoming pod can only be
-                                      scheduled to zone3 to become 1/1/1; scheduling
-                                      it onto zone1(zone2) would make the ActualSkew(2-0)
-                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                      is 2, incoming pod can be scheduled onto any
-                                      zone. It''s a required field. Default value
-                                      is 1 and 0 is not allowed.'
+                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. It's a required field.
+                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it - ScheduleAnyway
-                                      tells the scheduler to still schedule it It''s
-                                      considered as "Unsatisfiable" if and only if
-                                      placing incoming pod on any topology violates
-                                      "MaxSkew". For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -5261,8 +3002,7 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
                                 type: object
                               type: array
@@ -5272,8 +3012,7 @@ spec:
                       type: object
                     type: array
                   engineResources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
+                    description: ResourceRequirements describes the compute resource requirements.
                     properties:
                       limits:
                         additionalProperties:
@@ -5282,8 +3021,7 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                       requests:
                         additionalProperties:
@@ -5292,10 +3030,7 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
                   explainer:
@@ -5305,60 +3040,31 @@ spec:
                           type: string
                         type: object
                       containerSpec:
-                        description: A single application container that you want
-                          to run within a pod.
+                        description: A single application container that you want to run within a pod.
                         properties:
                           args:
-                            description: 'Arguments to the entrypoint. The docker
-                              image''s CMD is used if this is not provided. Variable
-                              references $(VAR_NAME) are expanded using the container''s
-                              environment. If a variable cannot be resolved, the reference
-                              in the input string will be unchanged. The $(VAR_NAME)
-                              syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                              Escaped references will never be expanded, regardless
-                              of whether the variable exists or not. Cannot be updated.
-                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                             items:
                               type: string
                             type: array
                           command:
-                            description: 'Entrypoint array. Not executed within a
-                              shell. The docker image''s ENTRYPOINT is used if this
-                              is not provided. Variable references $(VAR_NAME) are
-                              expanded using the container''s environment. If a variable
-                              cannot be resolved, the reference in the input string
-                              will be unchanged. The $(VAR_NAME) syntax can be escaped
-                              with a double $$, ie: $$(VAR_NAME). Escaped references
-                              will never be expanded, regardless of whether the variable
-                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container. Cannot be updated.
+                            description: List of environment variables to set in the container. Cannot be updated.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
+                              description: EnvVar represents an environment variable present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
+                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previous defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    The $(VAR_NAME) syntax can be escaped with a double
-                                    $$, ie: $$(VAR_NAME). Escaped references will
-                                    never be expanded, regardless of whether the variable
-                                    exists or not. Defaults to "".'
+                                  description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
+                                  description: Source for the environment variable's value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
                                       description: Selects a key of a ConfigMap.
@@ -5367,53 +3073,37 @@ spec:
                                           description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
+                                          description: Specify whether the ConfigMap or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, metadata.labels,
-                                        metadata.annotations, spec.nodeName, spec.serviceAccountName,
-                                        status.hostIP, status.podIP, status.podIPs.'
+                                      description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
+                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
+                                          description: Path of the field to select in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
+                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
+                                          description: 'Container name: required for volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
+                                          description: Specifies the output format of the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
@@ -5423,22 +3113,16 @@ spec:
                                       - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
+                                      description: Selects a key of a secret in the pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
+                                          description: The key of the secret to select from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
+                                          description: Specify whether the Secret or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -5449,111 +3133,66 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container. The keys defined within a source must
-                              be a C_IDENTIFIER. All invalid keys will be reported
-                              as an event when the container is starting. When a key
-                              exists in multiple sources, the value associated with
-                              the last source will take precedence. Values defined
-                              by an Env with a duplicate key will take precedence.
-                              Cannot be updated.
+                            description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                              description: EnvFromSource represents the source of a set of ConfigMaps
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
+                                      description: Specify whether the ConfigMap must be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
+                                      description: Specify whether the Secret must be defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                              This field is optional to allow higher level config
-                              management to default or override container images in
-                              workload controllers like Deployments and StatefulSets.'
+                            description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                             type: string
                           imagePullPolicy:
-                            description: 'Image pull policy. One of Always, Never,
-                              IfNotPresent. Defaults to Always if :latest tag is specified,
-                              or IfNotPresent otherwise. Cannot be updated. More info:
-                              https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                            description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                             type: string
                           lifecycle:
-                            description: Actions that the management system should
-                              take in response to container lifecycle events. Cannot
-                              be updated.
+                            description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                             properties:
                               postStart:
-                                description: 'PostStart is called immediately after
-                                  a container is created. If the handler fails, the
-                                  container is terminated and restarted according
-                                  to its restart policy. Other management of the container
-                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                 properties:
                                   exec:
-                                    description: One and only one of the following
-                                      should be specified. Exec specifies the action
-                                      to take.
+                                    description: One and only one of the following should be specified. Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/')
-                                          in the container's filesystem. The command
-                                          is simply exec'd, it is not run inside a
-                                          shell, so traditional shell instructions
-                                          ('|', etc) won't work. To use a shell, you
-                                          need to explicitly call out to that shell.
-                                          Exit status of 0 is treated as live/healthy
-                                          and non-zero is unhealthy.
+                                        description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request
-                                      to perform.
+                                    description: HTTPGet specifies the http request to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set
-                                          "Host" in httpHeaders instead.
+                                        description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
-                                        description: Custom headers to set in the
-                                          request. HTTP allows repeated headers.
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
                                         items:
-                                          description: HTTPHeader describes a custom
-                                            header to be used in HTTP probes
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
                                           properties:
                                             name:
                                               description: The header field name
@@ -5570,87 +3209,49 @@ spec:
                                         description: Path to access on the HTTP server.
                                         type: string
                                       port:
-                                        description: Name or number of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting
-                                          to the host. Defaults to HTTP.
+                                        description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
                                     required:
                                     - port
                                     type: object
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving
-                                      a TCP port. TCP hooks not yet supported TODO:
-                                      implement a realistic TCP lifecycle hook'
+                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
-                                        description: 'Optional: Host name to connect
-                                          to, defaults to the pod IP.'
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
                                       port:
-                                        description: Number or name of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - port
                                     type: object
                                 type: object
                               preStop:
-                                description: 'PreStop is called immediately before
-                                  a container is terminated due to an API request
-                                  or management event such as liveness/startup probe
-                                  failure, preemption, resource contention, etc. The
-                                  handler is not called if the container crashes or
-                                  exits. The reason for termination is passed to the
-                                  handler. The Pod''s termination grace period countdown
-                                  begins before the PreStop hooked is executed. Regardless
-                                  of the outcome of the handler, the container will
-                                  eventually terminate within the Pod''s termination
-                                  grace period. Other management of the container
-                                  blocks until the hook completes or until the termination
-                                  grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                 properties:
                                   exec:
-                                    description: One and only one of the following
-                                      should be specified. Exec specifies the action
-                                      to take.
+                                    description: One and only one of the following should be specified. Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/')
-                                          in the container's filesystem. The command
-                                          is simply exec'd, it is not run inside a
-                                          shell, so traditional shell instructions
-                                          ('|', etc) won't work. To use a shell, you
-                                          need to explicitly call out to that shell.
-                                          Exit status of 0 is treated as live/healthy
-                                          and non-zero is unhealthy.
+                                        description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   httpGet:
-                                    description: HTTPGet specifies the http request
-                                      to perform.
+                                    description: HTTPGet specifies the http request to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set
-                                          "Host" in httpHeaders instead.
+                                        description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
-                                        description: Custom headers to set in the
-                                          request. HTTP allows repeated headers.
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
                                         items:
-                                          description: HTTPHeader describes a custom
-                                            header to be used in HTTP probes
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
                                           properties:
                                             name:
                                               description: The header field name
@@ -5667,32 +3268,22 @@ spec:
                                         description: Path to access on the HTTP server.
                                         type: string
                                       port:
-                                        description: Name or number of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting
-                                          to the host. Defaults to HTTP.
+                                        description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
                                     required:
                                     - port
                                     type: object
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving
-                                      a TCP port. TCP hooks not yet supported TODO:
-                                      implement a realistic TCP lifecycle hook'
+                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
-                                        description: 'Optional: Host name to connect
-                                          to, defaults to the pod IP.'
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
                                       port:
-                                        description: Number or name of the port to
-                                          access on the container. Number must be
-                                          in the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                     - port
@@ -5700,49 +3291,31 @@ spec:
                                 type: object
                             type: object
                           livenessProbe:
-                            description: 'Periodic probe of container liveness. Container
-                              will be restarted if the probe fails. Cannot be updated.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
+                                description: One and only one of the following should be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
+                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the
-                                  probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
+                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
+                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
+                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
                                           description: The header field name
@@ -5759,104 +3332,67 @@ spec:
                                     description: Path to access on the HTTP server.
                                     type: string
                                   port:
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
                                     type: string
                                 required:
                                 - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                  has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the
-                                  probe. Default to 10 seconds. Minimum value is 1.
+                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the
-                                  probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup.
-                                  Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
+                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
+                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                  times out. Defaults to 1 second. Minimum value is
-                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
-                              Cannot be updated.
+                            description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                             type: string
                           ports:
-                            description: List of ports to expose from the container.
-                              Exposing a port here gives the system additional information
-                              about the network connections a container uses, but
-                              is primarily informational. Not specifying a port here
-                              DOES NOT prevent that port from being exposed. Any port
-                              which is listening on the default "0.0.0.0" address
-                              inside a container will be accessible from the network.
-                              Cannot be updated.
+                            description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                             items:
-                              description: ContainerPort represents a network port
-                                in a single container.
+                              description: ContainerPort represents a network port in a single container.
                               properties:
                                 containerPort:
-                                  description: Number of port to expose on the pod's
-                                    IP address. This must be a valid port number,
-                                    0 < x < 65536.
+                                  description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                   format: int32
                                   type: integer
                                 hostIP:
-                                  description: What host IP to bind the external port
-                                    to.
+                                  description: What host IP to bind the external port to.
                                   type: string
                                 hostPort:
-                                  description: Number of port to expose on the host.
-                                    If specified, this must be a valid port number,
-                                    0 < x < 65536. If HostNetwork is specified, this
-                                    must match ContainerPort. Most containers do not
-                                    need this.
+                                  description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                   format: int32
                                   type: integer
                                 name:
-                                  description: If specified, this must be an IANA_SVC_NAME
-                                    and unique within the pod. Each named port in
-                                    a pod must have a unique name. Name for the port
-                                    that can be referred to by services.
+                                  description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                   type: string
                                 protocol:
-                                  description: Protocol for port. Must be UDP, TCP,
-                                    or SCTP. Defaults to "TCP".
+                                  description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                   type: string
                               required:
                               - containerPort
@@ -5867,49 +3403,31 @@ spec:
                             - protocol
                             x-kubernetes-list-type: map
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                              Container will be removed from service endpoints if
-                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
+                                description: One and only one of the following should be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
+                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the
-                                  probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
+                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
+                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
+                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
                                           description: The header field name
@@ -5926,62 +3444,45 @@ spec:
                                     description: Path to access on the HTTP server.
                                     type: string
                                   port:
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
                                     type: string
                                 required:
                                 - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                  has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the
-                                  probe. Default to 10 seconds. Minimum value is 1.
+                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the
-                                  probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup.
-                                  Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
+                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
+                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                  times out. Defaults to 1 second. Minimum value is
-                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: 'Compute Resources required by this container.
-                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             properties:
                               limits:
                                 additionalProperties:
@@ -5990,8 +3491,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -6000,200 +3500,107 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           securityContext:
-                            description: 'Security options the pod should run with.
-                              More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                             properties:
                               allowPrivilegeEscalation:
-                                description: 'AllowPrivilegeEscalation controls whether
-                                  a process can gain more privileges than its parent
-                                  process. This bool directly controls if the no_new_privs
-                                  flag will be set on the container process. AllowPrivilegeEscalation
-                                  is true always when the container is: 1) run as
-                                  Privileged 2) has CAP_SYS_ADMIN'
+                                description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                 type: boolean
                               capabilities:
-                                description: The capabilities to add/drop when running
-                                  containers. Defaults to the default set of capabilities
-                                  granted by the container runtime.
+                                description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                 properties:
                                   add:
                                     description: Added capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities
-                                        type
+                                      description: Capability represent POSIX capabilities type
                                       type: string
                                     type: array
                                   drop:
                                     description: Removed capabilities
                                     items:
-                                      description: Capability represent POSIX capabilities
-                                        type
+                                      description: Capability represent POSIX capabilities type
                                       type: string
                                     type: array
                                 type: object
                               privileged:
-                                description: Run container in privileged mode. Processes
-                                  in privileged containers are essentially equivalent
-                                  to root on the host. Defaults to false.
+                                description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                 type: boolean
                               procMount:
-                                description: procMount denotes the type of proc mount
-                                  to use for the containers. The default is DefaultProcMount
-                                  which uses the container runtime defaults for readonly
-                                  paths and masked paths. This requires the ProcMountType
-                                  feature flag to be enabled.
+                                description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                 type: string
                               readOnlyRootFilesystem:
-                                description: Whether this container has a read-only
-                                  root filesystem. Default is false.
+                                description: Whether this container has a read-only root filesystem. Default is false.
                                 type: boolean
                               runAsGroup:
-                                description: The GID to run the entrypoint of the
-                                  container process. Uses runtime default if unset.
-                                  May also be set in PodSecurityContext.  If set in
-                                  both SecurityContext and PodSecurityContext, the
-                                  value specified in SecurityContext takes precedence.
+                                description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: Indicates that the container must run
-                                  as a non-root user. If true, the Kubelet will validate
-                                  the image at runtime to ensure that it does not
-                                  run as UID 0 (root) and fail to start the container
-                                  if it does. If unset or false, no such validation
-                                  will be performed. May also be set in PodSecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
+                                description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
-                                description: The UID to run the entrypoint of the
-                                  container process. Defaults to user specified in
-                                  image metadata if unspecified. May also be set in
-                                  PodSecurityContext.  If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: The SELinux context to be applied to
-                                  the container. If unspecified, the container runtime
-                                  will allocate a random SELinux context for each
-                                  container.  May also be set in PodSecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
+                                description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 properties:
                                   level:
-                                    description: Level is SELinux level label that
-                                      applies to the container.
+                                    description: Level is SELinux level label that applies to the container.
                                     type: string
                                   role:
-                                    description: Role is a SELinux role label that
-                                      applies to the container.
+                                    description: Role is a SELinux role label that applies to the container.
                                     type: string
                                   type:
-                                    description: Type is a SELinux type label that
-                                      applies to the container.
+                                    description: Type is a SELinux type label that applies to the container.
                                     type: string
                                   user:
-                                    description: User is a SELinux user label that
-                                      applies to the container.
+                                    description: User is a SELinux user label that applies to the container.
                                     type: string
                                 type: object
                               windowsOptions:
-                                description: The Windows specific settings applied
-                                  to all containers. If unspecified, the options from
-                                  the PodSecurityContext will be used. If set in both
-                                  SecurityContext and PodSecurityContext, the value
-                                  specified in SecurityContext takes precedence.
+                                description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: GMSACredentialSpec is where the GMSA
-                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                      inlines the contents of the GMSA credential
-                                      spec named by the GMSACredentialSpecName field.
-                                      This field is alpha-level and is only honored
-                                      by servers that enable the WindowsGMSA feature
-                                      flag.
+                                    description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                     type: string
                                   gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name
-                                      of the GMSA credential spec to use. This field
-                                      is alpha-level and is only honored by servers
-                                      that enable the WindowsGMSA feature flag.
+                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use. This field is alpha-level and is only honored by servers that enable the WindowsGMSA feature flag.
                                     type: string
                                   runAsUserName:
-                                    description: The UserName in Windows to run the
-                                      entrypoint of the container process. Defaults
-                                      to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence. This field is beta-level and may
-                                      be disabled with the WindowsRunAsUserName feature
-                                      flag.
+                                    description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. This field is beta-level and may be disabled with the WindowsRunAsUserName feature flag.
                                     type: string
                                 type: object
                             type: object
                           startupProbe:
-                            description: 'StartupProbe indicates that the Pod has
-                              successfully initialized. If specified, no other probes
-                              are executed until this completes successfully. If this
-                              probe fails, the Pod will be restarted, just as if the
-                              livenessProbe failed. This can be used to provide different
-                              probe parameters at the beginning of a Pod''s lifecycle,
-                              when it might take a long time to load data or warm
-                              a cache, than during steady-state operation. This cannot
-                              be updated. This is an alpha feature enabled by the
-                              StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is an alpha feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
+                                description: One and only one of the following should be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
+                                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the
-                                  probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
+                                description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
+                                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
+                                    description: Custom headers to set in the request. HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
+                                      description: HTTPHeader describes a custom header to be used in HTTP probes
                                       properties:
                                         name:
                                           description: The header field name
@@ -6213,120 +3620,71 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: Scheme to use for connecting to the host. Defaults to HTTP.
                                     type: string
                                 required:
                                 - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                  has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the
-                                  probe. Default to 10 seconds. Minimum value is 1.
+                                description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the
-                                  probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup.
-                                  Minimum value is 1.
+                                description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
+                                description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
+                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                  times out. Defaults to 1 second. Minimum value is
-                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           stdin:
-                            description: Whether this container should allocate a
-                              buffer for stdin in the container runtime. If this is
-                              not set, reads from stdin in the container will always
-                              result in EOF. Default is false.
+                            description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                             type: boolean
                           stdinOnce:
-                            description: Whether the container runtime should close
-                              the stdin channel after it has been opened by a single
-                              attach. When stdin is true the stdin stream will remain
-                              open across multiple attach sessions. If stdinOnce is
-                              set to true, stdin is opened on container start, is
-                              empty until the first client attaches to stdin, and
-                              then remains open and accepts data until the client
-                              disconnects, at which time stdin is closed and remains
-                              closed until the container is restarted. If this flag
-                              is false, a container processes that reads from stdin
-                              will never receive an EOF. Default is false
+                            description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                             type: boolean
                           terminationMessagePath:
-                            description: 'Optional: Path at which the file to which
-                              the container''s termination message will be written
-                              is mounted into the container''s filesystem. Message
-                              written is intended to be brief final status, such as
-                              an assertion failure message. Will be truncated by the
-                              node if greater than 4096 bytes. The total message length
-                              across all containers will be limited to 12kb. Defaults
-                              to /dev/termination-log. Cannot be updated.'
+                            description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                             type: string
                           terminationMessagePolicy:
-                            description: Indicate how the termination message should
-                              be populated. File will use the contents of terminationMessagePath
-                              to populate the container status message on both success
-                              and failure. FallbackToLogsOnError will use the last
-                              chunk of container log output if the termination message
-                              file is empty and the container exited with an error.
-                              The log output is limited to 2048 bytes or 80 lines,
-                              whichever is smaller. Defaults to File. Cannot be updated.
+                            description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                             type: string
                           tty:
-                            description: Whether this container should allocate a
-                              TTY for itself, also requires 'stdin' to be true. Default
-                              is false.
+                            description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                             type: boolean
                           volumeDevices:
-                            description: volumeDevices is the list of block devices
-                              to be used by the container. This is a beta feature.
+                            description: volumeDevices is the list of block devices to be used by the container. This is a beta feature.
                             items:
-                              description: volumeDevice describes a mapping of a raw
-                                block device within a container.
+                              description: volumeDevice describes a mapping of a raw block device within a container.
                               properties:
                                 devicePath:
-                                  description: devicePath is the path inside of the
-                                    container that the device will be mapped to.
+                                  description: devicePath is the path inside of the container that the device will be mapped to.
                                   type: string
                                 name:
-                                  description: name must match the name of a persistentVolumeClaim
-                                    in the pod
+                                  description: name must match the name of a persistentVolumeClaim in the pod
                                   type: string
                               required:
                               - devicePath
@@ -6334,43 +3692,27 @@ spec:
                               type: object
                             type: array
                           volumeMounts:
-                            description: Pod volumes to mount into the container's
-                              filesystem. Cannot be updated.
+                            description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
+                              description: VolumeMount describes a mounting of a Volume within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
+                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
+                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                   type: string
                                 name:
                                   description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
+                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
+                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                   type: string
                               required:
                               - mountPath
@@ -6378,10 +3720,7 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory. If not specified,
-                              the container runtime's default will be used, which
-                              might be configured in the container image. Cannot be
-                              updated.
+                            description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                             type: string
                         required:
                         - name
@@ -6434,18 +3773,13 @@ spec:
                                               implementation:
                                                 type: string
                                               logger:
-                                                description: Request/response  payload
-                                                  logging. v2alpha1 feature that is
-                                                  added to v1 for backwards compatibility
-                                                  while v1 is the storage version.
+                                                description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
                                                 properties:
                                                   mode:
-                                                    description: What payloads to
-                                                      log
+                                                    description: What payloads to log
                                                     type: string
                                                   url:
-                                                    description: URL to send request
-                                                      logging CloudEvents
+                                                    description: URL to send request logging CloudEvents
                                                     type: string
                                                 type: object
                                               methods:
@@ -6488,17 +3822,13 @@ spec:
                                         implementation:
                                           type: string
                                         logger:
-                                          description: Request/response  payload logging.
-                                            v2alpha1 feature that is added to v1 for
-                                            backwards compatibility while v1 is the
-                                            storage version.
+                                          description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
                                           properties:
                                             mode:
                                               description: What payloads to log
                                               type: string
                                             url:
-                                              description: URL to send request logging
-                                                CloudEvents
+                                              description: URL to send request logging CloudEvents
                                               type: string
                                           type: object
                                         methods:
@@ -6541,9 +3871,7 @@ spec:
                                   implementation:
                                     type: string
                                   logger:
-                                    description: Request/response  payload logging.
-                                      v2alpha1 feature that is added to v1 for backwards
-                                      compatibility while v1 is the storage version.
+                                    description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
                                     properties:
                                       mode:
                                         description: What payloads to log
@@ -6592,9 +3920,7 @@ spec:
                             implementation:
                               type: string
                             logger:
-                              description: Request/response  payload logging. v2alpha1
-                                feature that is added to v1 for backwards compatibility
-                                while v1 is the storage version.
+                              description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
                               properties:
                                 mode:
                                   description: What payloads to log
@@ -6643,9 +3969,7 @@ spec:
                       implementation:
                         type: string
                       logger:
-                        description: Request/response  payload logging. v2alpha1 feature
-                          that is added to v1 for backwards compatibility while v1
-                          is the storage version.
+                        description: Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
                         properties:
                           mode:
                             description: What payloads to log
@@ -6699,27 +4023,16 @@ spec:
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
+                          description: EnvVar represents an environment variable present in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
+                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
                                   description: Selects a key of a ConfigMap.
@@ -6728,52 +4041,37 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
+                                      description: Specify whether the ConfigMap or its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, metadata.labels,
-                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
-                                    status.hostIP, status.podIP, status.podIPs.'
+                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
+                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
+                                      description: Path of the field to select in the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
+                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
+                                      description: 'Container name: required for volumes, optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
+                                      description: Specifies the output format of the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
@@ -6783,22 +4081,16 @@ spec:
                                   - resource
                                   type: object
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
+                                  description: Selects a key of a secret in the pod's namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
+                                      description: The key of the secret to select from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
+                                      description: Specify whether the Secret or its key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -6812,8 +4104,7 @@ spec:
                         format: int32
                         type: integer
                       resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
+                        description: ResourceRequirements describes the compute resource requirements.
                         properties:
                           limits:
                             additionalProperties:
@@ -6822,8 +4113,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
@@ -6832,11 +4122,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
                     type: object


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Currently, gRPC traffic to Istio-enabled SeldonDeployments does not work with the new executor.  This is due to fact that pilot does not allow for a second listener to forward to the same targetPort, causing all traffic destined for the shared targetPort to use the first protocol registered to pilot (which is usually http since it is defined first in the service).  This updates the service to only create a single service port using the http2 protocol, which should allow both gRPC and http traffic through the istio-proxy sidecar and through to the executor.

This also adds the `sidecar.istio.io/rewriteAppHTTPProbers` annotation to all SeldonDeployment pods, as the HTTP health check sent from Kubelet does not have the certificate issued by Istio and will fail if mTLS is enabled.  More information is laid out [here](https://istio.io/latest/docs/ops/configuration/mesh/app-health-check/#liveness-and-readiness-probes-with-http-request-option).

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2189 

**Special notes for your reviewer**:  I have built and tested this change in my own cluster where I had been experiencing issues.  This is the image built from these changes that I tested with: `groszewn/seldon-core-operator:http2_fix`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
This PR updates services created by the controller (when the executor is enabled) to only expose a single service endpoint (8000 with http2 as the protocol).  This removes the separate port exposed for gRPC traffic, as istio-enabled deployments are not able to handle two service ports forwarding to the same targetPort.  As the executor multiplexes traffic, only a single exposed port is sufficient for handling both http and gRPC.
```