### PR TITLE
Auto set GOMAXPROCS based on container limits in executor and operator

### DIFF
--- a/executor/go.mod
+++ b/executor/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/tensorflow/tensorflow/tensorflow/go/core v0.0.0-00010101000000-000000000000
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
+	go.uber.org/automaxprocs v1.4.0
 	go.uber.org/zap v1.19.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/grpc v1.37.0
@@ -33,5 +34,7 @@ replace github.com/tensorflow/tensorflow/tensorflow/go/core => ./proto/tensorflo
 replace github.com/seldonio/seldon-core/operator => ./_operator
 
 replace k8s.io/client-go => k8s.io/client-go v0.21.3
+
+replace github.com/codahale/hdrhistogram => github.com/HdrHistogram/hdrhistogram-go v1.1.2
 
 exclude github.com/go-logr/logr v1.0.0

--- a/executor/go.sum
+++ b/executor/go.sum
@@ -165,6 +165,8 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced3
 github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.3/go.mod h1:f96W2HYy3tiBNV5zbbRc+NczwYHgG1PHXMQfoEWv680=
 github.com/GoogleCloudPlatform/testgrid v0.0.7/go.mod h1:lmtHGBL0M/MLbu1tR9BWV7FGZ1FEFIdPqmJiHNCL7y8=
 github.com/GoogleCloudPlatform/testgrid v0.0.13/go.mod h1:UlC/MvnkKjiVGijIKOHxnVyhDiTDCydw9H1XzmclQGU=
+github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
+github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Huawei/gophercloud v1.0.21/go.mod h1:TUtAO2PE+Nj7/QdfUXbhi5Xu0uFKVccyukPA7UCxD9w=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -195,6 +197,7 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/jsonschema v0.0.0-20180308105923-f2c93856175a/go.mod h1:qpebaTNSsyUn5rPSJMsfqEtDw71TTggXM6stUDI16HA=
 github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
@@ -312,8 +315,6 @@ github.com/cloudevents/sdk-go/v2 v2.0.0/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoa
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
-github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/confluentinc/confluent-kafka-go v1.4.2 h1:13EK9RTujF7lVkvHQ5Hbu6bM+Yfrq8L0MkJNnjHSd4Q=
 github.com/confluentinc/confluent-kafka-go v1.4.2/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -429,6 +430,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
+github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -578,6 +580,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -879,6 +882,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kedacore/keda v0.0.0-20200911122749-717aab81817f h1:WgdTgJ5JmSDV1Vn9bP5qo7Ku1xWL4kmfZxZ0/xdy2mo=
 github.com/kedacore/keda v0.0.0-20200911122749-717aab81817f/go.mod h1:BoHjot8ykiIgia7DiJIzRYOfOX4fXBCxWsJlWo5NoxM=
@@ -1405,6 +1409,7 @@ go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/automaxprocs v1.3.0/go.mod h1:9CWT6lKIep8U41DDaPiH6eFscnTyjfTANNQNx6LrIcA=
+go.uber.org/automaxprocs v1.4.0 h1:CpDZl6aOlLhReez+8S3eEotD7Jx0Os++lemPlMULQP0=
 go.uber.org/automaxprocs v1.4.0/go.mod h1:/mTEdr7LvHhs0v7mjdxDreTz1OG5zdZGqgOnhWiR/+Q=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
@@ -1469,6 +1474,7 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210415154028-4f45737414dc/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1484,6 +1490,7 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1834,11 +1841,14 @@ gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3m
 gomodules.xyz/jsonpatch/v2 v2.1.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
+gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
+gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
+gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181021000519-a2651947f503/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -2257,6 +2267,7 @@ pack.ag/amqp v0.11.2/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/letsencrypt v0.0.3/go.mod h1:buyQKZ6IXrRnB7TdkHP0RyEybLx18HHyOSoTyoOLqNY=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=

--- a/executor/licenses/additional_license_info.csv
+++ b/executor/licenses/additional_license_info.csv
@@ -100,3 +100,5 @@ https://github.com/klauspost/compress/blob/master/LICENSE,Apache License 2.0
 https://github.com/pelletier/go-toml/blob/master/LICENSE,MIT License
 https://github.com/samuel/go-zookeeper/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License
 https://github.com/tsenart/go-tsz/blob/master/LICENSE,Apache License 2.0
