### PR TITLE
yum update seemingly not needed for operator

### DIFF
--- a/operator/Dockerfile.redhat
+++ b/operator/Dockerfile.redhat
@@ -43,5 +43,4 @@ COPY generated/admissionregistration.k8s.io_v1beta1_validatingwebhookconfigurati
 COPY generated/~g_v1_service_seldon-webhook-service.yaml /tmp/operator-resources/service.yaml
 COPY generated/~g_v1_configmap_seldon-config.yaml /tmp/operator-resources/configmap.yaml
 COPY generated/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml /tmp/operator-resources/crd.yaml
-RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
realised yum isn't available in the go base image... think we don't need to run it for that one... so fixing mistake from https://github.com/SeldonIO/seldon-core/pull/2870

https://github.com/SeldonIO/seldon-core/blob/bc1c069f650aa2c86b068800126cad895adda2aa/jenkins-x/logs/SeldonIO/seldon-core/v1.6.0-release/5.log#L4211