### PR TITLE
add note on SO_REUSEPORT requirement

### DIFF
--- a/doc/source/reference/upgrading.md
+++ b/doc/source/reference/upgrading.md
@@ -8,6 +8,10 @@ Make sure you also [read the CHANGELOG](./changelog.html) to see the detailed fe
 
 ## Upgrading to 1.10
 
+### Seldon Core Wrapper
+
+ * With introduction of multi-processing in gRPC module the `SO_REUSEPORT` socket option is required. On certain Python distributions you may see `AttributeError: module 'socket' has no attribute 'SO_REUSEPORT'` error which would render gRPC endpoint non-operational. For Anaconda Python distributions we confirmed that upgrading to Python 3.7.10 or 3.8.10 removes the problem.
+
 ### Server Updates
 
  * SKLearn server has been updated to use sklearn 0.24.2


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Add note on `AttributeError: module 'socket' has no attribute 'SO_REUSEPORT'` to the upgrading page.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

- The issue is present on specific Python distributions: https://community.intel.com/t5/Intel-Distribution-for-Python/AttributeError-module-socket-has-no-attribute-SO-REUSEPORT/m-p/1257361/highlight/true
- PR that introduced the requirement SeldonIO/seldon-core#3356 

Difficult to establish universal minimum version requirements. For example for 3.8.x line it does not work with <3.8.5, works fine with 3.8.5 and 3.8.6. Couldn't test with 3.8.7 as there was no anaconda package, then was broken for 3.8.8 and fixed again for 3.8.10 for example. But this can actually lie in the compilation problem of the python itself so version compatibility is difficult to establish.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

