### PR TITLE
Documentation updates for the Ambassador Install process and to introduce CRD based config.

### DIFF
--- a/examples/ambassador/custom/ambassador_custom.ipynb
+++ b/examples/ambassador/custom/ambassador_custom.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "## Setup Seldon Core\n",
     "\n",
-    "Uset the setup notebook to [Setup Cluster](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Setup-Cluster) with [Ambassador Ingress](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Ambassador) and [Install Seldon Core](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Install-Seldon-Core). Instructions [also online](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html)."
+    "Use the setup notebook to [Setup Cluster](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Setup-Cluster) with [Ambassador Ingress](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Ambassador) and [Install Seldon Core](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html#Install-Seldon-Core). Instructions [also online](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_core_setup.html)."
    ]
   },
   {
@@ -97,7 +97,7 @@
     "  name: example-custom\n",
     "spec:\n",
     "  annotations:\n",
-    "    seldon.io/ambassador-config: 'apiVersion: ambassador/v1\n",
+    "    seldon.io/ambassador-config: 'apiVersion: ambassador/v2\n",
     "\n",
     "      kind: Mapping\n",
     "\n",

--- a/notebooks/seldon_core_setup.ipynb
+++ b/notebooks/seldon_core_setup.ipynb
@@ -130,7 +130,7 @@
     "\n",
     "[Ambassador install](https://docs.seldon.io/projects/seldon-core/en/latest/workflow/install.html#install-ambassador)\n",
     "\n",
-    "**Note:** There are reported gRPC issues with ambassador (see https://github.com/SeldonIO/seldon-core/issues/473)."
+    "Ambassador Edge Stack:"
    ]
   },
   {
@@ -158,9 +158,46 @@
    "outputs": [],
    "source": [
     "!helm install ambassador datawire/ambassador \\\n",
-    "    --set image.repository=quay.io/datawire/ambassador \\\n",
-    "    --set enableAES=false \\\n",
+    "    --set image.repository=docker.io/datawire/ambassador \\\n",
     "    --set crds.keep=false \\\n",
+    "    --namespace seldon-system"
+   ]
+  },
+  {
+   "source": [
+    "Ambassador API Gateway (Emissary Ingress):"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!helm repo add datawire https://www.getambassador.io"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!helm repo update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!helm install ambassador datawire/ambassador \\\n",
+    "    --set image.repository=docker.io/datawire/ambassador \\\n",
+    "    --set crds.keep=false \\\n",
+    "    --set enableAES=false \\\n",
     "    --namespace seldon-system"
    ]
   },
@@ -179,6 +216,36 @@
    "source": [
     "!kubectl rollout status deployment.apps/ambassador"
    ]
+  },
+  {
+   "source": [
+    "For Ambassador Edge Stack:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "source": [
+    "**Note:** Absent configuration, Ambassador Edge Stack will attempt to use TLS with a self-signed cert.  Either [set up TLS](https://www.getambassador.io/docs/edge-stack/latest/howtos/tls-termination/) or ignore certificate validation (i.e. `curl -k`)."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl port-forward $(kubectl get pods -n seldon-system -l app.kubernetes.io/name=ambassador -o jsonpath='{.items[0].metadata.name}') -n seldon-system 8003:8443"
+   ]
+  },
+  {
+   "source": [
+    "For Ambassador API Gateway:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR is intended to update the Ambassador Ingress configuration to the more current Emissary and Ambassador Edge Stack installation suggestions.  It primarily updates the API version to v2 and introduces Custom Resource Definition based configuration, as well as a basic example on how to translate CRD configs to Annotations, for those who want to use the `seldon.io/ambassador-config` annotation.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Changed primary image mirror from quay.io to docker.io.
Changed API version numbers in examples from v1 to v2.
Added more details on Ambassador feature capabilities.
Added some explanations to the custom configuration section to explain the difference between annotation-based config and CRD.
Removed old note regarding gRPC issues.
Added both Ambassador install options to the "Seldon Setup" notebook.
```

