### PR TITLE
Update workflow to work on Istio enabled namespace

### DIFF
--- a/examples/batch/argo-workflows-batch/helm-charts/seldon-batch-workflow/templates/workflow.yaml
+++ b/examples/batch/argo-workflows-batch/helm-charts/seldon-batch-workflow/templates/workflow.yaml
@@ -39,6 +39,9 @@ spec:
         template: upload-object-store-template
             
   - name: create-seldon-resource-template
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     resource:
       action: create
       manifest: |
@@ -81,6 +84,9 @@ spec:
               replicas: {{ .Values.seldonDeployment.replicas }}
                 
   - name: wait-seldon-resource-template
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     script:
       image: bitnami/kubectl:1.17
       command: [bash]
@@ -90,6 +96,9 @@ spec:
             deploy/$(kubectl get deploy -l seldon-deployment-id="{{ .Values.seldonDeployment.name }}" -o jsonpath='{.items[0].metadata.name}')
                      
   - name: download-object-store-template
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     script:
       image: minio/{{ .Values.minio.minioclient.image }}
       env:
@@ -114,6 +123,9 @@ spec:
         mc cp minio-local/{{ .Values.minio.inputDataPath }} /assets/input-data.txt
             
   - name: process-batch-inputs-template
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     script:
       image: {{ .Values.seldonDeployment.image }}
       volumeMounts:
@@ -136,6 +148,9 @@ spec:
             --output-data-path "/assets/output-data.txt"
       
   - name: upload-object-store-template
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     script:
       image: minio/{{ .Values.minio.minioclient.image }}
       volumeMounts:


### PR DESCRIPTION
Update workflow to work on Istio enabled namespaces because workflow-controller created pods should have no sidecar otherwise it waits forever on  first step

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

