### PR TITLE
Updated PIP in base image to align with Python Cryptography Framework version

### DIFF
--- a/components/alibi-detect-server/Makefile
+++ b/components/alibi-detect-server/Makefile
@@ -77,7 +77,7 @@ curl-metrics-server-metrics:
 	curl http://localhost:8080/v1/metrics
 
 docker-build: 
-	docker build --pull -f Dockerfile -t ${REPO}/${IMAGE}:${VERSION} .
+	docker build -f Dockerfile -t ${REPO}/${IMAGE}:${VERSION} .
 
 docker-push:
 	docker push ${REPO}/${IMAGE}:${VERSION} 

--- a/components/alibi-explain-server/Makefile
+++ b/components/alibi-explain-server/Makefile
@@ -37,7 +37,7 @@ type_check:
 	mypy --ignore-missing-imports alibiexplainer
 
 docker-build: build_apis
-	docker build --file=Dockerfile --force-rm=true -t seldonio/${IMAGE}:${VERSION} .
+	docker build --file=Dockerfile -t seldonio/${IMAGE}:${VERSION} .
 
 docker-push:
 	docker push seldonio/${IMAGE}:${VERSION}

--- a/doc/source/reference/upgrading.md
+++ b/doc/source/reference/upgrading.md
@@ -6,6 +6,19 @@ If you were running our Openshift 0.4.2 certified operator and are looking to up
 
 Make sure you also [read the CHANGELOG](./changelog.html) to see the detailed features and bug-fixes in each version.
 
+## Upgrading to 1.7
+
+### Python Dependency Updates
+
+Various CVEs were resolved via #2970, which included several packages upgrades which may affect applications that install packages which may not be compatible. This also includes the installation of pip==20.2, however this version of pip still uses the older resolver.
+
+## Upgrading to 1.6
+
+### Webhook Removal
+
+As part of the 1.6.0 release we are removing the Seldon Core Mutating Webhook. This won't cause any noticable changes, but it is recommended that you manually remove the webhook once you upgrade to version 1.6.0
+
+
 ## Upgrading to 1.5
 
 ### REST and gRPC

--- a/wrappers/s2i/python/Dockerfile
+++ b/wrappers/s2i/python/Dockerfile
@@ -9,6 +9,9 @@ ARG PYTHON_VERSION
 RUN conda install --yes python=$PYTHON_VERSION conda=$CONDA_VERSION
 RUN apt-get update --yes && apt-get install --yes gcc make build-essential
 
+# Upgrade pip version
+RUN pip install pip==20.2
+
 RUN mkdir microservice
 WORKDIR /microservice
 

--- a/wrappers/s2i/python/Dockerfile.redhat
+++ b/wrappers/s2i/python/Dockerfile.redhat
@@ -9,6 +9,9 @@ ARG PYTHON_VERSION
 RUN conda install --yes python=$PYTHON_VERSION conda=$CONDA_VERSION
 RUN dnf install -y make automake gcc gcc-c++
 
+# Upgrade pip version
+RUN pip install pip==20.2
+
 RUN mkdir microservice
 WORKDIR /microservice
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Follow up fix from #2970 to ensure all python derivative images build as the `pip` package is not compatible with the newer version of the cryptography library. This also includes an update on the UPGRADING.md page.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

