### PR TITLE
Add elastic logging for reference data logs

### DIFF
--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -148,6 +148,11 @@ def process_and_update_elastic_doc(
     # req or res might be batches of instances so split out into individual docs
     if "instance" in new_content_part:
 
+        if log_helper.is_reference_data(headers):
+            index_name = log_helper.build_index_name(headers, prefix="reference", suffix=False)
+            # Ignore payload for reference data
+            doc_body[message_type].pop("payload", None)
+
         if type(new_content_part["instance"]) == type([]) and not (new_content_part["dataType"] == "json"):
             # if we've a list then this is batch
             # we assume first dimension is always batch

--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -109,6 +109,11 @@ def metadata():
     sys.stdout.flush()
     return Response("problem looking up metadata", 500)
 
+
+class BadPayloadException(Exception):
+    pass
+
+
 def process_and_update_elastic_doc(
     elastic_object, message_type, message_body, request_id, headers, index_name
 ):
@@ -120,7 +125,13 @@ def process_and_update_elastic_doc(
         sys.stdout.flush()
 
     # first do any needed transformations
-    new_content_part = process_content(message_type, message_body, headers)
+    try:
+        new_content_part = process_content(message_type, message_body, headers)
+    except BadPayloadException as e:
+        logging.warning(f"bad payload received. " +
+                        f"Not inserting {message_type} data with request id {request_id} into elasticsearch: " +
+                        f"{e}")
+        return added_content
 
     # set metadata to go just in this part (request or response) and not top-level
     log_helper.field_from_header(
@@ -569,6 +580,9 @@ def createElementsWithMetadata(X, names, results, metadata_schema, message_type)
 
     if isinstance(X, np.ndarray):
         if len(X.shape) == 1:
+            if X.shape[0] != len(names):
+                raise BadPayloadException(
+                    f"size of columns ({X.shape[0]})do not match number of features ({len(names)})")
             temp_results = []
             results = []
             for i in range(X.shape[0]):
@@ -581,6 +595,9 @@ def createElementsWithMetadata(X, names, results, metadata_schema, message_type)
                 temp_results.append(d)
             results = mergeLinkedColumns(temp_results, metadata_dict)
         elif len(X.shape) >= 2:
+            if X.shape[1] != len(names):
+                raise BadPayloadException(
+                    f"size of columns ({X.shape[1]})do not match number of features ({len(names)})")
             temp_results = []
             results = []
             for i in range(X.shape[0]):

--- a/components/seldon-request-logger/app/log_helper.py
+++ b/components/seldon-request-logger/app/log_helper.py
@@ -46,7 +46,7 @@ def build_index_name(headers, prefix = "inference", suffix = True, name_override
        index_name = prefix+"-log-" + seldon_environment + "-" + serving_engine(headers)
     else:
        index_name = prefix+"-log-" + serving_engine(headers)
-   
+
     # otherwise create an index per deployment
     # index_name = "inference-log-" + serving_engine(headers)
     namespace = clean_header(NAMESPACE_HEADER_NAME, headers)
@@ -76,15 +76,27 @@ def build_index_name(headers, prefix = "inference", suffix = True, name_override
     return index_name
 
 
+def is_reference_data(headers):
+    type_header = headers.get(TYPE_HEADER_NAME)
+    if type_header.startswith("io.seldon.serving.reference") or \
+            type_header.startswith("org.kubeflow.serving.reference"):
+        return True
+    return False
+
+
 def parse_message_type(type_header):
     if (
         type_header == "io.seldon.serving.inference.request"
         or type_header == "org.kubeflow.serving.inference.request"
+        or type_header == "io.seldon.serving.reference.request"
+        or type_header == "org.kubeflow.serving.reference.request"
     ):
         return "request"
     if (
         type_header == "io.seldon.serving.inference.response"
         or type_header == "org.kubeflow.serving.inference.response"
+        or type_header == "io.seldon.serving.reference.response"
+        or type_header == "org.kubeflow.serving.reference.response"
     ):
         return "response"
     if (


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR adds elasticsearch logging for reference data in the request logger component. 

Reference data can be sent as cloud events to the request logger, which will parse and insert the data exactly like it would with live predictions, with the only differences being that:
1.  it inserts it into an index with pattern `reference-log-<deployment_type>-<deployment_namespace>-<deployment_name>`
2. it does not insert the entire payload into every instances document in elasticsearch

This PR also introduces a fix for catching bad payloads i.e. if metadata can be found for a request, but the payload does not match the metadata, this throws a `BadPayloadException`, which is caught, logs a warning, and **does not** insert the data into elasticsearch.

Previously, if the size of payload columns were larger than the number of metadata features, no errors are thrown and it would be inserted. If payload columns were less than metadata features, it would throw a runtime error ([here](https://github.com/SeldonIO/seldon-core/blob/13a5b1ea5a4a962d03965908e132aa4154ee9761/components/seldon-request-logger/app/default_logger.py#L577) or [here](https://github.com/SeldonIO/seldon-core/blob/13a5b1ea5a4a962d03965908e132aa4154ee9761/components/seldon-request-logger/app/default_logger.py#L589))

**Special notes for your reviewer**:
A new index pattern has been introduced, so the elastic token needs the required permissions

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Changed seldon-request-logger component to catch and not insert requests whose metadata do not match the payload dimensions
```

An example of data inserted into elasticsearch using a reference dataset from the tabular income dataset [in this example](https://docs.seldon.io/projects/alibi-detect/en/stable/examples/cd_chi2ks_adult.html) is shown here:
![image](https://user-images.githubusercontent.com/20640150/131996667-d96e5625-d9df-410b-8030-25bd9b2cab2a.png)

