### PR TITLE
Revert "Bump urllib3 from 1.25.9 to 1.26.4 in /python"

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -45,7 +45,7 @@ setup(
         # Addresses CVE PRISMA-2021-0020
         "click >= 8.0.0a1, < 8.1",
         # Addresses CVE CVE-2019-11236 and CVE-2020-26137
-        "urllib3 == 1.26.4",
+        "urllib3 == 1.25.9",
     ],
     extras_require=extras,
     entry_points={


### PR DESCRIPTION
Reverts SeldonIO/seldon-core#3082 to remove upgrade to `urllib3` which clashes with `requests`. 