### PR TITLE
fix kustomize patch to include storageInitializerImage in the CRD

### DIFF
--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -4089,6 +4089,8 @@ spec:
                                                 type: array
                                               serviceAccountName:
                                                 type: string
+                                              storageInitializerImage:
+                                                type: string
                                               type:
                                                 type: string
                                             type: object
@@ -4143,6 +4145,8 @@ spec:
                                             type: object
                                           type: array
                                         serviceAccountName:
+                                          type: string
+                                        storageInitializerImage:
                                           type: string
                                         type:
                                           type: string
@@ -4199,6 +4203,8 @@ spec:
                                     type: array
                                   serviceAccountName:
                                     type: string
+                                  storageInitializerImage:
+                                    type: string
                                   type:
                                     type: string
                                 type: object
@@ -4253,6 +4259,8 @@ spec:
                                 type: object
                               type: array
                             serviceAccountName:
+                              type: string
+                            storageInitializerImage:
                               type: string
                             type:
                               type: string

--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
@@ -4974,6 +4974,8 @@ spec:
                                                                                       type: array
                                                                                     serviceAccountName:
                                                                                       type: string
+                                                                                    storageInitializerImage:
+                                                                                      type: string
                                                                                     type:
                                                                                       type: string
                                                                                   required:
@@ -5034,6 +5036,8 @@ spec:
                                                                                   type: object
                                                                                 type: array
                                                                               serviceAccountName:
+                                                                                type: string
+                                                                              storageInitializerImage:
                                                                                 type: string
                                                                               type:
                                                                                 type: string
@@ -5096,6 +5100,8 @@ spec:
                                                                           type: array
                                                                         serviceAccountName:
                                                                           type: string
+                                                                        storageInitializerImage:
+                                                                          type: string
                                                                         type:
                                                                           type: string
                                                                       required:
@@ -5156,6 +5162,8 @@ spec:
                                                                       type: object
                                                                     type: array
                                                                   serviceAccountName:
+                                                                    type: string
+                                                                  storageInitializerImage:
                                                                     type: string
                                                                   type:
                                                                     type: string
@@ -5218,6 +5226,8 @@ spec:
                                                               type: array
                                                             serviceAccountName:
                                                               type: string
+                                                            storageInitializerImage:
+                                                              type: string
                                                             type:
                                                               type: string
                                                           required:
@@ -5278,6 +5288,8 @@ spec:
                                                           type: object
                                                         type: array
                                                       serviceAccountName:
+                                                        type: string
+                                                      storageInitializerImage:
                                                         type: string
                                                       type:
                                                         type: string
@@ -5340,6 +5352,8 @@ spec:
                                                   type: array
                                                 serviceAccountName:
                                                   type: string
+                                                storageInitializerImage:
+                                                  type: string
                                                 type:
                                                   type: string
                                               required:
@@ -5400,6 +5414,8 @@ spec:
                                               type: object
                                             type: array
                                           serviceAccountName:
+                                            type: string
+                                          storageInitializerImage:
                                             type: string
                                           type:
                                             type: string
@@ -5462,6 +5478,8 @@ spec:
                                       type: array
                                     serviceAccountName:
                                       type: string
+                                    storageInitializerImage:
+                                      type: string
                                     type:
                                       type: string
                                   required:
@@ -5523,6 +5541,8 @@ spec:
                                 type: array
                               serviceAccountName:
                                 type: string
+                              storageInitializerImage:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -5583,6 +5603,8 @@ spec:
                             type: object
                           type: array
                         serviceAccountName:
+                          type: string
+                        storageInitializerImage:
                           type: string
                         type:
                           type: string
@@ -10744,6 +10766,8 @@ spec:
                                                                                       type: array
                                                                                     serviceAccountName:
                                                                                       type: string
+                                                                                    storageInitializerImage:
+                                                                                      type: string
                                                                                     type:
                                                                                       type: string
                                                                                   required:
@@ -10804,6 +10828,8 @@ spec:
                                                                                   type: object
                                                                                 type: array
                                                                               serviceAccountName:
+                                                                                type: string
+                                                                              storageInitializerImage:
                                                                                 type: string
                                                                               type:
                                                                                 type: string
