### PR TITLE
Explore enabling send_feedback path for tensorflow protocol

### DIFF
--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -340,5 +340,9 @@ func (smc *JSONRestClient) TransformOutput(ctx context.Context, modelName string
 }
 
 func (smc *JSONRestClient) Feedback(ctx context.Context, modelName string, host string, port int32, req payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	// Currently feedback is enabled across all protocols but client only works on seldon protocol
+	if smc.Protocol != api.ProtocolSeldon {
+		return req, nil
+	}
 	return smc.call(ctx, modelName, smc.modifyMethod(client.SeldonFeedbackPath, modelName), host, port, req, meta)
 }

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -159,6 +159,8 @@ func (r *SeldonRestApi) Initialise() {
 			r.Router.NewRoute().Path("/v1/models:predict").Methods("OPTIONS", "POST").HandlerFunc(r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions))  // Nonstandard path - Seldon extension
 			r.Router.NewRoute().Path("/v1/models/{"+ModelHttpPathVariable+"}").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.StatusHttpServiceName, r.status))
 			r.Router.NewRoute().Path("/v1/models/{"+ModelHttpPathVariable+"}/metadata").Methods("GET", "OPTIONS").HandlerFunc(r.wrapMetrics(metric.MetadataHttpServiceName, r.metadata))
+			// Enabling for standard seldon core feedback API endpoint with standard schema
+			r.Router.NewRoute().Path("/api/v1.0/feedback").Methods("OPTIONS", "POST").HandlerFunc(r.wrapMetrics(metric.FeedbackHttpServiceName, r.feedback))
 		case api.ProtocolKFServing:
 			r.Router.NewRoute().Path("/v2/models/{"+ModelHttpPathVariable+"}/infer").Methods("OPTIONS", "POST").HandlerFunc(r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions))
 			r.Router.NewRoute().Path("/v2/models/infer").Methods("OPTIONS", "POST").HandlerFunc(r.wrapMetrics(metric.PredictionHttpServiceName, r.predictions)) // Nonstandard path - Seldon extension


### PR DESCRIPTION
Fixes: #2665 

Implementation enables:
* Feedback to be used with tensorflow protocol
* Currently limited to REST
* Would work with current batch demo (sending feedback, seeing accuracy/precision/etc)

Current considerations:
* Payload is sent to request logger until it reaches PredictorProcess (so guard can't be in server.go)
* Guard can't be in PredictorProcess as information about tensorflow protocol not available (pu.implementation cannot be used)
* Guard can only be in the client.go, which has been added as initial assessment

Extensions to discuss in this PR:
* Extend metrics server to work with Tensorflow schema - i.e. "instances" instead of "data.ndarray"
* Documentation

Currently could be explored if it can be moved higher up in the PredictorProcess instead. 