### PR TITLE
Revert "Bump pandas from 1.1.0 to 1.2.0 in /python"

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -16,7 +16,7 @@ tenacity==6.3.1
 coverage==5.3.1
 
 # Used in serving_test_gen
-pandas==1.2.0
+pandas==1.1.0
 
 # Fetch licenses
 pip-licenses==3.1.0


### PR DESCRIPTION
Reverts SeldonIO/seldon-core#2804

THis change breaks the integration and notebook tests due to pip not finding pandas==1.2.0