### PR TITLE
make combiner propagate requestPath from all children

### DIFF
--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -535,10 +535,12 @@ def aggregate(
 
     def merge_meta(meta_list):
         tags = {}
+        requestPath = {}
         for meta in meta_list:
             if meta:
                 tags.update(meta.get("tags", {}))
-        return {"tags": tags}
+                requestPath.update(meta.get("requestPath", {}))
+        return {"tags": tags, "requestPath": requestPath}
 
     def merge_metrics(meta_list, custom_metrics):
         metrics = []

--- a/python/seldon_core/utils.py
+++ b/python/seldon_core/utils.py
@@ -462,9 +462,11 @@ def construct_response_json(
     if meta:
         tags = meta.get("tags", {})
         metrics = meta.get("metrics", [])
+        request_path = meta.get("requestPath", {})
     else:
         tags = {}
         metrics = []
+        request_path = {}
     custom_tags = client_custom_tags(user_model)
     if custom_tags:
         tags.update(custom_tags)
@@ -480,7 +482,6 @@ def construct_response_json(
     if puid:
         response["meta"]["puid"] = puid
 
-    request_path = client_request_raw.get("meta", {}).get("requestPath", {})
     request_path = {**get_request_path(), **request_path}
     if request_path:
         response["meta"]["requestPath"] = request_path


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Combiners were only propagating requestPath from first children. This PR fixes it.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/SeldonIO/seldon-core/issues/3477

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

