### PR TITLE
Performance fix for the logger in the executor

### DIFF
--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -70,7 +70,10 @@ var (
 	transport      = flag.String("transport", "rest", "The network transport mechanism rest, grpc")
 	filename       = flag.String("file", "", "Load graph from file")
 	hostname       = flag.String("hostname", "", "The hostname of the running server")
-	logWorkers     = flag.Int("logger_workers", 5, "Number of workers handling payload logging")
+	// TODO(ivan): expose this through operator
+	logWorkers     = flag.Int("logger_workers", 10, "Number of workers handling payload logging")
+	logWorkBufferSize = flag.Int("log_work_buffer_size", 10000, "Limit of buffered logs in memory while waiting for downstream request ingestion")
+
 	prometheusPath = flag.String("prometheus_path", "/metrics", "The prometheus metrics path")
 	kafkaBroker    = flag.String("kafka_broker", "", "The kafka broker as host:port")
 	kafkaTopicIn   = flag.String("kafka_input_topic", "", "The kafka input topic")

--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -58,31 +58,30 @@ var (
 
 	debugDefault = false
 
-	configPath     = flag.String("config", "", "Path to kubconfig")
-	sdepName       = flag.String("sdep", "", "Seldon deployment name")
-	namespace      = flag.String("namespace", "", "Namespace")
-	predictorName  = flag.String("predictor", "", "Name of the predictor inside the SeldonDeployment")
-	httpPort       = flag.Int("http_port", 8080, "Executor http port")
-	grpcPort       = flag.Int("grpc_port", 5000, "Executor grpc port")
-	wait           = flag.Duration("graceful_timeout", time.Second*15, "Graceful shutdown secs")
-	delay          = flag.Duration("shutdown_delay", 0, "Shutdown delay secs")
-	protocol       = flag.String("protocol", "seldon", "The payload protocol")
-	transport      = flag.String("transport", "rest", "The network transport mechanism rest, grpc")
-	filename       = flag.String("file", "", "Load graph from file")
-	hostname       = flag.String("hostname", "", "The hostname of the running server")
-	// TODO(ivan): expose this through operator
-	logWorkers     = flag.Int("logger_workers", 10, "Number of workers handling payload logging")
+	configPath        = flag.String("config", "", "Path to kubconfig")
+	sdepName          = flag.String("sdep", "", "Seldon deployment name")
+	namespace         = flag.String("namespace", "", "Namespace")
+	predictorName     = flag.String("predictor", "", "Name of the predictor inside the SeldonDeployment")
+	httpPort          = flag.Int("http_port", 8080, "Executor http port")
+	grpcPort          = flag.Int("grpc_port", 5000, "Executor grpc port")
+	wait              = flag.Duration("graceful_timeout", time.Second*15, "Graceful shutdown secs")
+	delay             = flag.Duration("shutdown_delay", 0, "Shutdown delay secs")
+	protocol          = flag.String("protocol", "seldon", "The payload protocol")
+	transport         = flag.String("transport", "rest", "The network transport mechanism rest, grpc")
+	filename          = flag.String("file", "", "Load graph from file")
+	hostname          = flag.String("hostname", "", "The hostname of the running server")
+	logWorkers        = flag.Int("logger_workers", 10, "Number of workers handling payload logging")
 	logWorkBufferSize = flag.Int("log_work_buffer_size", 10000, "Limit of buffered logs in memory while waiting for downstream request ingestion")
-
-	prometheusPath = flag.String("prometheus_path", "/metrics", "The prometheus metrics path")
-	kafkaBroker    = flag.String("kafka_broker", "", "The kafka broker as host:port")
-	kafkaTopicIn   = flag.String("kafka_input_topic", "", "The kafka input topic")
-	kafkaTopicOut  = flag.String("kafka_output_topic", "", "The kafka output topic")
-	kafkaFullGraph = flag.Bool("kafka_full_graph", false, "Use kafka for internal graph processing")
-	kafkaWorkers   = flag.Int("kafka_workers", 4, "Number of kafka workers")
-	logKafkaBroker = flag.String("log_kafka_broker", "", "The kafka log broker")
-	logKafkaTopic  = flag.String("log_kafka_topic", "", "The kafka log topic")
-	debug          = flag.Bool(
+	logWriteTimeoutMs = flag.Int("log_write_timeout_ms", 2000, "Timeout before giving up writing log if buffer is full. If <= 0 will immediately drop log on full log buffer.")
+	prometheusPath    = flag.String("prometheus_path", "/metrics", "The prometheus metrics path")
+	kafkaBroker       = flag.String("kafka_broker", "", "The kafka broker as host:port")
+	kafkaTopicIn      = flag.String("kafka_input_topic", "", "The kafka input topic")
+	kafkaTopicOut     = flag.String("kafka_output_topic", "", "The kafka output topic")
+	kafkaFullGraph    = flag.Bool("kafka_full_graph", false, "Use kafka for internal graph processing")
+	kafkaWorkers      = flag.Int("kafka_workers", 4, "Number of kafka workers")
+	logKafkaBroker    = flag.String("log_kafka_broker", "", "The kafka log broker")
+	logKafkaTopic     = flag.String("log_kafka_topic", "", "The kafka log topic")
+	debug             = flag.Bool(
 		"debug",
 		util.GetEnvAsBool(debugEnvVar, debugDefault),
 		"Enable debug mode. Logs will be sampled and less structured.",
@@ -348,7 +347,7 @@ func main() {
 	}
 
 	//Start Logger Dispacther
-	err = loghandler.StartDispatcher(*logWorkers, logger, *sdepName, *namespace, *predictorName, *logKafkaBroker, *logKafkaTopic)
+	err = loghandler.StartDispatcher(*logWorkers, *logWorkBufferSize, *logWriteTimeoutMs, logger, *sdepName, *namespace, *predictorName, *logKafkaBroker, *logKafkaTopic)
 	if err != nil {
 		log.Fatal("Failed to start log dispatcher", err)
 	}

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/seldonio/seldon-core/operator v0.0.0-00010101000000-000000000000
 	github.com/tensorflow/tensorflow/tensorflow/go/core v0.0.0-00010101000000-000000000000
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
-	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	go.uber.org/automaxprocs v1.4.0
 	go.uber.org/zap v1.19.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
@@ -27,6 +26,63 @@ require (
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.21.3
 	sigs.k8s.io/controller-runtime v0.9.6
+)
+
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/kedacore/keda v0.0.0-20200911122749-717aab81817f // indirect
+	github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210416161957-9910b6c460de // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.9.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apiextensions-apiserver v0.21.3 // indirect
+	k8s.io/apimachinery v0.21.3 // indirect
+	k8s.io/client-go v12.0.0+incompatible // indirect
+	k8s.io/component-base v0.21.3 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471 // indirect
+	knative.dev/pkg v0.0.0-20210426101439-2a0fc657a712 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace github.com/tensorflow/tensorflow/tensorflow/go/core => ./proto/tensorflow/core

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -29,62 +29,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.9.6
 )
 
-require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-logr/zapr v0.4.0 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/json-iterator/go v1.1.11 // indirect
-	github.com/kedacore/keda v0.0.0-20200911122749-717aab81817f // indirect
-	github.com/lightstep/tracecontext.go v0.0.0-20181129014701-1757c391b1ac // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/sirupsen/logrus v1.7.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	go.opencensus.io v0.23.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
-	golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
-	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20210416161957-9910b6c460de // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
-	gopkg.in/evanphx/json-patch.v4 v4.9.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/apiextensions-apiserver v0.21.3 // indirect
-	k8s.io/apimachinery v0.21.3 // indirect
-	k8s.io/client-go v12.0.0+incompatible // indirect
-	k8s.io/component-base v0.21.3 // indirect
-	k8s.io/klog/v2 v2.8.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
-	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471 // indirect
-	knative.dev/pkg v0.0.0-20210426101439-2a0fc657a712 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
-)
-
 replace github.com/tensorflow/tensorflow/tensorflow/go/core => ./proto/tensorflow/core
 
 replace github.com/seldonio/seldon-core/operator => ./_operator

--- a/executor/logger/collector.go
+++ b/executor/logger/collector.go
@@ -1,11 +1,21 @@
 package logger
 
-const LoggerWorkerQueueSize = 100
+import (
+	"github.com/pkg/errors"
+	"time"
+)
+
+// TODO(ivan): Make configurable
+const LoggerWorkerQueueSize = 10000
 
 // A buffered channel that we can send work requests on.
 var WorkQueue = make(chan LogRequest, LoggerWorkerQueueSize)
 
 func QueueLogRequest(req LogRequest) error {
-	WorkQueue <- req
-	return nil
+	select {
+	case WorkQueue <- req:
+		return nil
+	case <- time.After(2 * time.Second): // TODO(ivan): make timeout configurable? The timeout is basically, maxLogWaitOnFullBuffer
+		return errors.New("timed out waiting to queue log request: buffer is full")
+	}
 }

--- a/executor/logger/collector.go
+++ b/executor/logger/collector.go
@@ -5,17 +5,24 @@ import (
 	"time"
 )
 
-// TODO(ivan): Make configurable
-const LoggerWorkerQueueSize = 10000
+const (
+	DefaultWorkQueueSize            = 10000
+	DefaultWriteTimeoutMilliseconds = 2000
+)
 
-// A buffered channel that we can send work requests on.
-var WorkQueue = make(chan LogRequest, LoggerWorkerQueueSize)
+var (
+	// Default values of these variables are declared here. StartDispatcher can overwrite them with user provided values.
+	// workQueue is a buffered channel that we can send work requests on.
+	workQueue = make(chan LogRequest, DefaultWorkQueueSize)
+	// writeTimeoutMilliseconds is the timeout for waiting for work to be written to the queue. If 0, will not wait if buffer is full.
+	writeTimeoutMilliseconds = DefaultWriteTimeoutMilliseconds
+)
 
 func QueueLogRequest(req LogRequest) error {
 	select {
-	case WorkQueue <- req:
+	case workQueue <- req:
 		return nil
-	case <- time.After(2 * time.Second): // TODO(ivan): make timeout configurable? The timeout is basically, maxLogWaitOnFullBuffer
+	case <-time.After(time.Duration(writeTimeoutMilliseconds) * time.Millisecond):
 		return errors.New("timed out waiting to queue log request: buffer is full")
 	}
 }

--- a/executor/logger/dispatcher.go
+++ b/executor/logger/dispatcher.go
@@ -31,25 +31,12 @@ func StartDispatcher(nworkers int, log logr.Logger, sdepName string, namespace s
 	// Now, create all of our workers.
 	for i := 0; i < nworkers; i++ {
 		log.Info("Starting", "worker", i+1)
-		worker, err := NewWorker(i+1, WorkerQueue, log, sdepName, namespace, predictorName, kafkaBroker, kafkaTopic)
+		worker, err := NewWorker(i+1, WorkQueue, log, sdepName, namespace, predictorName, kafkaBroker, kafkaTopic)
 		if err != nil {
 			return err
 		}
 		worker.Start()
 	}
-
-	go func() {
-		for {
-			select {
-			case work := <-WorkQueue:
-				go func() {
-					worker := <-WorkerQueue
-
-					worker <- work
-				}()
-			}
-		}
-	}()
 
 	return nil
 }

--- a/executor/logger/log_memory_benchmark_test.go
+++ b/executor/logger/log_memory_benchmark_test.go
@@ -1,0 +1,100 @@
+package logger
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+	"time"
+)
+
+func BenchmarkLoggerMemoryUsage(b *testing.B) {
+	//fmt.Println("starting benchmark..")
+	serverPort := startSlowLogListener()
+
+	err := StartDispatcher(5, logf.Log.WithName("test"), "test-name", "test-namespace", "test-predictor", "", "")
+	if err != nil {
+		b.Fatal(err)
+	}
+	logURL, err := url.Parse(fmt.Sprintf("http://localhost:%v/log",serverPort))
+	if err != nil {
+		b.Fatal(err)
+	}
+	testMessage := []byte("test message")
+
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		err = QueueLogRequest(LogRequest{
+			Url:         logURL,
+			Bytes:       &testMessage,
+			ContentType: "test",
+			ReqType:     InferenceRequest,
+			Id:          "test",
+			SourceUri:   logURL,
+			ModelId:     "1",
+			RequestId:   "1",
+		})
+		if err != nil {
+			b.Log(err)
+		}
+	}
+}
+//
+//func TestAsd(t *testing.T) {
+//	serverPort := startSlowLogListener()
+//
+//	err := StartDispatcher(5, logf.Log.WithName("test"), "test-name", "test-namespace", "test-predictor", "", "")
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//
+//	logURL, err := url.Parse(fmt.Sprintf("http://localhost:%v/log",serverPort))
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	testMessage := []byte("test message")
+//	err = QueueLogRequest(LogRequest{
+//		Url:         logURL,
+//		Bytes:       &testMessage,
+//		ContentType: "test",
+//		ReqType:     InferenceRequest,
+//		Id:          "test",
+//		SourceUri:   logURL,
+//		ModelId:     "1",
+//		RequestId:   "1",
+//	})
+//	if err != nil {
+//		panic(err)
+//	}
+//}
+
+func startSlowLogListener() int {
+	// Use a random free port by specifying port :0
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	fmt.Printf("listening on %v\n", port)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/log", func(w http.ResponseWriter, r *http.Request) {
+		//fmt.Println("received a message to the /log endpoint")
+		time.Sleep(2 * time.Second)
+		fmt.Fprint(w, "logged successfully")
+	})
+
+	go func() {
+		// todo: cleanup
+		panic(http.Serve(listener, mux))
+	}()
+
+	return port
+}

