### PR TITLE
fix build_all_local.sh script to use correct gpu-related scripts

### DIFF
--- a/wrappers/s2i/python/build_scripts/build_all_local.sh
+++ b/wrappers/s2i/python/build_scripts/build_all_local.sh
@@ -1,5 +1,5 @@
 ./build_local_python3.6.sh
 ./build_local_python3.7.sh
-./build_local_python3.6_gpu.sh
-./build_local_python3.7_gpu.sh
+./build_python3.6_gpu.sh
+./build_python3.7_gpu.sh
 ./build_redhat.sh


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Wrong name of script was referenced and because of that new gpu image has not been built. 
This fixes bug not caught in https://github.com/SeldonIO/seldon-core/issues/2509.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
None
```

