### PR TITLE
docs: use Helm v3 commands in Istio docs

### DIFF
--- a/doc/source/examples/istio_canary.nblink
+++ b/doc/source/examples/istio_canary.nblink
@@ -1,0 +1,3 @@
+{
+  "path": "../../../examples/istio/canary/istio_canary.ipynb"
+}

--- a/doc/source/examples/notebooks.rst
+++ b/doc/source/examples/notebooks.rst
@@ -144,7 +144,8 @@ Ingress
    Ambassador Shadow <ambassador_shadow>
    Ambassador Headers <ambassador_headers>
    Ambassador Custom Config <ambassador_custom>
-   Istio Examples <istio_examples>   
+   Istio Examples <istio_examples> 
+   Istio Canary <istio_canary>
 
 Infrastructure
 --------------

--- a/doc/source/ingress/istio.md
+++ b/doc/source/ingress/istio.md
@@ -95,9 +95,7 @@ Istio has the capability for fine grained traffic routing to your deployments. T
  * A/B testing
  * shadow deployments
 
-More information on these can be found in our [example showing canary
-updates](../examples/istio_canary.html) and [other examples, including shadow
-updates](../examples/istio_examples.html).
+More information can be found in our [examples](../examples/istio_examples.html).
 
 
 ## Troubleshoot

--- a/doc/source/ingress/istio.md
+++ b/doc/source/ingress/istio.md
@@ -1,13 +1,13 @@
 # Ingress with Istio
 
