### PR TITLE
Fix send_feedback response wrongly wrapped as ndarray

### DIFF
--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -218,8 +218,6 @@ def send_feedback(
 
         if client_response.data is None:
             client_response.data = np.array([])
-        else:
-            client_response.data = np.array(client_response.data)
 
         return construct_response(
             user_model,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Removes instructions that wrongly wrap the response of send_feedback in an ndarray even when it's of another type.
See the linked issue for more info.

**Which issue(s) this PR fixes**:
Fixes #2801 

**Special notes for your reviewer**:
I wasn't able to run tests as described in the [contributing guidelines](https://github.com/SeldonIO/seldon-core/blob/cee87866e4325f22a267813dfb808039575dd3a3/CONTRIBUTING.md).
The makefile doesn't have a test target... Maybe I'm doing something wrong.


**Does this PR introduce a user-facing change?**:
NONE, as in the correct behaviour (as described in the docs) is now implemented. See the linked issue for more details.
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->

