### PR TITLE
remove legacy Python2 components

### DIFF
--- a/python/seldon_core/proto/prediction_pb2_grpc.py
+++ b/python/seldon_core/proto/prediction_pb2_grpc.py
@@ -6,7 +6,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from seldon_core.proto import prediction_pb2 as proto_dot_prediction__pb2
 
 
-class GenericStub(object):
+class GenericStub:
     """[END Messages]
 
     [START Services]
@@ -46,7 +46,7 @@ class GenericStub(object):
                 )
 
 
-class GenericServicer(object):
+class GenericServicer:
     """[END Messages]
 
     [START Services]
@@ -118,7 +118,7 @@ def add_GenericServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Generic(object):
+class Generic:
     """[END Messages]
 
     [START Services]
@@ -211,7 +211,7 @@ class Generic(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class ModelStub(object):
+class ModelStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -237,7 +237,7 @@ class ModelStub(object):
                 )
 
 
-class ModelServicer(object):
+class ModelServicer:
     """Missing associated documentation comment in .proto file."""
 
     def Predict(self, request, context):
@@ -283,7 +283,7 @@ def add_ModelServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Model(object):
+class Model:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -338,7 +338,7 @@ class Model(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class RouterStub(object):
+class RouterStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -359,7 +359,7 @@ class RouterStub(object):
                 )
 
 
-class RouterServicer(object):
+class RouterServicer:
     """Missing associated documentation comment in .proto file."""
 
     def Route(self, request, context):
@@ -394,7 +394,7 @@ def add_RouterServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Router(object):
+class Router:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -432,7 +432,7 @@ class Router(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class TransformerStub(object):
+class TransformerStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -448,7 +448,7 @@ class TransformerStub(object):
                 )
 
 
-class TransformerServicer(object):
+class TransformerServicer:
     """Missing associated documentation comment in .proto file."""
 
     def TransformInput(self, request, context):
@@ -472,7 +472,7 @@ def add_TransformerServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Transformer(object):
+class Transformer:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -493,7 +493,7 @@ class Transformer(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class OutputTransformerStub(object):
+class OutputTransformerStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -509,7 +509,7 @@ class OutputTransformerStub(object):
                 )
 
 
-class OutputTransformerServicer(object):
+class OutputTransformerServicer:
     """Missing associated documentation comment in .proto file."""
 
     def TransformOutput(self, request, context):
@@ -533,7 +533,7 @@ def add_OutputTransformerServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class OutputTransformer(object):
+class OutputTransformer:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -554,7 +554,7 @@ class OutputTransformer(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class CombinerStub(object):
+class CombinerStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -570,7 +570,7 @@ class CombinerStub(object):
                 )
 
 
-class CombinerServicer(object):
+class CombinerServicer:
     """Missing associated documentation comment in .proto file."""
 
     def Aggregate(self, request, context):
@@ -594,7 +594,7 @@ def add_CombinerServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Combiner(object):
+class Combiner:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -615,7 +615,7 @@ class Combiner(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class SeldonStub(object):
+class SeldonStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -646,7 +646,7 @@ class SeldonStub(object):
                 )
 
 
-class SeldonServicer(object):
+class SeldonServicer:
     """Missing associated documentation comment in .proto file."""
 
     def Predict(self, request, context):
@@ -703,7 +703,7 @@ def add_SeldonServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Seldon(object):
+class Seldon:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod

--- a/python/seldon_core/proto/prediction_pb2_grpc.py
+++ b/python/seldon_core/proto/prediction_pb2_grpc.py
@@ -6,7 +6,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from seldon_core.proto import prediction_pb2 as proto_dot_prediction__pb2
 
 
-class GenericStub:
+class GenericStub(object):
     """[END Messages]
 
     [START Services]
@@ -46,7 +46,7 @@ class GenericStub:
                 )
 
 
-class GenericServicer:
+class GenericServicer(object):
     """[END Messages]
 
     [START Services]
@@ -118,7 +118,7 @@ def add_GenericServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Generic:
+class Generic(object):
     """[END Messages]
 
     [START Services]