+https://github.com/ajstarks/svgo/blob/master/LICENSE,Creative Commons Attribution 4.0 International Public License
+https://github.com/golang/freetype/blob/master/LICENSE,The GNU General Public License Version 3.0

--- a/executor/licenses/dep.txt
+++ b/executor/licenses/dep.txt
@@ -69,6 +69,7 @@ github.com/StackExchange/wmi
 github.com/VividCortex/gohistogram
 github.com/afex/hystrix-go
 github.com/agnivade/levenshtein
+github.com/ajstarks/svgo
 github.com/alcortesm/tgz
 github.com/alecthomas/jsonschema
 github.com/alecthomas/kingpin
@@ -200,6 +201,7 @@ github.com/fatih/camelcase
 github.com/fatih/color
 github.com/fatih/structs
 github.com/flynn/go-shlex
+github.com/fogleman/gg
 github.com/form3tech-oss/jwt-go
 github.com/fortytw2/leaktest
 github.com/franela/goblin
@@ -258,6 +260,7 @@ github.com/gofrs/flock
 github.com/gogo/googleapis
 github.com/gogo/protobuf
 github.com/golang-sql/civil
+github.com/golang/freetype
 github.com/golang/gddo
 github.com/golang/glog
 github.com/golang/groupcache
@@ -392,6 +395,7 @@ github.com/json-iterator/go
 github.com/jstemmer/go-junit-report
 github.com/jtolds/gls
 github.com/julienschmidt/httprouter
+github.com/jung-kurt/gofpdf
 github.com/kballard/go-shellquote
 github.com/kedacore/keda
 github.com/kelseyhightower/envconfig
@@ -648,6 +652,7 @@ golang.org/x/xerrors
 gomodules.xyz/jsonpatch/v2
 gonum.org/v1/gonum
 gonum.org/v1/netlib
+gonum.org/v1/plot
 google.golang.org/api
 google.golang.org/appengine
 google.golang.org/cloud
@@ -728,6 +733,7 @@ pack.ag/amqp
 pgregory.net/rapid
 rsc.io/binaryregexp
 rsc.io/letsencrypt
+rsc.io/pdf
 rsc.io/quote/v3
 rsc.io/sampler
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client

--- a/executor/licenses/license.txt
+++ b/executor/licenses/license.txt
@@ -282,7 +282,7 @@ Azure/azure-sdk-for-go  MIT License  https://github.com/Azure/azure-sdk-for-go/b
 --------------------------------------------------------------------------------
 The MIT License (MIT)
 
-Copyright (c) 2021 Microsoft
+Copyright (c) Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -301,6 +301,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
 --------------------------------------------------------------------------------
 Azure/azure-service-bus-go  MIT License  https://github.com/Azure/azure-service-bus-go/blob/master/LICENSE
 --------------------------------------------------------------------------------
