### PR TITLE
lock numba to 0.53.1 for alibi explain image

### DIFF
--- a/components/alibi-explain-server/Dockerfile
+++ b/components/alibi-explain-server/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM seldonio/seldon-core-s2i-python37-ubi8:1.11.0-dev
+FROM seldonio/seldon-core-s2i-python37-ubi8:$VERSION
 LABEL name="Seldon Alibi Wrapper" \
       vendor="Seldon Technologies" \
       version="1.11.0-dev" \
@@ -20,7 +20,8 @@ RUN pip install \
     --upgrade wheel
 
 # https://github.com/slundberg/shap/pull/1802#issuecomment-846299228
-RUN pip install numpy==1.19
+# https://github.com/SeldonIO/alibi/issues/466
+RUN pip install numpy==1.19 numba==0.53.1
 
 COPY setup.py setup.py
 COPY alibiexplainer alibiexplainer


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Fixes broken alibiexplainserver image.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

