### PR TITLE
Change to use gcr.io/distroless/base-debian10 as base image

### DIFF
--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -32,7 +32,7 @@ RUN chmod -R 660 /openapi/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base-debian10:latest
 WORKDIR /
 COPY --from=builder /workspace/executor .
 COPY licenses/license.txt licenses/license.txt

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -27,7 +27,7 @@ RUN wget -O hasicorp-hcl.tar.gz https://github.com/hashicorp/hcl/archive/hcl1.ta
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base-debian10:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY licenses/license.txt licenses/license.txt


### PR DESCRIPTION

**What this PR does / why we need it**:

Use the stable distroless base image.

**Which issue(s) this PR fixes**:

Fixes #2871


