### PR TITLE
Use more consistent and sensible requests and limits

### DIFF
--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -54,9 +54,9 @@ executor:
     tag: 1.8.0-dev
   resources:
     cpuLimit: 500m
-    cpuRequest: 500m
+    cpuRequest: 100m
     memoryLimit: 512Mi
-    memoryRequest: 512Mi
+    memoryRequest: 256Mi
   prometheus:
     path: /prometheus
   serviceAccount:
@@ -182,9 +182,9 @@ engine:
     tag: 1.8.0-dev
   resources:
     cpuLimit: 500m
-    cpuRequest: 500m
+    cpuRequest: 100m
     memoryLimit: 512Mi
-    memoryRequest: 512Mi
+    memoryRequest: 256Mi
   logMessagesExternally: false
   port: 8000
   prometheus:


### PR DESCRIPTION
I lowered the requests, such that there is actually a compelling reason to set separate limits and requests.

This is also done properly at other places in the same file https://github.com/SeldonIO/seldon-core/blob/fdbe433281a199ec9485c35b8d84deef3b9537d0/helm-charts/seldon-core-operator/values.yaml#L76-L80