### PR TITLE
Fix tags propogation with seldon client

### DIFF
--- a/python/licenses/license_info.no_versions.csv
+++ b/python/licenses/license_info.no_versions.csv
@@ -17,7 +17,7 @@
 "cffi","MIT License"
 "chardet","GNU Library or Lesser General Public License (LGPL)"
 "click","BSD License"
-"cryptography","Apache Software License
+"cryptography","Apache Software License; BSD License"
 "flatbuffers","Apache Software License"
 "gast","BSD License"
 "google-auth","Apache Software License"

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -297,13 +297,11 @@ def _send_batch_predict_multi_request(
     instance_ids = [x[1] for x in input_data]
 
     predict_kwargs = {}
-    meta = {
-        "tags": {
-            "batch_id": batch_id,
-        }
+    tags = {
+        "batch_id": batch_id,
     }
 
-    predict_kwargs["meta"] = meta
+    predict_kwargs["meta"] = tags
     predict_kwargs["headers"] = {"Seldon-Puid": instance_ids[0]}
 
     try:
@@ -327,7 +325,7 @@ def _send_batch_predict_multi_request(
     except Exception as e:
         error_resp = {
             "status": {"info": "FAILURE", "reason": str(e), "status": 1},
-            "meta": meta,
+            "meta": tags,
         }
         print("Exception: %s" % e)
         str_output = json.dumps(error_resp)
@@ -367,7 +365,7 @@ def _send_batch_predict_multi_request(
         except Exception as e:
             error_resp = {
                 "status": {"info": "FAILURE", "reason": str(e), "status": 1},
-                "meta": meta,
+                "meta": tags,
             }
             print("Exception: %s" % e)
             responses.append(json.dumps(error_resp))
@@ -413,14 +411,12 @@ def _send_batch_predict(
     """
 
     predict_kwargs = {}
-    meta = {
-        "tags": {
-            "batch_id": batch_id,
-            "batch_instance_id": batch_instance_id,
-            "batch_index": batch_idx,
-        }
+    tags = {
+        "batch_id": batch_id,
+        "batch_instance_id": batch_instance_id,
+        "batch_index": batch_idx,
     }
-    predict_kwargs["meta"] = meta
+    predict_kwargs["meta"] = tags
     predict_kwargs["headers"] = {"Seldon-Puid": batch_instance_id}
     try:
         data = json.loads(input_raw)
@@ -447,7 +443,7 @@ def _send_batch_predict(
     except Exception as e:
         error_resp = {
             "status": {"info": "FAILURE", "reason": str(e), "status": 1},
-            "meta": meta,
+            "meta": tags,
         }
         print("Exception: %s" % e)
         str_output = json.dumps(error_resp)

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -347,8 +347,8 @@ def _send_batch_predict_multi_request(
         if payload_type == "ndarray":
             # Format new responses for each original prediction request
             new_response["data"]["ndarray"] = [response["data"]["ndarray"][i]]
-            new_response["meta"]["tags"]["tags"]["batch_index"] = indexes[i]
-            new_response["meta"]["tags"]["tags"]["batch_instance_id"] = instance_ids[i]
+            new_response["meta"]["tags"]["batch_index"] = indexes[i]
+            new_response["meta"]["tags"]["batch_instance_id"] = instance_ids[i]
             responses.append(json.dumps(new_response))
         elif payload_type == "tensor":
             # Format new responses for each original prediction request
@@ -356,8 +356,8 @@ def _send_batch_predict_multi_request(
             new_response["data"]["tensor"]["values"] = np.ndarray.tolist(
                 tensor_ndarray[i]
             )
-            new_response["meta"]["tags"]["tags"]["batch_index"] = indexes[i]
-            new_response["meta"]["tags"]["tags"]["batch_instance_id"] = instance_ids[i]
+            new_response["meta"]["tags"]["batch_index"] = indexes[i]
+            new_response["meta"]["tags"]["batch_instance_id"] = instance_ids[i]
             responses.append(json.dumps(new_response))
         else:
             raise RuntimeError(

--- a/python/seldon_core/seldon_client.py
+++ b/python/seldon_core/seldon_client.py
@@ -327,7 +327,7 @@ class SeldonClient:
         http_path:
            Custom http path for predict call to use
         meta:
-           Custom meta map
+           Custom meta map, supplied as tags
         client_return_type
             the return type of all functions can be either dict or proto
         raw_data
@@ -1246,7 +1246,7 @@ def rest_predict_seldon(
 
     """
     metaKV = prediction_pb2.Meta()
-    metaJson = {meta}
+    metaJson = {"tags": meta}
     json_format.ParseDict(metaJson, metaKV)
     if raw_data:
         request = json_to_seldon_message(raw_data)
@@ -1459,7 +1459,7 @@ def rest_predict_gateway(
     """
     # Create meta data
     metaKV = prediction_pb2.Meta()
-    metaJson = {meta}
+    metaJson = {"tags": meta}
     json_format.ParseDict(metaJson, metaKV)
     if raw_data is not None:
         request = json_to_seldon_message(raw_data)
@@ -1814,7 +1814,7 @@ def grpc_predict_gateway(
     channel_credentials
        Channel credentials - see SeldonChannelCredentials
     meta
-       Custom meta data map
+       Custom meta data map, supplied as tags
     client_return_type
         the return type of all functions can be either dict or proto
     raw_data

--- a/python/seldon_core/seldon_client.py
+++ b/python/seldon_core/seldon_client.py
@@ -1237,7 +1237,7 @@ def rest_predict_seldon(
     raw_data
         Raw payload (dictionary) given by the user
     meta
-        Custom meta map
+        Custom meta data map, supplied as tags
     kwargs
 
     Returns


### PR DESCRIPTION
I discovered two small bugs in the seldon client when testing the batch processor. 

* Tags end up being wrapped twice in the response, so the result is `["meta"]["tags"]["tags"]`
* Meta isn't propagated when the gateway is `seldon` not `istio`