### PR TITLE
gcp notes for storage initializers

### DIFF
--- a/doc/source/servers/kfserving-storage-initializer.md
+++ b/doc/source/servers/kfserving-storage-initializer.md
@@ -143,10 +143,17 @@ Currently the Google Credentials require a file to be set up so the process requ
 
 You can also create a `ServiceAccount` and attach a differently formatted `Secret` to it similar to how kfserving does it. See kfserving documentation [on this topic](https://github.com/kubeflow/kfserving/blob/master/docs/samples/storage/s3/README.md). Supported annotation prefix includes `serving.kubeflow.org` and `machinelearning.seldon.io`.
 
-For GCP/GKE, go to gcloud console and create a key as json and export as a file. Then create a secret from the file using:
+For GCP/GKE, you will need create a service-account key and have it as local `json` file.
+First make sure that you have `[SA-NAME]@[PROJECT-ID].iam.gserviceaccount.com` service account created in the gcloud console that have sufficient permissions to access the bucket with your models (i.e. `Storage Object Admin`).
 
+Now, generate `keys` locally using the `gcloud` tool
 ```bash
-kubectl create secret generic user-gcp-sa --from-file=gcloud-application-credentials.json=<LOCALFILE>
+gcloud iam service-accounts keys create gcloud-application-credentials.json --iam-account [SA-NAME]@[PROJECT-ID].iam.gserviceaccount.com
+```
+
+Once you have `gcloud-application-credentials.json` file locally create the k8s `secret` with:
+```bash
+kubectl create secret generic user-gcp-sa --from-file=gcloud-application-credentials.json=<LOCALFILE JSON FILE>
 ```
 
 The file in the secret needs to be called `gcloud-application-credentials.json` (the name can be configured in the seldon configmap, visible in `kubectl get cm -n seldon-system seldon-config -o yaml`).

--- a/doc/source/servers/overview.md
+++ b/doc/source/servers/overview.md
@@ -297,6 +297,35 @@ stringData:
   RCLONE_CONFIG_S3_ENV_AUTH: "true"
 ```
 
+
+### Example for GCP/GKE
+
+Reference: [rclone documentation](https://rclone.org/googlecloudstorage/)
+
+For GCP/GKE, you will need create a service-account key and have it as local `json` file.
+First make sure that you have `[SA-NAME]@[PROJECT-ID].iam.gserviceaccount.com` service account created in the gcloud console that have sufficient permissions to access the bucket with your models (i.e. `Storage Object Admin`).
+
+Now, generate `keys` locally using the `gcloud` tool
+```bash
+gcloud iam service-accounts keys create gcloud-application-credentials.json --iam-account [SA-NAME]@[PROJECT-ID].iam.gserviceaccount.com
+```
+
+Now using the content of locally saved `gcloud-application-credentials.json` file create a secret
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: seldon-rclone-secret
+type: Opaque
+stringData:
+  RCLONE_CONFIG_GSC_TYPE: google cloud storage
+  RCLONE_CONFIG_GSC_ANONYMOUS: "false"
+  RCLONE_CONFIG_GSC_SERVICE_ACCOUNT_CREDENTIALS: '{"type":"service_account", ... <rest of gcloud-application-credentials.json>}'
+```
+
+Note: remote name is `gsc` here so urls would take form similar to `gsc:<your bucket>`.
+
+
 ### Directly from PVC
 
 You are able to make models available directly from PVCs instead of object stores. This may be desirable if you have a lot of very large files and you want to avoid uploading/downloading, for example through NFS drives.


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This adds / extends instructions on how to configure storage initializers with private Google Cloud buckets.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/SeldonIO/seldon-core/issues/3509

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

