### PR TITLE
Use UTF-8 code for check mark

### DIFF
--- a/doc/source/graph/protocols.md
+++ b/doc/source/graph/protocols.md
@@ -81,8 +81,8 @@ In particular,
 
 | Pre-packaged server | Supported | Underlying runtime |
 | -- | -- | -- |
-| [TRITON_SERVER](../servers/triton.md) | :heavy_check_mark: | [NVIDIA Triton](https://github.com/triton-inference-server/server) |
-| [SKLEARN_SERVER](../servers/sklearn.md) | :heavy_check_mark: | [Seldon MLServer](https://github.com/seldonio/mlserver) |
-| [XGBOOST_SERVER](../servers/xgboost.md) | :heavy_check_mark: | [Seldon MLServer](https://github.com/seldonio/mlserver) |
+| [TRITON_SERVER](../servers/triton.md) | ✅ | [NVIDIA Triton](https://github.com/triton-inference-server/server) |
+| [SKLEARN_SERVER](../servers/sklearn.md) | ✅  | [Seldon MLServer](https://github.com/seldonio/mlserver) |
+| [XGBOOST_SERVER](../servers/xgboost.md) | ✅  | [Seldon MLServer](https://github.com/seldonio/mlserver) |
 
 You can try out the `kfserving` in [this example notebook](../examples/protocol_examples.html). 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Sphinx doesn't support "emoji codes" like Markdown does. Thus, they get rendered in the docs as:

![image](https://user-images.githubusercontent.com/1577620/98837401-d1b5fc80-243a-11eb-9833-88623cb0a4c3.png)

This PR changes that `:heavy_check_mark:` into the equivalent UTF-8 code (i.e. ✅).


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

