### PR TITLE
Updating Security CI Script after requirements.txt all moved to setup.py

### DIFF
--- a/jenkins-x-securitychecks.yml
+++ b/jenkins-x-securitychecks.yml
@@ -43,5 +43,5 @@ pipelineConfig:
             - agent:
                 image: snyk/snyk:python-3.7
               dir: python
-              sh: "pip install -r requirements.txt && snyk test"
+              sh: "make install && snyk test"
 

--- a/jenkins-x-securitychecks.yml
+++ b/jenkins-x-securitychecks.yml
@@ -43,5 +43,5 @@ pipelineConfig:
             - agent:
                 image: snyk/snyk:python-3.7
               dir: python
-              sh: "make install && snyk test"
+              sh: "make install && snyk test --file=setup.py"
 


### PR DESCRIPTION
The requirements.txt was removed from the python folder to streamline the management of dependencies. Updating the security scripts to reflect these changes.