### PR TITLE
make rclone storage initializer more verbose

### DIFF
--- a/components/alibi-detect-server/adserver/base/storage.py
+++ b/components/alibi-detect-server/adserver/base/storage.py
@@ -47,7 +47,7 @@ class Rclone:
         if dest is None:
             dest = tempfile.mkdtemp()
 
-        args = ["-v"]
+        args = ["-vv"]
         kwargs = {}
         if self.cfg_file is not None:
             kwargs["config"] = os.path.abspath(os.path.expanduser(self.cfg_file))

--- a/components/rclone-storage-initializer/Dockerfile
+++ b/components/rclone-storage-initializer/Dockerfile
@@ -10,4 +10,4 @@ LABEL name="Storage Initializer (rclone based)" \
 ENV RCLONE_CONFIG_GS_TYPE google cloud storage
 ENV RCLONE_CONFIG_GS_ANONYMOUS true
 
-ENTRYPOINT ["rclone", "copy", "-v"]
+ENTRYPOINT ["rclone", "copy", "-vv"]


### PR DESCRIPTION
Increase verbosity level of rclone-based storage initialization to simplify debugging in case of problems