### PR TITLE
align gpu image with regular python wrappers (remove tensorflow)

### DIFF
--- a/doc/source/reference/images.md
+++ b/doc/source/reference/images.md
@@ -12,14 +12,14 @@
 ## Pre-packaged servers
 
 
-| Description | Image URL | Version | 
+| Description | Image URL | Version |
 |-------------|-----------|---------|
-| [MLFlow Server REST](../servers/mlflow.md) | [seldonio/mlflowserver_rest](https://hub.docker.com/r/seldonio/mlflowserver_rest/tags/) | 1.2.2 | 
-| [MLFlow Server GRPC](../servers/mlflow.md) | [seldonio/mlflowserver_grpc](https://hub.docker.com/r/seldonio/mlflowserver_grpc/tags/) | 1.2.2 | 
-| [SKLearn Server REST](../servers/sklearn.md) | [seldonio/sklearnserver_rest](https://hub.docker.com/r/seldonio/sklearnserver_rest/tags/) | 1.2.2 | 
-| [SKLearn Server GRPC](../servers/sklearn.md) | [seldonio/sklearnserver_grpc](https://hub.docker.com/r/seldonio/sklearnserver_grpc/tags/) | 1.2.2 | 
-| [XGBoost Server REST](../servers/xgboost.md) | [seldonio/xgboostserver_rest](https://hub.docker.com/r/seldonio/xgboostserver_rest/tags/) | 1.2.2 | 
-| [XGBoost Server GRPC](../servers/xgboost.md) | [seldonio/xgboostserver_grpc](https://hub.docker.com/r/seldonio/xgboostserver_grpc/tags/) | 1.2.2 | 
+| [MLFlow Server REST](../servers/mlflow.md) | [seldonio/mlflowserver_rest](https://hub.docker.com/r/seldonio/mlflowserver_rest/tags/) | 1.2.2 |
+| [MLFlow Server GRPC](../servers/mlflow.md) | [seldonio/mlflowserver_grpc](https://hub.docker.com/r/seldonio/mlflowserver_grpc/tags/) | 1.2.2 |
+| [SKLearn Server REST](../servers/sklearn.md) | [seldonio/sklearnserver_rest](https://hub.docker.com/r/seldonio/sklearnserver_rest/tags/) | 1.2.2 |
+| [SKLearn Server GRPC](../servers/sklearn.md) | [seldonio/sklearnserver_grpc](https://hub.docker.com/r/seldonio/sklearnserver_grpc/tags/) | 1.2.2 |
+| [XGBoost Server REST](../servers/xgboost.md) | [seldonio/xgboostserver_rest](https://hub.docker.com/r/seldonio/xgboostserver_rest/tags/) | 1.2.2 |
+| [XGBoost Server GRPC](../servers/xgboost.md) | [seldonio/xgboostserver_grpc](https://hub.docker.com/r/seldonio/xgboostserver_grpc/tags/) | 1.2.2 |
 
 ## Language wrappers
 
@@ -28,15 +28,17 @@
 | [Seldon Python 3 (3.6) Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python3](https://hub.docker.com/r/seldonio/seldon-core-s2i-python3/tags/) | 1.2.2 | 1.2.3-dev |
 | [Seldon Python 3.6 Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python36](https://hub.docker.com/r/seldonio/seldon-core-s2i-python36/tags/) | 1.2.2 | 1.2.3-dev |
 | [Seldon Python 3.7 Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python37](https://hub.docker.com/r/seldonio/seldon-core-s2i-python37/tags/) | 1.2.2 | 1.2.3-dev |
+| [Seldon Python 3.6 GPU Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python36-gpu](https://hub.docker.com/r/seldonio/seldon-core-s2i-python36-gpu/tags/) | 1.2.2 | 1.2.3-dev |
+| [Seldon Python 3.7 GPU Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python37-gpu](https://hub.docker.com/r/seldonio/seldon-core-s2i-python37-gpu/tags/) | 1.2.2 | 1.2.3-dev |
 
 ## Server proxies
 
 | Description | Image URL | Stable Version |
 |-------------|-----------|----------------|
-| [NVIDIA inference server proxy](integration_nvidia_link.rst) | [seldonio/nvidia-inference-server-proxy](https://hub.docker.com/r/seldonio/nvidia-inference-server-proxy/tags/) | 0.1 | 
-| [SageMaker proxy](https://github.com/SeldonIO/seldon-core/tree/master/integrations/sagemaker) | [seldonio/sagemaker-proxy](https://hub.docker.com/r/seldonio/sagemaker-proxy/tags/) | 0.1 | 
-| [Tensorflow Serving REST proxy](../servers/tensorflow.md) | [seldonio/tfserving-proxy_rest](https://hub.docker.com/r/seldonio/tfserving-proxy_rest/tags/) | 0.7 | 
-| [Tensorflow Serving GRPC proxy](../servers/tensorflow.md) | [seldonio/tfserving-proxy_grpc](https://hub.docker.com/r/seldonio/tfserving-proxy_grpc/tags/) | 0.7 | 
+| [NVIDIA inference server proxy](integration_nvidia_link.rst) | [seldonio/nvidia-inference-server-proxy](https://hub.docker.com/r/seldonio/nvidia-inference-server-proxy/tags/) | 0.1 |
+| [SageMaker proxy](https://github.com/SeldonIO/seldon-core/tree/master/integrations/sagemaker) | [seldonio/sagemaker-proxy](https://hub.docker.com/r/seldonio/sagemaker-proxy/tags/) | 0.1 |
+| [Tensorflow Serving REST proxy](../servers/tensorflow.md) | [seldonio/tfserving-proxy_rest](https://hub.docker.com/r/seldonio/tfserving-proxy_rest/tags/) | 0.7 |
+| [Tensorflow Serving GRPC proxy](../servers/tensorflow.md) | [seldonio/tfserving-proxy_grpc](https://hub.docker.com/r/seldonio/tfserving-proxy_grpc/tags/) | 0.7 |
 
 
 ## Python modules
@@ -47,7 +49,7 @@
 | [seldon-core](https://pypi.org/project/seldon-core/) | 2,>=3,<3.7 | 0.2.6 (deprecated) |
 
 
-## Incubating 
+## Incubating
 
 ### Language wrappers
 
@@ -76,4 +78,4 @@
 | Description | Image URL | Stable Version | Development |
 |-------------|-----------|----------------|-------------|
 | [Seldon Python 2 Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python2](https://hub.docker.com/r/seldonio/seldon-core-s2i-python2/tags/) | 0.5.1 | deprecated |
-
+| [seldon-core-s2i-python3-tf-gpu](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python36](https://hub.docker.com/repository/docker/seldonio/seldon-core-s2i-python3-tf-gpu) | 1.2.2 | deprecated |

--- a/wrappers/s2i/python/Dockerfile.gpu
+++ b/wrappers/s2i/python/Dockerfile.gpu
@@ -28,6 +28,10 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
     /opt/conda/bin/conda clean -afy
 
+# This is to install desired version of Python without updating conda version
+ARG PYTHON_VERSION
+RUN conda install --yes python=$PYTHON_VERSION conda=$CONDA_VERSION
+RUN apt-get update --yes && apt-get install --yes gcc make build-essential
 
 RUN mkdir microservice
 WORKDIR /microservice
@@ -38,10 +42,6 @@ COPY ./s2i/bin/ /s2i/bin
 COPY _python /microservice
 COPY version.txt /microservice/version.txt
 RUN cd /microservice/python && make install
-
-# Add gpu specific requirements
-COPY requirements_gpu.txt ./requirements.txt
-RUN pip install -r requirements.txt
 
 RUN mkdir -p /.conda && chmod a+rwx /.conda
 

--- a/wrappers/s2i/python/Makefile
+++ b/wrappers/s2i/python/Makefile
@@ -7,7 +7,7 @@ IMAGE_PYTHON_VERSION=`echo -n $(PYTHON_VERSION) | sed 's/\.//g'`
 DEFAULT_IMAGE_PYTHON_VERSION=`echo -n $(PYTHON_VERSION) | cut -d. -f1`
 IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python${IMAGE_PYTHON_VERSION}
 DEFAULT_IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python${DEFAULT_IMAGE_PYTHON_VERSION}
-GPU_IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python3-tf-gpu
+GPU_IMAGE_NAME = docker.io/seldonio/seldon-core-s2i-python${IMAGE_PYTHON_VERSION}-gpu
 
 SELDON_CORE_DIR=../../..
 
@@ -27,7 +27,7 @@ build: get_local_repo
 
 .PHONY: build_gpu
 build_gpu: get_local_repo
-	docker build -f Dockerfile.gpu --build-arg CONDA_VERSION=${CONDA_VERSION} -t ${GPU_IMAGE_NAME}:${IMAGE_VERSION} .
+	docker build -f Dockerfile.gpu --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg CONDA_VERSION=${CONDA_VERSION} -t ${GPU_IMAGE_NAME}:${IMAGE_VERSION} .
 
 .PHONY: build_local
 build_local: get_local_repo

--- a/wrappers/s2i/python/build_scripts/build_all_local.sh
+++ b/wrappers/s2i/python/build_scripts/build_all_local.sh
@@ -1,4 +1,5 @@
 ./build_local_python3.6.sh
 ./build_local_python3.7.sh
-./build_python_gpu.sh
+./build_local_python3.6_gpu.sh
+./build_local_python3.7_gpu.sh
 ./build_redhat.sh

--- a/wrappers/s2i/python/build_scripts/build_local_python3.6.sh
+++ b/wrappers/s2i/python/build_scripts/build_local_python3.6.sh
@@ -1,2 +1,1 @@
 make -C ../ build_local PYTHON_VERSION=3.6
-

--- a/wrappers/s2i/python/build_scripts/build_python3.6_gpu.sh
+++ b/wrappers/s2i/python/build_scripts/build_python3.6_gpu.sh
@@ -1,0 +1,1 @@
+make -C ../ build_gpu PYTHON_VERSION=3.6

--- a/wrappers/s2i/python/build_scripts/build_python3.7_gpu.sh
+++ b/wrappers/s2i/python/build_scripts/build_python3.7_gpu.sh
@@ -1,0 +1,1 @@
+make -C ../ build_gpu PYTHON_VERSION=3.7

--- a/wrappers/s2i/python/build_scripts/build_python_gpu.sh
+++ b/wrappers/s2i/python/build_scripts/build_python_gpu.sh
@@ -1,2 +1,0 @@
-make -C ../ build_gpu
-

--- a/wrappers/s2i/python/build_scripts/push_all.sh
+++ b/wrappers/s2i/python/build_scripts/push_all.sh
@@ -1,4 +1,5 @@
 ./push_python3.6.sh
 ./push_python3.7.sh
-./push_python_gpu.sh
+./push_python3.6_gpu.sh
+./push_python3.7_gpu.sh
 ./push_redhat.sh

--- a/wrappers/s2i/python/build_scripts/push_python3.6.sh
+++ b/wrappers/s2i/python/build_scripts/push_python3.6.sh
@@ -1,2 +1,1 @@
 make -C ../ push_to_dockerhub PYTHON_VERSION=3.6
-make -C ../ push_to_dockerhub_base_python PYTHON_VERSION=3.6

--- a/wrappers/s2i/python/build_scripts/push_python3.6_gpu.sh
+++ b/wrappers/s2i/python/build_scripts/push_python3.6_gpu.sh
@@ -1,0 +1,1 @@
+make -C ../ push_gpu_to_dockerhub PYTHON_VERSION=3.6

--- a/wrappers/s2i/python/build_scripts/push_python3.7.sh
+++ b/wrappers/s2i/python/build_scripts/push_python3.7.sh
@@ -1,1 +1,2 @@
 make -C ../ push_to_dockerhub PYTHON_VERSION=3.7
+make -C ../ push_to_dockerhub_base_python PYTHON_VERSION=3.7

--- a/wrappers/s2i/python/build_scripts/push_python3.7_gpu.sh
+++ b/wrappers/s2i/python/build_scripts/push_python3.7_gpu.sh
@@ -1,0 +1,1 @@
+make -C ../ push_gpu_to_dockerhub PYTHON_VERSION=3.7

--- a/wrappers/s2i/python/build_scripts/push_python_gpu.sh
+++ b/wrappers/s2i/python/build_scripts/push_python_gpu.sh
@@ -1,1 +1,0 @@
-make -C ../ push_gpu_to_dockerhub

--- a/wrappers/s2i/python/requirements_gpu.txt
+++ b/wrappers/s2i/python/requirements_gpu.txt
@@ -1,1 +1,0 @@
-tensorflow-gpu==1.15.3


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

GPU image from now on will only differ from regular python wrapper by having a different base.
User's should install tensorflow and / or other packages themselves. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/SeldonIO/seldon-core/issues/1789

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Deprecates `seldon-core-s2i-python3-tf-gpu` in favour of `seldon-core-s2i-python36-gpu` and `seldon-core-s2i-python37-gpu` images.
```

