### PR TITLE
Update cuda version in wrapper Dockerfile.GPU

### DIFF
--- a/wrappers/s2i/python/Dockerfile.gpu
+++ b/wrappers/s2i/python/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
+FROM nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04
 
 LABEL io.openshift.s2i.scripts-url="image:///s2i/bin"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates CUDA version from 10.0 to 10.2 and CudNN from 7 to 8 in s2i wrapper GPU Dockerfile, with the goal of supporting inference with `onnxruntime-gpu==1.6.0` with `torch==1.6.0` right out of the box

```release-note
Update CUDA version from 10.0 to 10.2 and CudNN from 7 to 8 in s2i wrapper GPU Dockerfile.
```

