### PR TITLE
Added workaround for alibi explainer image build

### DIFF
--- a/components/alibi-explain-server/Dockerfile
+++ b/components/alibi-explain-server/Dockerfile
@@ -12,6 +12,9 @@ COPY setup.py setup.py
 COPY alibiexplainer alibiexplainer
 COPY README.md README.md
 
+# Required for https://github.com/slundberg/shap/issues/1633
+RUN pip install numpy==1.19.04 
+
 RUN pip install . --no-binary protobuf
 
 RUN chmod -R a+rwx /opt/app-root/lib/python3.6

--- a/components/alibi-explain-server/alibiexplainer/proto/tensorflow/core/framework/types.proto
+++ b/components/alibi-explain-server/alibiexplainer/proto/tensorflow/core/framework/types.proto
@@ -84,4 +84,6 @@ enum SpecializedType {
   ST_INVALID = 0;
   // "tensorflow::TensorList" in the variant type registry.
   ST_TENSOR_LIST = 1;
+  // "tensorflow::data::Optional" in the variant type registry.
+  ST_OPTIONAL = 2;
 }


### PR DESCRIPTION
Provides a temporary workaround for https://github.com/SeldonIO/seldon-core/issues/2767

This will be a required cherrypick for 1.5.1 release once it's merged