### PR TITLE
executor: decompress gzip paloyads before logging them

### DIFF
--- a/executor/api/payload/utils.go
+++ b/executor/api/payload/utils.go
@@ -1,0 +1,30 @@
+package payload
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+)
+
+// Decompress payloads if Content-Encoding is set
+func DecompressSeldonPayload(msg SeldonPayload) ([]byte, error) {
+	data, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	if msg.GetContentEncoding() == "gzip" {
+		bytesReader := bytes.NewReader(data)
+		gzipReader, err := gzip.NewReader(bytesReader)
+		if err != nil {
+			return nil, err
+		}
+		output, err := ioutil.ReadAll(gzipReader)
+		if err != nil {
+			return nil, err
+		}
+		return output, nil
+	} else {
+		return data, nil
+	}
+}

--- a/executor/api/payload/utils.go
+++ b/executor/api/payload/utils.go
@@ -6,25 +6,29 @@ import (
 	"io/ioutil"
 )
 
-// Decompress payloads if Content-Encoding is set
+func DecompressBytes(data []byte, contentEncoding string) ([]byte, error) {
+	if contentEncoding != "gzip" {
+		return data, nil
+	}
+
+	bytesReader := bytes.NewReader(data)
+	gzipReader, err := gzip.NewReader(bytesReader)
+	if err != nil {
+		return nil, err
+	}
+	output, err := ioutil.ReadAll(gzipReader)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+// Decompress payloads if Content-Encoding is set to gzip
 func DecompressSeldonPayload(msg SeldonPayload) ([]byte, error) {
 	data, err := msg.GetBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	if msg.GetContentEncoding() == "gzip" {
-		bytesReader := bytes.NewReader(data)
-		gzipReader, err := gzip.NewReader(bytesReader)
-		if err != nil {
-			return nil, err
-		}
-		output, err := ioutil.ReadAll(gzipReader)
-		if err != nil {
-			return nil, err
-		}
-		return output, nil
-	} else {
-		return data, nil
-	}
+	return DecompressBytes(data, msg.GetContentEncoding())
 }

--- a/executor/api/rest/kfserving.go
+++ b/executor/api/rest/kfserving.go
@@ -1,33 +1,16 @@
 package rest
 
 import (
-	"compress/gzip"
 	"encoding/json"
-	"io/ioutil"
 
 	"github.com/pkg/errors"
 	"github.com/seldonio/seldon-core/executor/api/payload"
-
-	"bytes"
 )
 
 func ChainKFserving(msg payload.SeldonPayload) (payload.SeldonPayload, error) {
-	data, err := msg.GetBytes()
+	data, err := payload.DecompressSeldonPayload(msg)
 	if err != nil {
 		return nil, err
-	}
-
-	if msg.GetContentEncoding() == "gzip" {
-		bytesReader := bytes.NewReader(data)
-		gzipReader, err := gzip.NewReader(bytesReader)
-		if err != nil {
-			return nil, err
-		}
-		output, err := ioutil.ReadAll(gzipReader)
-		if err != nil {
-			return nil, err
-		}
-		data = output
 	}
 
 	var f interface{}

--- a/executor/logger/types.go
+++ b/executor/logger/types.go
@@ -13,12 +13,13 @@ const (
 )
 
 type LogRequest struct {
-	Url         *url.URL
-	Bytes       *[]byte
-	ContentType string
-	ReqType     LogRequestType
-	Id          string
-	SourceUri   *url.URL
-	ModelId     string
-	RequestId   string
+	Url             *url.URL
+	Bytes           *[]byte
+	ContentType     string
+	ContentEncoding string
+	ReqType         LogRequestType
+	Id              string
+	SourceUri       *url.URL
+	ModelId         string
+	RequestId       string
 }

--- a/executor/logger/worker.go
+++ b/executor/logger/worker.go
@@ -1,15 +1,19 @@
 package logger
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/go-logr/logr"
-	"net/http"
-	"time"
 )
 
 const (
@@ -122,6 +126,26 @@ func (w *Worker) sendKafkaEvent(logReq LogRequest) error {
 }
 
 func (w *Worker) sendCloudEvent(logReq LogRequest) error {
+	var data []byte
+
+	// This temporary fix related to the fact that Triton server responses
+	// are now gzipped compressed. Until we introduce support for gzip
+	// compressed payloads in the logger / adserver and include content-encoding
+	// header in the CloudEvent messages this can serve as temporary solution.
+	if logReq.ContentEncoding == "gzip" {
+		bytesReader := bytes.NewReader(*logReq.Bytes)
+		gzipReader, err := gzip.NewReader(bytesReader)
+		if err != nil {
+			return err
+		}
+		output, err := ioutil.ReadAll(gzipReader)
+		if err != nil {
+			return err
+		}
+		data = output
+	} else {
+		data = *logReq.Bytes
+	}
 
 	t, err := cloudevents.NewHTTPTransport(
 		cloudevents.WithTarget(logReq.Url.String()),
@@ -154,7 +178,7 @@ func (w *Worker) sendCloudEvent(logReq LogRequest) error {
 
 	event.SetSource(logReq.SourceUri.String())
 	event.SetDataContentType(logReq.ContentType)
-	if err := event.SetData(*logReq.Bytes); err != nil {
+	if err := event.SetData(data); err != nil {
 		return fmt.Errorf("while setting cloudevents data: %s", err)
 	}
 

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -333,17 +333,17 @@ func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqTyp
 	if err != nil {
 		return err
 	}
-
 	go func() {
 		err := payloadLogger.QueueLogRequest(payloadLogger.LogRequest{
-			Url:         logUrl,
-			Bytes:       &data,
-			ContentType: msg.GetContentType(),
-			ReqType:     reqType,
-			Id:          guuid.New().String(),
-			SourceUri:   p.ServerUrl,
-			ModelId:     nodeName,
-			RequestId:   puid,
+			Url:             logUrl,
+			Bytes:           &data,
+			ContentType:     msg.GetContentType(),
+			ContentEncoding: msg.GetContentEncoding(),
+			ReqType:         reqType,
+			Id:              guuid.New().String(),
+			SourceUri:       p.ServerUrl,
+			ModelId:         nodeName,
+			RequestId:       puid,
 		})
 		if err != nil {
 			p.Log.Error(err, "failed to log request")

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -325,16 +325,20 @@ func (p *PredictorProcess) getLogUrl(logger *v1.Logger) (*url.URL, error) {
 }
 
 func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqType payloadLogger.LogRequestType, msg payload.SeldonPayload, puid string) error {
-	data, err := msg.GetBytes()
-	if err != nil {
-		return err
-	}
 	logUrl, err := p.getLogUrl(logger)
 	if err != nil {
 		return err
 	}
 	go func() {
-		err := payloadLogger.QueueLogRequest(payloadLogger.LogRequest{
+		// This temporary fix related to the fact that Triton server responses
+		// are now gzipped compressed. Until we introduce support for gzip
+		// compressed payloads in the logger / adserver and include content-encoding
+		// header in the CloudEvent messages this can serve as temporary solution.
+		data, err := payload.DecompressSeldonPayload(msg)
+		if err != nil {
+			p.Log.Error(err, "failed to log request")
+		}
+		err = payloadLogger.QueueLogRequest(payloadLogger.LogRequest{
 			Url:             logUrl,
 			Bytes:           &data,
 			ContentType:     msg.GetContentType(),

--- a/executor/samples/local/kfserving/Makefile
+++ b/executor/samples/local/kfserving/Makefile
@@ -1,4 +1,5 @@
 BASE=../../..
+TRITON_VERSION ?= 21.08-py3
 
 triton-inference-server:
 	git clone https://github.com/NVIDIA/triton-inference-server
@@ -6,14 +7,19 @@ triton-inference-server:
 triton-inference-server/docs/examples/model_repository/simple: triton-inference-server
 	cd triton-inference-server/docs/examples && ./fetch_models.sh
 
+
+## dummy logger
+run_dummy_logsink:
+	docker run -it -p 2222:80 --rm -t mendhak/http-https-echo
+
 ## REST
 
 run_executor:
-	${BASE}/executor --sdep triton --namespace default --predictor simple --file ./model.yaml --http_port 8000 --grpc_port 5000 --protocol kfserving
+	${BASE}/executor --sdep triton --namespace default --predictor simple --file ./model.yaml --http_port 8000 --grpc_port 5000 --protocol kfserving --log_level DEBUG
 
 
 run_triton_simple:
-	docker run --rm --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 -p9000:9000 -p8001:8001 -p8002:8002 -p5001:5001 -v ${PWD}/triton-inference-server/docs/examples/model_repository:/models nvcr.io/nvidia/tritonserver:21.08-py3 /opt/tritonserver/bin/tritonserver --model-repository=/models --http-port=9000 --grpc-port=5001
+	docker run --rm --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 -p9000:9000 -p8001:8001 -p8002:8002 -p5001:5001 -v ${PWD}/triton-inference-server/docs/examples/model_repository:/models nvcr.io/nvidia/tritonserver:${TRITON_VERSION} /opt/tritonserver/bin/tritonserver --model-repository=/models --http-port=9000 --grpc-port=5001 --log-verbose=1
 
 curl_rest_triton:
 	curl -v -d '{"inputs":[{"name":"INPUT0","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]}]}'    -X POST http://0.0.0.0:9000/v2/models/simple/infer    -H "Content-Type: application/json"

--- a/executor/samples/local/kfserving/model.yaml
+++ b/executor/samples/local/kfserving/model.yaml
@@ -14,6 +14,9 @@ spec:
       implementation: TRITON_SERVER
       modelUri: gs://seldon-models/trtis/simple-model
       name: simple
-      type: MODEL      
+      type: MODEL
+      logger:
+        mode: all
+        url: http://localhost:2222
     name: simple
     replicas: 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This is temporary fix until we can close https://github.com/SeldonIO/seldon-core/issues/3690. 
It is to ensure that CloudEvents send to the logging endpoint are not compressed.


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/SeldonIO/seldon-core/issues/3749

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

