### PR TITLE
fix: missing string ending in python snippet in serving.md

### DIFF
--- a/doc/source/workflow/serving.md
+++ b/doc/source/workflow/serving.md
@@ -25,7 +25,7 @@ class MyModel:
         pass
 
     def predict(*args, **kwargs):
-        return ["hello, "world"]
+        return ["hello", "world"]
 ```
 
 You are able to test your model by running the microservice CLI that is provided by the [Python module](../python/python_module.md)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

```release-note
Docs fix: a Python snippet in serving.md had syntax errors.
```


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

