### PR TITLE
Support https on batch processor

### DIFF
--- a/doc/source/reference/release-1.7.0.md
+++ b/doc/source/reference/release-1.7.0.md
@@ -4,7 +4,7 @@ A summary of the main contributions to the [Seldon Core release 1.7.0](https://g
 
 ## Experimental GPU Accelerated Explainers and Drift Detection
 
-As part of our [NVIDIA GTC 2021 Talk](https://gtc21.event.nvidia.com/media/MLOps%20with%20NVIDIA%20GPUs%20on%20Kubernetes%20%5BS32020%5D/1_tgjkxf3l) this year we have added some new features for utilizing GPUs for explainability and drift detection.
+As part of our NVIDIA GTC 2021 Talk this year we have added some new features for utilizing GPUs for explainability and drift detection.
 
 ### XGBoost Model with GPU TreeShap Explainer
 

--- a/doc/source/servers/batch.md
+++ b/doc/source/servers/batch.md
@@ -95,14 +95,21 @@ Options:
                                   The log level for the batch processor
   -b, --benchmark                 If true the batch processor will print the
                                   elapsed time taken to run the process
-  -u, --batch-id TEXT             Unique batch ID to identify all datapoints
+  -u, --batch-id TEXT             Unique batch ID to identify all data points
                                   processed in this batch, if not provided is
                                   auto generated
-  -u, --batch-size INTEGER        Batch size greater than 1 can be used to
+  -s, --batch-size INTEGER        Batch size greater than 1 can be used to
                                   group multiple predictions into a single
                                   request.
-  -t, --batch-interval FLOAT      Minimum Time interval(in seconds) between
-                                  batch predictions made by every worker
+  -t, --batch-interval FLOAT      Minimum Time interval (in seconds) between
+                                  batch predictions made by every worker.
+  --use-ssl BOOLEAN               Whether to use https rather than http as the
+                                  REST transport protocol.
+  --call-credentials-token TEXT   Auth token used by Seldon Client, if
+                                  supplied and using REST the transport
+                                  protocol will be https.
+  --ssl-verify BOOLEAN            Can be set to false to avoid SSL
+                                  verification in REST.
   --help                          Show this message and exit.
 ```
 

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -11,7 +11,11 @@ import click
 import numpy as np
 import requests
 
-from seldon_core.seldon_client import SeldonCallCredentials, SeldonChannelCredentials, SeldonClient
+from seldon_core.seldon_client import (
+    SeldonCallCredentials,
+    SeldonChannelCredentials,
+    SeldonClient,
+)
 
 CHOICES_GATEWAY_TYPE = ["ambassador", "istio", "seldon"]
 CHOICES_TRANSPORT = ["rest", "grpc"]

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -3,7 +3,6 @@ import json
 import logging
 import time
 import uuid
-from itertools import groupby
 from queue import Empty, Queue
 from threading import Event, Thread
 from typing import Dict, List, Tuple

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -54,6 +54,7 @@ def start_multithreaded_batch_worker(
     benchmark: bool,
     batch_id: str,
     batch_interval: float,
+    call_credentials_token: str,
 ) -> None:
     """
     Starts the multithreaded batch worker which consists of three worker types and
@@ -79,7 +80,9 @@ def start_multithreaded_batch_worker(
             "Batch size greater than 1 is only supported for `data` data type."
         )
 
-    creds = SeldonCallCredentials(token=jwt)
+    creds = None
+    if len(call_credentials_token) > 0:
+        creds = SeldonCallCredentials(token=call_credentials_token)
 
     sc = SeldonClient(
         gateway=gateway_type,
@@ -776,7 +779,7 @@ def _send_batch_feedback(
     envvar="SELDON_BATCH_ID",
     default=str(uuid.uuid1()),
     type=str,
-    help="Unique batch ID to identify all datapoints processed in this batch, if not provided is auto generated",
+    help="Unique batch ID to identify all data points processed in this batch, if not provided is auto generated",
 )
 @click.option(
     "--batch-size",
@@ -792,14 +795,14 @@ def _send_batch_feedback(
     envvar="SELDON_BATCH_MIN_INTERVAL",
     default=0,
     type=float,
-    help="Minimum Time interval(in seconds) between batch predictions made by every worker.",
+    help="Minimum Time interval (in seconds) between batch predictions made by every worker.",
 )
 @click.option(
-    "--use-ssl",
-    envvar="SELDON_BATCH_USE_SSL",
-    default=False,
-    type=bool,
-    help="Whether to use SSL in transport.",
+    "--call-credentials-token",
+    envvar="SELDON_BATCH_CALL_CREDENTIALS_TOKEN",
+    default="",
+    type=str,
+    help="Auth token used by Seldon Client.",
 )
 def run_cli(
     deployment_name: str,
@@ -819,6 +822,7 @@ def run_cli(
     benchmark: bool,
     batch_id: str,
     batch_interval: float,
+    call_credentials_token: str,
 ):
     """
     Command line interface for Seldon Batch Processor, which can be used to send requests
@@ -849,6 +853,7 @@ def run_cli(
         benchmark,
         batch_id,
         batch_interval,
+        call_credentials_token,
     )
 
 

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -12,7 +12,7 @@ import click
 import numpy as np
 import requests
 
-from seldon_core.seldon_client import SeldonClient
+from seldon_core.seldon_client import SeldonClient, SeldonCallCredentials
 
 CHOICES_GATEWAY_TYPE = ["ambassador", "istio", "seldon"]
 CHOICES_TRANSPORT = ["rest", "grpc"]
@@ -79,6 +79,8 @@ def start_multithreaded_batch_worker(
             "Batch size greater than 1 is only supported for `data` data type."
         )
 
+    creds = SeldonCallCredentials(token=jwt)
+
     sc = SeldonClient(
         gateway=gateway_type,
         transport=transport,
@@ -87,6 +89,7 @@ def start_multithreaded_batch_worker(
         gateway_endpoint=host,
         namespace=namespace,
         client_return_type="dict",
+        call_credentials=creds,
     )
 
     t_in = Thread(
@@ -789,7 +792,14 @@ def _send_batch_feedback(
     envvar="SELDON_BATCH_MIN_INTERVAL",
     default=0,
     type=float,
-    help="Minimum Time interval(in seconds) between batch predictions made by every worker",
+    help="Minimum Time interval(in seconds) between batch predictions made by every worker.",
+)
+@click.option(
+    "--use-ssl",
+    envvar="SELDON_BATCH_USE_SSL",
+    default=False,
+    type=bool,
+    help="Whether to use SSL in transport.",
 )
 def run_cli(
     deployment_name: str,

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -82,7 +82,7 @@ def start_multithreaded_batch_worker(
         )
 
     # Providing call credentials sets the REST transport protocol to https,
-    # so we configure credentials even without a supplied token is use_ssl is set.
+    # so we configure credentials even without a supplied token if use_ssl is set.
     credentials = None
     if use_ssl or len(call_credentials_token) > 0:
         token = None

--- a/python/seldon_core/batch_processor.py
+++ b/python/seldon_core/batch_processor.py
@@ -12,7 +12,7 @@ import click
 import numpy as np
 import requests
 
-from seldon_core.seldon_client import SeldonClient, SeldonCallCredentials
+from seldon_core.seldon_client import SeldonCallCredentials, SeldonClient
 
 CHOICES_GATEWAY_TYPE = ["ambassador", "istio", "seldon"]
 CHOICES_TRANSPORT = ["rest", "grpc"]

--- a/python/seldon_core/seldon_client.py
+++ b/python/seldon_core/seldon_client.py
@@ -1478,7 +1478,7 @@ def rest_predict_gateway(
             request = prediction_pb2.SeldonMessage(data=datadef, meta=metaKV)
         payload = seldon_message_to_json(request)
 
-    if not headers is None:
+    if headers is not None:
         req_headers = headers.copy()
     else:
         req_headers = {}
@@ -1486,11 +1486,11 @@ def rest_predict_gateway(
         scheme = "http"
     else:
         scheme = "https"
-    if not call_credentials is None:
-        if not call_credentials.token is None:
+    if call_credentials is not None:
+        if call_credentials.token is not None:
             req_headers["X-Auth-Token"] = call_credentials.token
     if http_path is not None:
-        url = url = (
+        url = (
             scheme
             + "://"
             + gateway_endpoint
@@ -1532,12 +1532,12 @@ def rest_predict_gateway(
             )
     verify = True
     cert = None
-    if not channel_credentials is None:
-        if not channel_credentials.certificate_chain_file is None:
+    if channel_credentials is not None:
+        if channel_credentials.certificate_chain_file is not None:
             verify = channel_credentials.certificate_chain_file
         else:
             verify = channel_credentials.verify
-        if not channel_credentials.private_key_file is None:
+        if channel_credentials.private_key_file is not None:
             cert = (
                 channel_credentials.root_certificates_file,
                 channel_credentials.private_key_file,

--- a/testing/scripts/test_batch_processor.py
+++ b/testing/scripts/test_batch_processor.py
@@ -57,6 +57,9 @@ class TestBatchWorker(object):
             True,
             str(uuid.uuid1()),
             0,
+            "",
+            False,
+            True,
         )
 
         logging.info("Finished first batch. Checking.")
@@ -91,6 +94,9 @@ class TestBatchWorker(object):
             True,
             str(uuid.uuid1()),
             0,
+            "",
+            False,
+            True,
         )
 
         logging.info("Finished first batch. Checking.")
@@ -146,6 +152,9 @@ class TestBatchWorker(object):
             True,
             str(uuid.uuid1()),
             0,
+            "",
+            False,
+            True,
         )
 
         logging.info("Finished first batch. Checking.")
@@ -187,6 +196,9 @@ class TestBatchWorker(object):
             True,
             str(uuid.uuid1()),
             0,
+            "",
+            False,
+            True,
         )
 
         logging.info("Finished first batch. Checking.")
@@ -252,6 +264,9 @@ class TestBatchWorker(object):
             True,
             str(uuid.uuid1()),
             0,
+            "",
+            False,
+            True,
         )
 
         logging.info("Finished first batch. Checking.")
@@ -293,6 +308,9 @@ class TestBatchWorker(object):
             True,
             str(uuid.uuid1()),
             0,
+            "",
+            False,
+            True,
         )
 
         logging.info("Finished first batch. Checking.")


### PR DESCRIPTION
Adding https support to batch processor, as per customer request.

I've tested this against a cluster running with a signed TLS cert and it's working. Modified the Istio gateway to not accept http traffic, and the processor fails when use-ssl is false as expected.