### PR TITLE
Fix nil pointer dereference panics in mlserver

### DIFF
--- a/operator/controllers/mlserver.go
+++ b/operator/controllers/mlserver.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -22,6 +23,13 @@ const (
 )
 
 func mergeMLServerContainer(existing *v1.Container, mlServer *v1.Container) *v1.Container {
+	if mlServer == nil {
+		// Nothing to merge.
+		return existing
+	}
+	if existing == nil {
+		existing = &v1.Container{}
+	}
 	// Overwrite core items if not existing or required
 	if existing.Image == "" {
 		existing.Image = mlServer.Image
@@ -58,6 +66,9 @@ func mergeMLServerContainer(existing *v1.Container, mlServer *v1.Container) *v1.
 }
 
 func getMLServerContainer(pu *machinelearningv1.PredictiveUnit) (*v1.Container, error) {
+	if pu == nil {
+		return nil, errors.New("received nil predictive unit")
+	}
 	image, err := getMLServerImage(pu)
 	if err != nil {
 		return nil, err
@@ -126,6 +137,9 @@ func getMLServerContainer(pu *machinelearningv1.PredictiveUnit) (*v1.Container, 
 }
 
 func getMLServerImage(pu *machinelearningv1.PredictiveUnit) (string, error) {
+	if pu == nil {
+		return "", errors.New("received nil predictive unit")
+	}
 	prepackConfig := machinelearningv1.GetPrepackServerConfig(string(*pu.Implementation))
 	if prepackConfig == nil {
 		return "", fmt.Errorf("failed to get server config for %s", *pu.Implementation)
@@ -146,6 +160,9 @@ func getMLServerImage(pu *machinelearningv1.PredictiveUnit) (string, error) {
 }
 
 func getMLServerEnvVars(pu *machinelearningv1.PredictiveUnit) ([]v1.EnvVar, error) {
+	if pu == nil {
+		return nil, errors.New("received nil predictive unit")
+	}
 	httpPort := pu.Endpoint.HttpPort
 	grpcPort := pu.Endpoint.GrpcPort
 
@@ -184,6 +201,9 @@ func getMLServerEnvVars(pu *machinelearningv1.PredictiveUnit) ([]v1.EnvVar, erro
 }
 
 func getMLServerModelImplementation(pu *machinelearningv1.PredictiveUnit) (string, error) {
+	if pu == nil {
+		return "", errors.New("received nil predictive unit")
+	}
 	switch *pu.Implementation {
 	case machinelearningv1.PrepackSklearnName:
 		return MLServerSKLearnImplementation, nil

--- a/operator/controllers/mlserver_test.go
+++ b/operator/controllers/mlserver_test.go
@@ -47,6 +47,7 @@ var _ = Describe("MLServer helpers", func() {
 		It("should merge containers adding extra env", func() {
 			merged := mergeMLServerContainer(existing, mlServer)
 
+			Expect(merged).ToNot(BeNil())
 			Expect(merged.Env).To(ContainElement(v1.EnvVar{Name: "FOO", Value: "BAR"}))
 			Expect(merged.Env).To(ContainElements(mlServer.Env))
 			Expect(merged.Image).To(Equal(mlServer.Image))


### PR DESCRIPTION
Fixes https://github.com/SeldonIO/seldon-core/issues/2904

The panics in https://github.com/SeldonIO/seldon-core/issues/2904 are caused by nil pointer dereference of `*machinelearningv1.PredictiveUnit` in `getMLServerImage`. I found this out by running the tests with `-count=20` to trigger the flakiness and followed the logs. In general we should be checking for nil pointer dereference issues before using a pointer that can be nil - this is a panic waiting to happen :D There are linters that can check for this - I will look into adding some to the repo.