--- a/executor/logger/worker.go
+++ b/executor/logger/worker.go
@@ -47,10 +47,10 @@ func NewWorker(id int, workQueue chan LogRequest, log logr.Logger, sdepName stri
 
 	// Create, and return the worker.
 	return &Worker{
-		Log:         log,
-		ID:          id,
-		Work:        workQueue,
-		QuitChan:    make(chan bool),
+		Log:      log,
+		ID:       id,
+		Work:     workQueue,
+		QuitChan: make(chan bool),
 		Client: http.Client{
 			Timeout: 60 * time.Second,
 		},

--- a/executor/logger/worker.go
+++ b/executor/logger/worker.go
@@ -29,7 +29,7 @@ const (
 // NewWorker creates, and returns a new Worker object. Its only argument
 // is a channel that the worker can add itself to whenever it is done its
 // work.
-func NewWorker(id int, workerQueue chan chan LogRequest, log logr.Logger, sdepName string, namespace string, predictorName string, kafkaBroker string, kafkaTopic string) (*Worker, error) {
+func NewWorker(id int, workQueue chan LogRequest, log logr.Logger, sdepName string, namespace string, predictorName string, kafkaBroker string, kafkaTopic string) (*Worker, error) {
 
 	var producer *kafka.Producer
 	var err error
@@ -49,8 +49,7 @@ func NewWorker(id int, workerQueue chan chan LogRequest, log logr.Logger, sdepNa
 	return &Worker{
 		Log:         log,
 		ID:          id,
-		Work:        make(chan LogRequest),
-		WorkerQueue: workerQueue,
+		Work:        workQueue,
 		QuitChan:    make(chan bool),
 		Client: http.Client{
 			Timeout: 60 * time.Second,
@@ -68,7 +67,6 @@ type Worker struct {
 	Log           logr.Logger
 	ID            int
 	Work          chan LogRequest
-	WorkerQueue   chan chan LogRequest
 	QuitChan      chan bool
 	Client        http.Client
 	CeCtx         context.Context
@@ -173,9 +171,6 @@ func (w *Worker) sendCloudEvent(logReq LogRequest) error {
 func (w *Worker) Start() {
 	go func() {
 		for {
-			// Add ourselves into the worker queue.
-			w.WorkerQueue <- w.Work
-
 			select {
 			case work := <-w.Work:
 				// Receive a work request.

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -333,16 +333,23 @@ func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqTyp
 	if err != nil {
 		return err
 	}
-	payloadLogger.QueueLogRequest(payloadLogger.LogRequest{
-		Url:         logUrl,
-		Bytes:       &data,
-		ContentType: msg.GetContentType(),
-		ReqType:     reqType,
-		Id:          guuid.New().String(),
-		SourceUri:   p.ServerUrl,
-		ModelId:     nodeName,
-		RequestId:   puid,
-	})
+
+	go func() {
+		err := payloadLogger.QueueLogRequest(payloadLogger.LogRequest{
+			Url:         logUrl,
+			Bytes:       &data,
+			ContentType: msg.GetContentType(),
+			ReqType:     reqType,
+			Id:          guuid.New().String(),
+			SourceUri:   p.ServerUrl,
+			ModelId:     nodeName,
+			RequestId:   puid,
+		})
+		if err != nil {
+			// TODO(ivan): is this how to log to stderr?
+			p.Log.Error(err, "failed to log request")
+		}
+	}()
 	return nil
 }
 

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -346,7 +346,6 @@ func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqTyp
 			RequestId:   puid,
 		})
 		if err != nil {
-			// TODO(ivan): is this how to log to stderr?
 			p.Log.Error(err, "failed to log request")
 		}
 	}()

--- a/executor/predictor/predictor_process_test.go
+++ b/executor/predictor/predictor_process_test.go
@@ -444,7 +444,7 @@ func TestModelWithLogRequests(t *testing.T) {
 
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
-	logger.StartDispatcher(1, log, "", "", "", "", "")
+	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "")
 
 	model := v1.MODEL
 	graph := &v1.PredictiveUnit{
@@ -492,7 +492,7 @@ func TestModelWithLogRequestsAtDefaultedUrl(t *testing.T) {
 
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
-	logger.StartDispatcher(1, log, "", "", "", "", "")
+	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "")
 
 	model := v1.MODEL
 	graph := &v1.PredictiveUnit{
@@ -535,7 +535,7 @@ func TestModelWithLogResponses(t *testing.T) {
 
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
-	logger.StartDispatcher(1, log, "", "", "", "", "")
+	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "")
 
 	model := v1.MODEL
 	graph := &v1.PredictiveUnit{


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

The logger in the executor spins a goroutine for each prediction and waits until the payload can be logged. With a slow downstream request logger and a huge spike of requests, the executor can OOM. 

This PR makes a couple of changes to allow for more graceful handling of such spikes of traffic:
* Increase the default work queue size and make it configurable - now we use the channel to buffer work. We no longer use goroutines that wait to write to the channel as a buffer
* Add a configurable timeout for when the buffer is full. This means logs can be dropped if there is too much work for the executor and downstream log processing to handle.
* Increase the default workers - they are waiting on I/O most of the time so they can be more than they used to be.

There is also a general refactor of the consumer/producer pattern we use to make it easier to understand and use without changing the behaviour.

This PR also adds a benchmark for profiling the behaviour of the executor. It was used to confirm that before we can see a linear increase in the number of goroutines with the number of requests. These goroutines also never finished if the request logging was taking ages to process. The new implementation shows a steady number of goroutines allocated for logging no matter how many requests we have.

We will need to expose the following flags in the operator so that they can be configured from there:
* `logger_workers`
* `log_work_buffer_size`
* `log_write_timeout_ms`

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3726

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