@@ -3449,6 +3450,230 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+ajstarks/svgo  Creative Commons Attribution 4.0 International Public License  https://github.com/ajstarks/svgo/blob/master/LICENSE
+--------------------------------------------------------------------------------
+Creative Commons Attribution 4.0 International Public License 
+
+By exercising the Licensed Rights (defined below), You accept and agree to
+be bound by the terms and conditions of this Creative Commons Attribution
+4.0 International Public License ("Public License"). To the extent this
+Public License may be interpreted as a contract, You are granted the
+Licensed Rights in consideration of Your acceptance of these terms and
+conditions, and the Licensor grants You such rights in consideration
+of benefits the Licensor receives from making the Licensed Material
+available under these terms and conditions.
+
+Section 1 – Definitions.
+
+Adapted Material means material subject to Copyright and Similar Rights
+that is derived from or based upon the Licensed Material and in which
+the Licensed Material is translated, altered, arranged, transformed, or
+otherwise modified in a manner requiring permission under the Copyright
+and Similar Rights held by the Licensor. For purposes of this Public
+License, where the Licensed Material is a musical work, performance,
+or sound recording, Adapted Material is always produced where the
+Licensed Material is synched in timed relation with a moving image.
+Adapter's License means the license You apply to Your Copyright and
+Similar Rights in Your contributions to Adapted Material in accordance
+with the terms and conditions of this Public License.  Copyright and
+Similar Rights means copyright and/or similar rights closely related to
+copyright including, without limitation, performance, broadcast, sound
+recording, and Sui Generis Database Rights, without regard to how the
+rights are labeled or categorized. For purposes of this Public License,
+the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar
+Rights.  Effective Technological Measures means those measures that,
+in the absence of proper authority, may not be circumvented under laws
+fulfilling obligations under Article 11 of the WIPO Copyright Treaty
+adopted on December 20, 1996, and/or similar international agreements.
+Exceptions and Limitations means fair use, fair dealing, and/or any other
+exception or limitation to Copyright and Similar Rights that applies to
+Your use of the Licensed Material.  Licensed Material means the artistic
+or literary work, database, or other material to which the Licensor
+applied this Public License.  Licensed Rights means the rights granted
+to You subject to the terms and conditions of this Public License, which
+are limited to all Copyright and Similar Rights that apply to Your use
+of the Licensed Material and that the Licensor has authority to license.
+Licensor means the individual(s) or entity(ies) granting rights under
+this Public License.  Share means to provide material to the public by
+any means or process that requires permission under the Licensed Rights,
+such as reproduction, public display, public performance, distribution,
+dissemination, communication, or importation, and to make material
+available to the public including in ways that members of the public
+may access the material from a place and at a time individually chosen
+by them.  Sui Generis Database Rights means rights other than copyright
+resulting from Directive 96/9/EC of the European Parliament and of the
+Council of 11 March 1996 on the legal protection of databases, as amended
+and/or succeeded, as well as other essentially equivalent rights anywhere
+in the world.  You means the individual or entity exercising the Licensed
+Rights under this Public License. Your has a corresponding meaning.
+Section 2 – Scope.
+
+License grant.  Subject to the terms and conditions of this Public
+License, the Licensor hereby grants You a worldwide, royalty-free,
+non-sublicensable, non-exclusive, irrevocable license to exercise the
+Licensed Rights in the Licensed Material to: reproduce and Share the
+Licensed Material, in whole or in part; and produce, reproduce, and
+Share Adapted Material.  Exceptions and Limitations. For the avoidance
+of doubt, where Exceptions and Limitations apply to Your use, this
+Public License does not apply, and You do not need to comply with
+its terms and conditions.  Term. The term of this Public License is
+specified in Section 6(a).  Media and formats; technical modifications
+allowed. The Licensor authorizes You to exercise the Licensed Rights in
+all media and formats whether now known or hereafter created, and to make
+technical modifications necessary to do so. The Licensor waives and/or
+agrees not to assert any right or authority to forbid You from making
+technical modifications necessary to exercise the Licensed Rights,
+including technical modifications necessary to circumvent Effective
+Technological Measures. For purposes of this Public License, simply making
+modifications authorized by this Section 2(a)(4) never produces Adapted
+Material.  Downstream recipients.  Offer from the Licensor – Licensed
+Material. Every recipient of the Licensed Material automatically receives
+an offer from the Licensor to exercise the Licensed Rights under the terms
+and conditions of this Public License.  No downstream restrictions. You
+may not offer or impose any additional or different terms or conditions
+on, or apply any Effective Technological Measures to, the Licensed
+Material if doing so restricts exercise of the Licensed Rights by any
+recipient of the Licensed Material.  No endorsement. Nothing in this
+Public License constitutes or may be construed as permission to assert
+or imply that You are, or that Your use of the Licensed Material is,
+connected with, or sponsored, endorsed, or granted official status by,
+the Licensor or others designated to receive attribution as provided in
+Section 3(a)(1)(A)(i).  Other rights.
+
+Moral rights, such as the right of integrity, are not licensed under
+this Public License, nor are publicity, privacy, and/or other similar
+personality rights; however, to the extent possible, the Licensor waives
+and/or agrees not to assert any such rights held by the Licensor to the
+limited extent necessary to allow You to exercise the Licensed Rights, but
+not otherwise.  Patent and trademark rights are not licensed under this
+Public License.  To the extent possible, the Licensor waives any right
+to collect royalties from You for the exercise of the Licensed Rights,
+whether directly or through a collecting society under any voluntary or
+waivable statutory or compulsory licensing scheme. In all other cases
+the Licensor expressly reserves any right to collect such royalties.
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+Attribution.
+
+If You Share the Licensed Material (including in modified form), You must:
+
+retain the following if it is supplied by the Licensor with the Licensed
+Material: identification of the creator(s) of the Licensed Material and
+any others designated to receive attribution, in any reasonable manner
+requested by the Licensor (including by pseudonym if designated); a
+copyright notice; a notice that refers to this Public License; a notice
+that refers to the disclaimer of warranties; a URI or hyperlink to the
+Licensed Material to the extent reasonably practicable; indicate if You
+modified the Licensed Material and retain an indication of any previous
+modifications; and indicate the Licensed Material is licensed under this
+Public License, and include the text of, or the URI or hyperlink to,
+this Public License.  You may satisfy the conditions in Section 3(a)(1)
+in any reasonable manner based on the medium, means, and context in which
+You Share the Licensed Material. For example, it may be reasonable to
+satisfy the conditions by providing a URI or hyperlink to a resource
+that includes the required information.  If requested by the Licensor,
+You must remove any of the information required by Section 3(a)(1)(A)
+to the extent reasonably practicable.  If You Share Adapted Material You
+produce, the Adapter's License You apply must not prevent recipients of
+the Adapted Material from complying with this Public License.  Section 4
+– Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply
+to Your use of the Licensed Material:
+
+for the avoidance of doubt, Section 2(a)(1) grants You the right to
+extract, reuse, reproduce, and Share all or a substantial portion of the
+contents of the database; if You include all or a substantial portion of
+the database contents in a database in which You have Sui Generis Database
+Rights, then the database in which You have Sui Generis Database Rights
+(but not its individual contents) is Adapted Material; and You must comply
+with the conditions in Section 3(a) if You Share all or a substantial
+portion of the contents of the database.  For the avoidance of doubt,
+this Section 4 supplements and does not replace Your obligations under
+this Public License where the Licensed Rights include other Copyright and
+Similar Rights.  Section 5 – Disclaimer of Warranties and Limitation
+of Liability.
+
+Unless otherwise separately undertaken by the Licensor, to the
+extent possible, the Licensor offers the Licensed Material as-is and
+as-available, and makes no representations or warranties of any kind
+concerning the Licensed Material, whether express, implied, statutory,
+or other. This includes, without limitation, warranties of title,
+merchantability, fitness for a particular purpose, non-infringement,
+absence of latent or other defects, accuracy, or the presence or absence
+of errors, whether or not known or discoverable. Where disclaimers of
+warranties are not allowed in full or in part, this disclaimer may not
+apply to You.  To the extent possible, in no event will the Licensor
+be liable to You on any legal theory (including, without limitation,
+negligence) or otherwise for any direct, special, indirect, incidental,
+consequential, punitive, exemplary, or other losses, costs, expenses,
+or damages arising out of this Public License or use of the Licensed
+Material, even if the Licensor has been advised of the possibility of
+such losses, costs, expenses, or damages. Where a limitation of liability
+is not allowed in full or in part, this limitation may not apply to You.
+The disclaimer of warranties and limitation of liability provided above
+shall be interpreted in a manner that, to the extent possible, most
+closely approximates an absolute disclaimer and waiver of all liability.
+Section 6 – Term and Termination.
+
+This Public License applies for the term of the Copyright and Similar
+Rights licensed here. However, if You fail to comply with this
+Public License, then Your rights under this Public License terminate
+automatically.  Where Your right to use the Licensed Material has
+terminated under Section 6(a), it reinstates:
+
+automatically as of the date the violation is cured, provided it is
+cured within 30 days of Your discovery of the violation; or upon express
+reinstatement by the Licensor.  For the avoidance of doubt, this Section
+6(b) does not affect any right the Licensor may have to seek remedies
+for Your violations of this Public License.  For the avoidance of doubt,
+the Licensor may also offer the Licensed Material under separate terms
+or conditions or stop distributing the Licensed Material at any time;
+however, doing so will not terminate this Public License.  Sections 1,
+5, 6, 7, and 8 survive termination of this Public License.  Section 7
+– Other Terms and Conditions.
+
+The Licensor shall not be bound by any additional or different terms or
+conditions communicated by You unless expressly agreed.  Any arrangements,
+understandings, or agreements regarding the Licensed Material not stated
+herein are separate from and independent of the terms and conditions of
+this Public License.  Section 8 – Interpretation.
+
+For the avoidance of doubt, this Public License does not, and shall not be
+interpreted to, reduce, limit, restrict, or impose conditions on any use
+of the Licensed Material that could lawfully be made without permission
+under this Public License.  To the extent possible, if any provision of
+this Public License is deemed unenforceable, it shall be automatically
+reformed to the minimum extent necessary to make it enforceable. If
+the provision cannot be reformed, it shall be severed from this Public
+License without affecting the enforceability of the remaining terms
+and conditions.  No term or condition of this Public License will be
+waived and no failure to comply consented to unless expressly agreed
+to by the Licensor.  Nothing in this Public License constitutes or may
+be interpreted as a limitation upon, or waiver of, any privileges and
+immunities that apply to the Licensor or You, including from the legal
+processes of any jurisdiction or authority.  Creative Commons is not
+a party to its public licenses. Notwithstanding, Creative Commons may
+elect to apply one of its public licenses to material it publishes and
+in those instances will be considered the “Licensor.” The text of
+the Creative Commons public licenses is dedicated to the public domain
+under the CC0 Public Domain Dedication. Except for the limited purpose of
+indicating that material is shared under a Creative Commons public license
+or as otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark “Creative Commons” or any other trademark or
+logo of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements, understandings,
+or agreements concerning use of licensed material. For the avoidance of
+doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
 
 --------------------------------------------------------------------------------
 alcortesm/tgz  MIT License  https://github.com/alcortesm/tgz/blob/master/LICENSE
