### PR TITLE
Remove managedFields from seldon pod spec metadata

### DIFF
--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -440,7 +440,7 @@ spec:
                           - triggers
                           type: object
                         metadata:
-                          description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization.'
+                          description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization. * remove ManagedFields which contain unsupported "Any" type.'
                           properties:
                             annotations:
                               additionalProperties:
@@ -481,32 +481,6 @@ spec:
                                 type: string
                               description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
                               type: object
-                            managedFields:
-                              description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
-                              items:
-                                description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
-                                properties:
-                                  apiVersion:
-                                    description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
-                                    type: string
-                                  fieldsType:
-                                    description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
-                                    type: string
-                                  fieldsV1:
-                                    description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-                                    type: Any
-                                  manager:
-                                    description: Manager is an identifier of the workflow managing these fields.
-                                    type: string
-                                  operation:
-                                    description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
-                                    type: string
-                                  time:
-                                    description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
-                                    format: date-time
-                                    type: string
-                                type: object
-                              type: array
                             name:
                               description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                               type: string

--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
@@ -432,7 +432,7 @@ spec:
                             - triggers
                             type: object
                           metadata:
-                            description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization.'
+                            description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization. * remove ManagedFields which contain unsupported "Any" type.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -473,32 +473,6 @@ spec:
                                   type: string
                                 description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                 type: object
-                              managedFields:
-                                description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
-                                items:
-                                  description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
-                                  properties:
-                                    apiVersion:
-                                      description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
-                                      type: string
-                                    fieldsType:
-                                      description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
-                                      type: string
-                                    fieldsV1:
-                                      description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-                                      type: Any
-                                    manager:
-                                      description: Manager is an identifier of the workflow managing these fields.
-                                      type: string
-                                    operation:
-                                      description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
-                                      type: string
-                                    time:
-                                      description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                 type: string
@@ -6153,7 +6127,7 @@ spec:
                             - triggers
                             type: object
                           metadata:
-                            description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization.'
+                            description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization. * remove ManagedFields which contain unsupported "Any" type.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -6194,32 +6168,6 @@ spec:
                                   type: string
                                 description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                 type: object
-                              managedFields:
-                                description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
-                                items:
-                                  description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
-                                  properties:
-                                    apiVersion:
-                                      description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
-                                      type: string
-                                    fieldsType:
-                                      description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
-                                      type: string
-                                    fieldsV1:
-                                      description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-                                      type: Any
-                                    manager:
-                                      description: Manager is an identifier of the workflow managing these fields.
-                                      type: string
-                                    operation:
-                                      description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
-                                      type: string
-                                    time:
-                                      description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                 type: string
@@ -11874,7 +11822,7 @@ spec:
                             - triggers
                             type: object
                           metadata:
-                            description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization.'
+                            description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta. We copy it for 2 reasons: * to be included in the structural schema of the CRD. * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows better serialization. * remove ManagedFields which contain unsupported "Any" type.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -11915,32 +11863,6 @@ spec:
                                   type: string
                                 description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                 type: object
