### PR TITLE
add FILTER_METRICS_ACCESS_LOGS flag that allows to silence metrics ac…

### DIFF
--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -28,6 +28,8 @@ PARAMETERS_ENV_NAME = "PREDICTIVE_UNIT_PARAMETERS"
 SERVICE_PORT_ENV_NAME = "PREDICTIVE_UNIT_SERVICE_PORT"
 METRICS_SERVICE_PORT_ENV_NAME = "PREDICTIVE_UNIT_METRICS_SERVICE_PORT"
 
+FILTER_METRICS_ACCESS_LOGS_ENV_NAME = "FILTER_METRICS_ACCESS_LOGS"
+
 LOG_LEVEL_ENV = "SELDON_LOG_LEVEL"
 DEFAULT_LOG_LEVEL = "INFO"
 
@@ -175,6 +177,11 @@ def setup_tracing(interface_name: str) -> object:
     return config.initialize_tracer()
 
 
+class MetricsEndpointFilter(logging.Filter):
+    def filter(self, record):
+        return seldon_microservice.METRICS_ENDPOINT not in record.getMessage()
+
+
 def setup_logger(log_level: str) -> logging.Logger:
     # set up log level
     log_level_raw = os.environ.get(LOG_LEVEL_ENV, log_level.upper())
@@ -187,6 +194,11 @@ def setup_logger(log_level: str) -> logging.Logger:
     # Set right level on access logs
     flask_logger = logging.getLogger("werkzeug")
     flask_logger.setLevel(log_level_num)
+
+    if getenv_as_bool(FILTER_METRICS_ACCESS_LOGS_ENV_NAME, default=False):
+        flask_logger.addFilter(MetricsEndpointFilter())
+        gunicorn_logger = logging.getLogger("gunicorn.access")
+        gunicorn_logger.addFilter(MetricsEndpointFilter())
 
     logger.debug("Log level set to %s:%s", log_level, log_level_num)
 

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -182,7 +182,7 @@ class MetricsEndpointFilter(logging.Filter):
         return seldon_microservice.METRICS_ENDPOINT not in record.getMessage()
 
 
-def setup_logger(log_level: str) -> logging.Logger:
+def setup_logger(log_level: str, debug_mode: bool) -> logging.Logger:
     # set up log level
     log_level_raw = os.environ.get(LOG_LEVEL_ENV, log_level.upper())
     log_level_num = getattr(logging, log_level_raw, None)
@@ -195,7 +195,7 @@ def setup_logger(log_level: str) -> logging.Logger:
     flask_logger = logging.getLogger("werkzeug")
     flask_logger.setLevel(log_level_num)
 
-    if getenv_as_bool(FILTER_METRICS_ACCESS_LOGS_ENV_NAME, default=False):
+    if getenv_as_bool(FILTER_METRICS_ACCESS_LOGS_ENV_NAME, default=not debug_mode):
         flask_logger.addFilter(MetricsEndpointFilter())
         gunicorn_logger = logging.getLogger("gunicorn.access")
         gunicorn_logger.addFilter(MetricsEndpointFilter())
@@ -310,7 +310,7 @@ def main():
     args = parser.parse_args()
     parameters = parse_parameters(json.loads(args.parameters))
 
-    setup_logger(args.log_level)
+    setup_logger(args.log_level, args.debug)
 
     # set flask trace jaeger extra tags
     jaeger_extra_tags = list(


### PR DESCRIPTION
…cess logs

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This allow to silence access logs to the metrics endpoint. Due to periodic and constant probing from Prometheus this obscures the log.


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/SeldonIO/seldon-core/issues/1907

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Add `FILTER_METRICS_ACCESS_LOGS` flag (environmental variable) that allows to silence access logs related to metrics endpoint.
```

