### PR TITLE
Rclone as default storage initalizer

### DIFF
--- a/components/rclone-storage-initializer/Dockerfile
+++ b/components/rclone-storage-initializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rclone/rclone:1.54.0
+FROM rclone/rclone:1.55.1
 LABEL name="Storage Initializer (rclone based)" \
       vendor="Seldon Technologies" \
       version="1.8.0-dev" \

--- a/components/rclone-storage-initializer/Dockerfile
+++ b/components/rclone-storage-initializer/Dockerfile
@@ -6,4 +6,8 @@ LABEL name="Storage Initializer (rclone based)" \
       summary="Storage Initializer for Seldon Core" \
       description="Allows Seldon Core to download artifacts from cloud and local storage to a local volume"
 
+
+ENV RCLONE_CONFIG_GS_TYPE google cloud storage
+ENV RCLONE_CONFIG_GS_ANONYMOUS true
+
 ENTRYPOINT ["rclone", "copy"]

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -90,7 +90,7 @@ singleNamespace: false
 storageInitializer:
   cpuLimit: "1"
   cpuRequest: 100m
-  image: gcr.io/kfserving/storage-initializer:v0.4.0
+  image: seldonio/rclone-storage-initializer:1.8.0-dev
   memoryLimit: 1Gi
   memoryRequest: 100Mi
 usageMetrics:

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -45,6 +45,10 @@ kind_build_alibi_explain:
 kind_build_alibi_detect:
 	cd ../../components/alibi-detect-server && make kind_load
 
+.PHONY: kind_build_rclone_storage_initializer
+kind_build_rclone_storage_initializer:
+	cd ../../components/rclone-storage-initializer && make kind-load
+
 .PHONY: kind_build_misc
 kind_build_misc:
 	cd ../../components/seldon-request-logger && make kind_load
@@ -52,7 +56,7 @@ kind_build_misc:
 	cd ../../components/routers/epsilon-greedy && make kind_load
 
 .PHONY: kind_build_images
-kind_build_images: build_protos kind_build_engine kind_build_operator kind_build_executor kind_build_test_models kind_build_prepackaged kind_build_alibi_explain kind_build_alibi_detect kind_build_misc
+kind_build_images: build_protos kind_build_engine kind_build_operator kind_build_executor kind_build_test_models kind_build_prepackaged kind_build_alibi_explain kind_build_alibi_detect kind_build_rclone_storage_initializer kind_build_misc
 
 .PHONY: helm_setup
 helm_setup:

--- a/testing/scripts/kind_test_all.sh
+++ b/testing/scripts/kind_test_all.sh
@@ -112,9 +112,9 @@ if [[ ${KIND_EXIT_VALUE} -eq 0 ]]; then
         fi
 
         echo "Files changed in prepackaged, python, or wrapper folder:"
-        git --no-pager diff --exit-code --name-only origin/master ../../servers ../../integrations ../../python ../../wrappers/s2i/python
+        git --no-pager diff --exit-code --name-only origin/master ../../servers ../../integrations
         PREPACKAGED_MODIFIED=$?
-        if [[ $PREPACKAGED_MODIFIED -gt 0 ]]; then
+        if [[ $PREPACKAGED_MODIFIED -gt 0 ]] && [[ $PYTHON_MODIFIED -gt 0 ]]; then
             make kind_build_prepackaged
             PREPACKAGED_EXIT_VALUE=$?
             if [[ $PREPACKAGED_EXIT_VALUE -gt 0 ]]; then

--- a/testing/scripts/kind_test_all.sh
+++ b/testing/scripts/kind_test_all.sh
@@ -153,6 +153,20 @@ if [[ ${KIND_EXIT_VALUE} -eq 0 ]]; then
             echo "SKIPPING ALIBI DETECT IMAGE BUILD..."
         fi
 
+        echo "Files changed in rclone storage initializer folder:"
+        git --no-pager diff --exit-code --name-only origin/master ../../components/rclone-storage-initializer/
+        RCLONE_STRORAGE_INITIALIZER_MODIFIED=$?
+        if [[ $RCLONE_STRORAGE_INITIALIZER_MODIFIED -gt 0 ]]; then
+            make kind_build_rclone_storage_initializer
+            RCLONE_STRORAGE_INITIALIZER_EXIT_VALUE=$?
+            if [[ $RCLONE_STRORAGE_INITIALIZER_EXIT_VALUE -gt 0 ]]; then
+                echo "rclone storage initializer build returned errors"
+                return 1
+            fi
+        else
+            echo "SKIPPING RCLONE STORAGE INITIALIZER IMAGE BUILD..."
+        fi
+
         echo "Files changed in misc folders:"
         git --no-pager diff --exit-code --name-only origin/master ../../components/seldon-request-logger ../../components/storage-initializer ../../components/routers/epsilon-greedy
         MISC_MODIFIED=$?


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Make rclone storage initializer default in Seldon Core 1.8

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/SeldonIO/seldon-core/issues/2942

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

