### PR TITLE
Fix elasticsearch index

### DIFF
--- a/components/alibi-detect-server/adserver/cm_model.py
+++ b/components/alibi-detect-server/adserver/cm_model.py
@@ -137,7 +137,7 @@ class CustomMetricsModel(CEModel):  # pylint:disable=c-extension-no-member
                     seldon_namespace = headers.get(NAMESPACE_HEADER_NAME, "")
 
                     # Currently only supports SELDON inference type (not kfserving)
-                    elasticsearch_index = f"inference-log-{seldon_namespace}-seldon-{SELDON_DEPLOYMENT_ID}-{SELDON_PREDICTOR_ID}"
+                    elasticsearch_index = f"inference-log-seldon-{seldon_namespace}-{SELDON_DEPLOYMENT_ID}-{SELDON_PREDICTOR_ID}"
 
                     doc = self.elasticsearch_client.get(
                         index=elasticsearch_index, id=seldon_puid


### PR DESCRIPTION
**What this PR does / why we need it**:

The `elasticsearch_index = f"inference-log-{seldon_namespace}-seldon-...` of the metrics server is only correct if the namespace of the model happens to be `seldon` as the the elasticsearch index is called `'inference-log-seldon-<namespace>...'`



**Which issue(s) this PR fixes**:
Fixes #2971

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
None
```

