### PR TITLE
Allow leader election to use configurable seldon-manager service account

### DIFF
--- a/helm-charts/seldon-core-operator/templates/rolebinding_seldon-leader-election-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/rolebinding_seldon-leader-election-rolebinding.yaml
@@ -15,6 +15,6 @@ roleRef:
   name: seldon-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: seldon-manager
+  name: '{{ .Values.serviceAccount.name }}'
   namespace: '{{ include "seldon.namespace" . }}'
 {{- end }}

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -249,6 +249,7 @@ if __name__ == "__main__":
                 if (
                     name == "seldon1-manager-rolebinding"
                     or name == "seldon1-manager-sas-rolebinding"
+                    or name == "seldon-leader-election-rolebinding"
                 ):
                     res["subjects"][0]["name"] = helm_value("serviceAccount.name")
                     res["subjects"][0]["namespace"] = helm_namespace_override()


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

 * Adds missing Helm value usage for leader election template for seldon core operator helm chart

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3168

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