@@ -211,7 +211,7 @@ class Generic:
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class ModelStub:
+class ModelStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -237,7 +237,7 @@ class ModelStub:
                 )
 
 
-class ModelServicer:
+class ModelServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def Predict(self, request, context):
@@ -283,7 +283,7 @@ def add_ModelServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Model:
+class Model(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -338,7 +338,7 @@ class Model:
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class RouterStub:
+class RouterStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -359,7 +359,7 @@ class RouterStub:
                 )
 
 
-class RouterServicer:
+class RouterServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def Route(self, request, context):
@@ -394,7 +394,7 @@ def add_RouterServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Router:
+class Router(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -432,7 +432,7 @@ class Router:
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class TransformerStub:
+class TransformerStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -448,7 +448,7 @@ class TransformerStub:
                 )
 
 
-class TransformerServicer:
+class TransformerServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def TransformInput(self, request, context):
@@ -472,7 +472,7 @@ def add_TransformerServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Transformer:
+class Transformer(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -493,7 +493,7 @@ class Transformer:
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class OutputTransformerStub:
+class OutputTransformerStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -509,7 +509,7 @@ class OutputTransformerStub:
                 )
 
 
-class OutputTransformerServicer:
+class OutputTransformerServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def TransformOutput(self, request, context):
@@ -533,7 +533,7 @@ def add_OutputTransformerServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class OutputTransformer:
+class OutputTransformer(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -554,7 +554,7 @@ class OutputTransformer:
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class CombinerStub:
+class CombinerStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -570,7 +570,7 @@ class CombinerStub:
                 )
 
 
-class CombinerServicer:
+class CombinerServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def Aggregate(self, request, context):
@@ -594,7 +594,7 @@ def add_CombinerServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Combiner:
+class Combiner(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
@@ -615,7 +615,7 @@ class Combiner:
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
 
-class SeldonStub:
+class SeldonStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -646,7 +646,7 @@ class SeldonStub:
                 )
 
 
-class SeldonServicer:
+class SeldonServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def Predict(self, request, context):
@@ -703,7 +703,7 @@ def add_SeldonServicer_to_server(servicer, server):
 
 
  # This class is part of an EXPERIMENTAL API.
-class Seldon:
+class Seldon(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod

--- a/python/seldon_core/seldon_client.py
+++ b/python/seldon_core/seldon_client.py
@@ -32,7 +32,7 @@ class SeldonClientException(Exception):
         self.message = message
 
 
-class SeldonChannelCredentials(object):
+class SeldonChannelCredentials:
     """
     Channel credentials.
 
@@ -57,7 +57,7 @@ class SeldonChannelCredentials(object):
         self.certificate_chain_file = certificate_chain_file
 
 
-class SeldonCallCredentials(object):
+class SeldonCallCredentials:
     """
     Credentials for each call, currently implements the ability to provide
         an OAuth token which is currently made available through REST via
@@ -68,7 +68,7 @@ class SeldonCallCredentials(object):
         self.token = token
 
 
-class SeldonClientPrediction(object):
+class SeldonClientPrediction:
     """
     Data class to return from Seldon Client
     """
@@ -94,7 +94,7 @@ class SeldonClientPrediction(object):
         )
 
 
-class SeldonClientFeedback(object):
+class SeldonClientFeedback:
     """
     Data class to return from Seldon Client for feedback calls
     """
@@ -120,7 +120,7 @@ class SeldonClientFeedback(object):
         )
 
 
-class SeldonClientCombine(object):
+class SeldonClientCombine:
     """
     Data class to return from Seldon Client for aggregate calls
     """
@@ -146,7 +146,7 @@ class SeldonClientCombine(object):
         )
 
 
-class SeldonClient(object):
+class SeldonClient:
     """
     A reference Seldon API Client
     """

--- a/python/seldon_core/user_model.py
+++ b/python/seldon_core/user_model.py
@@ -51,7 +51,7 @@ class SeldonResponse:
             return cls(data=data)
 
 
