### PR TITLE
Add tolerations and annotations fields to SvcOrchSpec type definition

### DIFF
--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -261,9 +261,11 @@ const (
 )
 
 type SvcOrchSpec struct {
-	Resources *v1.ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,1,opt,name=resources"`
-	Env       []*v1.EnvVar             `json:"env,omitempty" protobuf:"bytes,2,opt,name=env"`
-	Replicas  *int32                   `json:"replicas,omitempty" protobuf:"bytes,3,opt,name=replicas"`
+	Resources   *v1.ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,1,opt,name=resources"`
+	Env         []*v1.EnvVar             `json:"env,omitempty" protobuf:"bytes,2,opt,name=env"`
+	Replicas    *int32                   `json:"replicas,omitempty" protobuf:"bytes,3,opt,name=replicas"`
+	Annotations map[string]string        `json:"annotations,omitempty" protobuf:"bytes,4,opt,name=annotations"`
+	Tolerations []v1.Toleration          `json:"tolerations,omitempty" protobuf:"bytes,5,opt,name=tolerations"`
 }
 
 type AlibiExplainerType string

--- a/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -8431,6 +8431,10 @@ spec:
                     type: object
                   svcOrchSpec:
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
                       env:
                         items:
                           description: EnvVar represents an environment variable present
@@ -8573,6 +8577,47 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                   traffic:
                     format: int32

--- a/operator/config/webhook/manifests.v1beta1.yaml
+++ b/operator/config/webhook/manifests.v1beta1.yaml
@@ -1,0 +1,65 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-machinelearning-seldon-io-v1-seldondeployment
+  failurePolicy: Fail
+  name: v1.vseldondeployment.kb.io
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+  sideEffects: None
+- clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-machinelearning-seldon-io-v1alpha2-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha2.vseldondeployment.kb.io
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+  sideEffects: None
+- clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-machinelearning-seldon-io-v1alpha3-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha3.vseldondeployment.kb.io
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+  sideEffects: None


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm adding two fields to the `SvcOrchSpec` type definition - this will allow us to specify annotations and tolerations when creating SeldonDeployment's in which the orchestrator is setup to run as a separate pod. After deploying, the annotations and tolerations will be copied onto the pod spec.

**Which issue(s) this PR fixes**:
Fixes #2629

**Special notes for your reviewer**:
I added a few tests, some small amount of documentation, and renamed a function for consistency.

**Does this PR introduce a user-facing change?**:
```release-note
Added `tolerations` and `annotations` fields to SvcOrchSpec type definition.
```