### PR TITLE
Allow deployment name as prefix when default name to long

### DIFF
--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -157,6 +157,8 @@ spec:
           value: '{{ .Values.engine.resources.cpuLimit }}'
         - name: ENGINE_DEFAULT_MEMORY_LIMIT
           value: '{{ .Values.engine.resources.memoryLimit }}'
+        - name: DEPLOYMENT_NAME_AS_PREFIX
+          value: '{{ .Values.manager.deploymentNameAsPrefix }}'
         image: '{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         name: manager

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -84,6 +84,7 @@ manager:
   leaderElectionID: a33bd623.machinelearning.seldon.io
   annotations: {}
   containerSecurityContext: {}
+  deploymentNameAsPrefix: false
 rbac:
   configmap:
     create: true

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types_test.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types_test.go
@@ -92,3 +92,88 @@ func TestGetDeploymentNameLong(t *testing.T) {
 	g.Expect(len(parts)).To(Equal(2))
 	g.Expect(parts[0]).To(Equal(DeploymentNamePrefix))
 }
+
+func TestGetDeploymentNames(t *testing.T) {
+	g := NewGomegaWithT(t)
+	type test struct {
+		name                      string
+		envDeploymentNameAsPrefix string
+		sdepName                  string
+		predictorName             string
+		modelName                 string
+		expected                  string
+	}
+
+	tests := []test{
+		{
+			name:                      "simple",
+			envDeploymentNameAsPrefix: "false",
+			sdepName:                  "s",
+			predictorName:             "p",
+			modelName:                 "m",
+			expected:                  "s-p-0-m",
+		},
+		{
+			name:                      "depAsPrefixSimple",
+			envDeploymentNameAsPrefix: "true",
+			sdepName:                  "s",
+			predictorName:             "p",
+			modelName:                 "m",
+			expected:                  "s-p-0-m",
+		},
+		{
+			name:                      "longName",
+			envDeploymentNameAsPrefix: "false",
+			sdepName:                  "s",
+			predictorName:             "C12345678912345678901234567890123456789012345678901234567890",
+			modelName:                 "m",
+			expected:                  "seldon-10eb0f02cdc303e74043e57c1d8147ab",
+		},
+		{
+			name:                      "longName",
+			envDeploymentNameAsPrefix: "true",
+			sdepName:                  "s",
+			predictorName:             "C12345678912345678901234567890123456789012345678901234567890",
+			modelName:                 "m",
+			expected:                  "s-10eb0f02cdc303e74043e57c1d8147ab",
+		},
+	}
+	resetState := func() { envDeploymentNameAsPrefix = "false" }
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Cleanup(resetState)
+			envDeploymentNameAsPrefix = test.envDeploymentNameAsPrefix
+			mlDep := &SeldonDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      test.sdepName,
+					Namespace: "default",
+				},
+				Spec: SeldonDeploymentSpec{
+					Protocol: "abc",
+					Predictors: []PredictorSpec{
+						{
+							Name: test.predictorName,
+							ComponentSpecs: []*SeldonPodSpec{
+								{
+									Spec: v1.PodSpec{
+										Containers: []v1.Container{
+											{
+												Image: "seldonio/mock_classifier:1.0",
+												Name:  test.modelName,
+											},
+										},
+									},
+								},
+							},
+							Graph: PredictiveUnit{
+								Name: test.modelName,
+							},
+						},
+					},
+				},
+			}
+			name := GetDeploymentName(mlDep, mlDep.Spec.Predictors[0], mlDep.Spec.Predictors[0].ComponentSpecs[0], 0)
+			g.Expect(name).To(Equal(test.expected))
+		})
+	}
+}

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -147,6 +147,8 @@ spec:
           value: "0.5"
         - name: ENGINE_DEFAULT_MEMORY_LIMIT
           value: "512Mi"
+        - name: DEPLOYMENT_NAME_AS_PREFIX
+          value: "false"
         image: controller:latest
         name: manager
         resources:

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -76,6 +76,7 @@ HELM_ENV_SUBST = {
     "MANAGER_LEADER_ELECTION_ID": "manager.leaderElectionID",
     "EXECUTOR_REQUEST_LOGGER_WORK_QUEUE_SIZE": "executor.requestLogger.workQueueSize",
     "EXECUTOR_REQUEST_LOGGER_WRITE_TIMEOUT_MS": "executor.requestLogger.writeTimeoutMs",
+    "DEPLOYMENT_NAME_AS_PREFIX": "manager.deploymentNameAsPrefix",
 }
 HELM_VALUES_IMAGE_PULL_POLICY = "{{ .Values.image.pullPolicy }}"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

 * Allows the deployment name to be sdep.name-<hash> rather than seldon-<hash> if an environment variable set for manager
 * Adds environment variable DEPLOYMENT_NAME_AS_PREFIX to manager
 * Adds Helm chart value `.manager.deploymentNameAsPrefix`

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1801

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

