### PR TITLE
Change version of JNI build image

### DIFF
--- a/doc/source/java-jni/README.md
+++ b/doc/source/java-jni/README.md
@@ -25,7 +25,7 @@ s2i](../wrappers/s2i.md) and then follow the steps below.
 To check everything is working you can run
 
 ```bash
-s2i usage seldonio/s2i-java-jni-build:0.5.0
+s2i usage seldonio/s2i-java-jni-build:0.5.1
 ```
 
 ## Step 2 - Create your source code
@@ -153,8 +153,8 @@ The general format is:
 ```bash
 s2i build \
   <git-repo | src-folder> \
-  seldonio/s2i-java-jni-build:0.5.0 \
-  --runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
+  seldonio/s2i-java-jni-build:0.5.1 \
+  --runtime-image seldonio/s2i-java-jni-runtime:0.5.1 \
   <my-image-name> 
 ```
 
@@ -164,8 +164,8 @@ An example invocation using the test template model inside `seldon-core`:
 s2i build \
   https://github.com/seldonio/seldon-core.git \
   --context-dir=incubating/wrappers/s2i/java-jni/test/model-template-app \
-  seldonio/s2i-java-jni-build:0.5.0 \
-  --runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
+  seldonio/s2i-java-jni-build:0.5.1 \
+  --runtime-image seldonio/s2i-java-jni-runtime:0.5.1 \
   jni-model-template:0.1.0
 ```
 
@@ -186,15 +186,15 @@ git clone https://github.com/seldonio/seldon-core.git
 cd seldon-core
 s2i build \
   incubating/wrappers/s2i/java-jni/test/model-template-app \
-  seldonio/s2i-java-jni-build:0.5.0 \
-  --runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
+  seldonio/s2i-java-jni-build:0.5.1 \
+  --runtime-image seldonio/s2i-java-jni-runtime:0.5.1 \
   jni-model-template:0.1.0
 ```
 
 For more help see:
 
 ```bash
-s2i usage seldonio/s2i-java-jni-build:0.5.0
+s2i usage seldonio/s2i-java-jni-build:0.5.1
 s2i build --help
 ```
 

--- a/doc/source/java-jni/README.md
+++ b/doc/source/java-jni/README.md
@@ -25,7 +25,7 @@ s2i](../wrappers/s2i.md) and then follow the steps below.
 To check everything is working you can run
 
 ```bash
-s2i usage seldonio/s2i-java-jni-build:0.3.0
+s2i usage seldonio/s2i-java-jni-build:0.5.0
 ```
 
 ## Step 2 - Create your source code
@@ -153,8 +153,8 @@ The general format is:
 ```bash
 s2i build \
   <git-repo | src-folder> \
-  seldonio/s2i-java-jni-build:0.3.0 \
-  --runtime-image seldonio/s2i-java-jni-runtime:0.3.0 \
+  seldonio/s2i-java-jni-build:0.5.0 \
+  --runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
   <my-image-name> 
 ```
 
@@ -164,8 +164,8 @@ An example invocation using the test template model inside `seldon-core`:
 s2i build \
   https://github.com/seldonio/seldon-core.git \
   --context-dir=incubating/wrappers/s2i/java-jni/test/model-template-app \
-  seldonio/s2i-java-jni-build:0.3.0 \
-  --runtime-image seldonio/s2i-java-jni-runtime:0.3.0 \
+  seldonio/s2i-java-jni-build:0.5.0 \
+  --runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
   jni-model-template:0.1.0
 ```
 
@@ -186,15 +186,15 @@ git clone https://github.com/seldonio/seldon-core.git
 cd seldon-core
 s2i build \
   incubating/wrappers/s2i/java-jni/test/model-template-app \
-  seldonio/s2i-java-jni-build:0.3.0 \
-  --runtime-image seldonio/s2i-java-jni-runtime:0.3.0 \
+  seldonio/s2i-java-jni-build:0.5.0 \
+  --runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
   jni-model-template:0.1.0
 ```
 
 For more help see:
 
 ```bash
-s2i usage seldonio/s2i-java-jni-build:0.3.0
+s2i usage seldonio/s2i-java-jni-build:0.5.0
 s2i build --help
 ```
 

