### PR TITLE
fix nblink to include image of pachyderm example

### DIFF
--- a/doc/source/examples/pachyderm-simple.nblink
+++ b/doc/source/examples/pachyderm-simple.nblink
@@ -1,3 +1,4 @@
 {
-  "path": "../../../examples/pachyderm-simple/index.ipynb"
+  "path": "../../../examples/pachyderm-simple/index.ipynb",
+  "extra-media": ["../../../examples/pachyderm-simple/images/pachyderm-simple-demo.png"]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor doc fix that makes sure that image renders properly in Pachyderm example.
