### PR TITLE
Disable parallel documentation build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j auto -n
+SPHINXOPTS    = -n
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
@@ -32,7 +32,7 @@ linkcheck:
 	# Check for links reported as broken, ignoring 429 (too many requests)
 	- LINKCHECK=true $(SPHINXBUILD) \
 		-b linkcheck \
-		 $(SPHINXOPTS) \
+		-j auto $(SPHINXOPTS) \
 		"$(SOURCEDIR)" \
 		"$(BUILDDIR)"
 	! grep -v '429' _build/output.txt | grep 'broken'
@@ -41,13 +41,13 @@ linkcheck:
 livehtml:
 	sphinx-autobuild \
 		-b html \
-		--ignore "*~" $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)"
+		--ignore "*~" -j auto $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)"
 
 livehtml-fast:
 	FAST_BUILD=true sphinx-autobuild \
 		 -b html \
 		 --ignore "*~" \
-		 $(SPHINXOPTS) \
+		 -j auto $(SPHINXOPTS) \
 		 "$(SOURCEDIR)" \
 		 "$(BUILDDIR)"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

It looks like the `sphinx_search.extension` plugin that was added recently to the docs (#3433) doesn't support building the docs in parallel. 
The build itself works, but it will trigger a warning that makes our CI/CI pipeline fail.

To account for the above, this PR disables the parallel build (by removing the `-j auto` flag) on the `make html` docs target, which is the one used in our CI/CD pipeline.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