--- a/incubating/wrappers/java/pom.xml
+++ b/incubating/wrappers/java/pom.xml
@@ -6,7 +6,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <groupId>io.seldon.wrapper</groupId>
   <artifactId>seldon-core-wrapper</artifactId>
   <packaging>jar</packaging>
-  <version>0.3.0</version>
+  <version>0.4.1</version>
   <name>Seldon Core Java Wrapper</name>
   <url>http://maven.apache.org</url>
   <description>Wrapper for seldon-core Java prediction models.
@@ -48,9 +48,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <version>2.2.4.RELEASE</version>
   </parent>
   <properties>
-    <java.version>13</java.version>
-    <maven.compiler.source>13</maven.compiler.source>
-    <maven.compiler.target>13</maven.compiler.target>
+    <!-- java.version is only used by Spring -->
+    <java.version>11</java.version>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>
     UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>
@@ -98,10 +98,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>13</source>
-          <target>13</target>
           <encoding>UTF-8</encoding>
           <showWarnings>true</showWarnings>
           <compilerArgs>

--- a/incubating/wrappers/s2i/java-jni/Dockerfile.build
+++ b/incubating/wrappers/s2i/java-jni/Dockerfile.build
@@ -1,7 +1,5 @@
-FROM maven:3.6.3-jdk-13
+FROM registry.access.redhat.com/ubi8/openjdk-11
 
 LABEL io.openshift.s2i.scripts-url="image:///s2i/bin"
 
 COPY ./s2i/bin/ /s2i/bin
-
-WORKDIR /build

--- a/incubating/wrappers/s2i/java-jni/Dockerfile.build
+++ b/incubating/wrappers/s2i/java-jni/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM seldonio/core-builder:0.16
+FROM maven:3.6.3-jdk-13
 
 LABEL io.openshift.s2i.scripts-url="image:///s2i/bin"
 

--- a/incubating/wrappers/s2i/java-jni/Dockerfile.runtime
+++ b/incubating/wrappers/s2i/java-jni/Dockerfile.runtime
@@ -1,57 +1,47 @@
-FROM openjdk:13.0.1-jdk-buster
+FROM registry.access.redhat.com/ubi8/python-36
 
-ENV PYTHON_VERSION "3.6.10"
+# NOTE: This Dockerfile installs OpenJDK on top of the Python UBI image.
+# This is required for the JNI runtime.
 
-# Compression and SSL libs required for installing Python
-RUN apt-get upgrade && \
-        apt-get update && \
-        apt-get install build-essential -y && \
-        apt-get install zlib1g -y && \
-        apt-get install zlib1g-dev -y && \
-        apt-get install libssl-dev -y && \
-        apt-get install libbz2-dev -y && \
-        apt-get install liblzma-dev -y
+LABEL io.openshift.s2i.scripts-url="image:///s2i/bin" \
+      io.openshift.s2i.assemble-input-files="/build"
 
-# Build and install Python
-RUN curl -SLO https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
-    && tar xvf Python-${PYTHON_VERSION}.tgz \
-    && cd Python-${PYTHON_VERSION} \
-    && ./configure --prefix=/usr/local --with-openssl \
-    && make \
-    && make altinstall \
-    && cd / \
-    && rm -rf Python-${PYTHON_VERSION}* \
-    && (cd /usr/local/bin && ln -svn python3.6 python)
+# Get privileges to install Java
+USER root
 