-Seldon core can be used in conjuction with [istio](https://istio.io/). Istio provides an [ingress gateway](https://istio.io/docs/tasks/traffic-management/ingress/) which Seldon Core can automatically wire up new deployments to. The steps to using istio are described below.
+Seldon Core can be used in conjunction with [istio](https://istio.io/). Istio provides an [ingress gateway](https://istio.io/docs/tasks/traffic-management/ingress/) which Seldon Core can automatically wire up new deployments to. The steps to using istio are described below.
 
 ## Install Seldon Core Operator
 
 Ensure when you install the seldon-core operator via Helm that you enabled istio. For example:
 
 ```bash 
-helm install seldon-core-operator --name seldon-core --set istio.enabled=true --repo https://storage.googleapis.com/seldon-charts --set usageMetrics.enabled=true
+helm install seldon-core seldon-core-operator --set istio.enabled=true --repo https://storage.googleapis.com/seldon-charts --set usageMetrics.enabled=true
 ```
 
 You need an istio gateway installed in the `istio-system` namespace. By default we assume one called seldon-gateway. For example you can create this with the following yaml:
@@ -70,14 +70,14 @@ spec:
 If you have your own gateway you will use then you can provide the name when installing the seldon operator. For example if your gateway is called `mygateway` you can install the operator with:
 
 ```bash 
-helm install seldon-core-operator --name seldon-core --set istio.enabled=true --set istio.gateway=mygateway --repo https://storage.googleapis.com/seldon-charts --set usageMetrics.enabled=true
+helm install seldon-core seldon-core-operator --set istio.enabled=true --set istio.gateway=mygateway --repo https://storage.googleapis.com/seldon-charts --set usageMetrics.enabled=true
 ```
 
 You can also provide the gateway on a per Seldon Deployment resource basis by providing it with the annotation `seldon.io/istio-gateway`.
 
 ## Istio Configuration Annotation Reference
 
-| Annotation | Default |Description | 
+| Annotation | Default |Description |
 |------------|---------|------------|
 |`seldon.io/istio-gateway:<gateway name>`| istio-system/seldon-gateway | The gateway to use for this deployment. If no namespace prefix is applied it will refer to the namespace of the Seldon Deployment. |
 | `seldon.io/istio-retries` | None | The number of istio retries |

--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -1,0 +1,3 @@
+# Seldon Core Istio Examples
+
+ * [Canary deployments](./canary)

--- a/examples/istio/canary/.gitignore
+++ b/examples/istio/canary/.gitignore
@@ -1,0 +1,2 @@
+canary.yaml
+model.yaml 

--- a/examples/istio/canary/README.md
+++ b/examples/istio/canary/README.md
@@ -1,0 +1,3 @@
+# Canary Rollout with Seldon and Istio
+
+Follow the [notebook](istio_canary.ipynb) to show how you can deploy Canary models with Seldon and Istio.

--- a/examples/istio/canary/istio_canary.ipynb
+++ b/examples/istio/canary/istio_canary.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Canary Rollout with Seldon and Ambassador\n"
+    "# Canary Rollout with Istio and Ambassador\n"
    ]
   },
   {
@@ -443,7 +443,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.3-final"
   },
   "metadata": {
    "interpreter": {

--- a/examples/istio/canary/istio_canary.ipynb
+++ b/examples/istio/canary/istio_canary.ipynb
@@ -1,0 +1,485 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Canary Rollout with Seldon and Ambassador\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup Seldon Core\n",
+    "\n",
+    "Use the setup notebook to [Setup Cluster](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Setup-Cluster) with [Istio Ingress](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Istio) and [Install Seldon Core](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Install-Seldon-Core). Instructions [also online](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "namespace/seldon created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl create namespace seldon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Context \"kind-kind\" modified.\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl config set-context $(kubectl config current-context) --namespace=seldon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.core.magic import register_line_cell_magic\n",
+    "\n",
+    "@register_line_cell_magic\n",
+    "def writetemplate(line, cell):\n",
+    "    with open(line, 'w') as f:\n",
+    "        f.write(cell.format(**globals()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ensure the istio ingress gatewaty is port-forwarded to localhost:8004\n",
+    "\n",
+    "\n",
+    "\n",
+    "* Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8004:8080`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'1.7.0-dev'"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ISTIO_GATEWAY=\"localhost:8004\"\n",
+    "\n",
+    "VERSION=!cat ../../../version.txt\n",
+    "VERSION=VERSION[0]\n",
+    "VERSION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Launch main model\n",
+    "\n",
+    "We will create a very simple Seldon Deployment with a dummy model image `seldonio/mock_classifier:1.0`. This deployment is named `example`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writetemplate model.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1alpha2\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  labels:\n",
+    "    app: seldon\n",
+    "  name: example\n",
+    "spec:\n",
+    "  name: canary-example\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/mock_classifier:{VERSION}\n",
+    "          imagePullPolicy: IfNotPresent\n",
+    "          name: classifier\n",
+    "        terminationGracePeriodSeconds: 1\n",
+    "    graph:\n",
+    "      children: []\n",
+    "      endpoint:\n",
+    "        type: REST\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: main\n",
+    "    replicas: 1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seldondeployment.machinelearning.seldon.io/example created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl create -f model.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for deployment \"example-main-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
+      "deployment \"example-main-0-classifier\" successfully rolled out\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl rollout status deploy/$(kubectl get deploy -l seldon-deployment-id=example -o jsonpath='{.items[0].metadata.name}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from seldon_core.seldon_client import SeldonClient\n",
+    "sc = SeldonClient(deployment_name=\"example\",namespace=\"seldon\",gateway_endpoint=ISTIO_GATEWAY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### REST Request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success:True message:\n",
+      "Request:\n",
+      "meta {\n",
+      "}\n",
+      "data {\n",
+      "  tensor {\n",
+      "    shape: 1\n",
+      "    shape: 1\n",
+      "    values: 0.6670563912281003\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "Response:\n",
+      "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.09538308704053941]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.7.0-dev'}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = sc.predict(gateway=\"istio\",transport=\"rest\")\n",
+    "assert(r.success==True)\n",
+    "print(r)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Launch Canary\n",
+    "\n",
+    "We will now extend the existing graph and add a new predictor as a canary using a new model `seldonio/mock_classifier_rest:1.1`. We will add traffic values to split traffic 75/25 to the main and canary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writetemplate canary.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1alpha2\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  labels:\n",
+    "    app: seldon\n",
+    "  name: example\n",
+    "spec:\n",
+    "  name: canary-example\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/mock_classifier:{VERSION}\n",
+    "          imagePullPolicy: IfNotPresent\n",
+    "          name: classifier\n",
+    "        terminationGracePeriodSeconds: 1\n",
+    "    graph:\n",
+    "      children: []\n",
+    "      endpoint:\n",
+    "        type: REST\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: main\n",
+    "    replicas: 1\n",
+    "    traffic: 75\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/mock_classifier:{VERSION}\n",
+    "          imagePullPolicy: IfNotPresent\n",
+    "          name: classifier\n",
+    "        terminationGracePeriodSeconds: 1\n",
+    "    graph:\n",
+    "      children: []\n",
+    "      endpoint:\n",
+    "        type: REST\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: canary\n",
+    "    replicas: 1\n",
+    "    traffic: 25\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply\n",
+      "seldondeployment.machinelearning.seldon.io/example configured\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f canary.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for deployment \"example-canary-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
+      "deployment \"example-canary-0-classifier\" successfully rolled out\n",
+      "deployment \"example-main-0-classifier\" successfully rolled out\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl rollout status deploy/$(kubectl get deploy -l seldon-deployment-id=example -o jsonpath='{.items[0].metadata.name}')\n",
+    "!kubectl rollout status deploy/$(kubectl get deploy -l seldon-deployment-id=example -o jsonpath='{.items[1].metadata.name}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show our REST requests are now split with roughly 25% going to the canary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "Success:True message:\nRequest:\nmeta {\n}\ndata {\n  tensor {\n    shape: 1\n    shape: 1\n    values: 0.5754642896429739\n  }\n}\n\nResponse:\n{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.08776759944872958]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.7.0-dev'}}}"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.predict(gateway=\"istio\",transport=\"rest\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "counts = defaultdict(int)\n",
+    "n = 100\n",
+    "for i in range(n):\n",
+    "    r = sc.predict(gateway=\"istio\",transport=\"rest\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Following checks number of prediction requests processed by default/canary predictors respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_count=!kubectl logs $(kubectl get pod -lseldon-app=example-main -o jsonpath='{.items[0].metadata.name}') classifier | grep \"root:predict\" | wc -l "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "canary_count=!kubectl logs $(kubectl get pod -lseldon-app=example-canary -o jsonpath='{.items[0].metadata.name}') classifier | grep \"root:predict\" | wc -l"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.275\n"
+     ]
+    }
+   ],
+   "source": [
+    "canary_percentage=float(canary_count[0])/float(default_count[0])\n",
+    "print(canary_percentage)\n",
+    "assert(canary_percentage > 0.1 and canary_percentage < 0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seldondeployment.machinelearning.seldon.io \"example\" deleted\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl delete -f canary.yaml"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3.8.3 64-bit ('dev': conda)",
+   "name": "python38364bitdevcondad734a5316bae475dbcbd6c3c03e10753"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  },
+  "metadata": {
+   "interpreter": {
+    "hash": "1d7f5a1859618f76ef4cef58ee850bddcfabb7d38d6aca091ca78ca6bd037618"
+   }
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/istio/canary/istio_canary.ipynb
+++ b/examples/istio/canary/istio_canary.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Canary Rollout with Istio and Ambassador\n"
+    "# Canary Rollout with Seldon and Istio\n"
    ]
   },
   {

--- a/notebooks/istio_example.ipynb
+++ b/notebooks/istio_example.ipynb
@@ -29,7 +29,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error from server (AlreadyExists): namespaces \"seldon\" already exists\r\n"
+      "namespace/seldon created\r\n"
      ]
     }
    ],
