### PR TITLE
Add golangci-lint to operator and executor test step and to core-builder image

### DIFF
--- a/.github/workflows/executor_tests.yml
+++ b/.github/workflows/executor_tests.yml
@@ -10,7 +10,7 @@ jobs:
   executor-tests:
 
     runs-on: ubuntu-18.04
-    container: seldonio/core-builder:0.22
+    container: seldonio/core-builder:0.24
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/operator_tests.yml
+++ b/.github/workflows/operator_tests.yml
@@ -10,7 +10,7 @@ jobs:
   operator-tests:
 
     runs-on: ubuntu-18.04
-    container: seldonio/core-builder:0.22
+    container: seldonio/core-builder:0.24
 
     steps:
     - uses: actions/checkout@v2

--- a/core-builder/Dockerfile
+++ b/core-builder/Dockerfile
@@ -98,6 +98,9 @@ RUN curl -sL https://go.kubebuilder.io/dl/2.3.0/linux/amd64 | tar -xz -C /tmp/ &
         mv /tmp/kubebuilder_2.3.0_linux_amd64 /usr/local/kubebuilder/
 ENV PATH /usr/local/kubebuilder/bin:$PATH
 
+# Install golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.35.2
+
 # DOWNLOAD HELM
 RUN curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.2.0
 

--- a/core-builder/Makefile
+++ b/core-builder/Makefile
@@ -1,5 +1,5 @@
 DOCKER_IMAGE_NAME=seldonio/core-builder
-DOCKER_IMAGE_VERSION=0.23
+DOCKER_IMAGE_VERSION=0.24
 
 build_docker_image:
 	cp ../testing/scripts/dev_requirements.txt .

--- a/executor/Makefile
+++ b/executor/Makefile
@@ -25,9 +25,12 @@ fmt:
 vet:
 	go vet ${EXECUTOR_FOLDERS}
 
+# Run the linters specified in the .golangci.yml config
+golangci-lint:
+	golangci-lint run
 
 # Build manager binary
-executor: copy_operator fmt vet
+executor: copy_operator fmt vet golangci-lint
 	go build -o executor cmd/executor/main.go
 
 
@@ -80,7 +83,7 @@ add_protos:
 	cd serving && find ./tensorflow_serving -name '*.proto' | cpio -pdm ../proto
 
 # Run tests
-test: copy_operator fmt vet
+test: copy_operator fmt vet golangci-lint
 	go test ${EXECUTOR_FOLDERS} -coverprofile cover.out
 
 copy_openapi_resources:

--- a/executor/README.md
+++ b/executor/README.md
@@ -58,4 +58,9 @@ spec:
 We assume:
 
  * Go 1.13
- 
+ * golangci-lint v1.35.2
+
+For linting the `golangci-lint` binary is required. To install, follow the [official install instructions](https://golangci-lint.run/usage/install/) by running:
+```shell
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.35.2
+```

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -30,11 +30,11 @@ lint: licenses/dep.txt
 		./licenses
 
 # Run tests
-test: generate fmt vet manifests_all generate-resources
+test: generate fmt vet golangci-lint manifests_all generate-resources
 	ginkgo -r -outputdir=. -cover -coverprofile=cover.out ./controllers ./utils ./apis
 
 # Build manager binary
-manager: generate fmt vet
+manager: generate fmt vet golangci-lint
 	go build -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
@@ -138,6 +138,10 @@ fmt:
 # Run go vet against code
 vet:
 	go vet ./...
+
+# Run the linters specified in the .golangci.yml config
+golangci-lint:
+	golangci-lint run
 
 # Generate code
 generate: controller-gen

--- a/operator/README.md
+++ b/operator/README.md
@@ -6,6 +6,7 @@ We assume:
 
  * Go 1.13
  * Kubebuilder 2.3.0
+ * golangci-lint v1.35.2
 
 ### Issues
 
@@ -15,6 +16,11 @@ We assume:
 ### Prerequisites
 
 For running locally `kind`, `kustomize` and `kubebuilder` should be installed.
+
+For linting the `golangci-lint` binary is required. To install, follow the [official install instructions](https://golangci-lint.run/usage/install/) by running:
+```shell
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.35.2
+```
 
 ### Testing
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

* Adds golangci-lint to the core-builder image
* Updates the version of core-builder used in executor and operator tests
* Run golangci-lint as part of the test make target in the executor and operator

The tests here will fail until we build and push the new image of the core-builder. Wanted to get your opinion on this change before building and pushing the new image.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
nope

