### PR TITLE
Docs: Removed argument from tags example

### DIFF
--- a/doc/source/python/python_component.md
+++ b/doc/source/python/python_component.md
@@ -150,7 +150,7 @@ class ModelWithTags(object):
     def predict(self,X,features_names):
         return X
 
-    def tags(self,X):
+    def tags(self):
         return {"system":"production"}
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes an example that snagged me. The `tags` method does not accept any arguments. This has been fixed.

```release-note NONE
```

