### PR TITLE
transmit event key from input topic to output topic in kafka

### DIFF
--- a/executor/api/kafka/server.go
+++ b/executor/api/kafka/server.go
@@ -231,6 +231,7 @@ func (ks *SeldonKafkaServer) Serve() error {
 
 				job := KafkaJob{
 					headers:    headers,
+					reqKey:     e.Key,
 					reqPayload: reqPayload,
 				}
 				// enqueue a job

--- a/executor/api/kafka/worker.go
+++ b/executor/api/kafka/worker.go
@@ -12,6 +12,7 @@ import (
 
 type KafkaJob struct {
 	headers    map[string][]string
+	reqKey     []byte
 	reqPayload payload.SeldonPayload
 }
 
@@ -62,6 +63,7 @@ func (ks *SeldonKafkaServer) processKafkaRequest(job *KafkaJob) {
 
 	err = ks.Producer.Produce(&kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: &ks.TopicOut, Partition: kafka.PartitionAny},
+		Key:            job.reqKey,
 		Value:          resBytes,
 		Headers:        kafkaHeaders,
 	}, nil)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
When doing stream serving with Kafka, we cannot receive event keys although it is required.
So we just need to send the event key from input topic to output topic.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

