### PR TITLE
Update manifests to use 0.4.1 controller gen for webhook creation

### DIFF
--- a/helm-charts/seldon-core-operator/templates/webhook.yaml
+++ b/helm-charts/seldon-core-operator/templates/webhook.yaml
@@ -4,20 +4,6 @@
 {{- $cert := genSignedCert "seldon-webhook-service" nil $altNames 365 $ca -}}
 ---
 
-{{- if not .Values.certManager.enabled -}}
-apiVersion: v1
-data:
-  ca.crt: '{{ $ca.Cert | b64enc }}'
-  tls.crt: '{{ $cert.Cert | b64enc }}'
-  tls.key: '{{ $cert.Key | b64enc }}'
-kind: Secret
-metadata:
-  name: seldon-webhook-server-cert
-  namespace: '{{ include "seldon.namespace" . }}'
-type: kubernetes.io/tls
-{{- end }}
----
-
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -31,7 +17,10 @@ metadata:
     app.kubernetes.io/version: '{{ .Chart.Version }}'
   name: seldon-validating-webhook-configuration-{{ include "seldon.namespace" . }}
 webhooks:
-- clientConfig:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: '{{ $ca.Cert | b64enc }}'
     service:
       name: seldon-webhook-service
@@ -184,5 +173,19 @@ webhooks:
     resources:
     - seldondeployments
   sideEffects: None
+---
+
+{{- if not .Values.certManager.enabled -}}
+apiVersion: v1
+data:
+  ca.crt: '{{ $ca.Cert | b64enc }}'
+  tls.crt: '{{ $cert.Cert | b64enc }}'
+  tls.key: '{{ $cert.Key | b64enc }}'
+kind: Secret
+metadata:
+  name: seldon-webhook-server-cert
+  namespace: '{{ include "seldon.namespace" . }}'
+type: kubernetes.io/tls
+{{- end }}
 
 {{- end }}

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -122,6 +122,8 @@ deploy-lite: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases crd:crdVersions=v1beta1
+	# temporary fix until we update to v1 webhooks by updating code to have webhookVersions=v1
+	mv config/webhook/manifests.v1beta1.yaml config/webhook/manifests.yaml
 
 # Commented out alternative is looking ahead to issue that on Openshift our v1 CRD is too large
 # to be installed. This may also affect operator-sdk community operators.

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -6,8 +6,10 @@ metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -26,7 +28,6 @@ webhooks:
     - seldondeployments
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -45,7 +46,6 @@ webhooks:
     - seldondeployments
   sideEffects: None
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

 * Fixes rouge webhook generation file created by 0.4.1 for v1beta1 webhooks

We need to decide when to upgrade to v1 webhooks which is now the default in Kubebuilder. They are available from k8s 1.16. So changing to this would drop support for pre-1.16 clusters.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2987

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

