### PR TITLE
Make metrics bin size adjustable

### DIFF
--- a/python/seldon_core/metrics.py
+++ b/python/seldon_core/metrics.py
@@ -26,6 +26,7 @@ ENV_MODEL_NAME = "PREDICTIVE_UNIT_ID"
 ENV_MODEL_IMAGE = "PREDICTIVE_UNIT_IMAGE"
 ENV_PREDICTOR_NAME = "PREDICTOR_ID"
 ENV_PREDICTOR_LABELS = "PREDICTOR_LABELS"
+ENV_BIN_SIZE = "METRIC_BIN_SIZE"
 
 FEEDBACK_KEY = "seldon_api_model_feedback"
 FEEDBACK_REWARD_KEY = "seldon_api_model_feedback_reward"
@@ -34,8 +35,9 @@ COUNTER = "COUNTER"
 GAUGE = "GAUGE"
 TIMER = "TIMER"
 
+BIN_SIZE = os.environ.get(METRIC_BIN_SIZE, 50)
 # This sets the bins spread logarithmically between 0.001 and 30
-BINS = [0] + list(np.logspace(-3, np.log10(30), 50)) + [np.inf]
+BINS = [0] + list(np.logspace(-3, np.log10(30), BIN_SIZE)) + [np.inf]
 
 
 def split_image_tag(tag: str) -> Tuple[str]:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Make Prometheus histogram bin size adjustable will help reduce Prometheus instance memory footprint.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/SeldonIO/seldon-core/issues/2863

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

