### PR TITLE
Executor Returns Clearer Errors on HTTP Failures

### DIFF
--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -293,6 +293,11 @@ func (smc *JSONRestClient) call(ctx context.Context, modelName string, method st
 	}
 	sm, contentType, contentEncoding, err := smc.doHttp(ctx, modelName, method, &url, bytes, meta, contentType, contentEncoding)
 	res := payload.BytesPayload{Msg: sm, ContentType: contentType, ContentEncoding: contentEncoding}
+	
+	// If an error is returned from doHttp, we should set it as the response object
+	if err != nil {
+		res.Msg = smc.CreateErrorPayload(err)
+	}
 	return &res, err
 }
 

--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -291,13 +291,13 @@ func (smc *JSONRestClient) call(ctx context.Context, modelName string, method st
 		contentType = req.GetContentType()
 		contentEncoding = req.GetContentEncoding()
 	}
+
 	sm, contentType, contentEncoding, err := smc.doHttp(ctx, modelName, method, &url, bytes, meta, contentType, contentEncoding)
-	res := payload.BytesPayload{Msg: sm, ContentType: contentType, ContentEncoding: contentEncoding}
-	
-	// If an error is returned from doHttp, we should set it as the response object
 	if err != nil {
-		res.Msg = smc.CreateErrorPayload(err)
+		return smc.CreateErrorPayload(err), err
 	}
+
+	res := payload.BytesPayload{Msg: sm, ContentType: contentType, ContentEncoding: contentEncoding}
 	return &res, err
 }
 

--- a/executor/api/rest/client_test.go
+++ b/executor/api/rest/client_test.go
@@ -329,8 +329,16 @@ func TestTimeout(t *testing.T) {
 	seldonRestClient, err := NewJSONRestClient(api.ProtocolSeldon, "test", &predictor, annotations)
 	g.Expect(err).To(BeNil())
 
-	_, err = seldonRestClient.Status(createTestContext(), "model", host, int32(port), nil, map[string][]string{})
+	r, err := seldonRestClient.Status(createTestContext(), "model", host, int32(port), nil, map[string][]string{})
 	g.Expect(err).ToNot(BeNil())
+	g.Expect(r).ToNot((BeNil()))
+
+	data := r.GetPayload().([]byte)
+	var smRes proto.SeldonMessage
+	err = jsonpb.UnmarshalString(string(data), &smRes)
+	g.Expect(err).Should(BeNil())
+	g.Expect(smRes.GetStatus().GetCode()).Should(BeEquivalentTo(int32(500)))
+	g.Expect(smRes.GetStatus().GetInfo()).Should(ContainSubstring("Client.Timeout exceeded while awaiting headers"))
 }
 
 func TestMarshall(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**: 
The executor will now format an HTTP error into a Seldon Message and return it in the body of the response. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3625 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
executor returns clearer http failure error messages
```

