### PR TITLE
feat(defaults): Add default resources to engine/executor container

### DIFF
--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -131,6 +131,22 @@ spec:
           value: '{{ .Values.executor.requestLogger.defaultEndpoint }}'
         - name: DEFAULT_USER_ID
           value: '{{ .Values.defaultUserID }}'
+        - name: EXECUTOR_DEFAULT_CPU_REQUEST
+          value: '{{ .Values.executor.resources.cpuRequest }}'
+        - name: EXECUTOR_DEFAULT_MEMORY_REQUEST
+          value: '{{ .Values.executor.resources.memoryRequest }}'
+        - name: EXECUTOR_DEFAULT_CPU_LIMIT
+          value: '{{ .Values.executor.resources.cpuLimit }}'
+        - name: EXECUTOR_DEFAULT_MEMORY_LIMIT
+          value: '{{ .Values.executor.resources.memoryLimit }}'
+        - name: ENGINE_DEFAULT_CPU_REQUEST
+          value: '{{ .Values.engine.resources.cpuRequest }}'
+        - name: ENGINE_DEFAULT_MEMORY_REQUEST
+          value: '{{ .Values.engine.resources.memoryRequest }}'
+        - name: ENGINE_DEFAULT_CPU_LIMIT
+          value: '{{ .Values.engine.resources.cpuLimit }}'
+        - name: ENGINE_DEFAULT_MEMORY_LIMIT
+          value: '{{ .Values.engine.resources.memoryLimit }}'
         image: '{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         name: manager

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -47,6 +47,11 @@ executor:
     registry: docker.io
     repository: seldonio/seldon-core-executor
     tag: 1.3.0-dev
+  resources:
+    cpuLimit: 500m
+    cpuRequest: 500m
+    memoryLimit: 512Mi
+    memoryRequest: 512Mi
   prometheus:
     path: /prometheus
   serviceAccount:
@@ -174,6 +179,11 @@ engine:
     registry: docker.io
     repository: seldonio/engine
     tag: 1.3.0-dev
+  resources:
+    cpuLimit: 500m
+    cpuRequest: 500m
+    memoryLimit: 512Mi
+    memoryRequest: 512Mi
   logMessagesExternally: false
   port: 8000
   prometheus:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -125,6 +125,22 @@ spec:
           value: "http://default-broker"
         - name: DEFAULT_USER_ID
           value: ''
+        - name: EXECUTOR_DEFAULT_CPU_REQUEST
+          value: "0.5"
+        - name: EXECUTOR_DEFAULT_MEMORY_REQUEST
+          value: "512Mi"
+        - name: EXECUTOR_DEFAULT_CPU_LIMIT
+          value: "0.5"
+        - name: EXECUTOR_DEFAULT_MEMORY_LIMIT
+          value: "512Mi"
+        - name: ENGINE_DEFAULT_CPU_REQUEST
+          value: "0.5"
+        - name: ENGINE_DEFAULT_MEMORY_REQUEST
+          value: "512Mi"
+        - name: ENGINE_DEFAULT_CPU_LIMIT
+          value: "0.5"
+        - name: ENGINE_DEFAULT_MEMORY_LIMIT
+          value: "512Mi"
         image: controller:latest
         name: manager
         resources:

--- a/operator/constants/constants.go
+++ b/operator/constants/constants.go
@@ -74,3 +74,15 @@ const (
 	ExplainerPathSuffix = "-explainer"
 	ExplainerNameSuffix = "-explainer"
 )
+
+// Default resources
+const (
+	DefaultExecutorCpuRequest    = "0.5"
+	DefaultExecutorCpuLimit      = "0.5"
+	DefaultExecutorMemoryRequest = "512Mi"
+	DefaultExecutorMemoryLimit   = "512Mi"
+	DefaultEngineCpuRequest      = "0.5"
+	DefaultEngineCpuLimit        = "0.5"
+	DefaultEngineMemoryRequest   = "512Mi"
+	DefaultEngineMemoryLimit     = "512Mi"
+)

