### PR TITLE
Bugfix request logger

### DIFF
--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -616,7 +616,7 @@ def createElementsWithMetadata(X, names, results, metadata_schema, message_type,
                     if isinstance(d[name], Iterable):
                         newlist = []
                         for val in d[name]:
-                            newlist.append(lookupValueWithMetadata(name,metadata_dict,val), force_raw_value)
+                            newlist.append(lookupValueWithMetadata(name, metadata_dict, val, force_raw_value))
                         d[name] = newlist
                     else:
                         d[name] = lookupValueWithMetadata(name,metadata_dict,d[name], force_raw_value)

--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -110,10 +110,6 @@ def metadata():
     return Response("problem looking up metadata", 500)
 
 
-class BadPayloadException(Exception):
-    pass
-
-
 def process_and_update_elastic_doc(
     elastic_object, message_type, message_body, request_id, headers, index_name
 ):
@@ -125,13 +121,7 @@ def process_and_update_elastic_doc(
         sys.stdout.flush()
 
     # first do any needed transformations
-    try:
-        new_content_part = process_content(message_type, message_body, headers)
-    except BadPayloadException as e:
-        logging.warning(f"bad payload received. " +
-                        f"Not inserting {message_type} data with request id {request_id} into elasticsearch: " +
-                        f"{e}")
-        return added_content
+    new_content_part = process_content(message_type, message_body, headers)
 
     # set metadata to go just in this part (request or response) and not top-level
     log_helper.field_from_header(
@@ -604,9 +594,6 @@ def createElementsWithMetadata(X, names, results, metadata_schema, message_type,
                 temp_results.append(d)
             results = mergeLinkedColumns(temp_results, metadata_dict)
         elif len(X.shape) >= 2:
-            if X.shape[1] != len(names):
-                raise BadPayloadException(
-                    f"size of columns ({X.shape[1]})do not match number of features ({len(names)})")
             temp_results = []
             results = []
             for i in range(X.shape[0]):

--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -592,9 +592,6 @@ def createElementsWithMetadata(X, names, results, metadata_schema, message_type,
 
     if isinstance(X, np.ndarray):
         if len(X.shape) == 1:
-            if X.shape[0] != len(names):
-                raise BadPayloadException(
-                    f"size of columns ({X.shape[0]})do not match number of features ({len(names)})")
             temp_results = []
             results = []
             for i in range(X.shape[0]):


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
1. Fixes code typo which leads to runtime error when creating elements with metadata- brackets not closed correctly around an append call.
2. Removes `BadPayloadException` (completely undoes this commit https://github.com/SeldonIO/seldon-core/pull/3566/commits/122ef993cda36c515651f70b42545355e3fbf8ea). This was originally introduced under the assumption that metadata column sizes should always equal the payload "column" size, e.g. typically for batched tabular data, the payload dimensions are NxC where N is the number of instances in the batch, and C is the number of tabular columns, thus it was important to ensure that the fields in the metadata matched the number of columns that came with the payload. However, this is not true in at least two cases which **currently fail but worked in 1.10.0** (both cases would be solved by removing `BadPayloadException` checks):
    1. For text data payloads where there is only dimension for the payload e.g. as in the [movie sentiment example](https://docs.seldon.io/projects/seldon-core/en/stable/examples/explainer_examples.html#Movie-Sentiment-Model), where only one metadata column is expected (i.e. `Text Reviews`). When the batch size is greater than 1, the `BadPayloadException` is triggered and the request is not logged.
    ```json
    {
      "data": {
        "ndarray": [
          "this film has bad actors",
          "the actors in this film are good"
        ]
      }
    }
    ```
    2. For [image data](https://docs.seldon.io/projects/seldon-core/en/stable/examples/explainer_examples.html#Tensorflow-CIFAR10-Model), payload dimensions are typically 1xNxHxWx3, where N is the number of instances in the batch, H is the number of row pixels values, and W the number of column pixel values  and 3 is the number of colours in RGB. This is typically flattened and processed one at a time as NxHxWx3 by the request logger. As the columns are expected to be found in the second dimension by the current request logger and there is only one expected "column" for image data, the `BadPayloadException` is triggered (because typically H != 1) and image data request is not logged

**Special notes for your reviewer**:

This PR ensures that behaviour of the next release of the request logger matches the behaviour of 1.10.0 version. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

