### PR TITLE
Request logger elastic mapping type unsetting

### DIFF
--- a/components/seldon-request-logger/README.md
+++ b/components/seldon-request-logger/README.md
@@ -39,7 +39,7 @@ And in another window run app/test.sh
 
 The output of the logger will say where docs are indexed. The contents can be checked in postman by querying on the elastic host e.g.
 ```
-localhost:9200/inference-log-seldon-unknown-namespace-strdata-unknown-endpoint/inferencerequest/7g
+localhost:9200/inference-log-seldon-unknown-namespace-strdata-unknown-endpoint/_doc/7g
 ```
 
 # Local Testing Against Seldon Executor
@@ -56,14 +56,14 @@ make run_local
 ```
 The log output from the request-logger will show the document id and index name, which is built from the seldon deployment name and namespace (if supplied).
 
-View the document at `localhost:9200/<index>/inferencerequest/<doc_id>`
+View the document at `localhost:9200/<index>/_doc/<doc_id>`
 
 Here is a truncated version of an example output for an image use-case with outlier:
 
 ```
 {
     "_index": "inference-log-inferenceservice-default-cifar10-default",
-    "_type": "inferencerequest",
+    "_type": "_doc",
     "_id": "9i",
     "_version": 3,
     "_seq_no": 2,

--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -444,7 +444,7 @@ def createElelmentsArray(X: np.ndarray, names: list):
             for i in range(X.shape[0]):
                 d = {}
                 for num, name in enumerate(names, start=0):
-                    d[name] = np.expand_dims(X[i, num], axis=0).tolist()
+                    d[name] = X[i, num].tolist()
                 results.append(d)
     return results
 

--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -44,7 +44,7 @@ def index():
             "body too large for "
             + index_name
             + "/"
-            + log_helper.DOC_TYPE_NAME
+            + (log_helper.DOC_TYPE_NAME if log_helper.DOC_TYPE_NAME != None else "_doc")
             + "/"
             + request_id
             + " adding "
@@ -193,7 +193,7 @@ def upsert_doc_to_elastic(
         "upserted to doc "
         + index_name
         + "/"
-        + log_helper.DOC_TYPE_NAME
+        + (log_helper.DOC_TYPE_NAME if log_helper.DOC_TYPE_NAME != None else "_doc")
         + "/"
         + request_id
         + " adding "

--- a/components/seldon-request-logger/app/log_helper.py
+++ b/components/seldon-request-logger/app/log_helper.py
@@ -17,7 +17,7 @@ TIMESTAMP_HEADER_NAME = "CE-Time"
 # inferenceservicename is k8s resource name for SeldonDeployment or InferenceService
 INFERENCESERVICE_HEADER_NAME = "Ce-Inferenceservicename"
 LENGTH_HEADER_NAME = "Content-Length"
-DOC_TYPE_NAME = "inferencerequest"
+DOC_TYPE_NAME = None
 
 
 def get_max_payload_bytes(default_value):

--- a/components/seldon-request-logger/requirements.txt
+++ b/components/seldon-request-logger/requirements.txt
@@ -2,5 +2,5 @@ Flask==1.0.2
 numpy==1.14.5
 dict_digger==0.2.1
 seldon_core
-elasticsearch==7.10.0
+elasticsearch==7.5.1
 click==8.0.0a1

--- a/components/seldon-request-logger/requirements.txt
+++ b/components/seldon-request-logger/requirements.txt
@@ -2,5 +2,5 @@ Flask==1.0.2
 numpy==1.14.5
 dict_digger==0.2.1
 seldon_core
-elasticsearch==7.5.1
+elasticsearch==7.10.0
 click==8.0.0a1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR accomplishes the following objectives
- [x] ~~Updating req logger elasticsearch package to `7.10.0`~~ (Not done as this causes breaking changes)
- [x] Setting mapping type to None as mentioned in issue #3013 
- [x] Sets elements object for request-response pairs to accurate value without the additional dimension
 
**Which issue(s) this PR fixes**:

Fixes #3013 

**Special notes for your reviewer**:

[Elastic Removal of mapping types](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html#removal-of-types)

**Does this PR introduce a user-facing change?**:
So with this PR, we deprecate the `inferencerequest` mapping type in the current request logger implementation in favour of a default `_doc` type. So new indexes created will not have a mapping type. Since we are using dynamic mapping there shouldn't be any breaking changes.


```release-note
```

