### PR TITLE
bulk insert batch requests

### DIFF
--- a/components/seldon-request-logger/app/default_logger.py
+++ b/components/seldon-request-logger/app/default_logger.py
@@ -147,9 +147,8 @@ def process_and_update_elastic_doc(
         if type(new_content_part["instance"]) == type([]) and not (new_content_part["dataType"] == "json"):
             # if we've a list then this is batch
             # we assume first dimension is always batch
-            item_body = doc_body.copy()
-            bulk_upsert_doc_to_elastic(elastic_object, message_type, item_body,
-                                       item_body[message_type].copy(), request_id, index_name)
+            bulk_upsert_doc_to_elastic(elastic_object, message_type, doc_body,
+                                       doc_body[message_type].copy(), request_id, index_name)
         else:
             #not batch so don't batch elements either
             if "elements" in new_content_part and type(new_content_part["elements"]) == type([]):
@@ -293,7 +292,7 @@ def bulk_upsert_doc_to_elastic(
 
     def gen_data():
         for num, item in enumerate(new_content_part["instance"], start=0):
-            print(f"bulk inserting item {num}")
+
             item_body = doc_body.copy()
             item_body[message_type]["instance"] = item
             if type(elements) == type([]) and len(elements) > num:
@@ -303,9 +302,20 @@ def bulk_upsert_doc_to_elastic(
                     request_id, no_items_in_batch, num
                 )
 
+            print(
+                "bulk upserting to doc "
+                + index_name
+                + "/"
+                + (log_helper.DOC_TYPE_NAME if log_helper.DOC_TYPE_NAME != None else "_doc")
+                + "/"
+                + request_id
+                + " adding "
+                + message_type
+            )
+
             yield {
                 "_index": index_name,
-                "_type": "_doc",
+                "_type": log_helper.DOC_TYPE_NAME,
                 "_op_type": "update",
                 "_id": item_request_id,
                 "_source": {"doc_as_upsert": True, "doc": item_body},


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
The previous implementation does a for loop and inserts each item in a batch request as an individual update to elasticsearch. This PR changes inserting batch requests by using **bulk updates**. This provides a significant improvement in performance.

**Special notes for your reviewer**:
* The content of docs created in elasticsearch is unchanged.
* One breaking change introduced where the response of for the request logger is now empty. i.e. previously a post request to the request logger would return a response body with the following content (this is the elasticsearch API response)
    ```json
    [{"_id": "abc123", "_index": "inference-log-seldon-seldon-iris-default", "_primary_term": 1, 
    "_seq_no": 2, "_shards": {"failed": 0, "successful": 1, "total": 2}, "_type": "_doc", 
    "_version": 1, "forced_refresh": true, "result": "created"}]]
    ```
    However, now an empty list is returned. It is possible to return a similar looking response by constructing it, but the Python elasticsearch client for bulk updates does not provide any way to return the same content.
    

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
seldon-request-logger post response when receiving a request with batch data does not include elasticsearch API response - returns an empty list
```

