### PR TITLE
upgrade core-builder to 0.18 and fix last 2 failing notebook tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ run_core_builder_in_host:
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v $${HOME}/.m2:/root/.m2 \
 			-v $(SELDON_CORE_LOCAL_DIR):/work \
-			seldonio/core-builder:0.17 bash
+			seldonio/core-builder:0.18 bash
 
 
 run_core_builder_in_minikube:
@@ -37,7 +37,7 @@ run_core_builder_in_minikube:
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v /home/docker/.m2:/root/.m2 \
 			-v $(SELDON_CORE_VM_DIR):/work \
-			seldonio/core-builder:0.17 bash
+			seldonio/core-builder:0.18 bash
 
 show_paths:
 	@echo "local: $(SELDON_CORE_LOCAL_DIR)"

--- a/core-builder/Dockerfile
+++ b/core-builder/Dockerfile
@@ -40,6 +40,7 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.16.2/bin/l
 RUN \
     apt-get update -y && \
     apt-get install -y vim && \
+    apt-get install -y jq && \
     apt-get install -y build-essential && \
     apt-get remove -y --auto-remove && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/core-builder/Makefile
+++ b/core-builder/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE_NAME=seldonio/core-builder
-DOCKER_IMAGE_VERSION=0.17
+DOCKER_IMAGE_VERSION=0.18
 
 build_docker_image:
 	cp ../testing/scripts/dev_requirements.txt .

--- a/examples/models/metadata/example-grpc.yaml
+++ b/examples/models/metadata/example-grpc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: graph-metadata-grpc
 spec:
   name: test-deployment
+  transport: grpc
   predictors:
   - componentSpecs:
     - spec:

--- a/examples/models/metadata/metadata_grpc.ipynb
+++ b/examples/models/metadata/metadata_grpc.ipynb
@@ -86,6 +86,7 @@
     "  name: graph-metadata-grpc\n",
     "spec:\n",
     "  name: test-deployment\n",
+    "  transport: grpc\n",
     "  predictors:\n",
     "  - componentSpecs:\n",
     "    - spec:\n",

--- a/incubating/wrappers/s2i/java/Dockerfile.build
+++ b/incubating/wrappers/s2i/java/Dockerfile.build
@@ -1,4 +1,4 @@
-ARG IMAGE_SOURCE=seldonio/core-builder:0.17
+ARG IMAGE_SOURCE=seldonio/core-builder:0.18
 FROM $IMAGE_SOURCE
 
 LABEL io.openshift.s2i.scripts-url="image:///s2i/bin"

--- a/jenkins-x-createrelease.yml
+++ b/jenkins-x-createrelease.yml
@@ -16,7 +16,7 @@ pipelineConfig:
           command: echo "skipping tag"
       pipeline:
         agent:
-          image: seldonio/core-builder:0.17
+          image: seldonio/core-builder:0.18
         stages:
           - name: create-release
             steps:

--- a/jenkins-x-engine.yml
+++ b/jenkins-x-engine.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.17
+          image: seldonio/core-builder:0.18
         stages:
           - name: pr-build-comment
             steps:

--- a/jenkins-x-integration.yml
+++ b/jenkins-x-integration.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.17
+          image: seldonio/core-builder:0.18
         stages:
           - name: pr-build-comment
             steps:

--- a/jenkins-x-lint.yml
+++ b/jenkins-x-lint.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.17
+          image: seldonio/core-builder:0.18
         stages:
         - name: pr-build-comment
           steps:
@@ -26,7 +26,7 @@ pipelineConfig:
                 - lint 
           - name: lint-operator
             agent:
-              image: seldonio/core-builder:0.17
+              image: seldonio/core-builder:0.18
             steps:
               - name: lint-operator
                 command: make
@@ -35,7 +35,7 @@ pipelineConfig:
                   - lint
           - name: lint-executor
             agent:
-              image: seldonio/core-builder:0.17
+              image: seldonio/core-builder:0.18
             steps:
               - name: lint-executor
                 command: make

--- a/jenkins-x-notebooks.yml
+++ b/jenkins-x-notebooks.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.17
+          image: seldonio/core-builder:0.18
         stages:
           - name: pr-build-comment
             steps:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -10,7 +10,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: seldonio/core-builder:0.17
+          image: seldonio/core-builder:0.18
         stages:
         - name: pr-build-comment
           steps:
@@ -60,7 +60,7 @@ pipelineConfig:
           command: echo "skipping tag"
       pipeline:
         agent:
-          image: seldonio/core-builder:0.17
+          image: seldonio/core-builder:0.18
         stages:
           - name: build-and-push
             steps:

--- a/operator/helm/Makefile
+++ b/operator/helm/Makefile
@@ -7,7 +7,7 @@ create:
 	docker run --rm -it \
 		--user=$$(id -u):$$(id -g) \
 		-v "$(SELDON_CORE_DIR)":/work \
-		seldonio/core-builder:0.17 bash -c 'cd /work/operator/helm && make create_helper'
+		seldonio/core-builder:0.18 bash -c 'cd /work/operator/helm && make create_helper'
 
 .PHONY: create_helper
 create_helper:

--- a/release
+++ b/release
@@ -13,5 +13,4 @@ docker run --rm -it \
     -e MAVEN_REPOSITORY_LOCATION=${MAVEN_REPOSITORY_LOCATION} \
     -v ${HOME}/.m2/repository:${MAVEN_REPOSITORY_LOCATION} \
     -v "${STARTUP_DIR}":/work \
-    seldonio/core-builder:0.17 python release.py "$@"
-
+    seldonio/core-builder:0.18 python release.py "$@"

--- a/testing/scripts/dev_requirements.txt
+++ b/testing/scripts/dev_requirements.txt
@@ -9,6 +9,7 @@ sh==1.13.1
 ipython==7.13.0
 nbconvert==5.6.1
 alibi==0.5.2
+shap==0.35.0
 matplotlib==3.1.3
 tensorflow==1.15.2
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

* adds `jq` to core-builder image and change references to 0.18 version
* adjusts `TestNotebooks.test_grpc_metadata` to reverse multiplexing-related changes
* fixes `TestNotebooks.test_explainer_examples` by forcing `shap==0.35.0` in integration tests `dev_requirements.txt`

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/SeldonIO/seldon-core/issues/2454

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
None
```