-                              managedFields:
-                                description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
-                                items:
-                                  description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
-                                  properties:
-                                    apiVersion:
-                                      description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
-                                      type: string
-                                    fieldsType:
-                                      description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
-                                      type: string
-                                    fieldsV1:
-                                      description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-                                      type: Any
-                                    manager:
-                                      description: Manager is an identifier of the workflow managing these fields.
-                                      type: string
-                                    operation:
-                                      description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
-                                      type: string
-                                    time:
-                                      description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                 type: string

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -295,6 +295,7 @@ type Explainer struct {
 // * to be included in the structural schema of the CRD.
 // * to edit the CreationTimestamp to be nullable and a pointer to metav1.Time instead of a struct which allows
 // better serialization.
+// * remove ManagedFields which contain unsupported "Any" type.
 type ObjectMeta struct {
 	// Name must be unique within a namespace. Is required when creating resources, although
 	// some resources may allow a client to request the generation of an appropriate name
@@ -457,17 +458,6 @@ type ObjectMeta struct {
 	// This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
 	// +optional
 	ClusterName string `json:"clusterName,omitempty" protobuf:"bytes,15,opt,name=clusterName"`
-
-	// ManagedFields maps workflow-id and version to the set of fields
-	// that are managed by that workflow. This is mostly for internal
-	// housekeeping, and users typically shouldn't need to set or
-	// understand this field. A workflow can be the user's name, a
-	// controller's name, or the name of a specific apply path like
-	// "ci-cd". The set of fields is always in the version that the
-	// workflow used when modifying the object.
-	//
-	// +optional
-	ManagedFields []metav1.ManagedFieldsEntry `json:"managedFields,omitempty" protobuf:"bytes,17,rep,name=managedFields"`
 }
 
 type SeldonPodSpec struct {

--- a/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -666,7 +666,8 @@ spec:
                             ObjectMeta. We copy it for 2 reasons: * to be included
                             in the structural schema of the CRD. * to edit the CreationTimestamp
                             to be nullable and a pointer to metav1.Time instead of
-                            a struct which allows better serialization.'
+                            a struct which allows better serialization. * remove ManagedFields
+                            which contain unsupported "Any" type.'
                           properties:
                             annotations:
                               additionalProperties:
@@ -783,56 +784,6 @@ spec:
                                 objects. May match selectors of replication controllers
                                 and services. More info: http://kubernetes.io/docs/user-guide/labels'
                               type: object
-                            managedFields:
-                              description: ManagedFields maps workflow-id and version
-                                to the set of fields that are managed by that workflow.
-                                This is mostly for internal housekeeping, and users
-                                typically shouldn't need to set or understand this
-                                field. A workflow can be the user's name, a controller's
-                                name, or the name of a specific apply path like "ci-cd".
-                                The set of fields is always in the version that the
-                                workflow used when modifying the object.
-                              items:
-                                description: ManagedFieldsEntry is a workflow-id,
-                                  a FieldSet and the group version of the resource
-                                  that the fieldset applies to.
-                                properties:
-                                  apiVersion:
-                                    description: APIVersion defines the version of
-                                      this resource that this field set applies to.
-                                      The format is "group/version" just like the
-                                      top-level APIVersion field. It is necessary
-                                      to track the version of a field set because
-                                      it cannot be automatically converted.
-                                    type: string
-                                  fieldsType:
-                                    description: 'FieldsType is the discriminator
-                                      for the different fields format and version.
-                                      There is currently only one possible value:
-                                      "FieldsV1"'
-                                    type: string
-                                  fieldsV1:
-                                    description: FieldsV1 holds the first JSON version
-                                      format as described in the "FieldsV1" type.
-                                    type: Any
-                                  manager:
-                                    description: Manager is an identifier of the workflow
-                                      managing these fields.
-                                    type: string
-                                  operation:
-                                    description: Operation is the type of operation
-                                      which lead to this ManagedFieldsEntry being
-                                      created. The only valid values for this field
-                                      are 'Apply' and 'Update'.
-                                    type: string
-                                  time:
-                                    description: Time is timestamp of when these fields
-                                      were set. It should always be empty if Operation
-                                      is 'Apply'
-                                    format: date-time
-                                    type: string
-                                type: object
-                              type: array
                             name:
                               description: 'Name must be unique within a namespace.
                                 Is required when creating resources, although some

--- a/operator/config/crd_v1/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd_v1/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -435,7 +435,8 @@ spec:
                               ObjectMeta. We copy it for 2 reasons: * to be included
                               in the structural schema of the CRD. * to edit the CreationTimestamp
                               to be nullable and a pointer to metav1.Time instead
-                              of a struct which allows better serialization.'
+                              of a struct which allows better serialization. * remove
+                              ManagedFields which contain unsupported "Any" type.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -556,56 +557,6 @@ spec:
                                   objects. May match selectors of replication controllers
                                   and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                 type: object
-                              managedFields:
-                                description: ManagedFields maps workflow-id and version
-                                  to the set of fields that are managed by that workflow.
-                                  This is mostly for internal housekeeping, and users
-                                  typically shouldn't need to set or understand this
-                                  field. A workflow can be the user's name, a controller's
-                                  name, or the name of a specific apply path like
-                                  "ci-cd". The set of fields is always in the version
-                                  that the workflow used when modifying the object.
-                                items:
-                                  description: ManagedFieldsEntry is a workflow-id,
-                                    a FieldSet and the group version of the resource
-                                    that the fieldset applies to.
-                                  properties:
-                                    apiVersion:
-                                      description: APIVersion defines the version
-                                        of this resource that this field set applies
-                                        to. The format is "group/version" just like
-                                        the top-level APIVersion field. It is necessary
-                                        to track the version of a field set because
-                                        it cannot be automatically converted.
-                                      type: string
-                                    fieldsType:
-                                      description: 'FieldsType is the discriminator
-                                        for the different fields format and version.
-                                        There is currently only one possible value:
-                                        "FieldsV1"'
-                                      type: string
-                                    fieldsV1:
-                                      description: FieldsV1 holds the first JSON version
-                                        format as described in the "FieldsV1" type.
-                                      type: Any
-                                    manager:
-                                      description: Manager is an identifier of the
-                                        workflow managing these fields.
-                                      type: string
-                                    operation:
-                                      description: Operation is the type of operation
-                                        which lead to this ManagedFieldsEntry being
-                                        created. The only valid values for this field
-                                        are 'Apply' and 'Update'.
-                                      type: string
-                                    time:
-                                      description: Time is timestamp of when these
-                                        fields were set. It should always be empty
-                                        if Operation is 'Apply'
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 description: 'Name must be unique within a namespace.
                                   Is required when creating resources, although some
@@ -5735,7 +5686,8 @@ spec:
                               ObjectMeta. We copy it for 2 reasons: * to be included
                               in the structural schema of the CRD. * to edit the CreationTimestamp
                               to be nullable and a pointer to metav1.Time instead
-                              of a struct which allows better serialization.'
+                              of a struct which allows better serialization. * remove
+                              ManagedFields which contain unsupported "Any" type.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -5856,56 +5808,6 @@ spec:
                                   objects. May match selectors of replication controllers
                                   and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                 type: object
-                              managedFields:
-                                description: ManagedFields maps workflow-id and version
-                                  to the set of fields that are managed by that workflow.
-                                  This is mostly for internal housekeeping, and users
-                                  typically shouldn't need to set or understand this
-                                  field. A workflow can be the user's name, a controller's
-                                  name, or the name of a specific apply path like
-                                  "ci-cd". The set of fields is always in the version
-                                  that the workflow used when modifying the object.
-                                items:
-                                  description: ManagedFieldsEntry is a workflow-id,
-                                    a FieldSet and the group version of the resource
-                                    that the fieldset applies to.
-                                  properties:
-                                    apiVersion:
-                                      description: APIVersion defines the version
-                                        of this resource that this field set applies
-                                        to. The format is "group/version" just like
-                                        the top-level APIVersion field. It is necessary
-                                        to track the version of a field set because
-                                        it cannot be automatically converted.
-                                      type: string
-                                    fieldsType:
-                                      description: 'FieldsType is the discriminator
-                                        for the different fields format and version.
-                                        There is currently only one possible value:
-                                        "FieldsV1"'
-                                      type: string
-                                    fieldsV1:
-                                      description: FieldsV1 holds the first JSON version
-                                        format as described in the "FieldsV1" type.
-                                      type: Any
-                                    manager:
-                                      description: Manager is an identifier of the
-                                        workflow managing these fields.
-                                      type: string
-                                    operation:
-                                      description: Operation is the type of operation
-                                        which lead to this ManagedFieldsEntry being
-                                        created. The only valid values for this field
-                                        are 'Apply' and 'Update'.
-                                      type: string
-                                    time:
-                                      description: Time is timestamp of when these
-                                        fields were set. It should always be empty
-                                        if Operation is 'Apply'
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 description: 'Name must be unique within a namespace.
                                   Is required when creating resources, although some
@@ -11035,7 +10937,8 @@ spec:
                               ObjectMeta. We copy it for 2 reasons: * to be included
                               in the structural schema of the CRD. * to edit the CreationTimestamp
                               to be nullable and a pointer to metav1.Time instead
-                              of a struct which allows better serialization.'
+                              of a struct which allows better serialization. * remove
+                              ManagedFields which contain unsupported "Any" type.'
                             properties:
                               annotations:
                                 additionalProperties:
@@ -11156,56 +11059,6 @@ spec:
                                   objects. May match selectors of replication controllers
                                   and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                 type: object
-                              managedFields:
-                                description: ManagedFields maps workflow-id and version
-                                  to the set of fields that are managed by that workflow.
-                                  This is mostly for internal housekeeping, and users
-                                  typically shouldn't need to set or understand this
-                                  field. A workflow can be the user's name, a controller's
-                                  name, or the name of a specific apply path like
-                                  "ci-cd". The set of fields is always in the version
-                                  that the workflow used when modifying the object.
-                                items:
-                                  description: ManagedFieldsEntry is a workflow-id,
-                                    a FieldSet and the group version of the resource
-                                    that the fieldset applies to.
-                                  properties:
-                                    apiVersion:
-                                      description: APIVersion defines the version
-                                        of this resource that this field set applies
-                                        to. The format is "group/version" just like
-                                        the top-level APIVersion field. It is necessary
-                                        to track the version of a field set because
-                                        it cannot be automatically converted.
-                                      type: string
-                                    fieldsType:
-                                      description: 'FieldsType is the discriminator
-                                        for the different fields format and version.
-                                        There is currently only one possible value:
-                                        "FieldsV1"'
-                                      type: string
-                                    fieldsV1:
-                                      description: FieldsV1 holds the first JSON version
-                                        format as described in the "FieldsV1" type.
-                                      type: Any
-                                    manager:
-                                      description: Manager is an identifier of the
-                                        workflow managing these fields.
-                                      type: string
-                                    operation:
-                                      description: Operation is the type of operation
-                                        which lead to this ManagedFieldsEntry being
-                                        created. The only valid values for this field
-                                        are 'Apply' and 'Update'.
-                                      type: string
-                                    time:
-                                      description: Time is timestamp of when these
-                                        fields were set. It should always be empty
-                                        if Operation is 'Apply'
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 description: 'Name must be unique within a namespace.
                                   Is required when creating resources, although some


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Otherwise applying the crd can fail with:
```
Error: CustomResourceDefinition.apiextensions.k8s.io "seldondeployments.machinelearning.seldon.io" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[predictors].items.properties[componentSpecs].items.properties[metadata].properties[managedFields].items.properties[fieldsV1].type: Unsupported value: "Any": supported values: "array", "boolean", "integer", "number", "object", "string"
```
**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to  https://github.com/SeldonIO/seldon-core/issues/2938

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

