### PR TITLE
Add more deps to cover whitebox TreeShap explainers

### DIFF
--- a/components/alibi-explain-server/Dockerfile
+++ b/components/alibi-explain-server/Dockerfile
@@ -7,24 +7,24 @@ LABEL name="Seldon Alibi Wrapper" \
       description="Allows Seldon Core inference models to run with a black box model explanation model from the Alibi:Explain project"
 
 USER root
-RUN pip install --upgrade pip
+RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
+
+USER default
+RUN pip install \
+    --upgrade pip \
+    --upgrade setuptools \
+    --upgrade wheel
+
 COPY setup.py setup.py
 COPY alibiexplainer alibiexplainer
 COPY README.md README.md
 
 # Required for https://github.com/slundberg/shap/issues/1633
-RUN pip install numpy==1.19.04 
-
-RUN pip install . --no-binary protobuf
-
-RUN chmod -R a+rwx /opt/app-root/lib/python3.6
+RUN pip install numpy==1.19.04 . --no-binary protobuf
 
 # Add licences
 RUN pip install pip-licenses
 RUN mkdir ./licenses && pip-licenses --from=mixed --format=csv --output-file=./licenses/license_info.csv && \
     pip-licenses --from=mixed --format=plain-vertical --with-license-file --no-license-path --output-file=./licenses/license.txt
-RUN mv ./licenses /licenses
-RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
-USER default
 
 ENTRYPOINT ["python", "-m", "alibiexplainer"]

--- a/components/alibi-explain-server/setup.py
+++ b/components/alibi-explain-server/setup.py
@@ -14,21 +14,17 @@
 
 from setuptools import setup, find_packages
 
-tests_require = [
-    'pytest',
-    'pytest-tornasync',
-    'mypy'
-]
+tests_require = ["pytest", "pytest-tornasync", "mypy"]
 
 setup(
-    name='alibiexplainer',
-    version='0.3.0',
-    author_email='cc@seldon.io',
-    license='../../LICENSE.txt',
-    url='https://github.com/SeldonIO/seldon-core/tree/master/components/alibi-explain-server',
-    description='Model Explaination Server.',
-    long_description=open('README.md').read(),
-    python_requires='>=3.6',
+    name="alibiexplainer",
+    version="0.3.0",
+    author_email="cc@seldon.io",
+    license="../../LICENSE.txt",
+    url="https://github.com/SeldonIO/seldon-core/tree/master/components/alibi-explain-server",
+    description="Model Explaination Server.",
+    long_description=open("README.md").read(),
+    python_requires=">=3.6",
     packages=find_packages("alibiexplainer"),
     install_requires=[
         "kfserving>=0.3.0",
@@ -40,8 +36,10 @@ setup(
         "dill>=0.3.0",
         "grpcio>=1.22.0",
         "xgboost==1.0.2",
-        "shap==0.36.0"
+        "lightgbm==3.1.1",
+        "catboost==0.24.4",
+        "shap==0.36.0",
     ],
     tests_require=tests_require,
-    extras_require={'test': tests_require}
+    extras_require={"test": tests_require},
 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Add `catboost` and `lightgbm` as extra dependencies of the image. The overall size doesn't increase by that much (around 200MBs).

This PR also includes some changes that make the overall image a bit smaller than before. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2812

**Special notes for your reviewer**:

Note that this PR doesn't fully address the issue. As `alibi` evolves, the list of dependencies would need to keep growing. However, it's a simple enough short-term workaround which includes the most common GBT frameworks. 

On the longer term, we are exploring a better solution from the MLServer side (https://github.com/SeldonIO/MLServer/pull/123) which would allow users to specify custom environments on their explainers. This could be leveraged to match the training and production environments up to the exact library version.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