-# Ensure python3 and pip3 are default
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py >>setup.py && \
-        python setup.py
-RUN update-alternatives --install /usr/bin/python python /usr/local/bin/python3.6 1
-RUN rm -rf /usr/local/bin/pip && \
-        ln -s /usr/local/bin/pip3.6 /usr/local/bin/pip
+# Install OpenJDK (same version as Dockerfile.build)
+ENV JAVA_MAJOR_VERSION=11 \
+    JAVA_HOME=/usr/lib/jvm/jre-11
 
-RUN pip install --upgrade pip setuptools wheel
+RUN INSTALL_PKGS="java-11-openjdk-headless" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
 
-RUN mkdir /build
+# Security upgrades
+RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
 
-LABEL io.openshift.s2i.scripts-url="image:///s2i/bin"
-LABEL io.openshift.s2i.assemble-input-files="/build"
+# CVE https://github.com/SeldonIO/seldon-core/issues/2960
+RUN yum remove -y nodejs httpd
+
+# Drop root and continue
+USER default
 
 COPY ./s2i/bin/ /s2i/bin
 
-WORKDIR /microservice
+RUN pip install --upgrade pip setuptools wheel
 
 # Install Seldon Core
-COPY _python /microservice
-RUN cd /microservice/python && make install
-COPY _python/python/licenses/license.txt .
+COPY --chown=1001 _python .
+RUN make -C python install
+COPY --chown=1001 _python/python/licenses/license.txt .
 
 # Install extra requirements for the JNI server
-COPY ./java-jni/requirements.txt ./requirements.txt
+COPY --chown=1001 ./java-jni/requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # Copy JNI server
-COPY ./java-jni ./
+COPY --chown=1001 ./java-jni ./
 
 EXPOSE 5000
 

--- a/incubating/wrappers/s2i/java-jni/Dockerfile.runtime
+++ b/incubating/wrappers/s2i/java-jni/Dockerfile.runtime
@@ -4,7 +4,7 @@ FROM registry.access.redhat.com/ubi8/python-36
 # This is required for the JNI runtime.
 
 LABEL io.openshift.s2i.scripts-url="image:///s2i/bin" \
-      io.openshift.s2i.assemble-input-files="/build"
+      io.openshift.s2i.assemble-input-files="/home/jboss"
 
 # Get privileges to install Java
 USER root

--- a/incubating/wrappers/s2i/java-jni/Dockerfile.runtime
+++ b/incubating/wrappers/s2i/java-jni/Dockerfile.runtime
@@ -24,7 +24,7 @@ RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Cri
 # CVE https://github.com/SeldonIO/seldon-core/issues/2960
 RUN yum remove -y nodejs httpd
 
-# Drop root and continue
+# Drop root and continue (base image uses 1001)
 USER default
 
 COPY ./s2i/bin/ /s2i/bin

--- a/incubating/wrappers/s2i/java-jni/Makefile
+++ b/incubating/wrappers/s2i/java-jni/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 SELDON_CORE_DIR = ../../../..
-VERSION := 0.4.0
+VERSION := 0.5.0
 IMAGE_REGISTRY = docker.io/seldonio
 IMAGE_NAME_BUILD = ${IMAGE_REGISTRY}/s2i-java-jni-build:${VERSION}
 IMAGE_NAME_RUNTIME = ${IMAGE_REGISTRY}/s2i-java-jni-runtime:${VERSION}

--- a/incubating/wrappers/s2i/java-jni/Makefile
+++ b/incubating/wrappers/s2i/java-jni/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 SELDON_CORE_DIR = ../../../..
-VERSION := 0.5.0
+VERSION := 0.5.1
 IMAGE_REGISTRY = docker.io/seldonio
 IMAGE_NAME_BUILD = ${IMAGE_REGISTRY}/s2i-java-jni-build:${VERSION}
 IMAGE_NAME_RUNTIME = ${IMAGE_REGISTRY}/s2i-java-jni-runtime:${VERSION}