-class SeldonComponent(object):
+class SeldonComponent:
     def __init__(self, **kwargs):
         pass
 

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -215,7 +215,7 @@ def _set_flask_app_configs(app):
 # ----------------------------
 
 
-class SeldonModelGRPC(object):
+class SeldonModelGRPC:
     def __init__(self, user_model, seldon_metrics):
         self.user_model = user_model
         self.seldon_metrics = seldon_metrics

--- a/python/tests/resources/model-template-app/MyModel.py
+++ b/python/tests/resources/model-template-app/MyModel.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class MyModel(object):
+class MyModel:
     """
     Model template. You can load your model parameters in __init__ from a location accessible at runtime
     """

--- a/python/tests/resources/model-template-app2/mymodule/my_model.py
+++ b/python/tests/resources/model-template-app2/mymodule/my_model.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class MyModel(object):
+class MyModel:
     """
     Model template. You can load your model parameters in __init__ from a location accessible at runtime
     """

--- a/python/tests/test_api_tester.py
+++ b/python/tests/test_api_tester.py
@@ -29,7 +29,7 @@ def mocked_requests_post_success(url, *args, **kwargs):
     return MockResponse(json, 200, text="{}")
 
 
-class Bunch(object):
+class Bunch:
     def __init__(self, adict):
         self.__dict__.update(adict)
 

--- a/python/tests/test_combiner_microservice.py
+++ b/python/tests/test_combiner_microservice.py
@@ -13,7 +13,7 @@ from seldon_core.user_model import SeldonComponent
 from typing import List, Dict, Union
 
 
-class UserObject(object):
+class UserObject:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -37,7 +37,7 @@ class UserObject(object):
             return [{"type": "BAD", "key": "mycounter", "value": 1}]
 
 
-class UserObjectLowLevel(object):
+class UserObjectLowLevel:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -63,7 +63,7 @@ class UserObjectLowLevel(object):
             return seldon_message_to_json(response)
 
 
-class UserObjectLowLevelGrpc(object):
+class UserObjectLowLevelGrpc:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -78,7 +78,7 @@ class UserObjectLowLevelGrpc(object):
         return request
 
 
-class UserObjectBad(object):
+class UserObjectBad:
     pass
 
 
@@ -483,7 +483,7 @@ def test_unimplemented_aggregate_raw_on_seldon_component():
 
 
 def test_unimplemented_aggregate_raw():
-    class CustomObject(object):
+    class CustomObject:
         def aggregate(self, Xs, features_names):
             return sum(Xs) * 2
 

--- a/python/tests/test_metrics.py
+++ b/python/tests/test_metrics.py
@@ -115,7 +115,7 @@ EXPECTED_COUNTER_METRIC = {"type": COUNTER, "key": "a", "value": 1}
 RAW_BAD_COUNTER_METRIC = {"type": "bad", "key": "a", "value": 1}
 
 
-class Component(object):
+class Component:
     def __init__(self, ok=True):
         self.ok = ok
 

--- a/python/tests/test_microservice_tester.py
+++ b/python/tests/test_microservice_tester.py
@@ -36,7 +36,7 @@ def mocked_requests_post_success(url, *args, **kwargs):
     return MockResponse(json, 200, text="{}")
 
 
-class Bunch(object):
+class Bunch:
     def __init__(self, adict):
         self.__dict__.update(adict)
 

--- a/python/tests/test_model_microservice.py
+++ b/python/tests/test_model_microservice.py
@@ -1024,7 +1024,7 @@ def test_unimplemented_predict_raw_on_seldon_component():
 
 
 def test_unimplemented_predict_raw():
-    class CustomObject(object):
+    class CustomObject:
         def predict(self, X, features_names, **kwargs):
             return X * 2
 
@@ -1059,7 +1059,7 @@ def test_unimplemented_feedback_raw_on_seldon_component():
 
 
 def test_unimplemented_feedback_raw():
-    class CustomObject(object):
+    class CustomObject:
         def feedback(self, features, feature_names, reward, truth):
             logging.info("Feedback called")
 

