### PR TITLE
Update sklearn_spacy_text_classifier_example.ipynb

### DIFF
--- a/examples/models/sklearn_spacy_text/sklearn_spacy_text_classifier_example.ipynb
+++ b/examples/models/sklearn_spacy_text/sklearn_spacy_text_classifier_example.ipynb
@@ -457,7 +457,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FROM seldonio/seldon-core-s2i-python3:1.3.0-dev
+      "FROM seldonio/seldon-core-s2i-python3:1.3.0-dev",
       "\n",
       "RUN pip install spacy\n",
       "RUN python -m spacy download en_core_web_sm\n"


### PR DESCRIPTION
Missing `",` at line 460, rendered notebook unusable without it

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Added `",` at line 460 for the specified notebook, otherwise notebook is rendered unusable.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2486 

**Special notes for your reviewer**:
NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Fixes sklearn_spacy_text_classifier_example.ipynb to be readable
```

