### PR TITLE
Update Alibi detect pkg version in alibi detect server component

### DIFF
--- a/components/alibi-detect-server/setup.py
+++ b/components/alibi-detect-server/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires=">3.4",
     packages=find_packages(),
     install_requires=[
-        "alibi-detect==0.6.2",
+        "alibi-detect==0.7.2",
         "kfserving>=0.2.0",
         "argparse >= 1.4.0",
         "numpy >= 1.8.2",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR updates the alibi_detect python package version from 0.6.2 to 0.7.2 following the [latest release](https://github.com/SeldonIO/alibi-detect/releases/tag/v0.7.2)

**Special notes for your reviewer**:
Alibi Detect introduces a breaking change between these versions, maily on the fact that detector artifacts expect dill format instead of pickle format
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->

```release-note

Remove support for detector artifacts created using previous versions of alibi_detect library in .pkl format
```

