### PR TITLE
add shutdown_delay option to executor & gRPC GracefulStop

### DIFF
--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -307,7 +307,9 @@ func main() {
 	logger := logf.Log.WithName("entrypoint")
 
 	// Set runtime.GOMAXPROCS to respect container limits if the env var GOMAXPROCS is not set or is invalid, preventing CPU throttling.
-	undo, err := maxprocs.Set(maxprocs.Logger(logger.Info))
+	undo, err := maxprocs.Set(maxprocs.Logger(func(format string, a ...interface{}) {
+		logger.WithName("maxprocs").Info(fmt.Sprintf(format, a...))
+	}))
 	defer undo()
 	if err != nil {
 		logger.Error(err, "failed to set GOMAXPROCS")

--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -3,14 +3,17 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
 	"path"
+	"sync"
 	"syscall"
 	"time"
 
@@ -37,8 +40,8 @@ import (
 	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/reflection"
-	zapf "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	zapf "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const (
@@ -62,6 +65,7 @@ var (
 	httpPort       = flag.Int("http_port", 8080, "Executor http port")
 	grpcPort       = flag.Int("grpc_port", 5000, "Executor grpc port")
 	wait           = flag.Duration("graceful_timeout", time.Second*15, "Graceful shutdown secs")
+	delay          = flag.Duration("shutdown_delay", 0, "Shutdown delay secs")
 	protocol       = flag.String("protocol", "seldon", "The payload protocol")
 	transport      = flag.String("transport", "rest", "The network transport mechanism rest, grpc")
 	filename       = flag.String("file", "", "Load graph from file")
@@ -73,7 +77,7 @@ var (
 	kafkaTopicOut  = flag.String("kafka_output_topic", "", "The kafka output topic")
 	kafkaFullGraph = flag.Bool("kafka_full_graph", false, "Use kafka for internal graph processing")
 	kafkaWorkers   = flag.Int("kafka_workers", 4, "Number of kafka workers")
-	logKafkaBroker  = flag.String("log_kafka_broker", "", "The kafka log broker")
+	logKafkaBroker = flag.String("log_kafka_broker", "", "The kafka log broker")
 	logKafkaTopic  = flag.String("log_kafka_topic", "", "The kafka log topic")
 	debug          = flag.Bool(
 		"debug",
@@ -95,8 +99,9 @@ func getServerUrl(hostname string, port int) (*url.URL, error) {
 	return url.Parse(fmt.Sprintf("http://%s:%d/", hostname, port))
 }
 
-func runHttpServer(lis net.Listener, logger logr.Logger, predictor *v1.PredictorSpec, client seldonclient.SeldonApiClient, port int,
-	probesOnly bool, serverUrl *url.URL, namespace string, protocol string, deploymentName string, prometheusPath string) {
+func runHttpServer(wg *sync.WaitGroup, shutdown chan bool, lis net.Listener, logger logr.Logger, predictor *v1.PredictorSpec, client seldonclient.SeldonApiClient, port int, probesOnly bool, serverUrl *url.URL, namespace string, protocol string, deploymentName string, prometheusPath string) {
+	wg.Add(1)
+	defer wg.Done()
 	defer lis.Close()
 
 	// Create REST API
@@ -104,37 +109,32 @@ func runHttpServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 	seldonRest.Initialise()
 	srv := seldonRest.CreateHttpServer(port)
 
+	var isShutdown bool
 	go func() {
+		logger.Info("http server started")
 		if err := srv.Serve(lis); err != nil {
-			logger.Error(err, "Server error")
+			if !(isShutdown && errors.Is(err, http.ErrServerClosed)) {
+				logger.Error(err, "http server error")
+			}
 		}
-		logger.Info("server started")
 	}()
 
-	c := make(chan os.Signal, 1)
-	// We'll accept graceful shutdowns when quit via SIGINT (Ctrl+C) and SIGTERM
-	// SIGKILL, SIGQUIT will not be caught.
-	signal.Notify(c, syscall.SIGINT)
-	signal.Notify(c, syscall.SIGTERM)
-
 	// Block until we receive our signal.
-	<-c
+	isShutdown = <-shutdown
 
-	// Create a deadline to wait for.
-	ctx, cancel := context.WithTimeout(context.Background(), *wait)
-	defer cancel()
-	// Doesn't block if no connections, but will otherwise wait
-	// until the timeout deadline.
-	srv.Shutdown(ctx)
-	// Optionally, you could run srv.Shutdown in a goroutine and block on
-	// <-ctx.Done() if your application should wait for other services
-	// to finalize based on context cancellation.
-	logger.Info("shutting down")
-	os.Exit(0)
-
+	// Doesn't block if no connections, otherwise this waits for context
+	// deadline. As shutdown is coordinated across multiple server by the
+	// caller, we just use a background context and wait indefinitely if there
+	// are active connections.
+	if err := srv.Shutdown(context.Background()); err != nil {
+		logger.Error(err, "http server shutdown error")
+	}
+	logger.Info("http server shutdown")
 }
 
-func runGrpcServer(lis net.Listener, logger logr.Logger, predictor *v1.PredictorSpec, client seldonclient.SeldonApiClient, serverUrl *url.URL, namespace string, protocol string, deploymentName string, annotations map[string]string) {
+func runGrpcServer(wg *sync.WaitGroup, shutdown chan bool, lis net.Listener, logger logr.Logger, predictor *v1.PredictorSpec, client seldonclient.SeldonApiClient, serverUrl *url.URL, namespace string, protocol string, deploymentName string, annotations map[string]string) {
+	wg.Add(1)
+	defer wg.Done()
 	defer lis.Close()
 	grpcServer, err := grpc.CreateGrpcServer(predictor, deploymentName, annotations, logger)
 	if err != nil {
@@ -154,9 +154,53 @@ func runGrpcServer(lis net.Listener, logger logr.Logger, predictor *v1.Predictor
 		kfservingGrpcServer := kfserving.NewGrpcKFServingServer(predictor, client, serverUrl, namespace)
 		kfproto.RegisterGRPCInferenceServiceServer(grpcServer, kfservingGrpcServer)
 	}
-	err = grpcServer.Serve(lis)
-	if err != nil {
-		logger.Error(err, "gRPC server error")
+
+	go func() {
+		logger.Info("gRPC server started")
+		if err := grpcServer.Serve(lis); err != nil {
+			logger.Error(err, "gRPC server error")
+		}
+	}()
+
+	<-shutdown // wait for signal
+	grpcServer.GracefulStop()
+	logger.Info("gRPC server shutdown")
+}
+
+func waitForShutdown(logger logr.Logger, wg *sync.WaitGroup, chs ...chan bool) {
+	// wait for and then signal servers have exited
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	c := make(chan os.Signal, 1)
+	// We'll accept graceful shutdowns when quit via SIGINT (Ctrl+C) and SIGTERM
+	// SIGKILL, SIGQUIT will not be caught.
+	signal.Notify(c, syscall.SIGINT)
+	signal.Notify(c, syscall.SIGTERM)
+
+	// Block until we receive our signal.
+	sig := <-c
+	logger.Info("shutdown signal received", "signal", sig, "shutdown_delay", *delay)
+	time.Sleep(*delay) // shutdown_delay
+
+	// Create a deadline to wait for graceful shutdown.
+	ctx, cancel := context.WithTimeout(context.Background(), *wait)
+	defer cancel()
+
+	// send signals to server channels to initiate shutdown.
+	for _, ch := range chs {
+		ch <- true
+	}
+
+	select {
+	case <-done:
+		return // servers shutdown
+	case <-ctx.Done():
+		logger.Error(ctx.Err(), "graceful_timeout exceeded, exiting immediately", "graceful_timeout", *wait)
+		os.Exit(1)
 	}
 }
 
@@ -342,11 +386,15 @@ func main() {
 		log.Fatalf("Failed to create grpc client. Unknown protocol %s: %v", *protocol, err)
 	}
 
+	wg := sync.WaitGroup{}
 	logger.Info("Running http server ", "port", *httpPort)
-	go runHttpServer(createListener(*httpPort, logger), logger, predictor, clientRest, *httpPort, false, serverUrl, *namespace, *protocol, *sdepName, *prometheusPath)
+	httpStop := make(chan bool, 1)
+	go runHttpServer(&wg, httpStop, createListener(*httpPort, logger), logger, predictor, clientRest, *httpPort, false, serverUrl, *namespace, *protocol, *sdepName, *prometheusPath)
 
 	logger.Info("Running grpc server ", "port", *grpcPort)
-	runGrpcServer(createListener(*grpcPort, logger), logger, predictor, clientGrpc, serverUrl, *namespace, *protocol, *sdepName, annotations)
+	grpcStop := make(chan bool, 1)
+	go runGrpcServer(&wg, grpcStop, createListener(*grpcPort, logger), logger, predictor, clientGrpc, serverUrl, *namespace, *protocol, *sdepName, annotations)
+	waitForShutdown(logger, &wg, httpStop, grpcStop)
 }
 
 func createListener(port int, logger logr.Logger) net.Listener {

--- a/executor/predictor/utils.go
+++ b/executor/predictor/utils.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 )
 
+const EnvKeyEnginePredictor = "ENGINE_PREDICTOR"
+
 func GetPredictor(predictorName, filename, sdepName, namespace string, configPath *string) (*v1.PredictorSpec, error) {
 	if filename != "" {
 		predictor, err := getPredictorFromFile(predictorName, filename)
@@ -25,7 +27,10 @@ func GetPredictor(predictorName, filename, sdepName, namespace string, configPat
 }
 
 func getPredictorFromEnv() (*v1.PredictorSpec, error) {
-	b64Predictor := os.Getenv("ENGINE_PREDICTOR")
+	b64Predictor, ok := os.LookupEnv(EnvKeyEnginePredictor)
+	if !ok {
+		return nil, fmt.Errorf("Predictor not found, enviroment variable %s not set", EnvKeyEnginePredictor)
+	}
 	if b64Predictor != "" {
 		bytes, err := base64.StdEncoding.DecodeString(b64Predictor)
 		if err != nil {

--- a/executor/predictor/utils_test.go
+++ b/executor/predictor/utils_test.go
@@ -1,0 +1,73 @@
+package predictor
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
+)
+
+func TestGetPredictorFromEnv(t *testing.T) {
+	t.Logf("Started")
+	g := NewGomegaWithT(t)
+	var b64Error base64.CorruptInputError
+
+	tests := []struct {
+		name      string
+		key       string
+		val       string
+		predictor *v1.PredictorSpec
+		err       error
+	}{
+		{
+			name: "missing env var",
+			err:  fmt.Errorf("Predictor not found, enviroment variable %s not set", EnvKeyEnginePredictor),
+		},
+		{
+			name: "empty value",
+			key:  EnvKeyEnginePredictor,
+		},
+		{
+			name: "non-b64 value",
+			key:  EnvKeyEnginePredictor,
+			val:  ":;,",
+			err:  b64Error,
+		},
+	}
+
+	// unset existing env var & reset at end of test
+	val, ok := os.LookupEnv(EnvKeyEnginePredictor)
+	if ok {
+		if err := os.Unsetenv(EnvKeyEnginePredictor); err != nil {
+			t.Fatalf("failed to unset env var %v: %v", EnvKeyEnginePredictor, err)
+		}
+		defer func() {
+			os.Setenv(EnvKeyEnginePredictor, val)
+		}()
+	}
+
+	setenv := func(key, val string) {
+		if key == "" {
+			return
+		}
+		if err := os.Setenv(key, val); err != nil {
+			t.Fatalf("failed to set env var: %v", err)
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setenv(tt.key, tt.val)
+			got, err := getPredictorFromEnv()
+			g.Expect(got).Should(Equal(tt.predictor))
+			if tt.err == nil {
+				g.Expect(err).Should(BeNil())
+			} else {
+				g.Expect(err).Should(Equal(tt.err))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Several changes changes are introduced in the PR, the individual commits reflect the changes and are described in more detail below; in summary and order of importance the changes are:

1. (3b098ea) Introduces `shutdown_delay` option in executor and adds graceful termination to gRPC server.
2. (33b04da) Fixes maxproc logging.
3. (b9122dc) Return error if `ENGINE_PREDICTOR` env var is not found when `getPredictorFromEnv()` is called.

#### gRPC graceful shutdown
The executor has a `graceful_timeout` (default: 15s) option, which allows for graceful termination of the http (REST) server through the net/http Server's [`Shutdown()` method][http_server_shutdown]. When there is no connections to the http server, the `Shutdown()` doesn't block and `os.Exit()` is immediately called. The gRPC server which is running in the main goroutine is abruptly terminated without calling its associated [`GracefulStop()` method][grpc_server_shutdown] to drain active connections.

The changes introduced here run both the http and gRPC servers in their own goroutines and use per-server channels to signal shutdown. The `context.WithTimeout()` created from the `graceful_timeout` option is moved out of `runHttpServer` and is used within the `waitForShutdown()` function. While the http server can now block for a period longer than the graceful timeout, the server will still be stopped when the program exits. The gRPC server does not use a context in its graceful shutdown method: the graceful timeout expiry is handled within `waitForShutdown()`.

#### server shutdown_delay
We run several Seldon models on a kubernetes cluster, and have configured Seldon to use Ambassador as a gateway. When we do RollingUpdates (redeployments) of the model we see a significant increase in error rate, as measured by an upstream service. The errors look something of the form:

```
<_Rendezvous of RPC that terminated with:	
status = StatusCode.UNAVAILABLE	
details = "upstream connect error or disconnect/reset before headers. reset reason: local reset"	
debug_error_string = "
{
  "created":"@1635250379.345962743",
  "description":"Error received from peer ipv4:xxx.xxx.xxx.xxx:80",
  "file":"src/core/lib/surface/call.cc",
  "file_line":1041,
  "grpc_message":"upstream connect error or disconnect/reset before headers. reset reason: local reset",
  "grpc_status":14
}"
>
```

These errors are seen in our upstream service whenever one of the pods (running a seldon-container-engine) is deleted. Some simple testing revealed that traffic is still directed at the terminating pod for a period after it has already received a SIGTERM and shutdown, this leads to the errors we see above. We deploy the seldondeployment CRD with a `seldon.io/headless-svc: "true"` annotation. What we think is happening is that Envoy (via Ambassador) continues to keep the terminated pod's IP in rotation even after the pod is rotated. Some rudimentary measurements suggest that it can take over 10 seconds for a terminated pod to stop showing up in DNS record for the service. Additionally, by default, Envoy [refreshes from DNS every 5 seconds][dns_refresh_rate].

We found that we could delete a pod without seeing gRPC errors if we utilized a `shutdown_delay` of 30s. By default this new option is set to 0, so there is no change in existing behavior.

#### maxproc logging
The `logger.Info` passed into maxprocs's [`Set()` method][maxproc_set] does not behave like `fmt.Printf()` which leads to panic-level errors in the logs:

```
{"level":"dpanic","ts":1635457222.747586,"logger":"entrypoint","msg":"odd number of arguments passed as key-value pairs for logging","ignored key":"1","stacktrace":"go.uber.org/automaxprocs/maxprocs.(*config).log\n\t/src/go/pkg/mod/go.uber.org/automaxprocs@v1.4.0/maxprocs/maxprocs.go:47\ngo.uber.org/automaxprocs/maxprocs.Set\n\t/src/go/pkg/mod/go.uber.org/automaxprocs@v1.4.0/maxprocs/maxprocs.go:101\nmain.main\n\t/src/seldon-core/executor/cmd/executor/main.go:310\nruntime.main\n\t/opt/local/lib/go/src/runtime/proc.go:255"}
```

This is because after the first argument logr expects paired arguments that are formatted as keyval pairs. The change here adds an inline function so that only a single argument is passed to `logger.Info` (a formatted string) and the above error is no longer generated. With this change, the above log line now appears as:

```
{"level":"info","ts":1635467960.469512,"logger":"entrypoint.maxprocs","msg":"maxprocs: Honoring GOMAXPROCS=\"1\" as set in environment"}
```

#### missing ENGINE_PREDICTOR env var
The `getPredictorFromEnv()` function is modified to error in a similar manner as the `getPredictorFromFile()`. If a predictor can't be loaded from a file (because the file is missing or unsupported) that function returns an error. If no filename is specified a predictor will be loaded from the environment. However, if the ENGINE_PREDICTOR env var is missing an nil pointer is returned which leads to a subsequent panic. This change returns an error if the `getPredictorFromEnv()` function is called and no corresponding ENGINE_PREDICTOR env var has been set.

[http_server_shutdown]: https://pkg.go.dev/net/http#Server.Shutdown
[grpc_server_shutdown]: https://pkg.go.dev/google.golang.org/grpc#Server.GracefulStop
[dns_refresh_rate]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-dns-refresh-rate
[maxproc_set]: https://pkg.go.dev/go.uber.org/automaxprocs@v1.4.0/maxprocs#Logger

**Which issue(s) this PR fixes**: None.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

The issue is described within this PR.

**Special notes for your reviewer**: None.

**Does this PR introduce a user-facing change?**: Yes.
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Adds shutdown_delay option to executor
```

