### PR TITLE
Dettach duplicated signal handler from workers

### DIFF
--- a/python/seldon_core/app.py
+++ b/python/seldon_core/app.py
@@ -1,10 +1,18 @@
 import os
 import logging
+import atexit
 
+from multiprocessing.util import _exit_function
 from typing import Dict, Union
 from gunicorn.app.base import BaseApplication
 
 logger = logging.getLogger(__name__)
+
+
+def post_worker_init(worker):
+    # Remove the atexit handler set up by the parent process
+    # https://github.com/benoitc/gunicorn/issues/1391#issuecomment-467010209
+    atexit.unregister(_exit_function)
 
 
 def accesslog(log_level: str) -> Union[str, None]:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Add a `post_worker_init` hook to dettach a signal handler from the Gunicorn worker processes to avoid calling `join()` when they exit. That signal handler is attached by `multiprocessing` on the root process, but gets inherited by the child workers because of how `fork()` works.

More details can be found in the following issue: https://github.com/benoitc/gunicorn/issues/1391  

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2094

**Special notes for your reviewer**:
The signal handler should still remain on the root process. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Fixed `can only join a child process` error when shutting down a Seldon deployment.
```

