### PR TITLE
bump cryptography to 3.4.8

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ setup(
         "setuptools >= 41.0.0",
         "prometheus_client >= 0.7.1, < 0.9.0",
         # Addresses CVE-2020-1971
-        "cryptography==3.4",
+        "cryptography==3.4.8",
         # Addresses CVE SNYK-PYTHON-PYYAML-590151
         "PyYAML >= 5.4, < 5.5",
         # Addresses CVE PRISMA-2021-0020


### PR DESCRIPTION
This PR updates cryptography to a version that does not have a circular import issue. The circular import issue arises when seldon-core is used together with `azure.identity` , `azure.keyvault`, or any other package from the Python Azure SDK that does authentication.

Bumping cryptography to a later bugfix version fixes the circular import issue.

/release-note-none

