### PR TITLE
mlflow example fix & image change: do not use editable install of SC for s2i wrapper

### DIFF
--- a/doc/source/servers/mlflow.md
+++ b/doc/source/servers/mlflow.md
@@ -12,7 +12,7 @@ To use the built-in MLflow server the following pre-requisites need to be met:
 
 - Your [MLmodel artifact
   folder](https://www.mlflow.org/docs/latest/models.html) needs to be
-  accessible remotely (e.g. as `gs://seldon-models/mlflow/elasticnet_wine`).
+  accessible remotely (e.g. as `gs://seldon-models/mlflow/elasticnet_wine_1.8.0`).
 - Your model needs to be compatible with the [python_function
   flavour](https://www.mlflow.org/docs/latest/models.html#python-function-python-function).
 - Your `MLproject` environment needs to be specified using Conda.
@@ -46,7 +46,7 @@ spec:
     - graph:
         children: []
         implementation: MLFLOW_SERVER
-        modelUri: gs://seldon-models/mlflow/elasticnet_wine
+        modelUri: gs://seldon-models/mlflow/elasticnet_wine_1.8.0
         name: classifier
       name: default
       replicas: 1
@@ -67,7 +67,7 @@ spec:
     - graph:
         children: []
         implementation: MLFLOW_SERVER
-        modelUri: gs://seldon-models/mlflow/elasticnet_wine
+        modelUri: gs://seldon-models/mlflow/elasticnet_wine_1.8.0
         name: classifier
         parameters:
         - name: xtype

--- a/examples/models/mlflow_server_ab_test_ambassador/mlflow_server_ab_test_ambassador.ipynb
+++ b/examples/models/mlflow_server_ab_test_ambassador/mlflow_server_ab_test_ambassador.ipynb
@@ -253,7 +253,7 @@
     "\n",
     "For this we have to create a Seldon definition of the model server definition, which we will break down further below.\n",
     "\n",
-    "We will be using the model we updated to our google bucket (gs://seldon-models/mlflow/elasticnet_wine), but you can use your model if you uploaded it to a public bucket."
+    "We will be using the model we updated to our google bucket (gs://seldon-models/mlflow/elasticnet_wine_1.8.0), but you can use your model if you uploaded it to a public bucket."
    ]
   },
   {

--- a/notebooks/server_examples.ipynb
+++ b/notebooks/server_examples.ipynb
@@ -2091,7 +2091,7 @@
     "    graph:\n",
     "      children: []\n",
     "      implementation: MLFLOW_SERVER\n",
-    "      modelUri: gs://seldon-models/mlflow/elasticnet_wine\n",
+    "      modelUri: gs://seldon-models/mlflow/elasticnet_wine_1.8.0\n",
     "      name: classifier\n",
     "    name: default\n",
     "    replicas: 1"

--- a/servers/mlflowserver/samples/elasticnet_wine.yaml
+++ b/servers/mlflowserver/samples/elasticnet_wine.yaml
@@ -32,7 +32,7 @@ spec:
     graph:
       children: []
       implementation: MLFLOW_SERVER
-      modelUri: gs://seldon-models/mlflow/elasticnet_wine
+      modelUri: gs://seldon-models/mlflow/elasticnet_wine_1.8.0
       name: classifier
     name: default
     replicas: 1

--- a/wrappers/s2i/python/Dockerfile.gpu
+++ b/wrappers/s2i/python/Dockerfile.gpu
@@ -41,7 +41,7 @@ COPY ./s2i/bin/ /s2i/bin
 # Install Seldon Core from local copy
 COPY _python /microservice
 COPY version.txt /microservice/version.txt
-RUN cd /microservice/python && make install
+RUN cd /microservice/python && pip install .
 
 RUN mkdir -p /.conda && chmod a+rwx /.conda
 

--- a/wrappers/s2i/python/Dockerfile.local
+++ b/wrappers/s2i/python/Dockerfile.local
@@ -20,7 +20,7 @@ COPY ./s2i/bin/ /s2i/bin
 # Install Seldon Core from local copy
 COPY _python /microservice
 COPY version.txt /microservice/version.txt
-RUN cd /microservice/python && make install
+RUN cd /microservice/python && pip install .
 
 RUN mkdir -p /.conda && chmod a+rwx /.conda
 

--- a/wrappers/s2i/python/Dockerfile.redhat
+++ b/wrappers/s2i/python/Dockerfile.redhat
@@ -19,7 +19,7 @@ COPY ./s2i/bin/ /s2i/bin
 
 # keep install of seldon-core after the COPY to force re-build of layer
 COPY _python /microservice
-RUN cd /microservice/python && make install
+RUN cd /microservice/python && pip install .
 COPY _python/python/licenses/license.txt .
 
 RUN mkdir -p /.conda && chmod a+rwx /.conda


### PR DESCRIPTION
Change default bucket for mlflow example. Closes https://github.com/SeldonIO/seldon-core/issues/3124

Modify s2i wrapper images such that Seldon Core is not installed in editable mode. 
This is required for compatibility with `conda-pack`.