### PR TITLE
Tfserving proxy custom data

### DIFF
--- a/servers/tfserving_proxy/TfServingProxy.py
+++ b/servers/tfserving_proxy/TfServingProxy.py
@@ -21,21 +21,24 @@ class TfServingProxy(object):
     """
 
     def __init__(
-            self,
-            rest_endpoint=None,
-            grpc_endpoint=None,
-            model_name=None,
-            signature_name=None,
-            model_input=None,
-            model_output=None):
+        self,
+        rest_endpoint=None,
+        grpc_endpoint=None,
+        model_name=None,
+        signature_name=None,
+        model_input=None,
+        model_output=None,
+    ):
         log.debug("rest_endpoint:", rest_endpoint)
         log.debug("grpc_endpoint:", grpc_endpoint)
 
         # grpc
         max_msg = 1000000000
-        options = [('grpc.max_message_length', max_msg),
-                   ('grpc.max_send_message_length', max_msg),
-                   ('grpc.max_receive_message_length', max_msg)]
+        options = [
+            ("grpc.max_message_length", max_msg),
+            ("grpc.max_send_message_length", max_msg),
+            ("grpc.max_receive_message_length", max_msg),
+        ]
         channel = grpc.insecure_channel(grpc_endpoint, options)
         self.stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
 
@@ -57,7 +60,9 @@ class TfServingProxy(object):
         log.debug("Preprocessing contents for predict function")
         request_data_type = request.WhichOneof("data_oneof")
         default_data_type = request.data.WhichOneof("data_oneof")
-        log.debug(f"Request data type: {request_data_type}, Default data type: {default_data_type}")
+        log.debug(
+            f"Request data type: {request_data_type}, Default data type: {default_data_type}"
+        )
 
         if request_data_type not in ["data", "customData"]:
             raise Exception("strData, binData and jsonData not supported.")
@@ -79,9 +84,8 @@ class TfServingProxy(object):
         else:
             data_arr = grpc_datadef_to_array(request.data)
             tfrequest.inputs[self.model_input].CopyFrom(
-                tf.make_tensor_proto(
-                    data_arr.tolist(),
-                    shape=data_arr.shape))
+                tf.make_tensor_proto(data_arr.tolist(), shape=data_arr.shape)
+            )
 
         # handle prediction
         tfresponse = self._handle_grpc_prediction(tfrequest)
@@ -153,7 +157,12 @@ class TfServingProxy(object):
                     result = numpy.expand_dims(result, axis=0)
                 return result
         else:
-            log.warning("Error from server: " + str(response) + " content: " + str(response.text))
+            log.warning(
+                "Error from server: "
+                + str(response)
+                + " content: "
+                + str(response.text)
+            )
             try:
                 return response.json()
             except ValueError:

--- a/servers/tfserving_proxy/TfServingProxy.py
+++ b/servers/tfserving_proxy/TfServingProxy.py
@@ -1,21 +1,19 @@
+import json
+import logging
+
 import grpc
 import numpy
+import requests
 import tensorflow as tf
-
+from google.protobuf.any_pb2 import Any
+from seldon_core.proto import prediction_pb2
+from seldon_core.utils import grpc_datadef_to_array
 from tensorflow.python.saved_model import signature_constants
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
-from seldon_core.utils import get_data_from_proto, array_to_grpc_datadef, json_to_seldon_message, grpc_datadef_to_array
-from seldon_core.proto import prediction_pb2
-from google.protobuf.json_format import ParseError
-
-import requests
-import json
-import numpy as np
-
-import logging
 
 log = logging.getLogger()
+
 
 class TfServingProxy(object):
     """
@@ -30,19 +28,19 @@ class TfServingProxy(object):
             signature_name=None,
             model_input=None,
             model_output=None):
-        log.debug("rest_endpoint:",rest_endpoint)
-        log.debug("grpc_endpoint:",grpc_endpoint)
+        log.debug("rest_endpoint:", rest_endpoint)
+        log.debug("grpc_endpoint:", grpc_endpoint)
 
         # grpc
         max_msg = 1000000000
         options = [('grpc.max_message_length', max_msg),
                    ('grpc.max_send_message_length', max_msg),
                    ('grpc.max_receive_message_length', max_msg)]
-        channel = grpc.insecure_channel(grpc_endpoint,options)
+        channel = grpc.insecure_channel(grpc_endpoint, options)
         self.stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
 
         # rest
-        self.rest_endpoint = rest_endpoint+"/v1/models/"+model_name+":predict"
+        self.rest_endpoint = rest_endpoint + "/v1/models/" + model_name + ":predict"
         self.model_name = model_name
         if signature_name is None:
             self.signature_name = signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY
@@ -51,7 +49,7 @@ class TfServingProxy(object):
         self.model_input = model_input
         self.model_output = model_output
 
