### PR TITLE
Add golangci-lint linters to the executor

### DIFF
--- a/executor/.errcheck_excludes.txt
+++ b/executor/.errcheck_excludes.txt
@@ -1,0 +1,2 @@
+fmt.Fprintln
+fmt.Fprint

--- a/executor/.golangci.yml
+++ b/executor/.golangci.yml
@@ -34,7 +34,7 @@ linters:
     - gosimple
     - govet
     - misspell
-#    - staticcheck
+    - staticcheck
     - structcheck
     - typecheck
     - varcheck
@@ -44,3 +44,9 @@ linters-settings:
     exclude: ./.errcheck_excludes.txt
   goconst:
     min-occurrences: 5
+
+issues:
+  exclude-rules:
+    - linters:
+        - staticcheck
+      text: "SA1019:" # Delete this exclusion once https://github.com/SeldonIO/seldon-core/issues/3452 is fixed.

--- a/executor/.golangci.yml
+++ b/executor/.golangci.yml
@@ -1,0 +1,46 @@
+# options for analysis running
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 5m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # which dirs to skip: they won't be analyzed;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but next dirs are always skipped independently
+  # from this option's value:
+  #     vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs: vendor
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+linters:
+  disable-all: true
+  enable:
+    # Sorted alphabetically.
+#    - errcheck
+    - exportloopref
+    - goimports
+    - gosimple
+    - govet
+    - misspell
+#    - staticcheck
+    - structcheck
+    - typecheck
+    - varcheck
+
+linters-settings:
+  errcheck:
+    exclude: ./.errcheck_excludes.txt
+  goconst:
+    min-occurrences: 5

--- a/executor/.golangci.yml
+++ b/executor/.golangci.yml
@@ -28,7 +28,7 @@ linters:
   disable-all: true
   enable:
     # Sorted alphabetically.
-#    - errcheck
+    - errcheck
     - exportloopref
     - goimports
     - gosimple

