### PR TITLE
WIP: Add add micro-batching to batch processor 

### DIFF
--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -402,7 +402,7 @@ def _send_batch_predict(
     traced back individually in the Seldon Request Logger context. Each request
     will be attempted for the number of retries, and will return the string
     serialised result.
-    Paramters
+    Parameters
     ---
     batch_idx
         The enumerated index given to the batch datapoint in order of local dataset
@@ -420,7 +420,7 @@ def _send_batch_predict(
         The unique identifier for the batch which is passed to all requests
     Returns
     ---
-        A string serialised result of the response (or equivallent data with error info)
+        A string serialised result of the response (or equivalent data with error info)
     """
 
     predict_kwargs = {}
@@ -507,7 +507,6 @@ def _send_batch_feedback(
     meta = {
         "tags": {
             "batch_id": batch_id,
-            # TODO: tidy these
             "batch_instance_id": batch_instance_id,
             "batch_index": batch_idx,
         }

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -4,6 +4,7 @@ import time
 import uuid
 from queue import Empty, Queue
 from threading import Event, Thread
+import copy
 
 import click
 import numpy as np
@@ -23,7 +24,6 @@ CHOICES_LOG_LEVEL = {
     "error": logging.ERROR,
 }
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -35,21 +35,22 @@ def setup_logging(log_level: str):
 
 
 def start_multithreaded_batch_worker(
-    deployment_name: str,
-    gateway_type: str,
-    namespace: str,
-    host: str,
-    transport: str,
-    data_type: str,
-    payload_type: str,
-    workers: int,
-    retries: int,
-    input_data_path: str,
-    output_data_path: str,
-    method: str,
-    log_level: str,
-    benchmark: bool,
-    batch_id: str,
+        deployment_name: str,
+        gateway_type: str,
+        namespace: str,
+        host: str,
+        transport: str,
+        data_type: str,
+        payload_type: str,
+        workers: int,
+        retries: int,
+        batch_size: int,
+        input_data_path: str,
+        output_data_path: str,
+        method: str,
+        log_level: str,
+        benchmark: bool,
+        batch_id: str,
 ) -> None:
     """
     Starts the multithreaded batch worker which consists of three worker types and
@@ -69,7 +70,9 @@ def start_multithreaded_batch_worker(
     q_out = Queue(workers * 2)
 
     if method == "feedback" and data_type != "raw":
-        raise RuntimeError("Feedback method is supported only with raw data type.")
+        raise RuntimeError("Feedback method is supported only with `raw` data type.")
+    elif data_type != "data" and batch_size > 1:
+        raise RuntimeError("Batch size greater than 1 is only supported for `data` data type.")
     elif data_type == "raw" and method != "feedback":
         raise RuntimeError("Raw input is currently only support for feedback method.")
 
@@ -84,14 +87,14 @@ def start_multithreaded_batch_worker(
     )
 
     t_in = Thread(
-        target=_start_input_file_worker, args=(q_in, input_data_path), daemon=True
+        target=_start_input_file_worker, args=(q_in, input_data_path, batch_size), daemon=True
     )
     t_in.start()
 
     for _ in range(workers):
         Thread(
             target=_start_request_worker,
-            args=(q_in, q_out, data_type, sc, method, retries, batch_id),
+            args=(q_in, q_out, data_type, sc, method, retries, batch_id, payload_type),
             daemon=True,
         ).start()
 
@@ -118,7 +121,7 @@ def start_multithreaded_batch_worker(
         logger.info(f"Elapsed time: {time.time() - start_time}")
 
 
-def _start_input_file_worker(q_in: Queue, input_data_path: str) -> None:
+def _start_input_file_worker(q_in: Queue, input_data_path: str, batch_size: int) -> None:
     """
     Runs logic for the input file worker which reads the input file from filestore
     and puts all of the lines into the input queue so it can be processed.
@@ -132,18 +135,23 @@ def _start_input_file_worker(q_in: Queue, input_data_path: str) -> None:
     """
     input_data_file = open(input_data_path, "r")
     enum_idx = 0
+    batch = []
     for line in input_data_file:
         unique_id = str(uuid.uuid1())
-        q_in.put((enum_idx, unique_id, line))
+        batch.append((enum_idx, unique_id, line))
+        # If the batch to send is the size then push to queue and rest batch
+        if len(batch) == batch_size:
+            q_in.put(batch)
+            batch = []
         enum_idx += 1
 
 
 def _start_output_file_worker(
-    q_out: Queue, output_data_path: str, stop_event: Event
+        q_out: Queue, output_data_path: str, stop_event: Event
 ) -> None:
     """
     Runs logic for the output file worker which receives all the processed output
-    fro the request worker through the queue and adds it into the output file in a
+    from the request worker through the queue and adds it into the output file in a
     thread safe manner.
 
     Parameters
@@ -171,13 +179,14 @@ def _start_output_file_worker(
 
 
 def _start_request_worker(
-    q_in: Queue,
-    q_out: Queue,
-    data_type: str,
-    sc: SeldonClient,
-    method: str,
-    retries: int,
-    batch_id: str,
+        q_in: Queue,
+        q_out: Queue,
+        data_type: str,
+        sc: SeldonClient,
+        method: str,
+        retries: int,
+        batch_id: str,
+        payload_type: str,
 ) -> None:
     """
     Runs logic for the worker that sends requests from the queue until the queue
@@ -202,8 +211,24 @@ def _start_request_worker(
         The unique identifier for the batch which is passed to all requests
     """
     while True:
-        batch_idx, batch_instance_id, input_raw = q_in.get()
+        input_data = q_in.get()
         if method == "predict":
+            # If we have a batch size > 1 then we wish to use the other method and add each output to queue
+            if len(input_data) > 1:
+                str_outputs = _send_batch_predict_multi_request(
+                    input_data,
+                    data_type,
+                    sc,
+                    retries,
+                    batch_id,
+                    payload_type,
+                )
+                for str_output in str_outputs:
+                    q_out.put(str_output)
+                # continue with next input
+                q_in.task_done()
+                continue
+            batch_idx, batch_instance_id, input_raw = input_data[0]
             str_output = _send_batch_predict(
                 batch_idx,
                 batch_instance_id,
@@ -213,29 +238,134 @@ def _start_request_worker(
                 retries,
                 batch_id,
             )
-            # Mark task as done in the queue to add space for new tasks
         elif method == "feedback":
             str_output = _send_batch_feedback(
-                batch_idx,
-                batch_instance_id,
-                input_raw,
-                data_type,
+                input_data,
                 sc,
                 retries,
                 batch_id,
             )
+        # Mark task as done in the queue to add space for new tasks
         q_out.put(str_output)
         q_in.task_done()
 
+def _send_batch_predict_multi_request(
+        input_raw: [],
+        data_type: str,
+        sc: SeldonClient,
+        retries: int,
+        batch_id: str,
+        payload_type: str,
+) -> str:
+    """
+    Send an request using the Seldon Client with batch context including the
+    unique ID of the batch and the Batch enumerated index as metadata. This
+    function also uses the unique batch ID as request ID so the request can be
+    traced back individually in the Seldon Request Logger context. Each request
+    will be attempted for the number of retries, and will return the string
+    serialised result.
+    Parameters
+    ---
+    # TODO: Change this
+    input_raw
+        The raw input in string format to be loaded to the respective format
+    data_type
+        The data type to send which can be str, json and data
+    sc
+        The instance of SeldonClient to use to send the requests to the seldon model
+    retries
+        The number of times to retry the request
+    batch_id
+        The unique identifier for the batch which is passed to all requests
+    Returns
+    ---
+        A string serialised result of the response (or equivalent data with error info)
+    """
+
+    instance_ids = [x[1] for x in input_raw]
+    indexes = [x[0] for x in input_raw]
+
+    predict_kwargs = {}
+    meta = {
+        "tags": {
+            "batch_id": batch_id,
+        }
+    }
+
+    predict_kwargs["meta"] = meta
+    predict_kwargs["headers"] = {"Seldon-Puid": instance_ids[0]}
+
+    try:
+        if data_type == "data":
+            data = json.loads(input_raw[0][2])
+            data_np = np.array(data)
+            overall = data_np
+            for i, raw_data in enumerate(input_raw):
+                if i == 0:
+                    continue
+                data = json.loads(raw_data[2])
+                data_np = np.array(data)
+                overall = np.concatenate((overall, data_np))
+            predict_kwargs["data"] = overall
+        data = json.loads(input_raw[0][2])
+        if data_type == "str":
+            predict_kwargs["str_data"] = data
+        elif data_type == "json":
+            predict_kwargs["json_data"] = data
+
+        response = None
+        for i in range(retries):
+            try:
+                seldon_payload = sc.predict(**predict_kwargs)
+                assert seldon_payload.success
+                response = seldon_payload.response
+                break
+            except (requests.exceptions.RequestException, AssertionError) as e:
+                logger.error(f"Exception: {e}, retries {retries}")
+                if i == (retries - 1):
+                    raise
+
+    except Exception as e:
+        error_resp = {
+            "status": {"info": "FAILURE", "reason": str(e), "status": 1},
+            "meta": meta,
+        }
+        print(e)
+        str_output = json.dumps(error_resp)
+        return [str_output]
+
+    # Take the response create new responses for each request
+    responses = []
+    for i in range(len(input_raw)):
+        newResponse = copy.deepcopy(response)
+        if payload_type == "ndarray":
+            newResponse["data"]["ndarray"] = [response["data"]["ndarray"][i]]
+            newResponse["meta"]["tags"]["tags"]["batch_index"] = indexes[i]
+            newResponse["meta"]["tags"]["tags"]["batch_instance_id"] = instance_ids[i]
+            responses.append(json.dumps(newResponse))
+        elif payload_type == "tensor":
+            tensor = np.array(response["data"]["tensor"]["values"])
+            shape = response["data"]["tensor"]["shape"]
+            ndarray = tensor.reshape(shape)
+            newResponse["data"]["tensor"]["shape"][0] = 1
+            newResponse["data"]["tensor"]["values"] = [np.ndarray.tolist(ndarray[i])]
+            newResponse["meta"]["tags"]["tags"]["batch_index"] = indexes[i]
+            newResponse["meta"]["tags"]["tags"]["batch_instance_id"] = instance_ids[i]
+            responses.append(json.dumps(newResponse))
+        else:
+            raise RuntimeError("Only `ndarray` and `tensor` input is currently supported for batch size greater than 1.")
+
+    return responses
+
 
 def _send_batch_predict(
-    batch_idx: int,
-    batch_instance_id: int,
-    input_raw: str,
-    data_type: str,
-    sc: SeldonClient,
-    retries: int,
-    batch_id: str,
+        batch_idx: int,
+        batch_instance_id: int,
+        input_raw: str,
+        data_type: str,
+        sc: SeldonClient,
+        retries: int,
+        batch_id: str,
 ) -> str:
     """
     Send an request using the Seldon Client with batch context including the
@@ -306,20 +436,16 @@ def _send_batch_predict(
 
     return str_output
 
-
 def _send_batch_feedback(
-    batch_idx: int,
-    batch_instance_id: int,
-    input_raw: str,
-    data_type: str,
-    sc: SeldonClient,
-    retries: int,
-    batch_id: str,
+        input_raw: [],
+        sc: SeldonClient,
+        retries: int,
+        batch_id: str,
 ) -> str:
     """
     Send an request using the Seldon Client with feedback
 
-    Paramters
+    Parameters
     ---
     batch_idx
         The enumerated index given to the batch datapoint in order of local dataset
@@ -338,20 +464,21 @@ def _send_batch_feedback(
 
     Returns
     ---
-        A string serialised result of the response (or equivallent data with error info)
+        A string serialised result of the response (or equivalent data with error info)
     """
 
     feedback_kwargs = {}
     meta = {
         "tags": {
             "batch_id": batch_id,
-            "batch_instance_id": batch_instance_id,
-            "batch_index": batch_idx,
+            # TODO: tidy these
+            "batch_instance_id": input_raw[0][1],
+            "batch_index": input_raw[0][0],
         }
     }
-    # Feedback Protos does not support meta - defined to include in file output only.
+    # Feedback protos do not support meta - defined to include in file output only.
     try:
-        data = json.loads(input_raw)
+        data = json.loads(input_raw[0][2])
         feedback_kwargs["raw_request"] = data
 
         str_output = None
@@ -360,7 +487,7 @@ def _send_batch_feedback(
                 seldon_payload = sc.feedback(**feedback_kwargs)
                 assert seldon_payload.success
 
-                # Update Tags so we can track feedback intances in output file
+                # Update Tags so we can track feedback instances in output file
                 tags = seldon_payload.response.get("meta", {}).get("tags", {})
                 tags.update(meta["tags"])
                 if "meta" not in seldon_payload.response:
@@ -500,22 +627,31 @@ def _send_batch_feedback(
     type=str,
     help="Unique batch ID to identify all datapoints processed in this batch, if not provided is auto generated",
 )
+@click.option(
+    "--batch-size",
+    "-u",
+    envvar="SELDON_BATCH_SIZE",
+    default=int(1),
+    type=int,
+    help="Batch size greater than 1 can be used to group multiple predictions into a single request.",
+)
 def run_cli(
-    deployment_name: str,
-    gateway_type: str,
-    namespace: str,
-    host: str,
-    transport: str,
-    data_type: str,
-    payload_type: str,
-    workers: int,
-    retries: int,
-    input_data_path: str,
-    output_data_path: str,
-    method: str,
-    log_level: str,
-    benchmark: bool,
-    batch_id: str,
+        deployment_name: str,
+        gateway_type: str,
+        namespace: str,
+        host: str,
+        transport: str,
+        data_type: str,
+        payload_type: str,
+        workers: int,
+        retries: int,
+        batch_size: int,
+        input_data_path: str,
+        output_data_path: str,
+        method: str,
+        log_level: str,
+        benchmark: bool,
+        batch_id: str,
 ):
     """
     Command line interface for Seldon Batch Processor, which can be used to send requests
@@ -538,6 +674,7 @@ def run_cli(
         payload_type,
         workers,
         retries,
+        batch_size,
         input_data_path,
         output_data_path,
         method,
@@ -545,3 +682,7 @@ def run_cli(
         benchmark,
         batch_id,
     )
+
+
+if __name__ == '__main__':
+    run_cli()

--- a/testing/scripts/test_batch_processor.py
+++ b/testing/scripts/test_batch_processor.py
@@ -45,6 +45,7 @@ class TestBatchWorker(object):
             "ndarray",
             100,
             3,
+            1,
             input_data_path,
             output_data_path,
             "predict",
@@ -58,6 +59,35 @@ class TestBatchWorker(object):
                 output = json.loads(line)
                 # Ensure all requests are successful
                 assert output.get("data", {}).get("ndarray", False)
+
+        # Now test that a batch size of 10 works
+        start_multithreaded_batch_worker(
+            "sklearn",
+            "istio",
+            namespace,
+            API_ISTIO_GATEWAY,
+            "rest",
+            "data",
+            "ndarray",
+            100,
+            3,
+            10,
+            input_data_path,
+            output_data_path,
+            "predict",
+            "debug",
+            True,
+            str(uuid.uuid1()),
+        )
+
+        with open(output_data_path, "r") as f:
+            count = 0
+            for line in f:
+                count +=1
+                output = json.loads(line)
+                # Ensure all requests are successful
+                assert output.get("data", {}).get("ndarray", False)
+            assert (count == batch_size)
 
         logging.info("Success for test_batch_worker")
         run(f"kubectl delete -f {spec} -n {namespace}", shell=True)


### PR DESCRIPTION
Fixes #2734 

* Can now specify batch size to combine single prediction instances
* Response split into single instances to maintain parity with batch size 1
* Added documentation
* Small extension of tests, no existing unit tests - can extend if reviewers feel necessary
* Tested using tensor and ndarray model

Benefits:

* Lower network overhead
* Benefit from vectorized implementations of underlying inference library
