### PR TITLE
Fixed broken "tutum/curl" image in Notebook tests tests

### DIFF
--- a/examples/models/custom_metrics/customMetrics.ipynb
+++ b/examples/models/custom_metrics/customMetrics.ipynb
@@ -235,7 +235,7 @@
    "source": [
     "%%writefile get-metrics.sh\n",
     "\n",
-    "kubectl run --quiet=true -it --rm curlmetrics --image=tutum/curl --restart=Never -- \\\n",
+    "kubectl run --quiet=true -it --rm curlmetrics --image=radial/busyboxplus:curl --restart=Never -- \\\n",
     "    curl -s seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query?query=mycounter_total"
    ]
   },

--- a/examples/models/custom_metrics/get-metrics.sh
+++ b/examples/models/custom_metrics/get-metrics.sh
@@ -1,3 +1,3 @@
 
-kubectl run --quiet=true -it --rm curlmetrics --image=tutum/curl --restart=Never -- \
+kubectl run --quiet=true -it --rm curlmetrics --image=radial/busyboxplus:curl --restart=Never -- \
     curl -s seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query?query=mycounter_total

--- a/examples/models/custom_metrics/tfservingMetrics.ipynb
+++ b/examples/models/custom_metrics/tfservingMetrics.ipynb
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "responseRaw=!kubectl run --quiet=true -it --rm curl --image=tutum/curl --restart=Never -- curl -s seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query?query=:tensorflow:core:graph_runs"
+    "responseRaw=!kubectl run --quiet=true -it --rm curl --image=radial/busyboxplus:curl --restart=Never -- curl -s seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query?query=:tensorflow:core:graph_runs"
    ]
   },
   {

--- a/examples/models/runtime_metrics_tags/runtime_metrics_tags.ipynb
+++ b/examples/models/runtime_metrics_tags/runtime_metrics_tags.ipynb
@@ -330,7 +330,7 @@
     }
    ],
    "source": [
-    "metrics =! kubectl run --quiet=true -it --rm curlmetrics --image=tutum/curl --restart=Never -- \\\n",
+    "metrics =! kubectl run --quiet=true -it --rm curlmetrics --image=radial/busyboxplus:curl --restart=Never -- \\\n",
     "    curl -s seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query?query=instance_counter_total\n",
     "\n",
     "json.loads(metrics[0])[\"data\"][\"result\"][0][\"value\"][1]"
@@ -353,7 +353,7 @@
     }
    ],
    "source": [
-    "metrics =! kubectl run --quiet=true -it --rm curlmetrics --image=tutum/curl --restart=Never -- \\\n",
+    "metrics =! kubectl run --quiet=true -it --rm curlmetrics --image=radial/busyboxplus:curl --restart=Never -- \\\n",
     "    curl -s seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query?query=requests_counter_total\n",
     "\n",
     "json.loads(metrics[0])[\"data\"][\"result\"][0][\"value\"][1]"


### PR DESCRIPTION
Currently notebook tests freeze because of an image being removed. This PR updates it to use `radial/busyboxplus:curl` instead.