--- a/executor/api/client/client.go
+++ b/executor/api/client/client.go
@@ -3,9 +3,10 @@ package client
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"golang.org/x/xerrors"
-	"io"
 )
 
 const (

--- a/executor/api/grpc/client.go
+++ b/executor/api/grpc/client.go
@@ -2,6 +2,9 @@ package grpc
 
 import (
 	"context"
+	"strconv"
+	"time"
+
 	"github.com/go-logr/logr"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
@@ -11,8 +14,6 @@ import (
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"strconv"
-	"time"
 )
 
 func AddMetadataToOutgoingGrpcContext(ctx context.Context, meta map[string][]string) context.Context {

--- a/executor/api/grpc/client_test.go
+++ b/executor/api/grpc/client_test.go
@@ -30,7 +30,7 @@ func TestAddPuidToCtx(t *testing.T) {
 func getProto(messageType string, messageBytes []byte) proto2.Message {
 	pbtype := proto2.MessageType(messageType)
 	msg := reflect.New(pbtype.Elem()).Interface().(proto2.Message)
-	proto2.Unmarshal(messageBytes, msg)
+	_ = proto2.Unmarshal(messageBytes, msg)
 	return msg
 }
 

--- a/executor/api/grpc/client_test.go
+++ b/executor/api/grpc/client_test.go
@@ -2,14 +2,15 @@ package grpc
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	"github.com/golang/protobuf/jsonpb"
 	proto2 "github.com/golang/protobuf/proto"
 	. "github.com/onsi/gomega"
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"google.golang.org/grpc/metadata"
-	"reflect"
-	"testing"
 )
 
 func TestAddPuidToCtx(t *testing.T) {

--- a/executor/api/grpc/kfserving/client.go
+++ b/executor/api/grpc/kfserving/client.go
@@ -3,6 +3,9 @@ package kfserving
 import (
 	"context"
 	"fmt"
+	"io"
+	"math"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/seldonio/seldon-core/executor/api/client"
@@ -11,8 +14,6 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"google.golang.org/grpc"
-	"io"
-	"math"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/executor/api/grpc/kfserving/client.go
+++ b/executor/api/grpc/kfserving/client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"google.golang.org/grpc"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type KFServingGrpcClient struct {

--- a/executor/api/grpc/kfserving/inference/grpc_service.pb.go
+++ b/executor/api/grpc/kfserving/inference/grpc_service.pb.go
@@ -6,11 +6,12 @@ package inference
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/executor/api/grpc/kfserving/inference/grpc_service.pb.go
+++ b/executor/api/grpc/kfserving/inference/grpc_service.pb.go
@@ -6,12 +6,11 @@ package inference
 import (
 	context "context"
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/executor/api/grpc/kfserving/inference/model_config.pb.go
+++ b/executor/api/grpc/kfserving/inference/model_config.pb.go
@@ -5,9 +5,8 @@ package inference
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/executor/api/grpc/kfserving/inference/model_config.pb.go
+++ b/executor/api/grpc/kfserving/inference/model_config.pb.go
@@ -5,8 +5,9 @@ package inference
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/executor/api/grpc/kfserving/server.go
+++ b/executor/api/grpc/kfserving/server.go
@@ -45,7 +45,7 @@ func (g GrpcKFServingServer) ServerReady(ctx context.Context, request *inference
 func (g GrpcKFServingServer) ModelReady(ctx context.Context, request *inference.ModelReadyRequest) (*inference.ModelReadyResponse, error) {
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
-	protoGrpc.SetHeader(ctx, header)
+	_ = protoGrpc.SetHeader(ctx, header)
 	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("infer"), g.ServerUrl, g.Namespace, md, request.GetName())
 	reqPayload := payload.ProtoPayload{Msg: request}
@@ -63,7 +63,7 @@ func (g GrpcKFServingServer) ServerMetadata(ctx context.Context, request *infere
 func (g GrpcKFServingServer) ModelMetadata(ctx context.Context, request *inference.ModelMetadataRequest) (*inference.ModelMetadataResponse, error) {
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
-	protoGrpc.SetHeader(ctx, header)
+	_ = protoGrpc.SetHeader(ctx, header)
 	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("infer"), g.ServerUrl, g.Namespace, md, request.GetName())
 	reqPayload := payload.ProtoPayload{Msg: request}
@@ -77,7 +77,7 @@ func (g GrpcKFServingServer) ModelMetadata(ctx context.Context, request *inferen
 func (g GrpcKFServingServer) ModelInfer(ctx context.Context, request *inference.ModelInferRequest) (*inference.ModelInferResponse, error) {
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
-	protoGrpc.SetHeader(ctx, header)
+	_ = protoGrpc.SetHeader(ctx, header)
 	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("infer"), g.ServerUrl, g.Namespace, md, request.GetModelName())
 	reqPayload := payload.ProtoPayload{Msg: request}

--- a/executor/api/grpc/kfserving/server.go
+++ b/executor/api/grpc/kfserving/server.go
@@ -46,7 +46,7 @@ func (g GrpcKFServingServer) ModelReady(ctx context.Context, request *inference.
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
 	protoGrpc.SetHeader(ctx, header)
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("infer"), g.ServerUrl, g.Namespace, md, request.GetName())
 	reqPayload := payload.ProtoPayload{Msg: request}
 	resPayload, err := seldonPredictorProcess.Status(&g.predictor.Graph, request.Name, &reqPayload)
@@ -64,7 +64,7 @@ func (g GrpcKFServingServer) ModelMetadata(ctx context.Context, request *inferen
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
 	protoGrpc.SetHeader(ctx, header)
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("infer"), g.ServerUrl, g.Namespace, md, request.GetName())
 	reqPayload := payload.ProtoPayload{Msg: request}
 	resPayload, err := seldonPredictorProcess.Metadata(&g.predictor.Graph, request.Name, &reqPayload)
@@ -78,7 +78,7 @@ func (g GrpcKFServingServer) ModelInfer(ctx context.Context, request *inference.
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
 	protoGrpc.SetHeader(ctx, header)
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("infer"), g.ServerUrl, g.Namespace, md, request.GetModelName())
 	reqPayload := payload.ProtoPayload{Msg: request}
 	resPayload, err := seldonPredictorProcess.Predict(&g.predictor.Graph, &reqPayload)

--- a/executor/api/grpc/kfserving/server.go
+++ b/executor/api/grpc/kfserving/server.go
@@ -2,6 +2,8 @@ package kfserving
 
 import (
 	"context"
+	"net/url"
+
 	"github.com/go-logr/logr"
 	"github.com/seldonio/seldon-core/executor/api/client"
 	"github.com/seldonio/seldon-core/executor/api/grpc"
@@ -11,8 +13,7 @@ import (
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	protoGrpc "google.golang.org/grpc"
 	protoGrpcMetadata "google.golang.org/grpc/metadata"
-	"net/url"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type GrpcKFServingServer struct {

--- a/executor/api/grpc/seldon/client.go
+++ b/executor/api/grpc/seldon/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/util"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"google.golang.org/grpc"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // TODO: make this configurable

--- a/executor/api/grpc/seldon/client.go
+++ b/executor/api/grpc/seldon/client.go
@@ -3,11 +3,16 @@ package seldon
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"sync"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/seldonio/seldon-core/executor/api/client"
-	"math/rand"
-	"sync"
+
+	"io"
+	"math"
+	"net/http"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	grpc2 "github.com/seldonio/seldon-core/executor/api/grpc"
@@ -16,9 +21,6 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/util"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"google.golang.org/grpc"
-	"io"
-	"math"
-	"net/http"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/executor/api/grpc/seldon/client_test.go
+++ b/executor/api/grpc/seldon/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/k8s"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var testProtoModelMetadata = proto.SeldonModelMetadata{

--- a/executor/api/grpc/seldon/client_test.go
+++ b/executor/api/grpc/seldon/client_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"testing"
+
 	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/gomega"
 	"github.com/seldonio/seldon-core/executor/api/grpc"
@@ -12,9 +15,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/k8s"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	"net"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"testing"
 )
 
 var testProtoModelMetadata = proto.SeldonModelMetadata{

--- a/executor/api/grpc/seldon/client_test.go
+++ b/executor/api/grpc/seldon/client_test.go
@@ -65,7 +65,9 @@ func createTestGrpcServer(g *GomegaWithT, annotations map[string]string) (*v1.Pr
 	testSeldonGrpcServer := test.NewSeldonTestServer(1, &testProtoModelMetadata)
 	proto.RegisterModelServer(grpcServer, testSeldonGrpcServer)
 
-	go grpcServer.Serve(lis)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
 	stopFunc := grpcServer.Stop
 
 	return &p, host, port, stopFunc

--- a/executor/api/grpc/seldon/proto/prediction.pb.go
+++ b/executor/api/grpc/seldon/proto/prediction.pb.go
@@ -6,8 +6,6 @@ package proto
 import (
 	context "context"
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	empty "github.com/golang/protobuf/ptypes/empty"
@@ -16,6 +14,7 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/executor/api/grpc/seldon/proto/prediction.pb.go
+++ b/executor/api/grpc/seldon/proto/prediction.pb.go
@@ -6,6 +6,8 @@ package proto
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	empty "github.com/golang/protobuf/ptypes/empty"
@@ -14,7 +16,6 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/executor/api/grpc/seldon/server.go
+++ b/executor/api/grpc/seldon/server.go
@@ -14,7 +14,7 @@ import (
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	protoGrpc "google.golang.org/grpc"
 	protoGrpcMetadata "google.golang.org/grpc/metadata"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type GrpcSeldonServer struct {
@@ -39,7 +39,7 @@ func (g GrpcSeldonServer) Predict(ctx context.Context, req *proto.SeldonMessage)
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
 	protoGrpc.SetHeader(ctx, header)
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("SeldonMessageRestClient"), g.ServerUrl, g.Namespace, md, "")
 	reqPayload := payload.ProtoPayload{Msg: req}
 	resPayload, err := seldonPredictorProcess.Predict(&g.predictor.Graph, &reqPayload)

--- a/executor/api/grpc/seldon/server.go
+++ b/executor/api/grpc/seldon/server.go
@@ -38,7 +38,7 @@ func NewGrpcSeldonServer(predictor *v1.PredictorSpec, client client.SeldonApiCli
 func (g GrpcSeldonServer) Predict(ctx context.Context, req *proto.SeldonMessage) (*proto.SeldonMessage, error) {
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
-	protoGrpc.SetHeader(ctx, header)
+	_ = protoGrpc.SetHeader(ctx, header)
 	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("SeldonMessageRestClient"), g.ServerUrl, g.Namespace, md, "")
 	reqPayload := payload.ProtoPayload{Msg: req}
@@ -53,7 +53,7 @@ func (g GrpcSeldonServer) Predict(ctx context.Context, req *proto.SeldonMessage)
 func (g GrpcSeldonServer) SendFeedback(ctx context.Context, req *proto.Feedback) (*proto.SeldonMessage, error) {
 	md := grpc.CollectMetadata(ctx)
 	header := protoGrpcMetadata.Pairs(payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
-	protoGrpc.SetHeader(ctx, header)
+	_ = protoGrpc.SetHeader(ctx, header)
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName("SeldonMessageRestClient"), g.ServerUrl, g.Namespace, md, "")
 	reqPayload := payload.ProtoPayload{Msg: req}
 	resPayload, err := seldonPredictorProcess.Feedback(&g.predictor.Graph, &reqPayload)

--- a/executor/api/grpc/seldon/server.go
+++ b/executor/api/grpc/seldon/server.go
@@ -2,6 +2,8 @@ package seldon
 
 import (
 	"context"
+	"net/url"
+
 	"github.com/go-logr/logr"
 	empty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/seldonio/seldon-core/executor/api/client"
@@ -12,7 +14,6 @@ import (
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	protoGrpc "google.golang.org/grpc"
 	protoGrpcMetadata "google.golang.org/grpc/metadata"
-	"net/url"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/executor/api/grpc/seldon/server_test.go
+++ b/executor/api/grpc/seldon/server_test.go
@@ -2,6 +2,9 @@ package seldon
 
 import (
 	"context"
+	"net/url"
+	"testing"
+
 	"github.com/golang/protobuf/jsonpb"
 	empty "github.com/golang/protobuf/ptypes/empty"
 	. "github.com/onsi/gomega"
@@ -9,11 +12,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/api/test"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	"net/url"
-	"testing"
 )
-
-const testSeldonPuid = "1"
 
 func TestPredict(t *testing.T) {
 	t.Logf("Started")

--- a/executor/api/grpc/seldon/test/test_server.go
+++ b/executor/api/grpc/seldon/test/test_server.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type GrpcSeldonTestServer struct {

--- a/executor/api/grpc/seldon/test/test_server.go
+++ b/executor/api/grpc/seldon/test/test_server.go
@@ -2,11 +2,12 @@ package test
 
 import (
 	"context"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"time"
 )
 
 type GrpcSeldonTestServer struct {

--- a/executor/api/grpc/tensorflow/client.go
+++ b/executor/api/grpc/tensorflow/client.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type TensorflowGrpcClient struct {

--- a/executor/api/grpc/tensorflow/client.go
+++ b/executor/api/grpc/tensorflow/client.go
@@ -3,6 +3,9 @@ package tensorflow
 import (
 	"context"
 	"fmt"
+	"io"
+	"math"
+
 	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -14,8 +17,6 @@ import (
 	"google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	"io"
-	"math"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/executor/api/grpc/tensorflow/server.go
+++ b/executor/api/grpc/tensorflow/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/predictor"
 	"github.com/seldonio/seldon-core/executor/proto/tensorflow/serving"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type GrpcTensorflowServer struct {
@@ -36,7 +36,7 @@ func NewGrpcTensorflowServer(predictor *v1.PredictorSpec, client client.SeldonAp
 
 func (g *GrpcTensorflowServer) execute(ctx context.Context, req proto.Message, method string, modelName string) (payload.SeldonPayload, error) {
 	md := grpc.CollectMetadata(ctx)
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, md.Get(payload.SeldonPUIDHeader)[0])
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), md.Get(payload.SeldonPUIDHeader)[0])
 	seldonPredictorProcess := predictor.NewPredictorProcess(ctx, g.Client, logf.Log.WithName(method), g.ServerUrl, g.Namespace, md, modelName)
 	reqPayload := payload.ProtoPayload{Msg: req}
 	return seldonPredictorProcess.Predict(&g.predictor.Graph, &reqPayload)

--- a/executor/api/grpc/tensorflow/server_test.go
+++ b/executor/api/grpc/tensorflow/server_test.go
@@ -2,6 +2,11 @@ package tensorflow
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
 	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/gomega"
 	"github.com/seldonio/seldon-core/executor/api/client"
@@ -12,10 +17,6 @@ import (
 	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	status "google.golang.org/grpc/status"
-	"io"
-	"net/http"
-	"net/url"
-	"testing"
 )
 
 const (

--- a/executor/api/kafka/client.go
+++ b/executor/api/kafka/client.go
@@ -31,7 +31,7 @@ func (kc *KafkaClient) IsGrpc() bool {
 	return false
 }
 
-func NewKafkaClient(hostname, deploymentName, namespace, protocol, transport string, predictor *v1.PredictorSpec, broker string, log logr.Logger) client.SeldonApiClient {
+func NewKafkaClient(hostname, deploymentName, namespace, protocol, transport string, predictor *v1.PredictorSpec, broker string, log logr.Logger) (client.SeldonApiClient, error) {
 	skc := &KafkaClient{
 		Hostname:       hostname,
 		DeploymentName: deploymentName,
@@ -43,8 +43,11 @@ func NewKafkaClient(hostname, deploymentName, namespace, protocol, transport str
 		Log:            log.WithName("KafkaClient"),
 		topicHandlers:  make(map[string]*KafkaRPC),
 	}
-	skc.createTopicHandlers(&predictor.Graph)
-	return skc
+	err := skc.createTopicHandlers(&predictor.Graph)
+	if err != nil {
+		return nil, err
+	}
+	return skc, nil
 }
 
 func (kc *KafkaClient) createTopicHandlers(node *v1.PredictiveUnit) error {

--- a/executor/api/kafka/client.go
+++ b/executor/api/kafka/client.go
@@ -3,6 +3,8 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/seldonio/seldon-core/executor/api"
@@ -11,7 +13,6 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/rest"
 	"github.com/seldonio/seldon-core/executor/api/util"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	"io"
 )
 
 type KafkaClient struct {

--- a/executor/api/kafka/proxy.go
+++ b/executor/api/kafka/proxy.go
@@ -130,7 +130,7 @@ func (kp *KafkaProxy) Consume() error {
 				headers := collectHeaders(e.Headers)
 				ctx := context.Background()
 				// Add Seldon Puid to Context
-				ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, puid)
+				ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), puid)
 
 				// Assume JSON if no content type - should maybe be application/octet-stream?
 				contentType := rest.ContentTypeJSON
@@ -157,6 +157,9 @@ func (kp *KafkaProxy) Consume() error {
 						continue
 					}
 					resPayload, err = kp.Client.Combine(ctx, kp.ModelName, kp.Hostname, kp.Port, msgs, headers)
+					if err != nil {
+						kp.Log.Error(err, "Failed to combine Payload")
+					}
 				}
 
 				if err != nil {

--- a/executor/api/kafka/proxy.go
+++ b/executor/api/kafka/proxy.go
@@ -2,15 +2,16 @@ package kafka
 
 import (
 	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/cloudevents/sdk-go/pkg/bindings/http"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/go-logr/logr"
 	"github.com/seldonio/seldon-core/executor/api/client"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/api/rest"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 type KafkaProxy struct {
@@ -79,7 +80,7 @@ func (kp *KafkaProxy) Consume() error {
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 
-	for run == true {
+	for run {
 		select {
 		case sig := <-sigchan:
 			kp.Log.Info("Terminating", "signal", sig)

--- a/executor/api/kafka/server.go
+++ b/executor/api/kafka/server.go
@@ -52,7 +52,10 @@ func NewKafkaServer(fullGraph bool, workers int, deploymentName, namespace, prot
 	var err error
 	if fullGraph {
 		log.Info("Starting full graph kafka server")
-		apiClient = NewKafkaClient(serverUrl.Hostname(), deploymentName, namespace, protocol, transport, predictor, broker, log)
+		apiClient, err = NewKafkaClient(serverUrl.Hostname(), deploymentName, namespace, protocol, transport, predictor, broker, log)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		switch transport {
 		case api.TransportRest:

--- a/executor/api/kafka/server_test.go
+++ b/executor/api/kafka/server_test.go
@@ -1,11 +1,12 @@
 package kafka
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/gomega"
 	seldon "github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
-	"testing"
 )
 
 func TestGetProtoSeldonMessage(t *testing.T) {

--- a/executor/api/kafka/server_test.go
+++ b/executor/api/kafka/server_test.go
@@ -14,7 +14,8 @@ func TestGetProtoSeldonMessage(t *testing.T) {
 
 	var sm seldon.SeldonMessage
 	var data = `{"data":{"ndarray":[1.1,2]}}`
-	jsonpb.UnmarshalString(data, &sm)
+	err := jsonpb.UnmarshalString(data, &sm)
+	g.Expect(err).To(BeNil())
 
 	b, err := proto.Marshal(&sm)
 	g.Expect(err).To(BeNil())

--- a/executor/api/kafka/topic.go
+++ b/executor/api/kafka/topic.go
@@ -2,15 +2,16 @@ package kafka
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
 	"github.com/cloudevents/sdk-go/pkg/bindings/http"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/go-logr/logr"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/api/rest"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
 )
 
 const (
@@ -96,7 +97,7 @@ func (tp *KafkaRPC) start() {
 		sigchan := make(chan os.Signal, 1)
 		signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 
-		for run == true {
+		for run {
 			select {
 			case sig := <-sigchan:
 				tp.Log.Info("Terminating", "signal", sig)

--- a/executor/api/kafka/worker.go
+++ b/executor/api/kafka/worker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/predictor"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type KafkaJob struct {
@@ -31,7 +31,7 @@ func (ks *SeldonKafkaServer) worker(jobChan <-chan *KafkaJob, cancelChan <-chan 
 func (ks *SeldonKafkaServer) processKafkaRequest(job *KafkaJob) {
 	ctx := context.Background()
 	// Add Seldon Puid to Context
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, job.headers[payload.SeldonPUIDHeader][0])
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), job.headers[payload.SeldonPUIDHeader][0])
 
 	// Apply tracing if active
 	if opentracing.IsGlobalTracerRegistered() {

--- a/executor/api/kafka/worker.go
+++ b/executor/api/kafka/worker.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"

--- a/executor/api/metric/client.go
+++ b/executor/api/metric/client.go
@@ -41,7 +41,7 @@ func NewClientMetrics(spec *v1.PredictorSpec, deploymentName string, modelName s
 		if e, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			if RecreateClientHistogram {
 				prometheus.Unregister(e.ExistingCollector)
-				prometheus.Register(histogram)
+				_ = prometheus.Register(histogram)
 			} else {
 				histogram = e.ExistingCollector.(*prometheus.HistogramVec)
 			}
@@ -62,7 +62,7 @@ func NewClientMetrics(spec *v1.PredictorSpec, deploymentName string, modelName s
 		if e, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			if RecreateClientSummary {
 				prometheus.Unregister(e.ExistingCollector)
-				prometheus.Register(summary)
+				_ = prometheus.Register(summary)
 			} else {
 				summary = e.ExistingCollector.(*prometheus.SummaryVec)
 			}

--- a/executor/api/metric/client_test.go
+++ b/executor/api/metric/client_test.go
@@ -1,10 +1,11 @@
 package metric
 
 import (
+	"testing"
+
 	. "github.com/onsi/gomega"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	v12 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func TestNewFromtMeta(t *testing.T) {

--- a/executor/api/metric/server.go
+++ b/executor/api/metric/server.go
@@ -36,7 +36,7 @@ func NewServerMetrics(spec *v1.PredictorSpec, deploymentName string) *ServerMetr
 		if e, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			if RecreateServerHistogram {
 				prometheus.Unregister(e.ExistingCollector)
-				prometheus.Register(histogram)
+				_ = prometheus.Register(histogram)
 			} else {
 				histogram = e.ExistingCollector.(*prometheus.HistogramVec)
 			}
@@ -56,7 +56,7 @@ func NewServerMetrics(spec *v1.PredictorSpec, deploymentName string) *ServerMetr
 		if e, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			if RecreateServerSummary {
 				prometheus.Unregister(e.ExistingCollector)
-				prometheus.Register(summary)
+				_ = prometheus.Register(summary)
 			} else {
 				summary = e.ExistingCollector.(*prometheus.SummaryVec)
 			}

--- a/executor/api/payload/metadata.go
+++ b/executor/api/payload/metadata.go
@@ -1,5 +1,7 @@
 package payload
 
+type SeldonPUIDHeaderIdentifier string
+
 const (
 	SeldonPUIDHeader = "Seldon-Puid"
 )

--- a/executor/api/payload/metadata.go
+++ b/executor/api/payload/metadata.go
@@ -13,9 +13,7 @@ func NewFromMap(m map[string][]string) *MetaData {
 		Meta: map[string][]string{},
 	}
 	for k, vv := range m {
-		for _, v := range vv {
-			meta.Meta[k] = append(meta.Meta[k], v)
-		}
+		meta.Meta[k] = append(meta.Meta[k], vv...)
 	}
 	return &meta
 }

--- a/executor/api/payload/metadata_test.go
+++ b/executor/api/payload/metadata_test.go
@@ -1,8 +1,9 @@
 package payload
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestNewFromtMeta(t *testing.T) {

--- a/executor/api/payload/payload_test.go
+++ b/executor/api/payload/payload_test.go
@@ -11,7 +11,8 @@ import (
 func TestGetPayload(t *testing.T) {
 	var sm proto.SeldonMessage
 	var data = `{"data":{"ndarray":[1.1,2]}}`
-	jsonpb.UnmarshalString(data, &sm)
+	err := jsonpb.UnmarshalString(data, &sm)
+	assert.NilError(t, err)
 
 	var sp SeldonPayload = &ProtoPayload{&sm}
 

--- a/executor/api/payload/payload_test.go
+++ b/executor/api/payload/payload_test.go
@@ -1,10 +1,11 @@
 package payload
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 	"gotest.tools/assert"
-	"testing"
 )
 
 func TestGetPayload(t *testing.T) {
@@ -14,8 +15,7 @@ func TestGetPayload(t *testing.T) {
 
 	var sp SeldonPayload = &ProtoPayload{&sm}
 
-	var sm2 *proto.SeldonMessage
-	sm2 = sp.GetPayload().(*proto.SeldonMessage)
+	var sm2 = sp.GetPayload().(*proto.SeldonMessage)
 
 	ma := jsonpb.Marshaler{}
 	msgStr, _ := ma.MarshalToString(sm2)

--- a/executor/api/payload/proto_test.go
+++ b/executor/api/payload/proto_test.go
@@ -1,11 +1,12 @@
 package payload
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/gomega"
 	seldon "github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
-	"testing"
 )
 
 func TestGetProtoPayload(t *testing.T) {

--- a/executor/api/payload/proto_test.go
+++ b/executor/api/payload/proto_test.go
@@ -13,13 +13,15 @@ func TestGetProtoPayload(t *testing.T) {
 	g := NewGomegaWithT(t)
 	var sm seldon.SeldonMessage
 	var data = `{"data":{"ndarray":[1.1,2]}}`
-	jsonpb.UnmarshalString(data, &sm)
+	err := jsonpb.UnmarshalString(data, &sm)
+	g.Expect(err).Should(BeNil())
 
 	payload := ProtoPayload{Msg: &sm}
 	b, err := payload.GetBytes()
 	g.Expect(err).Should(BeNil())
 	var sm2 seldon.SeldonMessage
-	proto.Unmarshal(b, &sm2)
+	err = proto.Unmarshal(b, &sm2)
+	g.Expect(err).Should(BeNil())
 
 	g.Expect(proto.Equal(&sm2, &sm)).Should(Equal(true))
 

--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -28,7 +28,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/util"
 	"github.com/seldonio/seldon-core/executor/k8s"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (

--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -198,7 +198,8 @@ func (smc *JSONRestClient) doHttp(ctx context.Context, modelName string, method 
 			method,
 			startSpanOptions...)
 		defer clientSpan.Finish()
-		tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
+		err := tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
+		smc.Log.Info("injecting trace failed", "error", err.Error())
 	}
 
 	client := smc.httpClient

--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -4,6 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
 	http2 "github.com/cloudevents/sdk-go/pkg/bindings/http"
 	"github.com/go-logr/logr"
 	"github.com/golang/protobuf/jsonpb"
@@ -19,15 +28,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/util"
 	"github.com/seldonio/seldon-core/executor/k8s"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	"io"
-	"io/ioutil"
-	"net"
-	"net/http"
-	"net/url"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (

--- a/executor/api/rest/client_test.go
+++ b/executor/api/rest/client_test.go
@@ -84,7 +84,7 @@ func createPayload(g *GomegaWithT) payload.SeldonPayload {
 
 func createTestContext() context.Context {
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, "1")
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), "1")
 	return ctx
 }
 

--- a/executor/api/rest/client_test.go
+++ b/executor/api/rest/client_test.go
@@ -92,7 +92,7 @@ func TestSimpleMethods(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(okPredictResponse))
+		_, _ = w.Write([]byte(okPredictResponse))
 	})
 	host, port, httpClient, teardown := testingHTTPClient(g, h)
 	defer teardown()
@@ -121,7 +121,7 @@ func TestRouter(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(okRouteResponse))
+		_, _ = w.Write([]byte(okRouteResponse))
 	})
 	host, port, httpClient, teardown := testingHTTPClient(g, h)
 	defer teardown()
@@ -142,7 +142,7 @@ func TestStatus(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(okStatusResponse))
+		_, _ = w.Write([]byte(okStatusResponse))
 	})
 	host, port, httpClient, teardown := testingHTTPClient(g, h)
 	defer teardown()
@@ -163,7 +163,7 @@ func TestMetadata(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(okMetadataResponse))
+		_, _ = w.Write([]byte(okMetadataResponse))
 	})
 	host, port, httpClient, teardown := testingHTTPClient(g, h)
 	defer teardown()
@@ -190,7 +190,7 @@ func TestCombiner(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(okPredictResponse))
+		_, _ = w.Write([]byte(okPredictResponse))
 	})
 	host, port, httpClient, teardown := testingHTTPClient(g, h)
 	defer teardown()
@@ -218,7 +218,7 @@ func TestClientMetrics(t *testing.T) {
 	metric.RecreateClientHistogram = true
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(okPredictResponse))
+		_, _ = w.Write([]byte(okPredictResponse))
 	})
 	host, port, httpClient, teardown := testingHTTPClient(g, h)
 	defer teardown()
@@ -285,7 +285,7 @@ func TestErrorResponse(t *testing.T) {
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(errorPredictResponse))
+		_, _ = w.Write([]byte(errorPredictResponse))
 	})
 	host, port, _, teardown := testingHTTPClient(g, h)
 
@@ -316,7 +316,7 @@ func TestTimeout(t *testing.T) {
 	g := NewGomegaWithT(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(1 * time.Second)
-		w.Write([]byte(okStatusResponse))
+		_, _ = w.Write([]byte(okStatusResponse))
 	})
 	host, port, _, teardown := testingHTTPClient(g, h)
 

--- a/executor/api/rest/kfserving.go
+++ b/executor/api/rest/kfserving.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+
 	"github.com/pkg/errors"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 )

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	http2 "github.com/cloudevents/sdk-go/pkg/bindings/http"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	http2 "github.com/cloudevents/sdk-go/pkg/bindings/http"
+
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
@@ -22,7 +25,6 @@ import (
 	"github.com/seldonio/seldon-core/executor/predictor"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"time"
 )
 
 type SeldonRestApi struct {

--- a/executor/api/rest/server.go
+++ b/executor/api/rest/server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/predictor"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type SeldonRestApi struct {
@@ -252,7 +252,7 @@ func (r *SeldonRestApi) status(w http.ResponseWriter, req *http.Request) {
 
 func (r *SeldonRestApi) feedback(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, req.Header.Get(payload.SeldonPUIDHeader))
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), req.Header.Get(payload.SeldonPUIDHeader))
 
 	// Apply tracing if active
 	if opentracing.IsGlobalTracerRegistered() {
@@ -287,7 +287,7 @@ func (r *SeldonRestApi) predictions(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 	// Add Seldon Puid to Context
-	ctx = context.WithValue(ctx, payload.SeldonPUIDHeader, req.Header.Get(payload.SeldonPUIDHeader))
+	ctx = context.WithValue(ctx, payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), req.Header.Get(payload.SeldonPUIDHeader))
 
 	// Apply tracing if active
 	if opentracing.IsGlobalTracerRegistered() {

--- a/executor/api/rest/server_test.go
+++ b/executor/api/rest/server_test.go
@@ -185,7 +185,7 @@ func TestRequestPuuidHeaderIsSet(t *testing.T) {
 		g.Expect(err).To(BeNil())
 		g.Expect(len(r.Header.Get(payload.SeldonPUIDHeader))).To(Equal(len(guuid.New().String())))
 		called = true
-		w.Write([]byte(bodyBytes))
+		_, _ = w.Write(bodyBytes)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -266,7 +266,7 @@ func TestModelWithServer(t *testing.T) {
 		g.Expect(err).To(BeNil())
 		g.Expect(r.Header.Get(payload.SeldonPUIDHeader)).To(Equal(TestSeldonPuid))
 		called = true
-		w.Write([]byte(bodyBytes))
+		_, _ = w.Write([]byte(bodyBytes))
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -609,7 +609,7 @@ func TestPredictErrorWithServer(t *testing.T) {
 		g.Expect(r.Header.Get(payload.SeldonPUIDHeader)).To(Equal(TestSeldonPuid))
 		called = true
 		w.WriteHeader(errorCode)
-		w.Write([]byte(errorPredictResponse))
+		_, _ = w.Write([]byte(errorPredictResponse))
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()

--- a/executor/api/rest/tensorflow.go
+++ b/executor/api/rest/tensorflow.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+
 	"github.com/pkg/errors"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 )

--- a/executor/api/rest/utils.go
+++ b/executor/api/rest/utils.go
@@ -127,6 +127,9 @@ func EmbedSeldonDeploymentValuesInSwaggerFile(namespace string, sdepName string)
 
 	// We use MarshalIndent so that the output can be humanly visible and indented
 	openapiOutputBytes, err := json.MarshalIndent(openapiInterface, "", "    ")
+	if err != nil {
+		return err
+	}
 
 	if err := ioutil.WriteFile(openapiFilePath, openapiOutputBytes, 0644); err != nil {
 		return err

--- a/executor/api/rest/utils.go
+++ b/executor/api/rest/utils.go
@@ -44,7 +44,10 @@ func ExtractSeldonMessagesFromJson(msg payload.SeldonPayload) ([]payload.SeldonP
 	}
 	var v []interface{}
 	sms := make([]payload.SeldonPayload, len(v))
-	json.Unmarshal(bytes, &v)
+	err = json.Unmarshal(bytes, &v)
+	if err != nil {
+		return nil, err
+	}
 	for _, m := range v {
 		mBytes, err := json.Marshal(m)
 		if err != nil {

--- a/executor/api/rest/utils.go
+++ b/executor/api/rest/utils.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/seldonio/seldon-core/executor/api/payload"
 	"io/ioutil"
 	"strings"
+
+	"github.com/seldonio/seldon-core/executor/api/payload"
 )
 
 const (

--- a/executor/api/rest/utils_test.go
+++ b/executor/api/rest/utils_test.go
@@ -2,10 +2,11 @@ package rest
 
 import (
 	"encoding/json"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/api/util"
-	"testing"
 )
 
 func TestCombineExtractMessages(t *testing.T) {

--- a/executor/api/test/seldonmessage_test_client.go
+++ b/executor/api/test/seldonmessage_test_client.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	// "errors"
 	"fmt"
+	"io"
+
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 	"github.com/seldonio/seldon-core/executor/api/payload"
-	"github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	"io"
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 )
 
 type SeldonMessageTestClient struct {
@@ -117,7 +118,7 @@ func (s SeldonMessageTestClient) Feedback(ctx context.Context, modelName string,
 		return nil, s.Err
 	}
 	protoFeedback, ok := msg.GetPayload().(*proto.Feedback)
-	if ok == true {
+	if ok {
 		resp := &payload.ProtoPayload{Msg: protoFeedback.Request}
 		return resp, nil
 	}

--- a/executor/api/tracing/trace_test.go
+++ b/executor/api/tracing/trace_test.go
@@ -1,10 +1,11 @@
 package tracing
 
 import (
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber/jaeger-client-go"
 	"os"
 	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
 )
 
 var (

--- a/executor/api/util/utils_test.go
+++ b/executor/api/util/utils_test.go
@@ -41,7 +41,9 @@ func TestExtractRouteFromSeldonMessage(t *testing.T) {
 
 	for _, c := range cases {
 		var sm proto.SeldonMessage
-		jsonpb.UnmarshalString(c.msg, &sm)
+		err := jsonpb.UnmarshalString(c.msg, &sm)
+		g.Expect(err).Should(BeNil())
+
 		routes := ExtractRouteFromSeldonMessage(&sm)
 
 		g.Expect(routes).To(Equal(c.expected))
@@ -108,7 +110,8 @@ func TestInjectRouteSeldonProto(t *testing.T) {
 
 	var smIn proto.SeldonMessage
 	jsonBytes := []byte(`{"data":{"ndarray":[0]},"meta":{"routing":{"test_route":22}}}`)
-	jsonpb.UnmarshalString(string(jsonBytes), &smIn)
+	err := jsonpb.UnmarshalString(string(jsonBytes), &smIn)
+	g.Expect(err).To(BeNil())
 	msg := payload.ProtoPayload{Msg: &smIn}
 
 	outMsg, err := InsertRouteToSeldonPredictPayload(&msg, &testRouting)
@@ -135,7 +138,8 @@ func TestInjectRouteSeldonJson(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	var sm proto.SeldonMessage
-	jsonpb.UnmarshalString(string(outBytes), &sm)
+	err = jsonpb.UnmarshalString(string(outBytes), &sm)
+	g.Expect(err).To(BeNil())
 	t.Log(string(outBytes))
 	routes := sm.GetMeta().GetRouting()
 

--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"strconv"
 	"syscall"
 	"time"
-
-	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/seldonio/seldon-core/executor/api"
@@ -41,12 +40,11 @@ import (
 )
 
 const (
-	logLevelEnvVar        = "SELDON_LOG_LEVEL"
-	logLevelDefault       = "INFO"
-	debugEnvVar           = "SELDON_DEBUG"
-	certMountPathEnvVar   = "SELDON_CERT_MOUNT_PATH"
-	certFileEnvVar        = "SELDON_CERT_FILE_NAME"
-	certKeyFileNameEnvVar = "SELDON_CERT_KEY_FILE_NAME"
+	logLevelEnvVar      = "SELDON_LOG_LEVEL"
+	logLevelDefault     = "INFO"
+	debugEnvVar         = "SELDON_DEBUG"
+	certMountPathEnvVar = "SELDON_CERT_MOUNT_PATH"
+	certFileEnvVar      = "SELDON_CERT_FILE_NAME"
 )
 
 var (

--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -35,8 +35,8 @@ import (
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/reflection"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	zapf "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 const (

--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -120,7 +120,8 @@ func runHttpServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 	defer cancel()
 	// Doesn't block if no connections, but will otherwise wait
 	// until the timeout deadline.
-	srv.Shutdown(ctx)
+	err := srv.Shutdown(ctx)
+	logger.Error(err, "shutdown did not complete successfully")
 	// Optionally, you could run srv.Shutdown in a goroutine and block on
 	// <-ctx.Done() if your application should wait for other services
 	// to finalize based on context cancellation.

--- a/executor/cmd/proxy/main.go
+++ b/executor/cmd/proxy/main.go
@@ -10,7 +10,8 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/rest"
 	"github.com/seldonio/seldon-core/executor/k8s"
 	predictor2 "github.com/seldonio/seldon-core/executor/predictor"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
@@ -61,8 +62,11 @@ func main() {
 	}
 
 	client, err := rest.NewJSONRestClient(*protocol, *sdepName, predictor, annotations)
+	if err != nil {
+		log.Error(err, "Failed to create JSON Rest Client")
+	}
 
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(zap.New(zap.UseDevMode(false)))
 	logger := logf.Log.WithName("entrypoint")
 
 	kafkaProxy := kafka.NewKafkaProxy(client, *modelName, *predictorName, *sdepName, *namespace, *broker, *hostname, int32(*httpPort), logger)

--- a/executor/cmd/proxy/main.go
+++ b/executor/cmd/proxy/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/prometheus/common/log"
 	"github.com/seldonio/seldon-core/executor/api"
 	"github.com/seldonio/seldon-core/executor/api/kafka"
 	"github.com/seldonio/seldon-core/executor/api/rest"
 	"github.com/seldonio/seldon-core/executor/k8s"
 	predictor2 "github.com/seldonio/seldon-core/executor/predictor"
-	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/executor/k8s/annotation.go
+++ b/executor/k8s/annotation.go
@@ -32,6 +32,9 @@ func GetAnnotations() (map[string]string, error) {
 	defer file.Close()
 
 	b, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
 	return getAnnotationMap(string(b))
 }
 

--- a/executor/k8s/annotation_test.go
+++ b/executor/k8s/annotation_test.go
@@ -1,8 +1,9 @@
 package k8s
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestGetAnnotationsSimple(t *testing.T) {

--- a/executor/logger/dispatcher.go
+++ b/executor/logger/dispatcher.go
@@ -18,7 +18,7 @@ func StartDispatcher(nworkers int, log logr.Logger, sdepName string, namespace s
 	}
 
 	go func() {
-		for {
+		for { //nolint. We can use for work := range WorkQueue here, but then the value passed to worker can be mutated.
 			select {
 			case work := <-WorkQueue:
 				go func() {

--- a/executor/logger/worker.go
+++ b/executor/logger/worker.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/cloudevents/sdk-go"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
-	"github.com/go-logr/logr"
 	"net/http"
 	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
+	"github.com/go-logr/logr"
 )
 
 const (

--- a/executor/predictor/components.go
+++ b/executor/predictor/components.go
@@ -1,9 +1,10 @@
 package predictor
 
 import (
-	"github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"math/rand"
 	"strconv"
+
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 )
 
 func (p *PredictorProcess) abTestRouter(node *v1.PredictiveUnit) (int, error) {

--- a/executor/predictor/metadata.go
+++ b/executor/predictor/metadata.go
@@ -3,7 +3,7 @@ package predictor
 import (
 	// "github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 	"github.com/seldonio/seldon-core/executor/api/payload"
-	"github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/executor/predictor/metadata.go
+++ b/executor/predictor/metadata.go
@@ -4,7 +4,7 @@ import (
 	// "github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type GraphMetadata struct {

--- a/executor/predictor/metadata_test.go
+++ b/executor/predictor/metadata_test.go
@@ -2,10 +2,11 @@ package predictor
 
 import (
 	"encoding/json"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	"github.com/seldonio/seldon-core/executor/api/payload"
-	"github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	"testing"
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 )
 
 var metadataMap = map[string]payload.ModelMetadata{

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -333,7 +333,7 @@ func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqTyp
 	if err != nil {
 		return err
 	}
-	payloadLogger.QueueLogRequest(payloadLogger.LogRequest{
+	return payloadLogger.QueueLogRequest(payloadLogger.LogRequest{
 		Url:         logUrl,
 		Bytes:       &data,
 		ContentType: msg.GetContentType(),
@@ -343,7 +343,6 @@ func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqTyp
 		ModelId:     nodeName,
 		RequestId:   puid,
 	})
-	return nil
 }
 
 func (p *PredictorProcess) getPUIDHeader() (string, error) {

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -348,7 +348,7 @@ func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqTyp
 
 func (p *PredictorProcess) getPUIDHeader() (string, error) {
 	// Check request ID is not nil
-	if puid, ok := p.Ctx.Value(payload.SeldonPUIDHeader).(string); ok {
+	if puid, ok := p.Ctx.Value(payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader)).(string); ok {
 		return puid, nil
 	}
 	return "", fmt.Errorf(NilPUIDError)

--- a/executor/predictor/predictor_process_test.go
+++ b/executor/predictor/predictor_process_test.go
@@ -435,7 +435,7 @@ func TestModelWithLogRequests(t *testing.T) {
 		g.Expect(r.Header.Get(modelIdHeaderName)).To(Equal(modelName))
 		g.Expect(r.Header.Get(contentTypeHeaderName)).To(Equal(grpc.ProtobufContentType))
 		g.Expect(r.Header.Get(requestIdHeaderName)).To(Equal(testSeldonPuid))
-		w.Write([]byte(""))
+		_, _ = w.Write([]byte(""))
 		logged = true
 		fmt.Printf("%+v\n", r.Header)
 		fmt.Printf("%+v\n", r.Body)
@@ -481,7 +481,7 @@ func TestModelWithLogRequestsAtDefaultedUrl(t *testing.T) {
 		g.Expect(r.Header.Get(modelIdHeaderName)).To(Equal(modelName))
 		g.Expect(r.Header.Get(contentTypeHeaderName)).To(Equal(grpc.ProtobufContentType))
 		g.Expect(r.Header.Get(requestIdHeaderName)).To(Equal(testSeldonPuid))
-		w.Write([]byte(""))
+		_, _ = w.Write([]byte(""))
 		logged = true
 		fmt.Printf("%+v\n", r.Header)
 		fmt.Printf("%+v\n", r.Body)
@@ -528,7 +528,7 @@ func TestModelWithLogResponses(t *testing.T) {
 		g.Expect(r.Header.Get(modelIdHeaderName)).To(Equal(modelName))
 		g.Expect(r.Header.Get(contentTypeHeaderName)).To(Equal(grpc.ProtobufContentType))
 		g.Expect(r.Header.Get(requestIdHeaderName)).To(Equal(testSeldonPuid))
-		w.Write([]byte(""))
+		_, _ = w.Write([]byte(""))
 		logged = true
 	})
 	server := httptest.NewServer(handler)

--- a/executor/predictor/predictor_process_test.go
+++ b/executor/predictor/predictor_process_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"testing"
 
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/gomega"
 	"github.com/seldonio/seldon-core/executor/api/grpc"
@@ -17,7 +19,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/test"
 	"github.com/seldonio/seldon-core/executor/logger"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -32,35 +34,35 @@ const (
 
 func createPredictorProcess(t *testing.T) *PredictorProcess {
 	url, _ := url.Parse(testSourceUrl)
-	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeader, testSeldonPuid)
+	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), testSeldonPuid)
 	pp := NewPredictorProcess(ctx, &test.SeldonMessageTestClient{}, logf.Log.WithName("SeldonMessageRestClient"), url, "default", map[string][]string{testCustomMetaKey: []string{testCustomMetaValue}}, "")
 	return &pp
 }
 
 func createPredictorProcessWithModel(t *testing.T, modelName string) *PredictorProcess {
 	url, _ := url.Parse(testSourceUrl)
-	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeader, testSeldonPuid)
+	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), testSeldonPuid)
 	pp := NewPredictorProcess(ctx, &test.SeldonMessageTestClient{}, logf.Log.WithName("SeldonMessageRestClient"), url, "default", map[string][]string{testCustomMetaKey: []string{testCustomMetaValue}}, modelName)
 	return &pp
 }
 
 func createPredictorProcessWithMetadata(t *testing.T, metadataResponse payload.SeldonPayload, modelMetadataMap map[string]payload.ModelMetadata) *PredictorProcess {
 	url, _ := url.Parse(testSourceUrl)
-	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeader, testSeldonPuid)
+	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), testSeldonPuid)
 	pp := NewPredictorProcess(ctx, &test.SeldonMessageTestClient{MetadataResponse: metadataResponse, ModelMetadataMap: modelMetadataMap}, logf.Log.WithName("SeldonMessageRestClient"), url, "default", map[string][]string{testCustomMetaKey: []string{testCustomMetaValue}}, "")
 	return &pp
 }
 
 func createPredictorProcessWithRoute(t *testing.T, chosenRoute int) *PredictorProcess {
 	url, _ := url.Parse(testSourceUrl)
-	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeader, testSeldonPuid)
+	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), testSeldonPuid)
 	pp := NewPredictorProcess(ctx, &test.SeldonMessageTestClient{ChosenRoute: chosenRoute}, logf.Log.WithName("SeldonMessageRestClient"), url, "default", map[string][]string{}, "")
 	return &pp
 }
 
 func createPredictorProcessWithError(t *testing.T, errMethod *v1.PredictiveUnitMethod, err error, errPayload payload.SeldonPayload) *PredictorProcess {
 	url, _ := url.Parse(testSourceUrl)
-	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeader, testSeldonPuid)
+	ctx := context.WithValue(context.TODO(), payload.SeldonPUIDHeaderIdentifier(payload.SeldonPUIDHeader), testSeldonPuid)
 	pp := NewPredictorProcess(ctx, &test.SeldonMessageTestClient{ErrMethod: errMethod, Err: err, ErrPayload: errPayload}, logf.Log.WithName("SeldonMessageRestClient"), url, "default", map[string][]string{}, "")
 	return &pp
 }
@@ -441,7 +443,7 @@ func TestModelWithLogRequests(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(zap.New(zap.UseDevMode(false)))
 	log := logf.Log.WithName("entrypoint")
 	logger.StartDispatcher(1, log, "", "", "")
 
@@ -489,7 +491,7 @@ func TestModelWithLogRequestsAtDefaultedUrl(t *testing.T) {
 
 	envRequestLoggerDefaultEndpoint = server.URL
 
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(zap.New(zap.UseDevMode(false)))
 	log := logf.Log.WithName("entrypoint")
 	logger.StartDispatcher(1, log, "", "", "")
 
@@ -532,7 +534,7 @@ func TestModelWithLogResponses(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(zap.New(zap.UseDevMode(false)))
 	log := logf.Log.WithName("entrypoint")
 	logger.StartDispatcher(1, log, "", "", "")
 

--- a/executor/predictor/predictor_process_test.go
+++ b/executor/predictor/predictor_process_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/api/payload"
 	"github.com/seldonio/seldon-core/executor/api/test"
 	"github.com/seldonio/seldon-core/executor/logger"
-	"github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/executor/predictor/ready_checker.go
+++ b/executor/predictor/ready_checker.go
@@ -2,8 +2,9 @@ package predictor
 
 import (
 	"fmt"
-	"github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"net"
+
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 )
 
 func Ready(node *v1.PredictiveUnit) error {

--- a/executor/predictor/ready_checker.go
+++ b/executor/predictor/ready_checker.go
@@ -18,11 +18,8 @@ func Ready(node *v1.PredictiveUnit) error {
 		c, err := net.Dial("tcp", fmt.Sprintf("%s:%d", node.Endpoint.ServiceHost, node.Endpoint.ServicePort))
 		if err != nil {
 			return err
-		} else {
-			err = c.Close()
-			return nil
 		}
-	} else {
-		return nil
+		_ = c.Close()
 	}
+	return nil
 }

--- a/executor/predictor/utils.go
+++ b/executor/predictor/utils.go
@@ -4,11 +4,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/ghodss/yaml"
-	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/ghodss/yaml"
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 )
 
 func GetPredictor(predictorName, filename, sdepName, namespace string, configPath *string) (*v1.PredictorSpec, error) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR adds a set of [golangci-lint](https://github.com/golangci/golangci-lint) linters to the executor package and fixes the errors they report. 

I plan on doing the same for the operator, adding the `golangci-lint` binary to the core-builder image, and making the linting a step in CI.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
nope

