### PR TITLE
Change rbac in example yaml to v1 api

### DIFF
--- a/helm-charts/seldon-core-analytics/templates/prometheus/prometheus-rbac.yaml
+++ b/helm-charts/seldon-core-analytics/templates/prometheus/prometheus-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -26,7 +26,7 @@ metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/helm-charts/seldon-core-operator/templates/clusterrole_seldon-spartakus-volunteer.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrole_seldon-spartakus-volunteer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.usageMetrics.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: seldon-spartakus-volunteer-{{ include "seldon.namespace" . }}

--- a/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-spartakus-volunteer.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-spartakus-volunteer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.usageMetrics.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: seldon-spartakus-volunteer-{{ include "seldon.namespace" . }}

--- a/notebooks/resources/ambassador-rbac.yaml
+++ b/notebooks/resources/ambassador-rbac.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: ambassador
@@ -22,7 +22,7 @@ kind: ServiceAccount
 metadata:
   name: ambassador
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ambassador

--- a/operator/config/spartakus/spartakus-rbac.yaml
+++ b/operator/config/spartakus/spartakus-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: seldon-spartakus-volunteer
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: seldon-spartakus-volunteer
@@ -16,7 +16,7 @@ rules:
   verbs:
   - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: seldon-spartakus-volunteer

--- a/testing/scripts/metrics.yaml
+++ b/testing/scripts/metrics.yaml
@@ -11,7 +11,7 @@ rules:
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator
@@ -24,7 +24,7 @@ subjects:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-server-auth-reader


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR resolves issue #3403 across the repo on top of within the helm charts explicitly mentioned in the issue.  All instances of `rbac.authorization.k8s.io/v1beta1` have been updated to `rbac.authorization.k8s.io/v1`.  All helm charts / manifests have been deployed successfully to a kind `v0.11.1` cluster.    

**Which issue(s) this PR fixes**:
Fixes #3403 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: Yes
```release-note
* seldon-core helm charts no longer have deprecation warnings for rbac.authorization.k8s.io/v1beta1
```

