### PR TITLE
fix: Update cryptography dependency from 3.4 to 3.4.7

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ setup(
         "setuptools >= 41.0.0",
         "prometheus_client >= 0.7.1, < 0.9.0",
         # Addresses CVE-2020-1971
-        "cryptography==3.4",
+        "cryptography==3.4.7",
         # Addresses CVE SNYK-PYTHON-PYYAML-590151
         "PyYAML >= 5.4, < 5.5",
         # Addresses CVE PRISMA-2021-0020


### PR DESCRIPTION
Background
---
Update cryptography dependency from 3.4 to 3.4.7 (includes fix to circular import: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#341---2021-02-07)

/release-note-none