@@ -14352,6 +14577,29 @@ flynn/go-shlex  Apache License 2.0  https://github.com/flynn-archive/go-shlex/bl
    limitations under the License.
 
 --------------------------------------------------------------------------------
+fogleman/gg  MIT License  https://github.com/fogleman/gg/blob/master/LICENSE.md
+--------------------------------------------------------------------------------
+Copyright (C) 2016 Michael Fogleman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
 form3tech-oss/jwt-go  MIT License  https://github.com/form3tech-oss/jwt-go/blob/master/LICENSE
 --------------------------------------------------------------------------------
 Copyright (c) 2012 Dave Grijalva
@@ -14881,7 +15129,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
-go-ini/ini  Apache License 2.0  https://github.com/go-ini/ini/blob/master/LICENSE
+go-ini/ini  Apache License 2.0  https://github.com/go-ini/ini/blob/main/LICENSE
 --------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -19220,6 +19468,22 @@ golang-sql/civil  Apache License 2.0  https://github.com/golang-sql/civil/blob/m
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+--------------------------------------------------------------------------------
+golang/freetype  The GNU General Public License Version 3.0  https://github.com/golang/freetype/blob/master/LICENSE
+--------------------------------------------------------------------------------
+Use of the Freetype-Go software is subject to your choice of exactly one of
+the following two licenses:
+  * The FreeType License, which is similar to the original BSD license with
+    an advertising clause, or
+  * The GNU General Public License (GPL), version 2 or later.
+
+The text of these licenses are available in the licenses/ftl.txt and the
+licenses/gpl.txt files respectively. They are also available at
+http://freetype.sourceforge.net/license.html
+
+The Luxi fonts in the testdata directory are licensed separately. See the
+testdata/COPYING file for details.
+
 --------------------------------------------------------------------------------
 golang/gddo  BSD 3-Clause "New" or "Revised" License  https://github.com/golang/gddo/blob/master/LICENSE
 --------------------------------------------------------------------------------
