### PR TITLE
fixed iris sklearn model example

### DIFF
--- a/examples/models/sklearn_iris/sklearn_iris.ipynb
+++ b/examples/models/sklearn_iris/sklearn_iris.ipynb
@@ -33,7 +33,7 @@
     "Then port-forward to that ingress on localhost:8003 in a separate terminal either with:\n",
     "\n",
     " * Ambassador: `kubectl port-forward $(kubectl get pods -n seldon-system -l app.kubernetes.io/name=ambassador -o jsonpath='{.items[0].metadata.name}') -n seldon-system 8003:8080`\n",
-    " * Istio: `kubectl port-forward svc/$(kubectl get svc -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:80 --address 0.0.0.0`"
+    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080 --address 0.0.0.0`"
    ]
   },
   {

--- a/examples/models/sklearn_iris/sklearn_iris.ipynb
+++ b/examples/models/sklearn_iris/sklearn_iris.ipynb
@@ -34,6 +34,7 @@
     "\n",
     " * Ambassador: `kubectl port-forward $(kubectl get pods -n seldon-system -l app.kubernetes.io/name=ambassador -o jsonpath='{.items[0].metadata.name}') -n seldon-system 8003:8080`\n",
     " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080 --address 0.0.0.0`"
+    " * Istio: `kubectl port-forward  -n istio-system svc/istio-ingressgateway 8003:80 --address 0.0.0.0`"
    ]
   },
   {

--- a/examples/models/sklearn_iris/sklearn_iris.ipynb
+++ b/examples/models/sklearn_iris/sklearn_iris.ipynb
@@ -33,7 +33,7 @@
     "Then port-forward to that ingress on localhost:8003 in a separate terminal either with:\n",
     "\n",
     " * Ambassador: `kubectl port-forward $(kubectl get pods -n seldon-system -l app.kubernetes.io/name=ambassador -o jsonpath='{.items[0].metadata.name}') -n seldon-system 8003:8080`\n",
-    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080 --address 0.0.0.0`",
+    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080 --address 0.0.0.0`\n",
     " * Istio: `kubectl port-forward  -n istio-system svc/istio-ingressgateway 8003:80 --address 0.0.0.0`"
    ]
   },

--- a/examples/models/sklearn_iris/sklearn_iris.ipynb
+++ b/examples/models/sklearn_iris/sklearn_iris.ipynb
@@ -33,8 +33,8 @@
     "Then port-forward to that ingress on localhost:8003 in a separate terminal either with:\n",
     "\n",
     " * Ambassador: `kubectl port-forward $(kubectl get pods -n seldon-system -l app.kubernetes.io/name=ambassador -o jsonpath='{.items[0].metadata.name}') -n seldon-system 8003:8080`\n",
-    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080 --address 0.0.0.0`\n",
-    " * Istio: `kubectl port-forward  -n istio-system svc/istio-ingressgateway 8003:80 --address 0.0.0.0`"
+    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080`\n",
+    " * Istio: `kubectl port-forward  -n istio-system svc/istio-ingressgateway 8003:80`"
    ]
   },
   {

--- a/examples/models/sklearn_iris/sklearn_iris.ipynb
+++ b/examples/models/sklearn_iris/sklearn_iris.ipynb
@@ -33,7 +33,7 @@
     "Then port-forward to that ingress on localhost:8003 in a separate terminal either with:\n",
     "\n",
     " * Ambassador: `kubectl port-forward $(kubectl get pods -n seldon-system -l app.kubernetes.io/name=ambassador -o jsonpath='{.items[0].metadata.name}') -n seldon-system 8003:8080`\n",
-    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080 --address 0.0.0.0`"
+    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:8080 --address 0.0.0.0`",
     " * Istio: `kubectl port-forward  -n istio-system svc/istio-ingressgateway 8003:80 --address 0.0.0.0`"
    ]
   },

--- a/examples/models/sklearn_iris/sklearn_iris.ipynb
+++ b/examples/models/sklearn_iris/sklearn_iris.ipynb
@@ -33,7 +33,7 @@
     "Then port-forward to that ingress on localhost:8003 in a separate terminal either with:\n",
     "\n",
     " * Ambassador: `kubectl port-forward $(kubectl get pods -n seldon-system -l app.kubernetes.io/name=ambassador -o jsonpath='{.items[0].metadata.name}') -n seldon-system 8003:8080`\n",
-    " * Istio: `kubectl port-forward $(kubectl get pods -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:80`"
+    " * Istio: `kubectl port-forward svc/$(kubectl get svc -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system 8003:80 --address 0.0.0.0`"
    ]
   },
   {


### PR DESCRIPTION
Fixed the tunnel issue in iris sklearn model example, as no 80 port running inside the pod. Tunnel should be created on Istio ingress gateway service

This Pull Request is for fixing the example where there is issue in creating tunnel for executing the REST API from local