-    def predict_grpc(self,request):
+    def predict_grpc(self, request):
         """
         predict_grpc will be called only when there is a GRPC call to the server
         which in this case, the request will be sent to the TFServer directly.
@@ -61,33 +59,51 @@ class TfServingProxy(object):
         default_data_type = request.data.WhichOneof("data_oneof")
         log.debug(f"Request data type: {request_data_type}, Default data type: {default_data_type}")
 
-        if request_data_type != "data":
+        if request_data_type not in ["data", "customData"]:
             raise Exception("strData, binData and jsonData not supported.")
 
         tfrequest = predict_pb2.PredictRequest()
-        tfrequest.model_spec.name = self.model_name
-        tfrequest.model_spec.signature_name = self.signature_name
 
-        # For GRPC case, if we have a TFTensor message we can pass it directly
-        if default_data_type == "tftensor":
-            tfrequest.inputs[self.model_input].CopyFrom(request.data.tftensor)
-            result = self.stub.Predict(tfrequest)
-            datadef = prediction_pb2.DefaultData(
-                tftensor=result.outputs[self.model_output]
-            )
-            return prediction_pb2.SeldonMessage(data=datadef)
+        # handle inputs
+        if request_data_type == "data":
+            # For GRPC case, if we have a TFTensor message we can pass it directly
+            if default_data_type == "tftensor":
+                tfrequest.inputs[self.model_input].CopyFrom(request.data.tftensor)
+            else:
+                data_arr = grpc_datadef_to_array(request.data)
+                tfrequest.inputs[self.model_input].CopyFrom(
+                    tf.make_tensor_proto(
+                        data_arr.tolist(),
+                        shape=data_arr.shape))
 
         else:
-            data_arr = grpc_datadef_to_array(request.data)
-            tfrequest.inputs[self.model_input].CopyFrom(
-                tf.make_tensor_proto(
-                    data_arr.tolist(),
-                    shape=data_arr.shape))
-            result = self.stub.Predict(tfrequest)
+            # Unpack custom data into tfrequest - taking raw inputs prepared by the user.
+            # This allows the use case when the model's input is not a single tftensor
+            # but a map of tensors like defined in predict.proto:
+            # PredictRequest.inputs: map<string, TensorProto>
+            request.customData.Unpack(tfrequest)
+
+        # handle prediction
+        tfrequest.model_spec.name = self.model_name
+        tfrequest.model_spec.signature_name = self.signature_name
+        tfresponse = self.stub.Predict(tfrequest)
+
+        # handle result
+        if request_data_type == "data":
             datadef = prediction_pb2.DefaultData(
-                tftensor=result.outputs[self.model_output]
+                tftensor=tfresponse.outputs[self.model_output]
             )
-            return prediction_pb2.SeldonMessage(data=datadef)
+            result = prediction_pb2.SeldonMessage(data=datadef)
+        else:
+            # Pack tfresponse into the SeldonMessage's custom data - letting user handle
+            # raw outputs. This allows the case when the model's output is not a single tftensor
+            # but a map of tensors like defined in predict.proto:
+            # PredictResponse: map<string, TensorProto>
+            custom_data = Any()
+            custom_data.Pack(tfresponse)
+            result = prediction_pb2.SeldonMessage(customData=custom_data)
+
+        return result
 
     def predict(self, X, features_names=[]):
         """
@@ -99,7 +115,7 @@ class TfServingProxy(object):
             data = X
         else:
             log.debug(f"Data Request: {X}")
-            data = {"instances":X.tolist()}
+            data = {"instances": X.tolist()}
             if not self.signature_name is None:
                 data["signature_name"] = self.signature_name
 
@@ -118,9 +134,8 @@ class TfServingProxy(object):
                     result = numpy.expand_dims(result, axis=0)
                 return result
         else:
-            log.warning("Error from server: "+ str(response) + " content: " + str(response.text))
+            log.warning("Error from server: " + str(response) + " content: " + str(response.text))
             try:
                 return response.json()
             except ValueError:
                 return response.text
-


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Currently there is no way to handle multiple input/output tensors for the model using Tensorflow Prepackaged Model Server. This PR enables the use of custom_data to pass and receive Tensorflow's predict_pb2.PredictRequest and  predict_pb2.PredictResponse respectively. E.g.
```python
import tensorflow as tf
from google.protobuf import any_pb2
from tensorflow_serving.apis import predict_pb2
from tensorflow.core.framework import types_pb2

# an input consisting of multiple ndarrays/tensors
input_data = {
    'input1': input1,
    'input2': input2,
    'input3': input3,
}

# prepare PredictRequest with multiple tensors in 'inputs'
tfrequest = predict_pb2.PredictRequest()
for k, v in input_data.items():
    tfrequest.inputs[k].CopyFrom(tf.make_tensor_proto(input_data[k], types_pb2.DT_FLOAT))

# pack PredictRequest to be acceptable/transferable by Seldon's 'custom_data' argument
custom_data = any_pb2.Any()
custom_data.Pack(tfrequest)

# run grpc prediction, e.g.
grpc_response = SeldonClient().microservice(microservice_endpoint='localhost:9500',
                                     method='predict',
                                     transport='grpc',
                                     custom_data=custom_data)

# unpack the response to PredictResponse
tfresponse = predict_pb2.PredictResponse()
grpc_response.response.customData.Unpack(tfresponse)

# translate outputs back to ndarrays
result = {} # Dict[str, np.ndarray]
result['output1'] = tf.make_ndarray(tfresponse.outputs['output1'])
result['output2'] = tf.make_ndarray(tfresponse.outputs['output2'])
```

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Added custom_data handling to Tensorflow Prepackaged Model Server
```

