### PR TITLE
Allow MLServer envs to be overriden

### DIFF
--- a/operator/controllers/mlserver.go
+++ b/operator/controllers/mlserver.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"github.com/seldonio/seldon-core/operator/utils"
 	"strconv"
 
 	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
@@ -41,8 +42,14 @@ func mergeMLServerContainer(existing *v1.Container, mlServer *v1.Container) *v1.
 		existing.Env = []v1.EnvVar{}
 	}
 
-	// TODO: Allow overriding some of the env vars
-	existing.Env = append(existing.Env, mlServer.Env...)
+	for _, envVar := range existing.Env {
+		if utils.HasEnvVar(mlServer.Env, envVar.Name) {
+			mlServer.Env = utils.SetEnvVar(mlServer.Env, envVar)
+		} else {
+			mlServer.Env = append(mlServer.Env, envVar)
+		}
+	}
+	existing.Env = mlServer.Env
 
 	if existing.ReadinessProbe == nil {
 		existing.ReadinessProbe = mlServer.ReadinessProbe

--- a/operator/controllers/mlserver_test.go
+++ b/operator/controllers/mlserver_test.go
@@ -33,11 +33,13 @@ var _ = Describe("MLServer helpers", func() {
 	Describe("mergeMLServerContainer", func() {
 		var existing *v1.Container
 		var mlServer *v1.Container
+		customEnvValue := "{\"custom\":1}"
 
 		BeforeEach(func() {
 			existing = &v1.Container{
 				Env: []v1.EnvVar{
 					{Name: "FOO", Value: "BAR"},
+					{Name: MLServerTempoRuntimeEnv, Value: customEnvValue},
 				},
 			}
 
@@ -49,6 +51,7 @@ var _ = Describe("MLServer helpers", func() {
 
 			Expect(merged).ToNot(BeNil())
 			Expect(merged.Env).To(ContainElement(v1.EnvVar{Name: "FOO", Value: "BAR"}))
+			Expect(merged.Env).To(ContainElement(v1.EnvVar{Name: MLServerTempoRuntimeEnv, Value: customEnvValue}))
 			Expect(merged.Env).To(ContainElements(mlServer.Env))
 			Expect(merged.Image).To(Equal(mlServer.Image))
 		})


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Allows MLServer envs to be overriden in component specs. Allows Tempo releases to change this without needing Core changes.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3282

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