@@ -34113,6 +34377,31 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
+jung-kurt/gofpdf  MIT License  https://github.com/jung-kurt/gofpdf/blob/master/LICENSE
+--------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2017 Kurt Jung and contributors acknowledged in the documentation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
 kballard/go-shellquote  MIT License  https://github.com/kballard/go-shellquote/blob/master/LICENSE
 --------------------------------------------------------------------------------
 Copyright (C) 2014 Kevin Ballard
@@ -34764,6 +35053,18 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----------------
+
+Files: s2/cmd/internal/filepathx/*
+
+Copyright 2016 The filepathx Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 klauspost/cpuid  MIT License  https://github.com/klauspost/cpuid/blob/master/LICENSE
@@ -39882,7 +40183,7 @@ nats-io/nats-server  Apache License 2.0  https://github.com/nats-io/nats-server/
    limitations under the License.
 
 --------------------------------------------------------------------------------
-nats-io/nats.go  Apache License 2.0  https://github.com/nats-io/nats.go/blob/master/LICENSE
+nats-io/nats.go  Apache License 2.0  https://github.com/nats-io/nats.go/blob/main/LICENSE
 --------------------------------------------------------------------------------
                                  Apache License
                            Version 2.0, January 2004
@@ -44195,7 +44496,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
-pierrec/lz4  BSD 3-Clause "New" or "Revised" License  https://github.com/pierrec/lz4/blob/master/LICENSE
+pierrec/lz4  BSD 3-Clause "New" or "Revised" License  https://github.com/pierrec/lz4/blob/v4/LICENSE
 --------------------------------------------------------------------------------
 Copyright (c) 2015, Pierre Curto
 All rights reserved.

--- a/executor/licenses/license_info.csv
+++ b/executor/licenses/license_info.csv
@@ -38,6 +38,7 @@ StackExchange/wmi,https://github.com/StackExchange/wmi/blob/master/LICENSE,MIT L
 VividCortex/gohistogram,https://github.com/VividCortex/gohistogram/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/VividCortex/gohistogram/master/LICENSE
 afex/hystrix-go,https://github.com/afex/hystrix-go/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/afex/hystrix-go/master/LICENSE
 agnivade/levenshtein,https://github.com/agnivade/levenshtein/blob/master/License.txt,MIT License,https://raw.githubusercontent.com/agnivade/levenshtein/master/License.txt
+ajstarks/svgo,https://github.com/ajstarks/svgo/blob/master/LICENSE,Creative Commons Attribution 4.0 International Public License,https://raw.githubusercontent.com/ajstarks/svgo/master/LICENSE
 alcortesm/tgz,https://github.com/alcortesm/tgz/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/alcortesm/tgz/master/LICENSE
 alecthomas/jsonschema,https://github.com/alecthomas/jsonschema/blob/master/COPYING,MIT License,https://raw.githubusercontent.com/alecthomas/jsonschema/master/COPYING
 alecthomas/kingpin,https://github.com/alecthomas/kingpin/blob/master/COPYING,MIT License,https://raw.githubusercontent.com/alecthomas/kingpin/master/COPYING
@@ -162,6 +163,7 @@ fatih/camelcase,https://github.com/fatih/camelcase/blob/master/LICENSE.md,MIT Li
 fatih/color,https://github.com/fatih/color/blob/master/LICENSE.md,MIT License,https://raw.githubusercontent.com/fatih/color/master/LICENSE.md
 fatih/structs,https://github.com/fatih/structs/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/fatih/structs/master/LICENSE
 flynn/go-shlex,https://github.com/flynn-archive/go-shlex/blob/master/COPYING,Apache License 2.0,https://raw.githubusercontent.com/flynn-archive/go-shlex/master/COPYING
+fogleman/gg,https://github.com/fogleman/gg/blob/master/LICENSE.md,MIT License,https://raw.githubusercontent.com/fogleman/gg/master/LICENSE.md
 form3tech-oss/jwt-go,https://github.com/form3tech-oss/jwt-go/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/form3tech-oss/jwt-go/master/LICENSE
 fortytw2/leaktest,https://github.com/fortytw2/leaktest/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/fortytw2/leaktest/master/LICENSE
 franela/goblin,https://github.com/franela/goblin/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/franela/goblin/master/LICENSE
@@ -176,7 +178,7 @@ globalsign/mgo,https://github.com/globalsign/mgo/blob/master/LICENSE,BSD 2-Claus
 go-bindata/go-bindata,https://github.com/go-bindata/go-bindata/blob/master/LICENSE,Public Domain per Creative Commons CC0 1.0 Universal (CC0 1.0),https://raw.githubusercontent.com/go-bindata/go-bindata/master/LICENSE
 go-critic/go-critic,https://github.com/go-critic/go-critic/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/go-critic/go-critic/master/LICENSE
 go-gl/glfw,https://github.com/go-gl/glfw/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/go-gl/glfw/master/LICENSE
-go-ini/ini,https://github.com/go-ini/ini/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/go-ini/ini/master/LICENSE
+go-ini/ini,https://github.com/go-ini/ini/blob/main/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/go-ini/ini/main/LICENSE
 go-kit/kit,https://github.com/go-kit/kit/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/go-kit/kit/master/LICENSE
 go-kit/log,https://github.com/go-kit/log/blob/main/LICENSE,MIT License,https://raw.githubusercontent.com/go-kit/log/main/LICENSE
 go-ldap/ldap,https://github.com/go-ldap/ldap/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/go-ldap/ldap/master/LICENSE
@@ -219,6 +221,7 @@ gofrs/flock,https://github.com/gofrs/flock/blob/master/LICENSE,BSD 3-Clause "New
 gogo/googleapis,https://github.com/gogo/googleapis/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/gogo/googleapis/master/LICENSE
 gogo/protobuf,https://github.com/gogo/protobuf/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/gogo/protobuf/master/LICENSE
 golang-sql/civil,https://github.com/golang-sql/civil/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/golang-sql/civil/master/LICENSE
+golang/freetype,https://github.com/golang/freetype/blob/master/LICENSE,The GNU General Public License Version 3.0,https://raw.githubusercontent.com/golang/freetype/master/LICENSE
 golang/gddo,https://github.com/golang/gddo/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/golang/gddo/master/LICENSE
 golang/glog,https://github.com/golang/glog/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/golang/glog/master/LICENSE
 golang/groupcache,https://github.com/golang/groupcache/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/golang/groupcache/master/LICENSE
@@ -335,6 +338,7 @@ json-iterator/go,https://github.com/json-iterator/go/blob/master/LICENSE,MIT Lic
 jstemmer/go-junit-report,https://github.com/jstemmer/go-junit-report/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/jstemmer/go-junit-report/master/LICENSE
 jtolds/gls,https://github.com/jtolio/gls/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/jtolio/gls/master/LICENSE
 julienschmidt/httprouter,https://github.com/julienschmidt/httprouter/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/julienschmidt/httprouter/master/LICENSE
+jung-kurt/gofpdf,https://github.com/jung-kurt/gofpdf/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/jung-kurt/gofpdf/master/LICENSE
 kballard/go-shellquote,https://github.com/kballard/go-shellquote/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/kballard/go-shellquote/master/LICENSE
 kedacore/keda,https://github.com/kedacore/keda/blob/main/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/kedacore/keda/main/LICENSE
 kelseyhightower/envconfig,https://github.com/kelseyhightower/envconfig/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/kelseyhightower/envconfig/master/LICENSE
@@ -407,7 +411,7 @@ nats-io/gnatsd,https://github.com/nats-io/nats-server/blob/main/LICENSE,Apache L
 nats-io/go-nats,https://github.com/nats-io/go-nats/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nats-io/go-nats/master/LICENSE
 nats-io/jwt,https://github.com/nats-io/jwt/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nats-io/jwt/master/LICENSE
 nats-io/nats-server,https://github.com/nats-io/nats-server/blob/main/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nats-io/nats-server/main/LICENSE
-nats-io/nats.go,https://github.com/nats-io/nats.go/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nats-io/nats.go/master/LICENSE
+nats-io/nats.go,https://github.com/nats-io/nats.go/blob/main/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nats-io/nats.go/main/LICENSE
 nats-io/nkeys,https://github.com/nats-io/nkeys/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nats-io/nkeys/master/LICENSE
 nats-io/nuid,https://github.com/nats-io/nuid/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nats-io/nuid/master/LICENSE
 nbio/st,https://github.com/nbio/st/blob/master/LICENSE,Apache License 2.0,https://raw.githubusercontent.com/nbio/st/master/LICENSE
@@ -446,7 +450,7 @@ performancecopilot/speed,https://github.com/performancecopilot/speed/blob/main/L
 peterbourgon/diskv,https://github.com/peterbourgon/diskv/blob/master/LICENSE,MIT License,https://raw.githubusercontent.com/peterbourgon/diskv/master/LICENSE
 phayes/checkstyle,https://github.com/phayes/checkstyle/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/phayes/checkstyle/master/LICENSE
 phayes/freeport,https://github.com/phayes/freeport/blob/master/LICENSE.md,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/phayes/freeport/master/LICENSE.md
-pierrec/lz4,https://github.com/pierrec/lz4/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/pierrec/lz4/master/LICENSE
+pierrec/lz4,https://github.com/pierrec/lz4/blob/v4/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/pierrec/lz4/v4/LICENSE
 pkg/errors,https://github.com/pkg/errors/blob/master/LICENSE,BSD 2-Clause "Simplified" License,https://raw.githubusercontent.com/pkg/errors/master/LICENSE
 pkg/profile,https://github.com/pkg/profile/blob/master/LICENSE,BSD 2-Clause "Simplified" License,https://raw.githubusercontent.com/pkg/profile/master/LICENSE
 pmezard/go-difflib,https://github.com/pmezard/go-difflib/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License,https://raw.githubusercontent.com/pmezard/go-difflib/master/LICENSE

--- a/executor/licenses/repo.txt
+++ b/executor/licenses/repo.txt
@@ -39,6 +39,7 @@ StackExchange/wmi
 VividCortex/gohistogram
 afex/hystrix-go
 agnivade/levenshtein
+ajstarks/svgo
 alcortesm/tgz
 alecthomas/jsonschema
 alecthomas/kingpin
@@ -165,6 +166,7 @@ fatih/camelcase
 fatih/color
 fatih/structs
 flynn/go-shlex
+fogleman/gg
 form3tech-oss/jwt-go
 fortytw2/leaktest
 franela/goblin
@@ -222,6 +224,7 @@ gofrs/flock
 gogo/googleapis
 gogo/protobuf
 golang-sql/civil
+golang/freetype
 golang/gddo
 golang/glog
 golang/groupcache
@@ -348,6 +351,7 @@ json-iterator/go
 jstemmer/go-junit-report
 jtolds/gls
 julienschmidt/httprouter
+jung-kurt/gofpdf
 kballard/go-shellquote
 kedacore/keda
 kelseyhightower/envconfig

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/kedacore/keda v0.0.0-20200911122749-717aab81817f
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
+	go.uber.org/automaxprocs v1.4.0
 	go.uber.org/zap v1.19.0
 	gopkg.in/yaml.v2 v2.4.0
 	istio.io/api v0.0.0-20200513175333-ae3da0d240e3

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -1394,6 +1394,7 @@ go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/automaxprocs v1.3.0/go.mod h1:9CWT6lKIep8U41DDaPiH6eFscnTyjfTANNQNx6LrIcA=
+go.uber.org/automaxprocs v1.4.0 h1:CpDZl6aOlLhReez+8S3eEotD7Jx0Os++lemPlMULQP0=
 go.uber.org/automaxprocs v1.4.0/go.mod h1:/mTEdr7LvHhs0v7mjdxDreTz1OG5zdZGqgOnhWiR/+Q=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

The default value of GOMAXPROCS is based on all visible CPUs by the go process (https://github.com/golang/go/issues/33803). In k8s this will be all CPUs available on the node. This is a problem because -  if we set a limit on the container, GOMAXPROCS will not respect that. This will result in throttling because we won't be able to use all resources we think we can use. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3468 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

