### PR TITLE
Removing trailing slash to tensorflow serving URL in status addressable

### DIFF
--- a/operator/utils/utils.go
+++ b/operator/utils/utils.go
@@ -54,7 +54,7 @@ func GetPredictionPath(mlDep *machinelearningv1.SeldonDeployment) string {
 
 	if protocol == machinelearningv1.ProtocolTensorflow {
 		// This will be updated as part of https://github.com/SeldonIO/seldon-core/issues/1611
-		return "/v1/models/" + mlDep.Spec.Predictors[0].Graph.Name + "/:predict"
+		return "/v1/models/" + mlDep.Spec.Predictors[0].Graph.Name + ":predict"
 	} else if protocol == machinelearningv1.ProtocolKfserving {
 		return "/v2/models/" + mlDep.Spec.Predictors[0].Graph.Name + "/infer"
 	} else {

--- a/operator/utils/utils_test.go
+++ b/operator/utils/utils_test.go
@@ -182,5 +182,5 @@ func TestTensorflowPredictionPath(t *testing.T) {
 	}
 
 	p := GetPredictionPath(sdep)
-	g.Expect(p).To(Equal("/v1/models/classifier/:predict"))
+	g.Expect(p).To(Equal("/v1/models/classifier:predict"))
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Currently the status addressable for tensorflow serving url contains a trailing slash in the form of `model/:predict`, whereas it should be without the trailing slash as `model:predict`. This PR updates the status addressable to reflect this.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

