### PR TITLE
Fix image Jenkinx X build failures

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -51,11 +51,11 @@ pipelineConfig:
         - name: create-version
           command: cat version.txt > VERSION
         - name: delete-existing-branch
-          command: git branch -D nightly-\$(cat version.txt) || echo "No branch exists"
+          command: git branch -D v\$(cat version.txt) || echo "No branch exists"
         - name: create-new-branch
-          command: git checkout -b nightly-\$(cat version.txt)
+          command: git checkout -b v\$(cat version.txt)
         - name: commit-new-branch
-          command: git push origin nightly-\$(cat version.txt) -f
+          command: git push origin v\$(cat version.txt) -f
         - name: skip-tag
           command: echo "skipping tag"
       pipeline:
@@ -71,7 +71,7 @@ pipelineConfig:
             - name: create-dated-version
               command: echo $(cat version.txt)_$(date +"%Y%m%d%H%M%S") > version.txt
             - name: create-new-branch
-              command: git checkout -b nightly-$(cat version.txt)
+              command: git checkout -b v$(cat version.txt)
             # This is necessary as the python release.py has a known bug which hangs if the JARs are not downloaded first
             - name: update-release-tags
               command: (cd engine && mvn versions:set -DnewVersion=$(cat ../version.txt)) && python release.py $(cat version.txt)
@@ -84,7 +84,7 @@ pipelineConfig:
               args:
               - ./ci_build_and_push_images.sh
             - name: push-new-branch
-              command: git push origin nightly-$(cat version.txt)
+              command: git push origin v$(cat version.txt)
             options:
               containerOptions:
                 volumeMounts:


### PR DESCRIPTION
Fixes #2443 

The jenkins X uses the VERSION branch as the base branch, so when it was changed to used `nighly-<version>` it broke the image build, resulting in the wrong branch being built. Now this builds on the correct branch back to `v<version>`