@@ -10866,6 +10892,8 @@ spec:
                                                                           type: array
                                                                         serviceAccountName:
                                                                           type: string
+                                                                        storageInitializerImage:
+                                                                          type: string
                                                                         type:
                                                                           type: string
                                                                       required:
@@ -10926,6 +10954,8 @@ spec:
                                                                       type: object
                                                                     type: array
                                                                   serviceAccountName:
+                                                                    type: string
+                                                                  storageInitializerImage:
                                                                     type: string
                                                                   type:
                                                                     type: string
@@ -10988,6 +11018,8 @@ spec:
                                                               type: array
                                                             serviceAccountName:
                                                               type: string
+                                                            storageInitializerImage:
+                                                              type: string
                                                             type:
                                                               type: string
                                                           required:
@@ -11048,6 +11080,8 @@ spec:
                                                           type: object
                                                         type: array
                                                       serviceAccountName:
+                                                        type: string
+                                                      storageInitializerImage:
                                                         type: string
                                                       type:
                                                         type: string
@@ -11110,6 +11144,8 @@ spec:
                                                   type: array
                                                 serviceAccountName:
                                                   type: string
+                                                storageInitializerImage:
+                                                  type: string
                                                 type:
                                                   type: string
                                               required:
@@ -11170,6 +11206,8 @@ spec:
                                               type: object
                                             type: array
                                           serviceAccountName:
+                                            type: string
+                                          storageInitializerImage:
                                             type: string
                                           type:
                                             type: string
@@ -11232,6 +11270,8 @@ spec:
                                       type: array
                                     serviceAccountName:
                                       type: string
+                                    storageInitializerImage:
+                                      type: string
                                     type:
                                       type: string
                                   required:
@@ -11293,6 +11333,8 @@ spec:
                                 type: array
                               serviceAccountName:
                                 type: string
+                              storageInitializerImage:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -11353,6 +11395,8 @@ spec:
                             type: object
                           type: array
                         serviceAccountName:
+                          type: string
+                        storageInitializerImage:
                           type: string
                         type:
                           type: string
@@ -16514,6 +16558,8 @@ spec:
                                                                                       type: array
                                                                                     serviceAccountName:
                                                                                       type: string
+                                                                                    storageInitializerImage:
+                                                                                      type: string
                                                                                     type:
                                                                                       type: string
                                                                                   required:
@@ -16574,6 +16620,8 @@ spec:
                                                                                   type: object
                                                                                 type: array
                                                                               serviceAccountName:
+                                                                                type: string
+                                                                              storageInitializerImage:
                                                                                 type: string
                                                                               type:
                                                                                 type: string
@@ -16636,6 +16684,8 @@ spec:
                                                                           type: array
                                                                         serviceAccountName:
                                                                           type: string
+                                                                        storageInitializerImage:
+                                                                          type: string
                                                                         type:
                                                                           type: string
                                                                       required:
@@ -16696,6 +16746,8 @@ spec:
                                                                       type: object
                                                                     type: array
                                                                   serviceAccountName:
+                                                                    type: string
+                                                                  storageInitializerImage:
                                                                     type: string
                                                                   type:
                                                                     type: string
@@ -16758,6 +16810,8 @@ spec:
                                                               type: array
                                                             serviceAccountName:
                                                               type: string
+                                                            storageInitializerImage:
+                                                              type: string
                                                             type:
                                                               type: string
                                                           required:
@@ -16818,6 +16872,8 @@ spec:
                                                           type: object
                                                         type: array
                                                       serviceAccountName:
+                                                        type: string
+                                                      storageInitializerImage:
                                                         type: string
                                                       type:
                                                         type: string
@@ -16880,6 +16936,8 @@ spec:
                                                   type: array
                                                 serviceAccountName:
                                                   type: string
+                                                storageInitializerImage:
+                                                  type: string
                                                 type:
                                                   type: string
                                               required:
@@ -16940,6 +16998,8 @@ spec:
                                               type: object
                                             type: array
                                           serviceAccountName:
+                                            type: string
+                                          storageInitializerImage:
                                             type: string
                                           type:
                                             type: string
@@ -17002,6 +17062,8 @@ spec:
                                       type: array
                                     serviceAccountName:
                                       type: string