@@ -113,7 +113,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error from server (AlreadyExists): error when creating \"resources/seldon-gateway.yaml\": gateways.networking.istio.io \"seldon-gateway\" already exists\r\n"
+      "gateway.networking.istio.io/seldon-gateway created\r\n"
      ]
     }
    ],
@@ -151,7 +151,7 @@
     {
      "data": {
       "text/plain": [
-       "'1.5.0-dev'"
+       "'1.7.0-dev'"
       ]
      },
      "execution_count": 6,
@@ -191,7 +191,7 @@
      "output_type": "stream",
      "text": [
       "NAME: mymodel\r\n",
-      "LAST DEPLOYED: Mon Nov  2 11:26:51 2020\r\n",
+      "LAST DEPLOYED: Wed Mar 10 16:37:01 2021\r\n",
       "NAMESPACE: seldon\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -214,47 +214,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[04m\u001b[31;01m-\u001b[39;49;00m\u001b[04m\u001b[31;01m-\u001b[39;49;00m\u001b[04m\u001b[31;01m-\u001b[39;49;00m\r\n",
-      "\u001b[04m\u001b[31;01m#\u001b[39;49;00m \u001b[04m\u001b[31;01mS\u001b[39;49;00m\u001b[04m\u001b[31;01mo\u001b[39;49;00m\u001b[04m\u001b[31;01mu\u001b[39;49;00m\u001b[04m\u001b[31;01mr\u001b[39;49;00m\u001b[04m\u001b[31;01mc\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01m:\u001b[39;49;00m \u001b[04m\u001b[31;01ms\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01ml\u001b[39;49;00m\u001b[04m\u001b[31;01md\u001b[39;49;00m\u001b[04m\u001b[31;01mo\u001b[39;49;00m\u001b[04m\u001b[31;01mn\u001b[39;49;00m\u001b[04m\u001b[31;01m-\u001b[39;49;00m\u001b[04m\u001b[31;01ms\u001b[39;49;00m\u001b[04m\u001b[31;01mi\u001b[39;49;00m\u001b[04m\u001b[31;01mn\u001b[39;49;00m\u001b[04m\u001b[31;01mg\u001b[39;49;00m\u001b[04m\u001b[31;01ml\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01m-\u001b[39;49;00m\u001b[04m\u001b[31;01mm\u001b[39;49;00m\u001b[04m\u001b[31;01mo\u001b[39;49;00m\u001b[04m\u001b[31;01md\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01ml\u001b[39;49;00m\u001b[04m\u001b[31;01m/\u001b[39;49;00m\u001b[04m\u001b[31;01mt\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01mm\u001b[39;49;00m\u001b[04m\u001b[31;01mp\u001b[39;49;00m\u001b[04m\u001b[31;01ml\u001b[39;49;00m\u001b[04m\u001b[31;01ma\u001b[39;49;00m\u001b[04m\u001b[31;01mt\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01ms\u001b[39;49;00m\u001b[04m\u001b[31;01m/\u001b[39;49;00m\u001b[04m\u001b[31;01ms\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01ml\u001b[39;49;00m\u001b[04m\u001b[31;01md\u001b[39;49;00m\u001b[04m\u001b[31;01mo\u001b[39;49;00m\u001b[04m\u001b[31;01mn\u001b[39;49;00m\u001b[04m\u001b[31;01md\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01mp\u001b[39;49;00m\u001b[04m\u001b[31;01ml\u001b[39;49;00m\u001b[04m\u001b[31;01mo\u001b[39;49;00m\u001b[04m\u001b[31;01my\u001b[39;49;00m\u001b[04m\u001b[31;01mm\u001b[39;49;00m\u001b[04m\u001b[31;01me\u001b[39;49;00m\u001b[04m\u001b[31;01mn\u001b[39;49;00m\u001b[04m\u001b[31;01mt\u001b[39;49;00m\u001b[04m\u001b[31;01m.\u001b[39;49;00m\u001b[04m\u001b[31;01mj\u001b[39;49;00m\u001b[04m\u001b[31;01ms\u001b[39;49;00m\u001b[04m\u001b[31;01mo\u001b[39;49;00m\u001b[04m\u001b[31;01mn\u001b[39;49;00m\r\n",
+      "\u001b[04m\u001b[91m-\u001b[39;49;00m\u001b[04m\u001b[91m-\u001b[39;49;00m\u001b[04m\u001b[91m-\u001b[39;49;00m\r\n",
+      "\u001b[04m\u001b[91m#\u001b[39;49;00m \u001b[04m\u001b[91mS\u001b[39;49;00m\u001b[04m\u001b[91mo\u001b[39;49;00m\u001b[04m\u001b[91mu\u001b[39;49;00m\u001b[04m\u001b[91mr\u001b[39;49;00m\u001b[04m\u001b[91mc\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91m:\u001b[39;49;00m \u001b[04m\u001b[91ms\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91ml\u001b[39;49;00m\u001b[04m\u001b[91md\u001b[39;49;00m\u001b[04m\u001b[91mo\u001b[39;49;00m\u001b[04m\u001b[91mn\u001b[39;49;00m\u001b[04m\u001b[91m-\u001b[39;49;00m\u001b[04m\u001b[91ms\u001b[39;49;00m\u001b[04m\u001b[91mi\u001b[39;49;00m\u001b[04m\u001b[91mn\u001b[39;49;00m\u001b[04m\u001b[91mg\u001b[39;49;00m\u001b[04m\u001b[91ml\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91m-\u001b[39;49;00m\u001b[04m\u001b[91mm\u001b[39;49;00m\u001b[04m\u001b[91mo\u001b[39;49;00m\u001b[04m\u001b[91md\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91ml\u001b[39;49;00m\u001b[04m\u001b[91m/\u001b[39;49;00m\u001b[04m\u001b[91mt\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91mm\u001b[39;49;00m\u001b[04m\u001b[91mp\u001b[39;49;00m\u001b[04m\u001b[91ml\u001b[39;49;00m\u001b[04m\u001b[91ma\u001b[39;49;00m\u001b[04m\u001b[91mt\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91ms\u001b[39;49;00m\u001b[04m\u001b[91m/\u001b[39;49;00m\u001b[04m\u001b[91ms\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91ml\u001b[39;49;00m\u001b[04m\u001b[91md\u001b[39;49;00m\u001b[04m\u001b[91mo\u001b[39;49;00m\u001b[04m\u001b[91mn\u001b[39;49;00m\u001b[04m\u001b[91md\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91mp\u001b[39;49;00m\u001b[04m\u001b[91ml\u001b[39;49;00m\u001b[04m\u001b[91mo\u001b[39;49;00m\u001b[04m\u001b[91my\u001b[39;49;00m\u001b[04m\u001b[91mm\u001b[39;49;00m\u001b[04m\u001b[91me\u001b[39;49;00m\u001b[04m\u001b[91mn\u001b[39;49;00m\u001b[04m\u001b[91mt\u001b[39;49;00m\u001b[04m\u001b[91m.\u001b[39;49;00m\u001b[04m\u001b[91mj\u001b[39;49;00m\u001b[04m\u001b[91ms\u001b[39;49;00m\u001b[04m\u001b[91mo\u001b[39;49;00m\u001b[04m\u001b[91mn\u001b[39;49;00m\r\n",
       "{\r\n",
-      "  \u001b[34;01m\"kind\"\u001b[39;49;00m: \u001b[33m\"SeldonDeployment\"\u001b[39;49;00m,\r\n",
-      "  \u001b[34;01m\"apiVersion\"\u001b[39;49;00m: \u001b[33m\"machinelearning.seldon.io/v1\"\u001b[39;49;00m,\r\n",
-      "  \u001b[34;01m\"metadata\"\u001b[39;49;00m: {\r\n",
-      "    \u001b[34;01m\"name\"\u001b[39;49;00m: \u001b[33m\"mymodel\"\u001b[39;49;00m,\r\n",
-      "    \u001b[34;01m\"namespace\"\u001b[39;49;00m: \u001b[33m\"seldon\"\u001b[39;49;00m,\r\n",
-      "    \u001b[34;01m\"labels\"\u001b[39;49;00m: {}\r\n",
+      "  \u001b[94m\"kind\"\u001b[39;49;00m: \u001b[33m\"SeldonDeployment\"\u001b[39;49;00m,\r\n",
+      "  \u001b[94m\"apiVersion\"\u001b[39;49;00m: \u001b[33m\"machinelearning.seldon.io/v1\"\u001b[39;49;00m,\r\n",
+      "  \u001b[94m\"metadata\"\u001b[39;49;00m: {\r\n",
+      "    \u001b[94m\"name\"\u001b[39;49;00m: \u001b[33m\"mymodel\"\u001b[39;49;00m,\r\n",
+      "    \u001b[94m\"namespace\"\u001b[39;49;00m: \u001b[33m\"seldon\"\u001b[39;49;00m,\r\n",
+      "    \u001b[94m\"labels\"\u001b[39;49;00m: {}\r\n",
       "  },\r\n",
-      "  \u001b[34;01m\"spec\"\u001b[39;49;00m: {\r\n",
-      "      \u001b[34;01m\"name\"\u001b[39;49;00m: \u001b[33m\"mymodel\"\u001b[39;49;00m,\r\n",
-      "      \u001b[34;01m\"protocol\"\u001b[39;49;00m: \u001b[33m\"seldon\"\u001b[39;49;00m,\r\n",
-      "    \u001b[34;01m\"annotations\"\u001b[39;49;00m: {},\r\n",
-      "    \u001b[34;01m\"predictors\"\u001b[39;49;00m: [\r\n",
+      "  \u001b[94m\"spec\"\u001b[39;49;00m: {\r\n",
+      "      \u001b[94m\"name\"\u001b[39;49;00m: \u001b[33m\"mymodel\"\u001b[39;49;00m,\r\n",
+      "      \u001b[94m\"protocol\"\u001b[39;49;00m: \u001b[33m\"seldon\"\u001b[39;49;00m,\r\n",
+      "    \u001b[94m\"annotations\"\u001b[39;49;00m: {},\r\n",
+      "    \u001b[94m\"predictors\"\u001b[39;49;00m: [\r\n",
       "      {\r\n",
-      "        \u001b[34;01m\"name\"\u001b[39;49;00m: \u001b[33m\"default\"\u001b[39;49;00m,\r\n",
-      "        \u001b[34;01m\"graph\"\u001b[39;49;00m: {\r\n",
-      "          \u001b[34;01m\"name\"\u001b[39;49;00m: \u001b[33m\"model\"\u001b[39;49;00m,\r\n",
-      "          \u001b[34;01m\"type\"\u001b[39;49;00m: \u001b[33m\"MODEL\"\u001b[39;49;00m,\r\n",
+      "        \u001b[94m\"name\"\u001b[39;49;00m: \u001b[33m\"default\"\u001b[39;49;00m,\r\n",
+      "        \u001b[94m\"graph\"\u001b[39;49;00m: {\r\n",
+      "          \u001b[94m\"name\"\u001b[39;49;00m: \u001b[33m\"model\"\u001b[39;49;00m,\r\n",
+      "          \u001b[94m\"type\"\u001b[39;49;00m: \u001b[33m\"MODEL\"\u001b[39;49;00m,\r\n",
       "        },\r\n",
-      "        \u001b[34;01m\"componentSpecs\"\u001b[39;49;00m: [\r\n",
+      "        \u001b[94m\"componentSpecs\"\u001b[39;49;00m: [\r\n",
       "          {\r\n",
-      "            \u001b[34;01m\"spec\"\u001b[39;49;00m: {\r\n",
-      "              \u001b[34;01m\"containers\"\u001b[39;49;00m: [\r\n",
+      "            \u001b[94m\"spec\"\u001b[39;49;00m: {\r\n",
+      "              \u001b[94m\"containers\"\u001b[39;49;00m: [\r\n",
       "                {\r\n",
-      "                  \u001b[34;01m\"name\"\u001b[39;49;00m: \u001b[33m\"model\"\u001b[39;49;00m,\r\n",
-      "                  \u001b[34;01m\"image\"\u001b[39;49;00m: \u001b[33m\"seldonio/mock_classifier:1.5.0-dev\"\u001b[39;49;00m,\r\n",
-      "                  \u001b[34;01m\"env\"\u001b[39;49;00m: [\r\n",
+      "                  \u001b[94m\"name\"\u001b[39;49;00m: \u001b[33m\"model\"\u001b[39;49;00m,\r\n",
+      "                  \u001b[94m\"image\"\u001b[39;49;00m: \u001b[33m\"seldonio/mock_classifier:1.7.0-dev\"\u001b[39;49;00m,\r\n",
+      "                  \u001b[94m\"env\"\u001b[39;49;00m: [\r\n",
       "                      {\r\n",
-      "                        \u001b[34;01m\"name\"\u001b[39;49;00m: \u001b[33m\"LOG_LEVEL\"\u001b[39;49;00m,\r\n",
-      "                        \u001b[34;01m\"value\"\u001b[39;49;00m: \u001b[33m\"INFO\"\u001b[39;49;00m\r\n",
+      "                        \u001b[94m\"name\"\u001b[39;49;00m: \u001b[33m\"LOG_LEVEL\"\u001b[39;49;00m,\r\n",
+      "                        \u001b[94m\"value\"\u001b[39;49;00m: \u001b[33m\"INFO\"\u001b[39;49;00m\r\n",
       "                      },\r\n",
       "                    ],\r\n",
-      "                  \u001b[34;01m\"resources\"\u001b[39;49;00m: {\u001b[34;01m\"requests\"\u001b[39;49;00m:{\u001b[34;01m\"memory\"\u001b[39;49;00m:\u001b[33m\"1Mi\"\u001b[39;49;00m}},\r\n",
+      "                  \u001b[94m\"resources\"\u001b[39;49;00m: {\u001b[94m\"requests\"\u001b[39;49;00m:{\u001b[94m\"memory\"\u001b[39;49;00m:\u001b[33m\"1Mi\"\u001b[39;49;00m}},\r\n",
       "                }\r\n",
       "              ]\r\n",
       "            },\r\n",
       "          }\r\n",
       "        ],\r\n",
-      "        \u001b[34;01m\"replicas\"\u001b[39;49;00m: \u001b[34m1\u001b[39;49;00m\r\n",
+      "        \u001b[94m\"replicas\"\u001b[39;49;00m: \u001b[34m1\u001b[39;49;00m\r\n",
       "      }\r\n",
       "    ]\r\n",
       "  }\r\n",
@@ -331,12 +331,12 @@
       "  tensor {\n",
       "    shape: 1\n",
       "    shape: 1\n",
-      "    values: 0.7700289654241149\n",
+      "    values: 0.721679221744617\n",
       "  }\n",
       "}\n",
       "\n",
       "Response:\n",
-      "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.10464583547528208]}}, 'meta': {}}\n"
+      "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.1002015221659356]}}, 'meta': {'requestPath': {'model': 'seldonio/mock_classifier:1.7.0-dev'}}}\n"
      ]
     }
    ],
