### PR TITLE
Address MLServer flakiness in CI tests

### DIFF
--- a/operator/controllers/mlserver.go
+++ b/operator/controllers/mlserver.go
@@ -69,12 +69,18 @@ func mergeMLServerContainer(existing *v1.Container, mlServer *v1.Container) *v1.
 	}
 	existing.Env = mlServer.Env
 
+	// If the readiness or liveness probe already exist, ensure the handler is
+	// V2-compatible (otherwise, set all to default)
 	if existing.ReadinessProbe == nil {
 		existing.ReadinessProbe = mlServer.ReadinessProbe
+	} else {
+		existing.ReadinessProbe.Handler = mlServer.ReadinessProbe.Handler
 	}
 
 	if existing.LivenessProbe == nil {
 		existing.LivenessProbe = mlServer.LivenessProbe
+	} else {
+		existing.LivenessProbe.Handler = mlServer.LivenessProbe.Handler
 	}
 
 	if existing.SecurityContext == nil {

--- a/operator/controllers/mlserver.go
+++ b/operator/controllers/mlserver.go
@@ -127,21 +127,21 @@ func getMLServerContainer(pu *machinelearningv1.PredictiveUnit, namespace string
 				Port: intstr.FromString("http"),
 			}},
 			InitialDelaySeconds: 20,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       10,
-			SuccessThreshold:    1,
+			PeriodSeconds:       5,
 			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      60,
 		},
 		LivenessProbe: &v1.Probe{
 			Handler: v1.Handler{HTTPGet: &v1.HTTPGetAction{
 				Path: constants.KFServingProbeLivePath,
 				Port: intstr.FromString("http"),
 			}},
-			InitialDelaySeconds: 60,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       10,
-			SuccessThreshold:    1,
+			InitialDelaySeconds: 20,
+			PeriodSeconds:       5,
 			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      60,
 		},
 		VolumeMounts: []v1.VolumeMount{
 			{

--- a/servers/mlflowserver/Makefile
+++ b/servers/mlflowserver/Makefile
@@ -1,8 +1,8 @@
 SHELL := /bin/bash
 VERSION := $(shell cat ../../version.txt)
+KIND_NAME ?= kind
 IMAGE_NAME_BASE=mlflowserver
 IMAGE_NAME=seldonio/${IMAGE_NAME_BASE}
-KIND_NAME ?= kind
 
 build:
 	s2i build \

--- a/testing/scripts/e2e_utils/v2_protocol.py
+++ b/testing/scripts/e2e_utils/v2_protocol.py
@@ -4,19 +4,22 @@ from tenacity import retry, retry_if_result, stop_after_attempt, wait_exponentia
 from seldon_e2e_utils import API_AMBASSADOR
 
 
-def _is_404(res):
-    return res.status_code == 404
+def _is_transient_error(res):
+    to_retry = [404, 503, 504]
+    return res.status_code in to_retry
 
 
 @retry(
     wait=wait_exponential(multiplier=1),
     stop=stop_after_attempt(3),
-    retry=retry_if_result(_is_404),
+    retry=retry_if_result(_is_transient_error),
 )
 def inference_request(
-    deployment_name: str, model_name: str, namespace: str, payload: dict, host: str = API_AMBASSADOR
+    deployment_name: str,
+    model_name: str,
+    namespace: str,
+    payload: dict,
+    host: str = API_AMBASSADOR,
 ):
-    endpoint = (
-        f"http://{host}/seldon/{namespace}/{deployment_name}/v2/models/{model_name}/infer"
-    )
+    endpoint = f"http://{host}/seldon/{namespace}/{deployment_name}/v2/models/{model_name}/infer"
     return requests.post(endpoint, json=payload)

--- a/wrappers/s2i/python/Dockerfile
+++ b/wrappers/s2i/python/Dockerfile
@@ -28,10 +28,15 @@ COPY _python/python/licenses/license.txt .
 COPY _python /microservice
 RUN cd /microservice/python && pip install .
 
-RUN mkdir -p /.conda && chmod a+rwx /.conda
 RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
 
-# Default user is 8888 so changing for permissiosn to modify (needed in mlflow server)
-RUN chown -R 8888 /microservice
+# Default user is 8888 so changing for permissiosn to modify (needed in mlflow
+# server).
+# Clean Conda's cache to avoid cache file conflicts between user IDs:
+# https://github.com/conda/conda/issues/7227
+RUN mkdir -p /.conda && \
+    chmod a+rwx /.conda && \
+    chown -R 8888 /microservice  && \
+    conda clean --index-cache
 
 EXPOSE 5000


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Ensure that the readiness and liveness probes of the MLServer containers are always set as HTTP probes querying the [health endpoints of the V2 protocol](https://kserve.github.io/website/modelserving/inference_api/#health). Previously, this was being overriden to a plain TCP ping. Hopefully, this should address the flakiness that's been appearing recently on the tests leveraging MLServer containers.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3639 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

