### PR TITLE
Update Python Builder to use latest git for compatibility with github actions

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -10,7 +10,7 @@ jobs:
   python-lint:
 
     runs-on: ubuntu-18.04
-    container: seldonio/python-builder:0.2
+    container: seldonio/python-builder:0.3
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -10,7 +10,7 @@ jobs:
   python-tests:
 
     runs-on: ubuntu-18.04
-    container: seldonio/python-builder:0.2
+    container: seldonio/python-builder:0.3
 
     steps:
     - uses: actions/checkout@v2

--- a/python-builder/Dockerfile
+++ b/python-builder/Dockerfile
@@ -28,6 +28,16 @@ RUN pip install flatbuffers
 RUN pip install twine
 RUN pip install mypy-protobuf
 
+# Install latest git
+RUN apt-get upgrade -y
+RUN apt-get update -y
+RUN apt-get install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip
+RUN wget https://github.com/git/git/archive/v2.30.0.zip -O git.zip
+RUN unzip git.zip
+RUN apt-get remove git -y
+RUN make prefix=/usr/local -C git-2.30.0/ all install
+
+
 WORKDIR /work
 
 # Define default command.

--- a/python-builder/Makefile
+++ b/python-builder/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE_NAME=seldonio/python-builder
-DOCKER_IMAGE_VERSION=0.2
+DOCKER_IMAGE_VERSION=0.3
 
 build_docker_image:
 	docker build --force-rm=true -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) .


### PR DESCRIPTION
Currently the Python lint test is failing due to old version of git being used (2.11) as per https://github.com/actions/checkout/issues/126

This PR upgrades the version of git, which is ultimately required in the `python lint` job as it performs a diff with master.