### PR TITLE
disallow 2 shadows only for ambassador

### DIFF
--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
@@ -39,6 +39,7 @@ var (
 	envPredictiveUnitGrpcServicePort    = os.Getenv(ENV_PREDICTIVE_UNIT_GRPC_SERVICE_PORT)
 	envPredictiveUnitServicePortMetrics = os.Getenv(ENV_PREDICTIVE_UNIT_SERVICE_PORT_METRICS)
 	envPredictiveUnitMetricsPortName    = GetEnv(ENV_PREDICTIVE_UNIT_METRICS_PORT_NAME, constants.DefaultMetricsPortName)
+	envAmbassadorEnabled                = GetEnv("AMBASSADOR_ENABLED", "false")
 )
 
 // Get an environment variable given by key or return the fallback.
@@ -132,7 +133,7 @@ func checkTraffic(spec *SeldonDeploymentSpec, fldPath *field.Path, allErrs field
 
 		if p.Shadow == true {
 			shadows += 1
-			if shadows > 1 {
+			if envAmbassadorEnabled == "true" && shadows > 1 {
 				allErrs = append(allErrs, field.Invalid(fldPath, spec.Predictors[i].Name, "Multiple shadows are not allowed"))
 			}
 		}

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
@@ -1288,7 +1288,7 @@ func TestNoPredictors(t *testing.T) {
 	g.Expect(err).ToNot(BeNil())
 }
 
-func TestValidateTwoShadows(t *testing.T) {
+func TestValidateTwoShadowsAmbassadorEnabled(t *testing.T) {
 	g := NewGomegaWithT(t)
 	err := setupTestConfigMap()
 	g.Expect(err).To(BeNil())
@@ -1305,7 +1305,7 @@ func TestValidateTwoShadows(t *testing.T) {
 				},
 			},
 			{
-				Name: "p1",
+				Name: "p2",
 				Graph: PredictiveUnit{
 					Name:           "classifier",
 					Implementation: &impl,
@@ -1314,7 +1314,7 @@ func TestValidateTwoShadows(t *testing.T) {
 				Shadow: true,
 			},
 			{
-				Name: "p1",
+				Name: "p3",
 				Graph: PredictiveUnit{
 					Name:           "classifier",
 					Implementation: &impl,
@@ -1325,7 +1325,54 @@ func TestValidateTwoShadows(t *testing.T) {
 		},
 	}
 
+	backupEnvAmbassadorEnabled := envAmbassadorEnabled
+	envAmbassadorEnabled = "true"
 	spec.DefaultSeldonDeployment("mydep", "default")
 	err = spec.ValidateSeldonDeployment()
 	g.Expect(err).ToNot(BeNil())
+	envAmbassadorEnabled = backupEnvAmbassadorEnabled
+}
+
+func TestValidateTwoShadowsAmbassadorDisabled(t *testing.T) {
+	g := NewGomegaWithT(t)
+	err := setupTestConfigMap()
+	g.Expect(err).To(BeNil())
+	impl := PredictiveUnitImplementation(constants.PrePackedServerTensorflow)
+	spec := &SeldonDeploymentSpec{
+		Protocol: ProtocolTensorflow,
+		Predictors: []PredictorSpec{
+			{
+				Name: "p1",
+				Graph: PredictiveUnit{
+					Name:           "classifier",
+					Implementation: &impl,
+					ModelURI:       "s3://mybucket/model",
+				},
+			},
+			{
+				Name: "p2",
+				Graph: PredictiveUnit{
+					Name:           "classifier",
+					Implementation: &impl,
+					ModelURI:       "s3://mybucket/model",
+				},
+				Shadow: true,
+			},
+			{
+				Name: "p3",
+				Graph: PredictiveUnit{
+					Name:           "classifier",
+					Implementation: &impl,
+					ModelURI:       "s3://mybucket/model",
+				},
+				Shadow: true,
+			},
+		},
+	}
+	backupEnvAmbassadorEnabled := envAmbassadorEnabled
+	envAmbassadorEnabled = "false"
+	spec.DefaultSeldonDeployment("mydep", "default")
+	err = spec.ValidateSeldonDeployment()
+	g.Expect(err).To(BeNil())
+	envAmbassadorEnabled = backupEnvAmbassadorEnabled
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Reason to disallow 2 shadows in https://github.com/SeldonIO/seldon-core/commit/76d9a483938881395fc01843c26ed10ce87d421c was specific to ambassador https://github.com/SeldonIO/seldon-core/issues/2383

This issue allows again to deploy more than one shadow if `ambassador.enabled: false` in the helm values.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/SeldonIO/seldon-core/issues/2991

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

