### PR TITLE
remove explainer_examples.ipynb from notebook test

### DIFF
--- a/testing/scripts/test_notebooks.py
+++ b/testing/scripts/test_notebooks.py
@@ -16,9 +16,6 @@ class TestNotebooks(object):
     def test_helm_examples(self):
         create_and_run_script("../../notebooks", "helm_examples")
 
-    def test_explainer_examples(self):
-        create_and_run_script("../../notebooks", "explainer_examples")
-
     def test_istio_examples(self):
         create_and_run_script("../../notebooks", "istio_example")
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR remove explainer_examples.ipynb from notebook tests as we rely now on integration tests in `test_alibi_explain.py`
and `test_alibi_explain_v2.py`

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3777 

**Special notes for your reviewer**:

This PR doesnt actually remove the file `explainer_examples.ipynb`, just the reference to it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
```

