### PR TITLE
use copy of operator instead of symlink to keep docker build context local

### DIFF
--- a/executor/.gitignore
+++ b/executor/.gitignore
@@ -8,3 +8,4 @@ cover.out
 executor.tar
 openapi/
 executor/api/rest/openapi/
+_operator

--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -3,20 +3,20 @@ FROM golang:1.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY executor/go.mod go.mod
-COPY executor/go.sum go.sum
-COPY executor/proto/ proto/
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY proto/ proto/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-COPY executor/operator/ operator/
+COPY _operator/ _operator/
 RUN go mod download
 
 # Copy the go source
-COPY executor/cmd/ cmd/
-COPY executor/api/ api/
-COPY executor/predictor/ predictor/
-COPY executor/logger/ logger/
-COPY executor/k8s/ k8s/
+COPY cmd/ cmd/
+COPY api/ api/
+COPY predictor/ predictor/
+COPY logger/ logger/
+COPY k8s/ k8s/
 
 # Build
 RUN go build -a -o executor cmd/executor/main.go
@@ -27,7 +27,7 @@ RUN wget -O armon-consul-api.tar.gz https://github.com/armon/consul-api/archive/
 RUN wget -O hasicorp-hcl.tar.gz https://github.com/hashicorp/hcl/archive/master.tar.gz
 
 # Copy OpenAPI folder and change the permissions
-COPY executor/api/rest/openapi/ /openapi/
+COPY api/rest/openapi/ /openapi/
 RUN chmod -R 660 /openapi/
 
 # Use distroless as minimal base image to package the manager binary
@@ -35,7 +35,7 @@ RUN chmod -R 660 /openapi/
 FROM gcr.io/distroless/base:latest
 WORKDIR /
 COPY --from=builder /workspace/executor .
-COPY executor/licenses/license.txt licenses/license.txt
+COPY licenses/license.txt licenses/license.txt
 COPY --from=builder /workspace/hashicorp-golang-lru.tar.gz licenses/mpl_source/hashicorp-golang-lru.tar.gz
 COPY --from=builder /workspace/armon-consul-api.tar.gz licenses/mpl_source/armon-consul-api.tar.gz
 COPY --from=builder /workspace/hasicorp-hcl.tar.gz licenses/mpl_source/hasicorp-hcl.tar.gz

--- a/executor/Dockerfile.executor.redhat
+++ b/executor/Dockerfile.executor.redhat
@@ -3,20 +3,20 @@ FROM golang:1.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY executor/go.mod go.mod
-COPY executor/go.sum go.sum
-COPY executor/proto/ proto/
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY proto/ proto/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-COPY executor/operator/ operator/
+COPY _operator/ _operator/
 RUN go mod download
 
 # Copy the go source
-COPY executor/cmd/ cmd/
-COPY executor/api/ api/
-COPY executor/predictor/ predictor/
-COPY executor/logger/ logger/
-COPY executor/k8s/ k8s/
+COPY cmd/ cmd/
+COPY api/ api/
+COPY predictor/ predictor/
+COPY logger/ logger/
+COPY k8s/ k8s/
 
 # Build
 RUN go build -a -o executor cmd/executor/main.go
@@ -27,7 +27,7 @@ RUN wget -O armon-consul-api.tar.gz https://github.com/armon/consul-api/archive/
 RUN wget -O hasicorp-hcl.tar.gz https://github.com/hashicorp/hcl/archive/master.tar.gz
 
 # Copy OpenAPI folder and change the permissions
-COPY executor/api/rest/openapi/ /openapi/
+COPY api/rest/openapi/ /openapi/
 RUN chmod -R 660 /openapi/
 
 FROM registry.access.redhat.com/ubi7/ubi
@@ -40,7 +40,7 @@ LABEL name="Seldon Executor" \
 
 WORKDIR /
 COPY --from=builder /workspace/executor .
-COPY executor/licenses/license.txt licenses/license.txt
+COPY licenses/license.txt licenses/license.txt
 COPY --from=builder /workspace/hashicorp-golang-lru.tar.gz licenses/mpl_source/hashicorp-golang-lru.tar.gz
 COPY --from=builder /workspace/armon-consul-api.tar.gz licenses/mpl_source/armon-consul-api.tar.gz
 COPY --from=builder /workspace/hasicorp-hcl.tar.gz licenses/mpl_source/hasicorp-hcl.tar.gz

--- a/executor/Makefile
+++ b/executor/Makefile
@@ -27,11 +27,18 @@ vet:
 
 
 # Build manager binary
-executor: fmt vet
+executor: copy_operator fmt vet
 	go build -o executor cmd/executor/main.go
 
-kafka-proxy: fmt vet
+
+kafka-proxy: copy_operator fmt vet
 	go build -o kafka-proxy cmd/proxy/main.go
+
+
+.PHONE: copy_operator
+copy_operator:
+	rm _operator -rf
+	cp -r ../operator _operator
 
 
 .PHONY: copy_protos
@@ -62,7 +69,7 @@ add_protos:
 	cd serving && find ./tensorflow_serving -name '*.proto' | cpio -pdm ../proto
 
 # Run tests
-test: fmt vet
+test: copy_operator fmt vet
 	go test ${EXECUTOR_FOLDERS} -coverprofile cover.out
 
 copy_openapi_resources:
@@ -72,11 +79,11 @@ copy_openapi_resources:
 
 # Build the docker image
 docker-build: test copy_openapi_resources
-	cd .. && docker build -f executor/Dockerfile.executor -t ${IMG} .
+	docker build -f Dockerfile.executor -t ${IMG} .
 
 # Build the docker image for Redhat
 docker-build-redhat: test copy_openapi_resources
-	cd .. && docker build -f executor/Dockerfile.executor.redhat -t ${IMG_REDHAT} .
+	docker build -f Dockerfile.executor.redhat -t ${IMG_REDHAT} .
 
 # Push the docker image
 docker-push:

--- a/executor/Makefile
+++ b/executor/Makefile
@@ -140,7 +140,7 @@ licenses: licenses/dep.txt
 
 
 .PHONY: lint
-lint: licenses/dep.txt
+lint: copy_operator licenses/dep.txt
 	# Check if licenses have changed
 	git \
 		--no-pager diff \

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -30,4 +30,4 @@ require (
 
 replace github.com/tensorflow/tensorflow/tensorflow/go/core => ./proto/tensorflow/core
 
-replace github.com/seldonio/seldon-core/operator => ./operator
+replace github.com/seldonio/seldon-core/operator => ./_operator

--- a/executor/operator
+++ b/executor/operator
@@ -1,1 +1,0 @@
-../operator


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Uses (automated) copy of `operator` into `executor/_operator` to avoid symlinks and keep Docker build context local to `executor` folder

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/SeldonIO/seldon-core/issues/2186

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

