### PR TITLE
Extend CRD: allow to define storageInitializerImage in the graph definition

### DIFF
--- a/examples/init_containers/Makefile
+++ b/examples/init_containers/Makefile
@@ -1,5 +1,6 @@
-IMAGE_NAME=seldonio/rclone-init-container
-IMAGE_VERSION := $(shell cat ../../version.txt)
+IMAGE_NAME=seldonio/rclone-init-container-example
+# IMAGE_VERSION := $(shell cat ../../version.txt)
+IMAGE_VERSION=0.1
 
 KIND_NAME ?= kind
 

--- a/examples/init_containers/custom_init_container.ipynb
+++ b/examples/init_containers/custom_init_container.ipynb
@@ -45,9 +45,9 @@
       "Added `gcs` successfully.\n",
       "Bucket created successfully `minio-seldon/iris`.\n",
       "`gcs/seldon-models/sklearn/iris/model.joblib` -> `minio-seldon/iris/model.joblib`\n",
-      "Total: 0 B, Transferred: 1.06 KiB, Speed: 8.57 KiB/s\n",
+      "Total: 0 B, Transferred: 1.06 KiB, Speed: 10.35 KiB/s\n",
       "`gcs/seldon-models/sklearn/iris/metadata.yaml` -> `minio-seldon/iris/metadata.yaml`\n",
-      "Total: 0 B, Transferred: 162 B, Speed: 1.23 KiB/s\n"
+      "Total: 0 B, Transferred: 162 B, Speed: 1.35 KiB/s\n"
      ]
     }
    ],
@@ -69,8 +69,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2021-01-07 18:45:12 GMT]    162B metadata.yaml\n",
-      "[2021-01-07 18:45:11 GMT]  1.1KiB model.joblib\n"
+      "[2021-02-09 18:11:17 GMT]    162B metadata.yaml\n",
+      "[2021-02-09 18:11:16 GMT]  1.1KiB model.joblib\n"
      ]
     }
    ],
@@ -308,7 +308,35 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"data\": {\n",
+      "    \"names\": [\n",
+      "      \"t:0\",\n",
+      "      \"t:1\",\n",
+      "      \"t:2\"\n",
+      "    ],\n",
+      "    \"ndarray\": [\n",
+      "      [\n",
+      "        0.9548873249364169,\n",
+      "        0.04505474761561406,\n",
+      "        5.7927447968952436e-05\n",
+      "      ]\n",
+      "    ]\n",
+      "  },\n",
+      "  \"meta\": {\n",
+      "    \"requestPath\": {\n",
+      "      \"classifier\": \"seldonio/sklearnserver:1.6.0-dev\"\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "%%bash\n",
     "curl -s -X POST -H 'Content-Type: application/json' \\\n",
@@ -320,9 +348,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Custom Init Container (as default container)\n",
+    "## Custom Init Container (the right way)\n",
     "\n",
-    "It is also possible to prepare a custom init container image and set it as default one. \n",
+    "It is also possible to prepare a custom init container image to:\n",
+    "- use it on an individual deployment\n",
+    "- set as a new default \n",
+    "\n",
     "For this purpose we need to build a docker image which entrypoint will accept two arguments:\n",
     "- source\n",
     "- destination\n",
@@ -357,7 +388,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This image is build and published as `seldonio/rclone-init-container`.\n",
+    "This image example is build and published as `seldonio/rclone-init-container-example`.\n",
     "\n",
     "`rclone` tool can be configured using both `rclone.conf` config file (as above) and environmental variables.\n",
     "Note the remote name `mys3` in the name of environmental variables defined in the following secret:"
@@ -414,20 +445,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**IMPORTANT** For the following example to work Seldon Core need to be installed with following helm values\n",
-    "```yaml\n",
-    "storageInitializer:\n",
-    "  image: seldonio/rclone-init-container:latest\n",
-    "\n",
-    "predictiveUnit:\n",
-    "  defaultEnvSecretRefName: seldon-rclone-secret\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "With above defined we can easily define our sklear server using `modelUri: mys3:sklearn/iris`:"
    ]
   },
@@ -454,13 +471,14 @@
     "spec:\n",
     "  name: iris\n",
     "  predictors:\n",
-    "  - graph:\n",
-    "      children: []\n",
+    "  - name: default\n",
+    "    replicas: 1\n",
+    "    graph:\n",
+    "      name: classifier\n",
     "      implementation: SKLEARN_SERVER\n",
     "      modelUri: mys3:sklearn/iris\n",
