### PR TITLE
Add retries for V2 protocol tests

### DIFF
--- a/components/alibi-detect-server/adserver/od_model.py
+++ b/components/alibi-detect-server/adserver/od_model.py
@@ -106,9 +106,17 @@ class AlibiDetectOutlierModel(CEModel):  # pylint:disable=c-extension-no-member
                 return_instance_score=ret_instance_score,
             )
         # clean result
-        if "data" in od_preds and "instance_score" in od_preds["data"] and od_preds["data"]["instance_score"] is None:
+        if (
+            "data" in od_preds
+            and "instance_score" in od_preds["data"]
+            and od_preds["data"]["instance_score"] is None
+        ):
             del od_preds["data"]["instance_score"]
-        if "data" in od_preds and "feature_score" in od_preds["data"] and od_preds["data"]["feature_score"] is None:
+        if (
+            "data" in od_preds
+            and "feature_score" in od_preds["data"]
+            and od_preds["data"]["feature_score"] is None
+        ):
             del od_preds["data"]["feature_score"]
 
         return json.loads(json.dumps(od_preds, cls=NumpyEncoder))

--- a/testing/scripts/e2e_utils/v2_protocol.py
+++ b/testing/scripts/e2e_utils/v2_protocol.py
@@ -1,8 +1,18 @@
 import requests
 
+from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_result
 from seldon_e2e_utils import API_AMBASSADOR
 
 
+def _is_404(res):
+    return res.status_code == 404
+
+
+@retry(
+    wait=wait_exponential(multiplier=1),
+    stop=stop_after_attempt(3),
+    retry=retry_if_result(_is_404),
+)
 def inference_request(
     model_name: str, namespace: str, payload: dict, host: str = API_AMBASSADOR
 ):


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Tests with the "classic Seldon" API retry the initial requests a couple times. This is apparently done to work around some delay on the initial set up of the services by Istio and Ambassador. 

This PR adds a similar mechanism to the integration tests against the V2 API. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2589

**Special notes for your reviewer**:

This PR also includes a formatting unrelated change in `od_model.py`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

