### PR TITLE
Extending ephimeral storage for notebooks tests

### DIFF
--- a/.lighthouse/jenkins-x/notebooks.yaml
+++ b/.lighthouse/jenkins-x/notebooks.yaml
@@ -37,11 +37,11 @@ spec:
             requests:
               cpu: 3
               memory: 10000Mi
-              ephemeral-storage: "100Gi"
+              ephemeral-storage: "150Gi"
             limits:
               cpu: 3
               memory: 10000Mi
-              ephemeral-storage: "100Gi"
+              ephemeral-storage: "150Gi"
           securityContext:
             privileged: true
           imagePullPolicy: Always


### PR DESCRIPTION
Tests were erroring out as ephimeral storage was exceeding 100Gb so extending to 150

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

