### PR TITLE
Allow nil graph TYPE

### DIFF
--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook.go
@@ -80,7 +80,7 @@ func (r *SeldonDeploymentSpec) checkPredictiveUnits(pu *PredictiveUnit, p *Predi
 			allErrs = append(allErrs, field.Invalid(fldPath, pu.Name, "Can't find container for Predictive Unit"))
 		}
 
-		if *pu.Type == UNKNOWN_TYPE && (pu.Methods == nil || len(*pu.Methods) == 0) {
+		if pu.Type != nil && *pu.Type == UNKNOWN_TYPE && (pu.Methods == nil || len(*pu.Methods) == 0) {
 			allErrs = append(allErrs, field.Invalid(fldPath, pu.Name, "Predictive Unit has no implementation methods defined. Change to a known type or add what methods it defines"))
 		}
 

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_webhook_test.go
@@ -50,6 +50,38 @@ func TestValidProtocolTransportServerType(t *testing.T) {
 	g.Expect(err).To(BeNil())
 }
 
+func TestNoGraphType(t *testing.T) {
+	g := NewGomegaWithT(t)
+	spec := &SeldonDeploymentSpec{
+		ServerType: ServerRPC,
+		Protocol:   ProtocolTensorflow,
+		Transport:  TransportGrpc,
+		Predictors: []PredictorSpec{
+			{
+				Name: "p1",
+				ComponentSpecs: []*SeldonPodSpec{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Image: "seldonio/mock_classifier:1.0",
+									Name:  "classifier",
+								},
+							},
+						},
+					},
+				},
+				Graph: PredictiveUnit{
+					Name: "classifier",
+				},
+			},
+		},
+	}
+
+	err := spec.ValidateSeldonDeployment()
+	g.Expect(err).To(BeNil())
+}
+
 func createScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

 * Allow predictiveUnit Type to be missing. Previously when we had a MutatingWebhook this was defaulted so no check for nil was necessary.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3105

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

