### PR TITLE
Update k8s version check and add force override to helm

### DIFF
--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-{{- if semverCompare "<1.18.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if or (lt (int (regexFind "[0-9]+" .Capabilities.KubeVersion.Minor)) 18) (.Values.crd.forcev1beta1) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -4022,6 +4022,11 @@ spec:
                     type: integer
                   shadow:
                     type: boolean
+                  ssl:
+                    properties:
+                      certSecretName:
+                        type: string
+                    type: object
                   svcOrchSpec:
                     properties:
                       env:

--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-{{- if semverCompare ">=1.18.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if or (ge (int (regexFind "[0-9]+" .Capabilities.KubeVersion.Minor)) 18) (.Values.crd.forcev1) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5259,6 +5259,11 @@ spec:
                       type: integer
                     shadow:
                       type: boolean
+                    ssl:
+                      properties:
+                        certSecretName:
+                          type: string
+                      type: object
                     svcOrchSpec:
                       properties:
                         env:
@@ -10683,6 +10688,11 @@ spec:
                       type: integer
                     shadow:
                       type: boolean
+                    ssl:
+                      properties:
+                        certSecretName:
+                          type: string
+                      type: object
                     svcOrchSpec:
                       properties:
                         env:
@@ -16107,6 +16117,11 @@ spec:
                       type: integer
                     shadow:
                       type: boolean
+                    ssl:
+                      properties:
+                        certSecretName:
+                          type: string
+                      type: object
                     svcOrchSpec:
                       properties:
                         env:

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -131,6 +131,9 @@ predictor_servers:
 # it will try to create the CRD but only if it does not exist
 crd:
   create: true
+  # Whether to force the use of the v1beta1 or v1 CRD.
+  forceV1: false
+  forceV1beta1: false
 
 # Warning: credentials will be depricated soon, please use defaultEnvSecretRefName above
 # For more info please check the documentation
@@ -166,3 +169,4 @@ engine:
 # Explainer image
 explainer:
   image: seldonio/alibiexplainer:1.2.3-dev
+

--- a/operator/config/crd_v1/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd_v1/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -8159,6 +8159,11 @@ spec:
                       type: integer
                     shadow:
                       type: boolean
+                    ssl:
+                      properties:
+                        certSecretName:
+                          type: string
+                      type: object
                     svcOrchSpec:
                       properties:
                         env:
@@ -16522,6 +16527,11 @@ spec:
                       type: integer
                     shadow:
                       type: boolean
+                    ssl:
+                      properties:
+                        certSecretName:
+                          type: string
+                      type: object
                     svcOrchSpec:
                       properties:
                         env:
@@ -24885,6 +24895,11 @@ spec:
                       type: integer
                     shadow:
                       type: boolean
+                    ssl:
+                      properties:
+                        certSecretName:
+                          type: string
+                      type: object
                     svcOrchSpec:
                       properties:
                         env:

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -26,8 +26,8 @@ HELM_KUBEFLOW_IF_START = "{{- if .Values.kubeflow }}\n"
 HELM_KUBEFLOW_IF_NOT_START = "{{- if not .Values.kubeflow }}\n"
 HELM_CREATERESOURCES_IF_START = "{{- if not .Values.managerCreateResources }}\n"
 HELM_CREATERESOURCES_RBAC_IF_START = "{{- if .Values.managerCreateResources }}\n"
-HELM_K8S_V1_CRD_IF_START = '{{- if semverCompare ">=1.18.0" .Capabilities.KubeVersion.GitVersion }}\n'
-HELM_K8S_V1BETA1_CRD_IF_START = '{{- if semverCompare "<1.18.0" .Capabilities.KubeVersion.GitVersion }}\n'
+HELM_K8S_V1_CRD_IF_START = '{{- if or (ge (int (regexFind "[0-9]+" .Capabilities.KubeVersion.Minor)) 18) (.Values.crd.forcev1) }}\n'
+HELM_K8S_V1BETA1_CRD_IF_START = '{{- if or (lt (int (regexFind "[0-9]+" .Capabilities.KubeVersion.Minor)) 18) (.Values.crd.forcev1beta1) }}\n'
 HELM_IF_END = "{{- end }}\n"
 
 HELM_ENV_SUBST = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
 * Makes k8s helm check more robust by just using Minor check.
    * However, Google GKE clusters can have Minor version like "15+" so need to strip non numeric characters
    * semverCompare does not work on GKE on the whole version
* Adds 2 Helm variables to allow forcing of the v1 or v1beta1 CRD if desired

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2367 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

