### PR TITLE
print tfproxy exit value in ci_build_and_push_images script

### DIFF
--- a/ci_build_and_push_images.sh
+++ b/ci_build_and_push_images.sh
@@ -170,6 +170,7 @@ echo "Executor exit value: $EXECUTOR_EXIT_VALUE"
 echo "Mock model exit value: $MOCK_MODEL_EXIT_VALUE"
 echo "Alibi Detect exit value: $ALIBI_DETECT_EXIT_VALUE"
 echo "Request Logger exit value: $LOGGER_EXIT_VALUE"
+echo "Tensorflow Proxy exit value: $TFPROXY_EXIT_VALUE"
 
 exit $((${PYTHON_EXIT_VALUE} \
     + ${OPERATOR_EXIT_VALUE} \


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Print exit value of build_push_tfproxy function in ci_build_and_push_images script.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related to https://github.com/SeldonIO/seldon-core/issues/2477 but not sure if it closes it.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
None
```

