### PR TITLE
Chart annotations cont, manager container security context

### DIFF
--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -22,7 +22,7 @@ spec:
     metadata:
       annotations:
 {{- with .Values.manager.annotations }}
-{{- toYaml . | nindent 4}}
+{{- toYaml . | nindent 8}}
 {{- end }}
         prometheus.io/scrape: 'true'
         sidecar.istio.io/inject: 'false'

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -41,6 +41,9 @@ spec:
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)
         - '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
+{{- with .Values.manager.containerSecurityContext }}
+{{- toYaml . | nindent 8}}
+{{- end }}
         command:
         - /manager
         env:

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -81,6 +81,7 @@ manager:
   logLevel: INFO
   leaderElectionID: a33bd623.machinelearning.seldon.io
   annotations: {}
+  containerSecurityContext: {}
 rbac:
   configmap:
     create: true

--- a/operator/helm/create_templates.sh
+++ b/operator/helm/create_templates.sh
@@ -6,7 +6,7 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 kustomize build ../../config/$1 > tt.yaml
-csplit --suppress-matched   tt.yaml "/^---/" "{*}"
+gcsplit --suppress-matched   tt.yaml "/^---/" "{*}"
 # manually add secret file from cert kustomize option
 cp ../../config/cert/secret.yaml xxSecret
-python ../split_resources.py --folder ../../../helm-charts/seldon-core-operator/templates
+python3 ../split_resources.py --folder ../../../helm-charts/seldon-core-operator/templates

--- a/operator/helm/create_templates.sh
+++ b/operator/helm/create_templates.sh
@@ -6,7 +6,7 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 kustomize build ../../config/$1 > tt.yaml
-gcsplit --suppress-matched   tt.yaml "/^---/" "{*}"
+csplit --suppress-matched   tt.yaml "/^---/" "{*}"
 # manually add secret file from cert kustomize option
 cp ../../config/cert/secret.yaml xxSecret
-python3 ../split_resources.py --folder ../../../helm-charts/seldon-core-operator/templates
+python ../split_resources.py --folder ../../../helm-charts/seldon-core-operator/templates

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -31,7 +31,8 @@ HELM_CREATERESOURCES_RBAC_IF_START = "{{- if .Values.managerCreateResources }}\n
 HELM_K8S_V1_CRD_IF_START = '{{- if or (ge (int (regexFind "[0-9]+" .Capabilities.KubeVersion.Minor)) 18) (.Values.crd.forcev1) }}\n'
 HELM_K8S_V1BETA1_CRD_IF_START = '{{- if or (lt (int (regexFind "[0-9]+" .Capabilities.KubeVersion.Minor)) 18) (.Values.crd.forcev1beta1) }}\n'
 HELM_CRD_ANNOTATIONS_WITH_START = '{{- with .Values.crd.annotations }}\n'
-HELM_ANNOTATIONS_TOYAML = '{{- toYaml . | nindent 4}}\n'
+HELM_ANNOTATIONS_TOYAML4 = '{{- toYaml . | nindent 4}}\n'
+HELM_ANNOTATIONS_TOYAML8 = '{{- toYaml . | nindent 8}}\n'
 HELM_CONTROLER_DEP_ANNOTATIONS_WITH_START = '{{- with .Values.manager.annotations }}\n'
 HELM_IF_END = "{{- end }}\n"
 
@@ -406,7 +407,7 @@ if __name__ == "__main__":
                     + re.sub(
                         r"(.*controller-gen.kubebuilder.io/version.*\n)",
                         r"\1" + HELM_CRD_ANNOTATIONS_WITH_START +
-                        HELM_ANNOTATIONS_TOYAML + HELM_IF_END,
+                        HELM_ANNOTATIONS_TOYAML4 + HELM_IF_END,
                         fdata,
                         re.M,
                     )
@@ -423,7 +424,7 @@ if __name__ == "__main__":
                     + re.sub(
                         r"(.*controller-gen.kubebuilder.io/version.*\n)",
                         r"\1" + HELM_CRD_ANNOTATIONS_WITH_START +
-                        HELM_ANNOTATIONS_TOYAML + HELM_IF_END,
+                        HELM_ANNOTATIONS_TOYAML4 + HELM_IF_END,
                         fdata,
                         re.M,
                     )
@@ -451,7 +452,7 @@ if __name__ == "__main__":
                 fdata = re.sub(
                     r"(.*template:\n.*metadata:\n.*annotations:\n)",
                     r"\1" + HELM_CONTROLER_DEP_ANNOTATIONS_WITH_START +
-                    HELM_ANNOTATIONS_TOYAML + HELM_IF_END,
+                    HELM_ANNOTATIONS_TOYAML8 + HELM_IF_END,
                     fdata,
                     re.M,
                 )

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -34,6 +34,7 @@ HELM_CRD_ANNOTATIONS_WITH_START = '{{- with .Values.crd.annotations }}\n'
 HELM_ANNOTATIONS_TOYAML4 = '{{- toYaml . | nindent 4}}\n'
 HELM_ANNOTATIONS_TOYAML8 = '{{- toYaml . | nindent 8}}\n'
 HELM_CONTROLER_DEP_ANNOTATIONS_WITH_START = '{{- with .Values.manager.annotations }}\n'
+HELM_CONTROLER_DEP_POD_SEC_CTX_WITH_START = '{{- with .Values.manager.containerSecurityContext }}\n'
 HELM_IF_END = "{{- end }}\n"
 
 HELM_ENV_SUBST = {
@@ -437,6 +438,14 @@ if __name__ == "__main__":
                 fdata = HELM_CREATERESOURCES_IF_START + fdata + HELM_IF_END
             elif kind == "deployment" and name == "seldon-controller-manager":
                 fdata = re.sub(
+                    r"(.*template:\n.*metadata:\n.*annotations:\n)",
+                    r"\1" + HELM_CONTROLER_DEP_ANNOTATIONS_WITH_START +
+                    HELM_ANNOTATIONS_TOYAML8 + HELM_IF_END,
+                    fdata,
+                    re.M,
+                )
+
+                fdata = re.sub(
                     r"(.*volumeMounts:\n.*\n.*\n.*\n)",
                     HELM_CREATERESOURCES_IF_START + r"\1" + HELM_IF_END,
                     fdata,
@@ -450,9 +459,9 @@ if __name__ == "__main__":
                 )
 
                 fdata = re.sub(
-                    r"(.*template:\n.*metadata:\n.*annotations:\n)",
-                    r"\1" + HELM_CONTROLER_DEP_ANNOTATIONS_WITH_START +
-                    HELM_ANNOTATIONS_TOYAML8 + HELM_IF_END,
+                    r"(.*command:\n)",
+                    HELM_CONTROLER_DEP_POD_SEC_CTX_WITH_START +
+                    HELM_ANNOTATIONS_TOYAML8 + HELM_IF_END + r"\1",
                     fdata,
                     re.M,
                 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Fixes @agrski 's comment for the correct indentation on the manager deployment annotations, adds a _container_ security context to the same deployment. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3698

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
add container security context to controller manager
```

