### PR TITLE
Python generic exception handling

### DIFF
--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -43,14 +43,12 @@ def get_rest_microservice(user_model, seldon_metrics):
     if hasattr(user_model, "model_error_handler"):
         logger.info("Registering the custom error handler...")
         app.register_blueprint(user_model.model_error_handler)
-    
+
     @app.errorhandler(Exception)
     def handle_generic_exception(e):
         error = SeldonMicroserviceException(
-            message=str(e),
-            status_code=500,
-            reason="MICROSERVICE_INTERNAL_ERROR"
-        ) 
+            message=str(e), status_code=500, reason="MICROSERVICE_INTERNAL_ERROR"
+        )
         response = jsonify(error.to_dict())
         logger.error("%s", error.to_dict())
         response.status_code = error.status_code
@@ -62,7 +60,6 @@ def get_rest_microservice(user_model, seldon_metrics):
         logger.error("%s", error.to_dict())
         response.status_code = error.status_code
         return response
-    
 
     @app.route("/seldon.json", methods=["GET"])
     def openAPI():

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -43,13 +43,6 @@ def get_rest_microservice(user_model, seldon_metrics):
     if hasattr(user_model, "model_error_handler"):
         logger.info("Registering the custom error handler...")
         app.register_blueprint(user_model.model_error_handler)
-
-    @app.errorhandler(SeldonMicroserviceException)
-    def handle_invalid_usage(error):
-        response = jsonify(error.to_dict())
-        logger.error("%s", error.to_dict())
-        response.status_code = error.status_code
-        return response
     
     @app.errorhandler(Exception)
     def handle_generic_exception(e):
@@ -62,6 +55,14 @@ def get_rest_microservice(user_model, seldon_metrics):
         logger.error("%s", error.to_dict())
         response.status_code = error.status_code
         return response
+
+    @app.errorhandler(SeldonMicroserviceException)
+    def handle_invalid_usage(error):
+        response = jsonify(error.to_dict())
+        logger.error("%s", error.to_dict())
+        response.status_code = error.status_code
+        return response
+    
 
     @app.route("/seldon.json", methods=["GET"])
     def openAPI():

--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -50,6 +50,18 @@ def get_rest_microservice(user_model, seldon_metrics):
         logger.error("%s", error.to_dict())
         response.status_code = error.status_code
         return response
+    
+    @app.errorhandler(Exception)
+    def handle_generic_exception(e):
+        error = SeldonMicroserviceException(
+            message=str(e),
+            status_code=500,
+            reason="MICROSERVICE_INTERNAL_ERROR"
+        ) 
+        response = jsonify(error.to_dict())
+        logger.error("%s", error.to_dict())
+        response.status_code = error.status_code
+        return response
 
     @app.route("/seldon.json", methods=["GET"])
     def openAPI():


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This fixes how exceptions are handled by the REST Python server. Previously, any unhandle-ed exceptions would result in a very generic Flask error, which is not parse-able into a seldon message. This adds a generic exception handler that returns a 500 error in a Seldon message. Custom error handlers inside the user object still function correctly. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes  #2338

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Python microservice generic exception handling
```