@@ -9,6 +9,7 @@ IMAGE_NAME_RUNTIME = ${IMAGE_REGISTRY}/s2i-java-jni-runtime:${VERSION}
 get_local_repo:
 	mkdir -p _python
 	cp -r $(SELDON_CORE_DIR)/python _python
+	cp $(SELDON_CORE_DIR)/version.txt _python/version.txt
 
 .PHONY: build
 build: get_local_repo

--- a/incubating/wrappers/s2i/java-jni/s2i/bin/assemble
+++ b/incubating/wrappers/s2i/java-jni/s2i/bin/assemble
@@ -18,10 +18,6 @@ if [[ -z "$SERVICE_TYPE" ]]; then
     exit 1
 fi
 
-
-
-cd /build
-
 echo "---> Installing application source..."
 cp -Rf /tmp/src/. ./
 

--- a/incubating/wrappers/s2i/java-jni/s2i/bin/assemble-runtime
+++ b/incubating/wrappers/s2i/java-jni/s2i/bin/assemble-runtime
@@ -8,6 +8,6 @@
 #
 
 # Move jar binary with inference runtime implementation
-mv ./build/target/*.jar ./model.jar
+cp ./jboss/target/*.jar ./model.jar
 
 

--- a/incubating/wrappers/s2i/java-jni/s2i/bin/assemble-runtime
+++ b/incubating/wrappers/s2i/java-jni/s2i/bin/assemble-runtime
@@ -8,6 +8,6 @@
 #
 
 # Move jar binary with inference runtime implementation
-mv /microservice/build/target/*.jar /microservice/model.jar
+mv ./build/target/*.jar ./model.jar
 
 

--- a/incubating/wrappers/s2i/java-jni/s2i/bin/run
+++ b/incubating/wrappers/s2i/java-jni/s2i/bin/run
@@ -16,9 +16,7 @@ fi
 
 PAYLOAD_PASSTHROUGH=${PAYLOAD_PASSTHROUGH:-true}
 MODEL_NAME=${MODEL_NAME:-"JavaJNIServer"}
-JAVA_JAR_PATH=${JAVA_JAR_PATH:-"/microservice/model.jar"}
-
-cd /microservice
+JAVA_JAR_PATH=${JAVA_JAR_PATH:-"./model.jar"}
 
 echo "Starting microservice"
 exec \

--- a/incubating/wrappers/s2i/java-jni/test/model-template-app/Makefile
+++ b/incubating/wrappers/s2i/java-jni/test/model-template-app/Makefile
@@ -7,8 +7,8 @@ build_jar:
 
 build:
 	s2i build . \
-		seldonio/s2i-java-jni-build:0.5.0 \
-		--runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
+		seldonio/s2i-java-jni-build:0.5.1 \
+		--runtime-image seldonio/s2i-java-jni-runtime:0.5.1 \
 		${IMAGE}
 
 run:

--- a/incubating/wrappers/s2i/java-jni/test/model-template-app/Makefile
+++ b/incubating/wrappers/s2i/java-jni/test/model-template-app/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.1.0
+VERSION := 0.2.0
 IMAGE_NAME_BASE=jni-model-template
 IMAGE=seldonio/${IMAGE_NAME_BASE}:${VERSION}
 
@@ -14,7 +14,7 @@ build:
 run:
 	docker run \
 		--rm -it \
-		-p 5000:5000 \
+		-p 9000:9000 \
 		${IMAGE}
 
 clean:

--- a/incubating/wrappers/s2i/java-jni/test/model-template-app/Makefile
+++ b/incubating/wrappers/s2i/java-jni/test/model-template-app/Makefile
@@ -7,8 +7,8 @@ build_jar:
 
 build:
 	s2i build . \
-		seldonio/s2i-java-jni-build:0.3.0 \
-		--runtime-image seldonio/s2i-java-jni-runtime:0.3.0 \
+		seldonio/s2i-java-jni-build:0.5.0 \
+		--runtime-image seldonio/s2i-java-jni-runtime:0.5.0 \
 		${IMAGE}
 
 run:

--- a/incubating/wrappers/s2i/java-jni/test/model-template-app/pom.xml
+++ b/incubating/wrappers/s2i/java-jni/test/model-template-app/pom.xml
@@ -6,13 +6,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <groupId>io.seldon.example</groupId>
   <artifactId>seldon-core-model-template</artifactId>
   <packaging>jar</packaging>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <name>Seldon Core Model Template</name>
   <url>http://maven.apache.org</url>
   <properties>
-    <java.version>13</java.version>
-    <maven.compiler.source>13</maven.compiler.source>
-    <maven.compiler.target>13</maven.compiler.target>
+    <java.version>11</java.version>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>
     UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>
@@ -33,8 +32,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>13</source>
-          <target>13</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -63,7 +60,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <dependency>
       <groupId>io.seldon.wrapper</groupId>
       <artifactId>seldon-core-wrapper</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/incubating/wrappers/s2i/java-jni/test/model-template-app/pom.xml
+++ b/incubating/wrappers/s2i/java-jni/test/model-template-app/pom.xml
@@ -30,7 +30,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.8.1</version>
         <configuration>
           <encoding>UTF-8</encoding>
         </configuration>

--- a/testing/s2i/java/pom.xml
+++ b/testing/s2i/java/pom.xml
@@ -6,13 +6,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <groupId>io.seldon.example</groupId>
   <artifactId>seldon-core-model-template</artifactId>
   <packaging>jar</packaging>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <name>Seldon Core Model Template</name>
   <url>http://maven.apache.org</url>
   <properties>
-    <java.version>13</java.version>
-    <maven.compiler.source>13</maven.compiler.source>
-    <maven.compiler.target>13</maven.compiler.target>
+    <java.version>11</java.version>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>
     UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>
@@ -31,10 +30,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>13</source>
-          <target>13</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -63,7 +60,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <dependency>
       <groupId>io.seldon.wrapper</groupId>
       <artifactId>seldon-core-wrapper</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/testing/scripts/test_s2i_java.py
+++ b/testing/scripts/test_s2i_java.py
@@ -12,9 +12,9 @@ JAVA_S2I_FOLDER = os.path.join(SC_ROOT_PATH, "testing", "s2i", "java")
 
 S2I_JNI_PARAMETERS = {
     "s2i_folder": JAVA_S2I_FOLDER,
-    "s2i_image": "seldonio/s2i-java-jni-build:0.5.0",
+    "s2i_image": "seldonio/s2i-java-jni-build:0.5.1",
     "image_name": "seldonio/test-s2i-java-jni:0.2.0",
-    "s2i_runtime_image": "seldonio/s2i-java-jni-runtime:0.5.0",
+    "s2i_runtime_image": "seldonio/s2i-java-jni-runtime:0.5.1",
 }
 
 S2I_JAVA_PARAMETERS = {

--- a/testing/scripts/test_s2i_java.py
+++ b/testing/scripts/test_s2i_java.py
@@ -12,9 +12,9 @@ JAVA_S2I_FOLDER = os.path.join(SC_ROOT_PATH, "testing", "s2i", "java")
 
 S2I_JNI_PARAMETERS = {
     "s2i_folder": JAVA_S2I_FOLDER,
-    "s2i_image": "seldonio/s2i-java-jni-build:0.4.0",
+    "s2i_image": "seldonio/s2i-java-jni-build:0.5.0",
     "image_name": "seldonio/test-s2i-java-jni:0.2.0",
-    "s2i_runtime_image": "seldonio/s2i-java-jni-runtime:0.4.0",
+    "s2i_runtime_image": "seldonio/s2i-java-jni-runtime:0.5.0",
 }
 
 S2I_JAVA_PARAMETERS = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Move the `Dockerfile.build` image of the JNI server to use `maven`'s official image. This should address some of the CVEs listed in #2968. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2968

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