@@ -364,9 +364,9 @@
      "text": [
       "Success:True message:\n",
       "Request:\n",
-      "{'meta': {}, 'data': {'tensor': {'shape': [1, 1], 'values': [0.12757803284172686]}}}\n",
+      "{'meta': {}, 'data': {'tensor': {'shape': [1, 1], 'values': [0.17825624441824628]}}}\n",
       "Response:\n",
-      "{'meta': {}, 'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.05791666150083342]}}}\n"
+      "{'meta': {'requestPath': {'model': 'seldonio/mock_classifier:1.7.0-dev'}}, 'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.06074453279395597]}}}\n"
      ]
     }
    ],
@@ -394,13 +394,6 @@
    "source": [
     "!helm delete mymodel"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -420,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.3"
   },
   "varInspector": {
    "cols": {

--- a/notebooks/seldon_core_setup.ipynb
+++ b/notebooks/seldon_core_setup.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "### Istio\n",
     "\n",
-    "[Istio install](https://docs.seldon.io/projects/seldon-core/en/latest/workflow/install.html#install-istio-ingress-gateway)\n",
+    "[Istio install](https://docs.seldon.io/projects/seldon-core/en/latest/workflow/install.html#ingress-support)\n",
     "\n",
     "**Note:** Remember to add ```--set istio.enabled=true``` flag when installing Seldon Core with Istio Ingress."
    ]
@@ -205,9 +205,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "display_name": "Python 3.8.3 64-bit",
+   "name": "python38364bitdevcondad734a5316bae475dbcbd6c3c03e10753"
   },
   "language_info": {
    "codemirror_mode": {
@@ -219,7 +218,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.3-final"
+  },
+  "metadata": {
+   "interpreter": {
+    "hash": "1d7f5a1859618f76ef4cef58ee850bddcfabb7d38d6aca091ca78ca6bd037618"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Within the Istio docs, this PR:

1. Updates instances of `helm install` in the docs to be compatible with Helm v3 (the `--name foo` option for Helm release names is no longer supported in Helm v3 and the release name is now a positional argument).
2. Removes a broken link to `./examples/istio_canary.html`
3. Regenerates the Istio Jupyter notebook to remove minor errors that are shown here: https://docs.seldon.io/projects/seldon-core/en/v1.6.0/examples/istio_examples.html (the outputs for cells `[1]` and `[4]`)

@cliveseldon, for reference the original discussion on Slack was here: https://seldondev.slack.com/archives/CSVSD5S75/p1610047087283500?thread_ts=1609611010.277400&cid=CSVSD5S75

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

