### PR TITLE
Updated setup.py to work with security CI 

### DIFF
--- a/jenkins-x-securitychecks.yml
+++ b/jenkins-x-securitychecks.yml
@@ -43,5 +43,5 @@ pipelineConfig:
             - agent:
                 image: snyk/snyk:python-3.7
               dir: python
-              sh: "pip install -r requirements.txt && snyk test"
+              sh: "make install && snyk test --file=setup.py"
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,11 +2,6 @@ import os
 from itertools import chain
 from setuptools import find_packages, setup
 
-version = {}
-dir_path = os.path.dirname(os.path.realpath(__file__))
-with open(os.path.join(dir_path, "seldon_core/version.py")) as fp:
-    exec(fp.read(), version)
-
 # Extra dependencies, with special 'all' key
 extras = {"tensorflow": ["tensorflow"]}
 all_extra_deps = chain.from_iterable(extras.values())
@@ -16,7 +11,7 @@ setup(
     name="seldon-core",
     author="Seldon Technologies Ltd.",
     author_email="hello@seldon.io",
-    version=version["__version__"],
+    version="1.2.3-dev",
     description="Seldon Core client and microservice wrapper",
     url="https://github.com/SeldonIO/seldon-core",
     license="Apache 2.0",

--- a/release.py
+++ b/release.py
@@ -206,7 +206,7 @@ def update_versions_py(seldon_core_version, debug=False):
         's/version="\(.*\)"/version="{seldon_core_version}"/g'.format(
             **locals()
         ),
-        "operator/config/manager/manager.yaml",
+        "python/setup.py",
     ]
     err, out = run_command(args, debug)
     # Updating the version in module __version__.py

--- a/release.py
+++ b/release.py
@@ -199,6 +199,17 @@ def update_versions_txt(seldon_core_version, debug=False):
 
 
 def update_versions_py(seldon_core_version, debug=False):
+    # Updating the version in setup.py
+    args = [
+        "sed",
+        "-i",
+        's/version="\(.*\)"/version="{seldon_core_version}"/g'.format(
+            **locals()
+        ),
+        "operator/config/manager/manager.yaml",
+    ]
+    err, out = run_command(args, debug)
+    # Updating the version in module __version__.py
     with open("python/seldon_core/version.py", "w") as f:
         f.write('__version__ = "{seldon_core_version}"\n'.format(**locals()))
     print("Updated python/seldon_core/version.py")


### PR DESCRIPTION
Fixes #2065 

### Context

* Moving to setup.py broke the CI script
* After investigation it was the `open("local/path/file")` that was breaking snyk
* This relative path was removed and updated release.py