### PR TITLE
Update fluentd-values.yaml

### DIFF
--- a/examples/centralised-logging/fluentd-values.yaml
+++ b/examples/centralised-logging/fluentd-values.yaml
@@ -1,6 +1,7 @@
 elasticsearch:
   hosts: ['elasticsearch-master']
-  logstash_prefix: 'kubernetes_cluster'
+  logstash:
+    prefix: 'kubernetes_cluster'
 
 configMaps:
   useDefaults:


### PR DESCRIPTION
with current line ( logstash_prefix: 'kubernetes_cluster') it does not work and logs to default index called logstash so this fixes it.

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

There is nothing like logstash_prefix: 'kubernetes_cluster' (maybe old syntax) new one is like I have added.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

