### PR TITLE
Fix jx pipeline "release"

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -32,11 +32,11 @@ spec:
             name: jenkins-docker-config-volume
           resources:
             requests:
-              cpu: 1
+              cpu: 2
               memory: 2000Mi
               ephemeral-storage: "60Gi"
             limits:
-              cpu: 1
+              cpu: 2
               memory: 2000Mi
               ephemeral-storage: "60Gi"
           securityContext:

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -32,12 +32,12 @@ spec:
             name: jenkins-docker-config-volume
           resources:
             requests:
-              cpu: 2
-              memory: 2000Mi
+              cpu: 1
+              memory: 3000Mi
               ephemeral-storage: "60Gi"
             limits:
-              cpu: 2
-              memory: 2000Mi
+              cpu: 1
+              memory: 3000Mi
               ephemeral-storage: "60Gi"
           securityContext:
             privileged: true


### PR DESCRIPTION
Currently executor build is failing due to not enough cores, so increasing the number of cores of release pipeline to 2

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