+                                    storageInitializerImage:
+                                      type: string
                                     type:
                                       type: string
                                   required:
@@ -17063,6 +17125,8 @@ spec:
                                 type: array
                               serviceAccountName:
                                 type: string
+                              storageInitializerImage:
+                                type: string
                               type:
                                 type: string
                             required:
@@ -17123,6 +17187,8 @@ spec:
                             type: object
                           type: array
                         serviceAccountName:
+                          type: string
+                        storageInitializerImage:
                           type: string
                         type:
                           type: string

--- a/helm-charts/seldon-core-operator/templates/webhook.yaml
+++ b/helm-charts/seldon-core-operator/templates/webhook.yaml
@@ -4,6 +4,20 @@
 {{- $cert := genSignedCert "seldon-webhook-service" nil $altNames 365 $ca -}}
 ---
 
+{{- if not .Values.certManager.enabled -}}
+apiVersion: v1
+data:
+  ca.crt: '{{ $ca.Cert | b64enc }}'
+  tls.crt: '{{ $cert.Cert | b64enc }}'
+  tls.key: '{{ $cert.Key | b64enc }}'
+kind: Secret
+metadata:
+  name: seldon-webhook-server-cert
+  namespace: '{{ include "seldon.namespace" . }}'
+type: kubernetes.io/tls
+{{- end }}
+---
+
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -170,19 +184,5 @@ webhooks:
     resources:
     - seldondeployments
   sideEffects: None
----
-
-{{- if not .Values.certManager.enabled -}}
-apiVersion: v1
-data:
-  ca.crt: '{{ $ca.Cert | b64enc }}'
-  tls.crt: '{{ $cert.Cert | b64enc }}'
-  tls.key: '{{ $cert.Key | b64enc }}'
-kind: Secret
-metadata:
-  name: seldon-webhook-server-cert
-  namespace: '{{ include "seldon.namespace" . }}'
-type: kubernetes.io/tls
-{{- end }}
 
 {{- end }}

--- a/notebooks/explainer_examples.ipynb
+++ b/notebooks/explainer_examples.ipynb
@@ -95,7 +95,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Context \"gke_seldon-demos_europe-west1-d_gtc\" modified.\r\n"
+      "Context \"gke_seldon-demos_europe-west1-d_gtc\" modified.\n"
      ]
     }
    ],
