### PR TITLE
Extend drift detect server to expose metrics

### DIFF
--- a/components/alibi-detect-server/adserver/cd_model.py
+++ b/components/alibi-detect-server/adserver/cd_model.py
@@ -27,7 +27,7 @@ def _drift_to_metrics(drift):
             {
                 "key": "seldon_metric_drift_feature_score",
                 "value": feature_score,
-                "type": "GAUGE",
+                "type": "COUNTER",
             }
         )
 

--- a/components/alibi-detect-server/adserver/cd_model.py
+++ b/components/alibi-detect-server/adserver/cd_model.py
@@ -126,11 +126,8 @@ class AlibiDetectConceptDriftModel(
             self.batch = None
 
             output = json.loads(json.dumps(cd_preds, cls=NumpyEncoder))
-            logging.info(output.get("data", {}))
 
             metrics = _drift_to_metrics(output.get("data", {}))
-            logging.info("metrics:")
-            logging.info(metrics)
 
             seldon_response = SeldonResponse(output, None, metrics)
 

--- a/components/alibi-detect-server/adserver/server.py
+++ b/components/alibi-detect-server/adserver/server.py
@@ -236,7 +236,7 @@ class EventHandler(tornado.web.RequestHandler):
         runtime_metrics = seldon_response.metrics
         if runtime_metrics is not None:
             if validate_metrics(runtime_metrics):
-                self.seldon_metrics.update(runtime_metrics, "ce_server")
+                self.seldon_metrics.update(runtime_metrics, self.event_type)
             else:
                 logging.error("Metrics returned are invalid: " + str(runtime_metrics))
 

--- a/components/alibi-detect-server/adserver/tests/test_cd_model.py
+++ b/components/alibi-detect-server/adserver/tests/test_cd_model.py
@@ -31,7 +31,7 @@ class TestAEModel(TestCase):
         req = [[1, 2]]
         headers = {}
         res = ad_model.process_event(req, headers)
-        self.assertEqual(res["data"]["is_drift"], 0)
+        self.assertEqual(res.data["data"]["is_drift"], 0)
 
     def test_batch(self):
         model = DummyCDModel()
@@ -44,7 +44,7 @@ class TestAEModel(TestCase):
         self.assertEqual(res, None)
 
         res = ad_model.process_event(req, headers)
-        self.assertEqual(res["data"]["is_drift"], 0)
+        self.assertEqual(res.data["data"]["is_drift"], 0)
 
         res = ad_model.process_event(req, headers)
         self.assertEqual(res, None)

--- a/components/alibi-detect-server/setup.py
+++ b/components/alibi-detect-server/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires=">3.4",
     packages=find_packages(),
     install_requires=[
-        "alibi-detect",
+        "alibi-detect==0.4.1",
         "kfserving>=0.2.0",
         "argparse >= 1.4.0",
         "numpy >= 1.8.2",


### PR DESCRIPTION
Fixes #2537

* Extends concept drift server to return metrics
* Locks alibi detect version to 0.4.1 due to breaking change on naming of UAE class https://github.com/SeldonIO/alibi-detect/blob/13bed2f70ba20e5c1360245f0c19a29dc1ae8889/alibi_detect/cd/preprocess.py#L14 
