### PR TITLE
fix problem with aliquoting when using mini-batching, closes 3377

### DIFF
--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -150,6 +150,7 @@ def _start_input_file_worker(
             q_in.put(batch)
             batch = []
         enum_idx += 1
+    q_in.put(batch)
 
 
 def _start_output_file_worker(


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Because we need to fix https://github.com/SeldonIO/seldon-core/issues/3377

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/SeldonIO/seldon-core/issues/3377

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

