### PR TITLE
Upgrade alibi component to use alibi 0.5.4

### DIFF
--- a/components/alibi-explain-server/alibiexplainer/kernel_shap.py
+++ b/components/alibi-explain-server/alibiexplainer/kernel_shap.py
@@ -4,7 +4,7 @@ import alibi
 from alibi.api.interfaces import Explanation
 from alibiexplainer.explainer_wrapper import ExplainerWrapper
 from alibiexplainer.constants import SELDON_LOGLEVEL
-from shap.common import Model
+from shap.utils._legacy import  Model
 from typing import Callable, List, Optional
 
 logging.basicConfig(level=SELDON_LOGLEVEL)
@@ -26,7 +26,7 @@ class KernelShap(ExplainerWrapper):
     def explain(self, inputs: List) -> Explanation:
         arr = np.array(inputs)
         self.kernel_shap.predictor = self.predict_fn
-        self.kernel_shap._explainer.model = Model(self.predict_fn,None)
+        self.kernel_shap._explainer.model = Model(self.predict_fn, None)
         logging.info("kernel Shap call with %s", self.kwargs)
         logging.info("kernel shap data shape %s",arr.shape)
         shap_exp = self.kernel_shap.explain(arr, l1_reg=False, **self.kwargs)

--- a/components/alibi-explain-server/setup.py
+++ b/components/alibi-explain-server/setup.py
@@ -32,15 +32,15 @@ setup(
     packages=find_packages("alibiexplainer"),
     install_requires=[
         "kfserving>=0.3.0",
-        "alibi==0.5.2",
+        "alibi==0.5.4",
         "scikit-learn>= 0.23.0",
         "argparse>=1.4.0",
         "requests>=2.22.0",
         "joblib>=0.13.2",
         "dill>=0.3.0",
         "grpcio>=1.22.0",
-        "xgboost==1.0.2",
-        "shap==0.35.0"
+        "xgboost==1.2.0",
+        "shap==0.36.0"
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}

--- a/testing/scripts/dev_requirements.txt
+++ b/testing/scripts/dev_requirements.txt
@@ -8,7 +8,7 @@ sh==1.13.1
 # notebooks test deps
 ipython==7.13.0
 nbconvert==5.6.1
-alibi==0.5.2
+alibi==0.5.4
 matplotlib==3.1.3
 tensorflow==1.15.2
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Upgrades alibi-explain-server to use `alibi=0.5.4`.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
updates alibi to version 0.5.4
```

