### PR TITLE
Update ambassador-rbac.yaml

### DIFF
--- a/notebooks/resources/ambassador-rbac.yaml
+++ b/notebooks/resources/ambassador-rbac.yaml
@@ -66,17 +66,21 @@ spec:
     app.kubernetes.io/name: ambassador
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ambassador
   template:
     metadata:
       annotations:
         sidecar.istio.io/inject: 'false'
       labels:
+        app: ambassador
         app.kubernetes.io/name: ambassador
     spec:
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `notebooks/resources/ambassador-rbac.yaml` to use the `apps/v1` apiversion since the `extensions/v1beta` has been fully deprecated.  Also adding the appropriate `selector` labels.   This resolves #3677 

**Which issue(s) this PR fixes**: 
Fixes #3677 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: Yes
```release-note
* updates Deployment apiversion in `notebooks/resources/ambassdor-rbac.yaml` 
```