--- a/python/tests/test_router_microservice.py
+++ b/python/tests/test_router_microservice.py
@@ -10,12 +10,12 @@ from seldon_core.user_model import SeldonComponent
 from typing import Dict, List, Union
 
 
-class MinimalUserObject(object):
+class MinimalUserObject:
     def route(self, X, features_names):
         return 22
 
 
-class UserObject(object):
+class UserObject:
     def __init__(self, metrics_ok=True, ret_meta=False):
         self.metrics_ok = metrics_ok
         self.ret_meta = ret_meta
@@ -42,7 +42,7 @@ class UserObject(object):
             return [{"type": "BAD", "key": "mycounter", "value": 1}]
 
 
-class UserObjectLowLevel(object):
+class UserObjectLowLevel:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -66,7 +66,7 @@ class UserObjectLowLevel(object):
         logging.info("Feedback called")
 
 
-class UserObjectLowLevelGrpc(object):
+class UserObjectLowLevelGrpc:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -84,7 +84,7 @@ class UserObjectLowLevelGrpc(object):
         logging.info("Feedback called")
 
 
-class UserObjectLowLevelRaw(object):
+class UserObjectLowLevelRaw:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -110,7 +110,7 @@ class UserObjectLowLevelRaw(object):
         logging.info("Feedback called")
 
 
-class UserObjectBad(object):
+class UserObjectBad:
     pass
 
 
@@ -339,7 +339,7 @@ def test_unimplemented_route_raw_on_seldon_component():
 
 
 def test_unimplemented_route_raw():
-    class CustomObject(object):
+    class CustomObject:
         def route(self, X, features_names):
             return 53
 

--- a/python/tests/test_seldon_client.py
+++ b/python/tests/test_seldon_client.py
@@ -236,7 +236,7 @@ def test_feedback_microservice_rest(mock_post):
     assert mock_post.call_count == 1
 
 
-class MyStub(object):
+class MyStub:
     def __init__(self, channel):
         self.channel = channel
 

--- a/python/tests/test_transformer_microservice.py
+++ b/python/tests/test_transformer_microservice.py
@@ -14,7 +14,7 @@ from seldon_core.utils import seldon_message_to_json
 from typing import Dict, List, Union
 
 
-class UserObject(object):
+class UserObject:
     def __init__(self, metrics_ok=True, ret_nparray=False, ret_meta=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -54,7 +54,7 @@ class UserObject(object):
             return [{"type": "BAD", "key": "mycounter", "value": 1}]
 
 
-class UserObjectLowLevel(object):
+class UserObjectLowLevel:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -83,7 +83,7 @@ class UserObjectLowLevel(object):
         return request
 
 
-class UserObjectLowLevelGrpc(object):
+class UserObjectLowLevelGrpc:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -106,7 +106,7 @@ class UserObjectLowLevelGrpc(object):
         return request
 
 
-class UserObjectLowLevelRaw(object):
+class UserObjectLowLevelRaw:
     def __init__(self, metrics_ok=True, ret_nparray=False):
         self.metrics_ok = metrics_ok
         self.ret_nparray = ret_nparray
@@ -802,7 +802,7 @@ def test_unimplemented_transform_input_raw_on_seldon_component():
 
 
 def test_unimplemented_transform_input_raw():
-    class CustomObject(object):
+    class CustomObject:
         def transform_input(self, X, features_names, **kwargs):
             return X * 2
 
@@ -836,7 +836,7 @@ def test_unimplemented_transform_output_raw_on_seldon_component():
 
 
 def test_unimplemented_transform_output_raw():
-    class CustomObject(object):
+    class CustomObject:
         def transform_output(self, X, features_names, **kwargs):
             return X * 2
 

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -15,7 +15,7 @@ if _TF_PRESENT:
     import tensorflow as tf
 
 
-class UserObject(object):
+class UserObject:
     def __init__(
         self, metrics_ok=True, ret_nparray=False, ret_meta=False, ret_dict=False
     ):


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Remove some obsolete elements relevant only for Python2.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Closes https://github.com/SeldonIO/seldon-core/issues/1438

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Python 2 compatibility layer removed completely. 
```