@@ -1577,13 +1577,14 @@
     }
    ],
    "source": [
-    "decoded_features = decode_data(data, explanation.feature_names, explanation.categorical_names)\n",
-    "shap.force_plot(\n",
-    "        explanation.expected_value[0], # 0 is a class index but we have single-output model\n",
-    "        explanation.shap_values[0] , \n",
-    "        decoded_features,  \n",
-    "        explanation.feature_names,\n",
-    ")"
+    "if explanation is not None:\n",
+    "    decoded_features = decode_data(data, explanation.feature_names, explanation.categorical_names)\n",
+    "    shap.force_plot(\n",
+    "            explanation.expected_value[0], # 0 is a class index but we have single-output model\n",
+    "            explanation.shap_values[0],\n",
+    "            decoded_features,\n",
+    "            explanation.feature_names,\n",
+    "    )"
    ]
   },
   {
@@ -1613,7 +1614,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.9"
   },
   "varInspector": {
    "cols": {

--- a/operator/config/crd/patches/graph_children.yaml
+++ b/operator/config/crd/patches/graph_children.yaml
@@ -23,7 +23,7 @@ spec:
                   graph:
                     properties:
                       children:
-                        type: array                        
+                        type: array
                         items:
                           properties:
                             children:
@@ -54,6 +54,8 @@ spec:
                                                   type:
                                                     type: string
                                                 type: object
+                                              storageInitializerImage:
+                                                type: string
                                               envSecretRefName:
                                                 type: string
                                               implementation:
@@ -110,6 +112,8 @@ spec:
                                             type:
                                               type: string
                                           type: object
+                                        storageInitializerImage:
+                                          type: string
                                         envSecretRefName:
                                           type: string
                                         implementation:
@@ -166,6 +170,8 @@ spec:
                                       type:
                                         type: string
                                     type: object
+                                  storageInitializerImage:
+                                    type: string
                                   envSecretRefName:
                                     type: string
                                   implementation:
@@ -222,6 +228,8 @@ spec:
                                 type:
                                   type: string
                               type: object
+                            storageInitializerImage:
+                              type: string
                             envSecretRefName:
                               type: string
                             implementation:
@@ -269,7 +277,7 @@ spec:
                             type: integer
                           httpPort:
                             format: int32
-                            type: integer                          
+                            type: integer
                           service_host:
                             type: string
                           service_port:
@@ -278,6 +286,8 @@ spec:
                           type:
                             type: string
                         type: object
+                      storageInitializerImage:
+                        type: string
                       envSecretRefName:
                         type: string
                       implementation:
@@ -316,5 +326,5 @@ spec:
                           url:
                             description: URL to send request logging CloudEvents
                             type: string
-                        type: object                        
+                        type: object
                     type: object

--- a/operator/config/crd_v1/patches/graph_children.yaml
+++ b/operator/config/crd_v1/patches/graph_children.yaml
@@ -48,6 +48,8 @@
                                                                       type:
                                                                         type: string
                                                                     type: object
+                                                                  storageInitializerImage:
+                                                                    type: string
                                                                   envSecretRefName:
                                                                     type: string
                                                                   implementation:
@@ -109,6 +111,8 @@
                                                                 type:
                                                                   type: string
                                                               type: object
+                                                            storageInitializerImage:
+                                                              type: string
                                                             envSecretRefName:
                                                               type: string
                                                             implementation:
@@ -170,6 +174,8 @@
                                                           type:
                                                             type: string
                                                         type: object
+                                                      storageInitializerImage:
+                                                        type: string
                                                       envSecretRefName:
                                                         type: string
                                                       implementation:
@@ -231,6 +237,8 @@
                                                     type:
                                                       type: string
                                                   type: object
+                                                storageInitializerImage:
+                                                  type: string
                                                 envSecretRefName:
                                                   type: string
                                                 implementation:
@@ -292,6 +300,8 @@
                                               type:
                                                 type: string
                                             type: object
+                                          storageInitializerImage:
+                                            type: string
                                           envSecretRefName:
                                             type: string
                                           implementation:
@@ -353,6 +363,8 @@
                                         type:
                                           type: string
                                       type: object
+                                    storageInitializerImage:
+                                      type: string
                                     envSecretRefName:
                                       type: string
                                     implementation:
@@ -414,6 +426,8 @@
                                   type:
                                     type: string
                                 type: object
+                              storageInitializerImage:
+                                type: string
                               envSecretRefName:
                                 type: string
                               implementation:
@@ -475,6 +489,8 @@
                             type:
                               type: string
                           type: object
+                        storageInitializerImage:
+                          type: string
                         envSecretRefName:
                           type: string
                         implementation:
@@ -536,6 +552,8 @@
                       type:
                         type: string
                     type: object
+                  storageInitializerImage:
+                    type: string
                   envSecretRefName:
                     type: string
                   implementation:
@@ -597,6 +615,8 @@
                 type:
                   type: string
               type: object
+            storageInitializerImage:
+              type: string
             envSecretRefName:
               type: string
             implementation:
@@ -658,6 +678,8 @@
           type:
             type: string
         type: object
+      storageInitializerImage:
+        type: string
       envSecretRefName:
         type: string
       implementation:
@@ -752,6 +774,8 @@
                                                                       type:
                                                                         type: string
                                                                     type: object
+                                                                  storageInitializerImage:
+                                                                    type: string
                                                                   envSecretRefName:
                                                                     type: string
                                                                   implementation:
@@ -813,6 +837,8 @@
                                                                 type:
                                                                   type: string
                                                               type: object
+                                                            storageInitializerImage:
+                                                              type: string
                                                             envSecretRefName:
                                                               type: string
                                                             implementation:
@@ -874,6 +900,8 @@
                                                           type:
                                                             type: string
                                                         type: object
+                                                      storageInitializerImage:
+                                                        type: string
                                                       envSecretRefName:
                                                         type: string
                                                       implementation:
@@ -935,6 +963,8 @@
                                                     type:
                                                       type: string
                                                   type: object
+                                                storageInitializerImage:
+                                                  type: string
                                                 envSecretRefName:
                                                   type: string
                                                 implementation:
@@ -996,6 +1026,8 @@
                                               type:
                                                 type: string
                                             type: object
+                                          storageInitializerImage:
+                                            type: string
                                           envSecretRefName:
                                             type: string
                                           implementation:
@@ -1057,6 +1089,8 @@
                                         type:
                                           type: string
                                       type: object
+                                    storageInitializerImage:
+                                      type: string
                                     envSecretRefName:
                                       type: string
                                     implementation:
@@ -1118,6 +1152,8 @@
                                   type:
                                     type: string
                                 type: object
+                              storageInitializerImage:
+                                type: string
                               envSecretRefName:
                                 type: string
                               implementation:
@@ -1179,6 +1215,8 @@
                             type:
                               type: string
                           type: object
+                        storageInitializerImage:
+                          type: string
                         envSecretRefName:
                           type: string
                         implementation:
@@ -1240,6 +1278,8 @@
                       type:
                         type: string
                     type: object
+                  storageInitializerImage:
+                    type: string
                   envSecretRefName:
                     type: string
                   implementation:
@@ -1301,6 +1341,8 @@
                 type:
                   type: string
               type: object
+            storageInitializerImage:
+              type: string
             envSecretRefName:
               type: string
             implementation:
@@ -1362,6 +1404,8 @@
           type:
             type: string
         type: object
+      storageInitializerImage:
+        type: string
       envSecretRefName:
         type: string
       implementation:
@@ -1456,6 +1500,8 @@
                                                                       type:
                                                                         type: string
                                                                     type: object
+                                                                  storageInitializerImage:
+                                                                    type: string
                                                                   envSecretRefName:
                                                                     type: string
                                                                   implementation:
@@ -1517,6 +1563,8 @@
                                                                 type:
                                                                   type: string
                                                               type: object
+                                                            storageInitializerImage:
+                                                              type: string
                                                             envSecretRefName:
                                                               type: string
                                                             implementation:
@@ -1578,6 +1626,8 @@
                                                           type:
                                                             type: string
                                                         type: object
+                                                      storageInitializerImage:
+                                                        type: string
                                                       envSecretRefName:
                                                         type: string
                                                       implementation:
@@ -1639,6 +1689,8 @@
                                                     type:
                                                       type: string
                                                   type: object
+                                                storageInitializerImage:
+                                                  type: string
                                                 envSecretRefName:
                                                   type: string
                                                 implementation:
@@ -1700,6 +1752,8 @@
                                               type:
                                                 type: string
                                             type: object
+                                          storageInitializerImage:
+                                            type: string
                                           envSecretRefName:
                                             type: string
                                           implementation:
@@ -1761,6 +1815,8 @@
                                         type:
                                           type: string
                                       type: object
+                                    storageInitializerImage:
+                                      type: string
                                     envSecretRefName:
                                       type: string
                                     implementation:
@@ -1822,6 +1878,8 @@
                                   type:
                                     type: string
                                 type: object
+                              storageInitializerImage:
+                                type: string
                               envSecretRefName:
                                 type: string
                               implementation:
@@ -1883,6 +1941,8 @@
                             type:
                               type: string
                           type: object
+                        storageInitializerImage:
+                          type: string
                         envSecretRefName:
                           type: string
                         implementation:
@@ -1944,6 +2004,8 @@
                       type:
                         type: string
                     type: object
+                  storageInitializerImage:
+                    type: string
                   envSecretRefName:
                     type: string
                   implementation:
@@ -2005,6 +2067,8 @@
                 type:
                   type: string
               type: object
+            storageInitializerImage:
+              type: string
             envSecretRefName:
               type: string
             implementation:
@@ -2066,6 +2130,8 @@
           type:
             type: string
         type: object
+      storageInitializerImage:
+        type: string
       envSecretRefName:
         type: string
       implementation:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Updating `graph` part of the CRD requires modifying the kustomize patch. 
This was forgotten when CRD was extended to allow for `storageInitializerImage` being defined there. 


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/SeldonIO/seldon-core/issues/3087

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

