### PR TITLE
Added prometheus port to avoid the scraping of port 6443

### DIFF
--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
+        promethues.io/port: '8080'
         sidecar.istio.io/inject: 'false'
       labels:
         app: seldon

--- a/operator/config/default/manager_prometheus_metrics_patch.yaml
+++ b/operator/config/default/manager_prometheus_metrics_patch.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
+        promethues.io/port: '8080'
     spec:
       containers:
       # Expose the prometheus metrics on default port

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -876,6 +876,7 @@ func createDeploymentWithoutEngine(depName string, seldonId string, seldonPodSpe
 	// Add prometheus annotations
 	deploy.Spec.Template.Annotations["prometheus.io/path"] = getPrometheusPath(mlDep)
 	deploy.Spec.Template.Annotations["prometheus.io/scrape"] = "true"
+	deploy.Spec.Template.Annotations["prometheus.io/port"] = "8080"
 
 	if p.Shadow == true {
 		deploy.Spec.Template.ObjectMeta.Labels[machinelearningv1.Label_shadow] = "true"

--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -493,7 +493,7 @@ func createEngineDeployment(mlDep *machinelearningv1.SeldonDeployment, p *machin
 					Labels: map[string]string{machinelearningv1.Label_seldon_app: seldonId, machinelearningv1.Label_seldon_id: seldonId, "app": depName},
 					Annotations: map[string]string{
 						"prometheus.io/path": getPrometheusPath(mlDep),
-						// "prometheus.io/port":   strconv.Itoa(engine_http_port),
+						"prometheus.io/port": strconv.Itoa(engine_http_port),
 						"prometheus.io/scrape": "true",
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

I need this to prevent Prometheus from scraping port 6443.

You can see an example of the problem from the screenshots attached to this ticket #2860 

**Which issue(s) this PR fixes**:
None directly, address partially the aforementioned issue.

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

