### PR TITLE
Add -2 as option for route abort

### DIFF
--- a/doc/source/analytics/routers.md
+++ b/doc/source/analytics/routers.md
@@ -9,7 +9,15 @@ Currently we provide two reference implementations of routers in Python. Both ar
 * [Thompson Sampling](https://github.com/SeldonIO/seldon-core/tree/master/components/routers/thompson-sampling)
 
 ## Implementing custom routers
-A router component must implement a ```Route``` method which will return one of the children that the router component is connected to for routing an incoming request. Optionally a ```SendFeedback``` method can be implemented to provide a mechanism for informing the router on the quality of its decisions. This would be used in adaptive routers such as multi-armed bandits, refer to the [epsilon-greedy](https://github.com/SeldonIO/seldon-core/tree/master/components/routers/epsilon-greedy) example for more detail.
+A router component must implement a ```Route``` method which will return one of the children that the router component is connected to for routing an incoming request. The options for the return value for a custom router at present are
+
+ * -1 : Route to all children
+ * -2 : Route to no children and return the current request as the response
+ * N >= 0 : Route to child N
+
+The response for REST calls should be returned as a SeldonMessage with the payload containing the route value or a JSON array containing a single integer.
+
+Optionally a ```SendFeedback``` method can be implemented to provide a mechanism for informing the router on the quality of its decisions. This would be used in adaptive routers such as multi-armed bandits, refer to the [epsilon-greedy](https://github.com/SeldonIO/seldon-core/tree/master/components/routers/epsilon-greedy) example for more detail.
 
 As an example, consider writing a custom A/B/C... testing component with a user-specified number of children and routing probabilities (two-model routing is already supported in Seldon Core: [RANDOM_ABTEST](../reference/seldon-deployment.md#proto-buffer-definition)). In this scenario because the routing logic is static there is no need to implement ```SendFeedback``` as we will not be dynamically changing the routing by providing feedback for its routing choices. On the other hand, an adaptive router whose routing is required to change dynamically by providing feedback will need to implement the ```SendFeedback``` method.
 

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -195,6 +195,9 @@ func (p *PredictorProcess) predictChildren(node *v1.PredictiveUnit, msg payload.
 					return cmsgs[i], err
 				}
 			}
+		} else if route == -2 {
+			//Abort and return request
+			return msg, nil
 		} else {
 			cmsgs = make([]payload.SeldonPayload, 1)
 			cmsgs[0], err = p.Predict(&node.Children[route], msg)

--- a/executor/predictor/predictor_process_test.go
+++ b/executor/predictor/predictor_process_test.go
@@ -328,6 +328,12 @@ func TestRouter(t *testing.T) {
 	smRes = pResp.GetPayload().(*proto.SeldonMessage)
 	g.Expect(smRes.GetData().GetNdarray().Values[0].GetNumberValue()).Should(Equal(1.1))
 	g.Expect(smRes.GetData().GetNdarray().Values[1].GetNumberValue()).Should(Equal(2.0))
+
+	pResp, err = createPredictorProcessWithRoute(t, -2).Predict(graph, createPredictPayload(g))
+	g.Expect(err).Should(BeNil())
+	smRes = pResp.GetPayload().(*proto.SeldonMessage)
+	g.Expect(smRes.GetData().GetNdarray().Values[0].GetNumberValue()).Should(Equal(1.1))
+	g.Expect(smRes.GetData().GetNdarray().Values[1].GetNumberValue()).Should(Equal(2.0))
 }
 
 func TestModelError(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

 * Adds new option for route requests to return -2 meaning abort and return current request.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2400

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