-    "      name: classifier\n",
-    "    name: default\n",
-    "    replicas: 1"
+    "      storageInitializerImage: seldonio/rclone-init-container-example:0.1\n",
+    "      envSecretRefName: seldon-rclone-secret    "
    ]
   },
   {
@@ -502,7 +520,35 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"data\": {\n",
+      "    \"names\": [\n",
+      "      \"t:0\",\n",
+      "      \"t:1\",\n",
+      "      \"t:2\"\n",
+      "    ],\n",
+      "    \"ndarray\": [\n",
+      "      [\n",
+      "        0.9548873249364169,\n",
+      "        0.04505474761561406,\n",
+      "        5.7927447968952436e-05\n",
+      "      ]\n",
+      "    ]\n",
+      "  },\n",
+      "  \"meta\": {\n",
+      "    \"requestPath\": {\n",
+      "      \"classifier\": \"seldonio/sklearnserver:1.6.0-dev\"\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "%%bash\n",
     "curl -s -X POST -H 'Content-Type: application/json' \\\n",
@@ -514,12 +560,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Set new default storage initializer\n",
+    "\n",
+    "To user our newly created init container as default we need to configure `Seldon Core` installations by setting following helm values:\n",
+    "```yaml\n",
+    "storageInitializer:\n",
+    "  image: seldonio/rclone-init-container-example:0.1\n",
+    "\n",
+    "predictiveUnit:\n",
+    "  defaultEnvSecretRefName: seldon-rclone-secret\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Cleanup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {

--- a/examples/init_containers/rclone-default-init.yaml
+++ b/examples/init_containers/rclone-default-init.yaml
@@ -6,10 +6,11 @@ metadata:
 spec:
   name: iris
   predictors:
-  - graph:
-      children: []
+  - name: default
+    replicas: 1
+    graph:
+      name: classifier
       implementation: SKLEARN_SERVER
       modelUri: mys3:sklearn/iris
-      name: classifier
-    name: default
-    replicas: 1
+      storageInitializerImage: seldonio/rclone-init-container-example:0.1
+      envSecretRefName: seldon-rclone-secret    

--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -4019,6 +4019,8 @@ spec:
                         type: string
                       serviceAccountName:
                         type: string
+                      storageInitializerImage:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -4310,6 +4312,8 @@ spec:
                           type: object
                         type: array
                       serviceAccountName:
+                        type: string
+                      storageInitializerImage:
                         type: string
                       type:
                         type: string

--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
@@ -4882,6 +4882,8 @@ spec:
                           type: string
                         serviceAccountName:
                           type: string
+                        storageInitializerImage:
+                          type: string
                         type:
                           type: string
                       type: object
@@ -10650,6 +10652,8 @@ spec:
                           type: string
                         serviceAccountName:
                           type: string
+                        storageInitializerImage:
+                          type: string
                         type:
                           type: string
                       type: object
@@ -16417,6 +16421,8 @@ spec:
                         modelUri:
                           type: string
                         serviceAccountName:
+                          type: string
+                        storageInitializerImage:
                           type: string
                         type:
                           type: string

--- a/helm-charts/seldon-core-operator/templates/webhook.yaml
+++ b/helm-charts/seldon-core-operator/templates/webhook.yaml
@@ -4,6 +4,20 @@
 {{- $cert := genSignedCert "seldon-webhook-service" nil $altNames 365 $ca -}}
 ---
 
+{{- if not .Values.certManager.enabled -}}
+apiVersion: v1
+data:
+  ca.crt: '{{ $ca.Cert | b64enc }}'
+  tls.crt: '{{ $cert.Cert | b64enc }}'
+  tls.key: '{{ $cert.Key | b64enc }}'
+kind: Secret
+metadata:
+  name: seldon-webhook-server-cert
+  namespace: '{{ include "seldon.namespace" . }}'
+type: kubernetes.io/tls
+{{- end }}
+---
+
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -170,19 +184,5 @@ webhooks:
     resources:
     - seldondeployments
   sideEffects: None
----
-
-{{- if not .Values.certManager.enabled -}}
-apiVersion: v1
-data:
-  ca.crt: '{{ $ca.Cert | b64enc }}'
-  tls.crt: '{{ $cert.Cert | b64enc }}'
-  tls.key: '{{ $cert.Key | b64enc }}'
-kind: Secret
-metadata:
-  name: seldon-webhook-server-cert
-  namespace: '{{ include "seldon.namespace" . }}'
-type: kubernetes.io/tls
-{{- end }}
 
 {{- end }}

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -52,9 +52,6 @@ install-cert-manager:
 
 manifests_all: manifests manifests_v1
 
-install_all: install install_v1
-
-
 # Install CRDs into a cluster
 install: manifests
 	kustomize build config/crd | kubectl apply -f -

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -30,7 +30,7 @@ lint: licenses/dep.txt
 		./licenses
 
 # Run tests
-test: generate fmt vet manifests generate-resources
+test: generate fmt vet manifests_all generate-resources
 	ginkgo -r -outputdir=. -cover -coverprofile=cover.out ./controllers ./utils ./apis
 
 # Build manager binary
@@ -38,7 +38,7 @@ manager: generate fmt vet
 	go build -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet manifests
+run: generate fmt vet manifests_all
 	go run ./main.go --webhook-port=9000
 
 install-cert-manager:
@@ -48,6 +48,12 @@ install-cert-manager:
 	kubectl rollout status deployment.apps/cert-manager -n cert-manager
 	kubectl rollout status deployment.apps/cert-manager-cainjector -n cert-manager
 	kubectl rollout status deployment.apps/cert-manager-webhook -n cert-manager
+
+
+manifests_all: manifests manifests_v1
+
+install_all: install install_v1
+
 
 # Install CRDs into a cluster
 install: manifests

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -63,7 +63,7 @@ install_v1: manifests_v1
 	kustomize build config/crd_v1 | kubectl create -f -
 
 # Uninstall V1 CRDs into a cluster
-uninstall_v1: 
+uninstall_v1:
 	kustomize build config/crd_v1 | kubectl delete -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
@@ -326,7 +326,7 @@ update_upstream:
 # https://redhat-connect.gitbook.io/certified-operator-guide/appendix/bundle-maintenance-after-migration
 
 PKG_CERT=packagemanifests-certified
-create_certified_bundle: 
+create_certified_bundle:
 	rm -rf ${PKG_CERT}/${VERSION}
 	mkdir -p ${PKG_CERT}/${VERSION}
 	cp bundle/manifests/* ${PKG_CERT}/${VERSION}
@@ -371,7 +371,7 @@ bundle_certified_push:
 update_old_certified_packages:
 	cd packagemanifests-certified && make build_push
 
-update_openshift_certified: update_old_certified_packages create_certified_bundle create_bundle_image_certified push_bundle_image_certified validate_bundle_image_certified opm_index_certified opm_push_certified 
+update_openshift_certified: update_old_certified_packages create_certified_bundle create_bundle_image_certified push_bundle_image_certified validate_bundle_image_certified opm_index_certified opm_push_certified
 
 # Run last to prepare for future release
 PREV_VERSION=1.2.2

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -281,13 +281,14 @@ const (
 )
 
 type Explainer struct {
-	Type               AlibiExplainerType `json:"type,omitempty" protobuf:"string,1,opt,name=type"`
-	ModelUri           string             `json:"modelUri,omitempty" protobuf:"string,2,opt,name=modelUri"`
-	ServiceAccountName string             `json:"serviceAccountName,omitempty" protobuf:"string,3,opt,name=serviceAccountName"`
-	ContainerSpec      v1.Container       `json:"containerSpec,omitempty" protobuf:"bytes,4,opt,name=containerSpec"`
-	Config             map[string]string  `json:"config,omitempty" protobuf:"bytes,5,opt,name=config"`
-	Endpoint           *Endpoint          `json:"endpoint,omitempty" protobuf:"bytes,6,opt,name=endpoint"`
-	EnvSecretRefName   string             `json:"envSecretRefName,omitempty" protobuf:"bytes,7,opt,name=envSecretRefName"`
+	Type                    AlibiExplainerType `json:"type,omitempty" protobuf:"string,1,opt,name=type"`
+	ModelUri                string             `json:"modelUri,omitempty" protobuf:"string,2,opt,name=modelUri"`
+	ServiceAccountName      string             `json:"serviceAccountName,omitempty" protobuf:"string,3,opt,name=serviceAccountName"`
+	ContainerSpec           v1.Container       `json:"containerSpec,omitempty" protobuf:"bytes,4,opt,name=containerSpec"`
+	Config                  map[string]string  `json:"config,omitempty" protobuf:"bytes,5,opt,name=config"`
+	Endpoint                *Endpoint          `json:"endpoint,omitempty" protobuf:"bytes,6,opt,name=endpoint"`
+	EnvSecretRefName        string             `json:"envSecretRefName,omitempty" protobuf:"bytes,7,opt,name=envSecretRefName"`
+	StorageInitializerImage string             `json:"storageInitializerImage,omitempty" protobuf:"bytes,8,opt,name=storageInitializerImage"`
 }
 
 // ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta.
@@ -570,16 +571,17 @@ type Parameter struct {
 }
 
 type PredictiveUnit struct {
-	Name               string                        `json:"name" protobuf:"string,1,opt,name=name"`
-	Children           []PredictiveUnit              `json:"children,omitempty" protobuf:"bytes,2,opt,name=children"`
-	Type               *PredictiveUnitType           `json:"type,omitempty" protobuf:"int,3,opt,name=type"`
-	Implementation     *PredictiveUnitImplementation `json:"implementation,omitempty" protobuf:"int,4,opt,name=implementation"`
-	Methods            *[]PredictiveUnitMethod       `json:"methods,omitempty" protobuf:"int,5,opt,name=methods"`
-	Endpoint           *Endpoint                     `json:"endpoint,omitempty" protobuf:"bytes,6,opt,name=endpoint"`
-	Parameters         []Parameter                   `json:"parameters,omitempty" protobuf:"bytes,7,opt,name=parameters"`
-	ModelURI           string                        `json:"modelUri,omitempty" protobuf:"bytes,8,opt,name=modelUri"`
-	ServiceAccountName string                        `json:"serviceAccountName,omitempty" protobuf:"bytes,9,opt,name=serviceAccountName"`
-	EnvSecretRefName   string                        `json:"envSecretRefName,omitempty" protobuf:"bytes,10,opt,name=envSecretRefName"`
+	Name                    string                        `json:"name" protobuf:"string,1,opt,name=name"`
+	Children                []PredictiveUnit              `json:"children,omitempty" protobuf:"bytes,2,opt,name=children"`
+	Type                    *PredictiveUnitType           `json:"type,omitempty" protobuf:"int,3,opt,name=type"`
+	Implementation          *PredictiveUnitImplementation `json:"implementation,omitempty" protobuf:"int,4,opt,name=implementation"`
+	Methods                 *[]PredictiveUnitMethod       `json:"methods,omitempty" protobuf:"int,5,opt,name=methods"`
+	Endpoint                *Endpoint                     `json:"endpoint,omitempty" protobuf:"bytes,6,opt,name=endpoint"`
+	Parameters              []Parameter                   `json:"parameters,omitempty" protobuf:"bytes,7,opt,name=parameters"`
+	ModelURI                string                        `json:"modelUri,omitempty" protobuf:"bytes,8,opt,name=modelUri"`
+	ServiceAccountName      string                        `json:"serviceAccountName,omitempty" protobuf:"bytes,9,opt,name=serviceAccountName"`
+	EnvSecretRefName        string                        `json:"envSecretRefName,omitempty" protobuf:"bytes,10,opt,name=envSecretRefName"`
+	StorageInitializerImage string                        `json:"storageInitializerImage,omitempty" protobuf:"bytes,11,opt,name=storageInitializerImage"`
 	// Request/response  payload logging. v2alpha1 feature that is added to v1 for backwards compatibility while v1 is the storage version.
 	Logger *Logger `json:"logger,omitempty"`
 }

--- a/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -8339,6 +8339,8 @@ spec:
                         type: string
                       serviceAccountName:
                         type: string
+                      storageInitializerImage:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -8403,6 +8405,8 @@ spec:
                           type: object
                         type: array
                       serviceAccountName:
+                        type: string
+                      storageInitializerImage:
                         type: string
                       type:
                         type: string

--- a/operator/config/crd_v1/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd_v1/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -8580,6 +8580,8 @@ spec:
                           type: string
                         serviceAccountName:
                           type: string
+                        storageInitializerImage:
+                          type: string
                         type:
                           type: string
                       type: object
@@ -8644,6 +8646,8 @@ spec:
                             type: object
                           type: array
                         serviceAccountName:
+                          type: string
+                        storageInitializerImage:
                           type: string
                         type:
                           type: string
@@ -17450,6 +17454,8 @@ spec:
                           type: string
                         serviceAccountName:
                           type: string
+                        storageInitializerImage:
+                          type: string
                         type:
                           type: string
                       type: object
@@ -17514,6 +17520,8 @@ spec:
                             type: object
                           type: array
                         serviceAccountName:
+                          type: string
+                        storageInitializerImage:
                           type: string
                         type:
                           type: string
@@ -26320,6 +26328,8 @@ spec:
                           type: string
                         serviceAccountName:
                           type: string
+                        storageInitializerImage:
+                          type: string
                         type:
                           type: string
                       type: object
@@ -26384,6 +26394,8 @@ spec:
                             type: object
                           type: array
                         serviceAccountName:
+                          type: string
+                        storageInitializerImage:
                           type: string
                         type:
                           type: string

--- a/operator/controllers/model_initializer_injector_test.go
+++ b/operator/controllers/model_initializer_injector_test.go
@@ -31,7 +31,7 @@ func TestStorageInitalizerInjector(t *testing.T) {
 			},
 		},
 	}
-	_, err = mi.InjectModelInitializer(&d, containerName, "gs://mybucket/mymodel", "", "")
+	_, err = mi.InjectModelInitializer(&d, containerName, "gs://mybucket/mymodel", "", "", "")
 	g.Expect(err).To(BeNil())
 	g.Expect(len(d.Spec.Template.Spec.InitContainers)).To(Equal(1))
 	g.Expect(d.Spec.Template.Spec.InitContainers[0].Image).To(Equal("gcr.io/kfserving/storage-initializer:v0.4.0"))
@@ -59,7 +59,7 @@ func TestStorageInitalizerInjectorWithRelatedImage(t *testing.T) {
 		},
 	}
 	envStorageInitializerImage = "abc:1.2"
-	_, err = mi.InjectModelInitializer(&d, containerName, "gs://mybucket/mymodel", "", "")
+	_, err = mi.InjectModelInitializer(&d, containerName, "gs://mybucket/mymodel", "", "", "")
 	g.Expect(err).To(BeNil())
 	g.Expect(len(d.Spec.Template.Spec.InitContainers)).To(Equal(1))
 	g.Expect(d.Spec.Template.Spec.InitContainers[0].Image).To(Equal(envStorageInitializerImage))

--- a/operator/controllers/seldondeployment_explainers.go
+++ b/operator/controllers/seldondeployment_explainers.go
@@ -216,7 +216,7 @@ func (ei *ExplainerInitialiser) createExplainer(mlDep *machinelearningv1.SeldonD
 			var err error
 
 			mi := NewModelInitializer(ei.ctx, ei.clientset)
-			deploy, err = mi.InjectModelInitializer(deploy, explainerContainer.Name, p.Explainer.ModelUri, p.Explainer.ServiceAccountName, p.Explainer.EnvSecretRefName)
+			deploy, err = mi.InjectModelInitializer(deploy, explainerContainer.Name, p.Explainer.ModelUri, p.Explainer.ServiceAccountName, p.Explainer.EnvSecretRefName, p.Explainer.StorageInitializerImage)
 			if err != nil {
 				return err
 			}

--- a/operator/controllers/seldondeployment_prepackaged_servers.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers.go
@@ -59,10 +59,6 @@ func extractEnvSecretRefName(pu *machinelearningv1.PredictiveUnit) string {
 	return envSecretRefName
 }
 
-func extractStorageInitializerImage(pu *machinelearningv1.PredictiveUnit) string {
-	return pu.StorageInitializerImage
-}
-
 func createTensorflowServingContainer(mlDepSepc *machinelearningv1.SeldonDeploymentSpec, pu *machinelearningv1.PredictiveUnit, tensorflowProtocol bool) *v1.Container {
 	ServerConfig := machinelearningv1.GetPrepackServerConfig(string(*pu.Implementation))
 
@@ -133,10 +129,9 @@ func (pi *PrePackedInitialiser) addTFServerContainer(mlDepSpec *machinelearningv
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
-	storageInitializerImage := extractStorageInitializerImage(pu)
 
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err := mi.InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
+	_, err := mi.InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
 	if err != nil {
 		return err
 	}
@@ -234,9 +229,8 @@ func (pi *PrePackedInitialiser) addTritonServer(mlDepSpec *machinelearningv1.Sel
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
-	storageInitializerImage := extractStorageInitializerImage(pu)
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err := mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
+	_, err := mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
 	if err != nil {
 		return err
 	}
@@ -262,10 +256,9 @@ func (pi *PrePackedInitialiser) addMLServerDefault(pu *machinelearningv1.Predict
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
-	storageInitializerImage := extractStorageInitializerImage(pu)
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
 
-	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
+	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
 	if err != nil {
 		return err
 	}
@@ -330,10 +323,9 @@ func (pi *PrePackedInitialiser) addModelDefaultServers(mlDepSepc *machinelearnin
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
-	storageInitializerImage := extractStorageInitializerImage(pu)
 
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
+	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
 	if err != nil {
 		return err
 	}

--- a/operator/controllers/seldondeployment_prepackaged_servers.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers.go
@@ -59,6 +59,10 @@ func extractEnvSecretRefName(pu *machinelearningv1.PredictiveUnit) string {
 	return envSecretRefName
 }
 
+func extractStorageInitializerImage(pu *machinelearningv1.PredictiveUnit) string {
+	return pu.StorageInitializerImage
+}
+
 func createTensorflowServingContainer(mlDepSepc *machinelearningv1.SeldonDeploymentSpec, pu *machinelearningv1.PredictiveUnit, tensorflowProtocol bool) *v1.Container {
 	ServerConfig := machinelearningv1.GetPrepackServerConfig(string(*pu.Implementation))
 
@@ -129,9 +133,10 @@ func (pi *PrePackedInitialiser) addTFServerContainer(mlDepSpec *machinelearningv
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
+	storageInitializerImage := extractStorageInitializerImage(pu)
 
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err := mi.InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName)
+	_, err := mi.InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
 	if err != nil {
 		return err
 	}
@@ -229,8 +234,9 @@ func (pi *PrePackedInitialiser) addTritonServer(mlDepSpec *machinelearningv1.Sel
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
+	storageInitializerImage := extractStorageInitializerImage(pu)
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err := mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName)
+	_, err := mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
 	if err != nil {
 		return err
 	}
@@ -256,9 +262,10 @@ func (pi *PrePackedInitialiser) addMLServerDefault(pu *machinelearningv1.Predict
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
+	storageInitializerImage := extractStorageInitializerImage(pu)
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
 
-	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName)
+	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
 	if err != nil {
 		return err
 	}
@@ -323,9 +330,10 @@ func (pi *PrePackedInitialiser) addModelDefaultServers(mlDepSepc *machinelearnin
 	}
 
 	envSecretRefName := extractEnvSecretRefName(pu)
+	storageInitializerImage := extractStorageInitializerImage(pu)
 
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName)
+	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, storageInitializerImage)
 	if err != nil {
 		return err
 	}

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -969,6 +969,7 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: seldon-system/seldon-serving-cert
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.4.1
   labels:
     app: seldon
     app.kubernetes.io/instance: seldon1
@@ -4520,9 +4520,3 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/testing/machinelearning.seldon.io_seldondeployments.yaml
@@ -4015,6 +4015,8 @@ spec:
                         type: string
                       serviceAccountName:
                         type: string
+                      storageInitializerImage:
+                        type: string
                       type:
                         type: string
                     type: object
@@ -4306,6 +4308,8 @@ spec:
                           type: object
                         type: array
                       serviceAccountName:
+                        type: string
+                      storageInitializerImage:
                         type: string
                       type:
                         type: string


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This allows to define image used by the `Storage Initializer` as part of the `PredictiveUnit` definition - `graph` section in the `CR` e.g.
```yaml
apiVersion: machinelearning.seldon.io/v1
kind: SeldonDeployment
metadata:
  name: rclone-sklearn
spec:
  predictors:
  - name: default
    replicas: 1
    graph:
      name: classifier
      implementation: SKLEARN_SERVER
      modelUri: s3://sklearn/iris
      storageInitializerImage: gcr.io/kfserving/storage-initializer:v0.4.0
      envSecretRefName: seldon-init-container-secret
```

This allow to have elegant way to overwrite used `storageInitializerImage` on per-deployment basis.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/SeldonIO/seldon-core/issues/2821

**Special notes for your reviewer**:

To be finished:
- [x] unit test
- [x] doc entry and example

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
One can now define image used by `storageInitializer` init container by defining `storageInitializerImage` in the `graph` section of `SeldonDeployment` CR definition. 
```