--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -35,6 +35,14 @@ import (
 const (
 	ENV_DEFAULT_EXECUTOR_SERVER_PORT      = "EXECUTOR_SERVER_PORT"
 	ENV_DEFAULT_EXECUTOR_SERVER_GRPC_PORT = "EXECUTOR_SERVER_GRPC_PORT"
+	ENV_DEFAULT_EXECUTOR_CPU_REQUEST      = "EXECUTOR_DEFAULT_CPU_REQUEST"
+	ENV_DEFAULT_EXECUTOR_MEMORY_REQUEST   = "EXECUTOR_DEFAULT_MEMORY_REQUEST"
+	ENV_DEFAULT_EXECUTOR_CPU_LIMIT        = "EXECUTOR_DEFAULT_CPU_LIMIT"
+	ENV_DEFAULT_EXECUTOR_MEMORY_LIMIT     = "EXECUTOR_DEFAULT_MEMORY_LIMIT"
+	ENV_DEFAULT_ENGINE_CPU_REQUEST        = "ENGINE_DEFAULT_CPU_REQUEST"
+	ENV_DEFAULT_ENGINE_MEMORY_REQUEST     = "ENGINE_DEFAULT_MEMORY_REQUEST"
+	ENV_DEFAULT_ENGINE_CPU_LIMIT          = "ENGINE_DEFAULT_CPU_LIMIT"
+	ENV_DEFAULT_ENGINE_MEMORY_LIMIT       = "ENGINE_DEFAULT_MEMORY_LIMIT"
 	ENV_EXECUTOR_METRICS_PORT_NAME        = "EXECUTOR_SERVER_METRICS_PORT_NAME"
 	ENV_EXECUTOR_PROMETHEUS_PATH          = "EXECUTOR_PROMETHEUS_PATH"
 	ENV_ENGINE_PROMETHEUS_PATH            = "ENGINE_PROMETHEUS_PATH"
@@ -62,6 +70,16 @@ var (
 	envUseExecutor          = os.Getenv(ENV_USE_EXECUTOR)
 
 	executorMetricsPortName = utils.GetEnv(ENV_EXECUTOR_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
+
+	executorDefaultCpuRequest    = utils.GetEnv(ENV_DEFAULT_EXECUTOR_CPU_REQUEST, constants.DefaultExecutorCpuRequest)
+	executorDefaultCpuLimit      = utils.GetEnv(ENV_DEFAULT_EXECUTOR_CPU_LIMIT, constants.DefaultExecutorCpuLimit)
+	executorDefaultMemoryRequest = utils.GetEnv(ENV_DEFAULT_EXECUTOR_MEMORY_REQUEST, constants.DefaultExecutorMemoryRequest)
+	executorDefaultMemoryLimit   = utils.GetEnv(ENV_DEFAULT_EXECUTOR_MEMORY_LIMIT, constants.DefaultExecutorMemoryLimit)
+
+	engineDefaultCpuRequest    = utils.GetEnv(ENV_DEFAULT_ENGINE_CPU_REQUEST, constants.DefaultEngineCpuRequest)
+	engineDefaultCpuLimit      = utils.GetEnv(ENV_DEFAULT_ENGINE_CPU_LIMIT, constants.DefaultEngineCpuLimit)
+	engineDefaultMemoryRequest = utils.GetEnv(ENV_DEFAULT_ENGINE_MEMORY_REQUEST, constants.DefaultEngineMemoryRequest)
+	engineDefaultMemoryLimit   = utils.GetEnv(ENV_DEFAULT_ENGINE_MEMORY_LIMIT, constants.DefaultEngineMemoryLimit)
 )
 
 func addEngineToDeployment(mlDep *machinelearningv1.SeldonDeployment, p *machinelearningv1.PredictorSpec, engine_http_port int, engine_grpc_port int, pSvcName string, deploy *appsv1.Deployment) error {
@@ -367,12 +385,31 @@ func createEngineContainer(mlDep *machinelearningv1.SeldonDeployment, p *machine
 	}
 
 	//Engine resources
-	engineResources := p.SvcOrchSpec.Resources
+	var engineResources *corev1.ResourceRequirements = p.SvcOrchSpec.Resources
 	if engineResources == nil {
-		cpuQuantity, _ := resource.ParseQuantity("0.1")
+		var cpu_request resource.Quantity
+		var cpu_limit resource.Quantity
+		var memory_request resource.Quantity
+		var memory_limit resource.Quantity
+		if isExecutorEnabled(mlDep) {
+			cpu_request = resource.MustParse(executorDefaultCpuRequest)
+			cpu_limit = resource.MustParse(executorDefaultCpuLimit)
+			memory_request = resource.MustParse(executorDefaultMemoryRequest)
+			memory_limit = resource.MustParse(executorDefaultMemoryLimit)
+		} else {
+			cpu_request = resource.MustParse(engineDefaultCpuRequest)
+			cpu_limit = resource.MustParse(engineDefaultCpuLimit)
+			memory_request = resource.MustParse(engineDefaultMemoryRequest)
+			memory_limit = resource.MustParse(engineDefaultMemoryLimit)
+		}
 		engineResources = &corev1.ResourceRequirements{
 			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU: cpuQuantity,
+				corev1.ResourceCPU:    cpu_request,
+				corev1.ResourceMemory: memory_request,
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    cpu_limit,
+				corev1.ResourceMemory: memory_limit,
 			},
 		}
 	}

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -57,6 +57,14 @@ HELM_ENV_SUBST = {
     "MANAGER_CREATE_RESOURCES": "managerCreateResources",
     "EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT": "executor.requestLogger.defaultEndpoint",
     "DEFAULT_USER_ID": "defaultUserID",
+    "EXECUTOR_DEFAULT_CPU_LIMIT": "executor.resources.cpuLimit",
+    "EXECUTOR_DEFAULT_CPU_REQUEST": "executor.resources.cpuRequest",
+    "EXECUTOR_DEFAULT_MEMORY_LIMIT": "executor.resources.memoryLimit",
+    "EXECUTOR_DEFAULT_MEMORY_REQUEST": "executor.resources.memoryRequest",
+    "ENGINE_DEFAULT_CPU_LIMIT": "engine.resources.cpuLimit",
+    "ENGINE_DEFAULT_CPU_REQUEST": "engine.resources.cpuRequest",
+    "ENGINE_DEFAULT_MEMORY_LIMIT": "engine.resources.memoryLimit",
+    "ENGINE_DEFAULT_MEMORY_REQUEST": "engine.resources.memoryRequest",
 }
 HELM_VALUES_IMAGE_PULL_POLICY = "{{ .Values.image.pullPolicy }}"
 


### PR DESCRIPTION
Defines default requests and limits on the engine/executor container.

Contributes to #2475

Signed-off-by: Nick Groszewski <groszewn@gmail.com>

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Addition of default engine/executor container resources, which helps in clusters with OPA policies defined to require requests and limits be set.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2475 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Added default resources to engine/executor container
```

