### PR TITLE
Use consistent identity not per-request UUID for worker IDs

### DIFF
--- a/components/alibi-detect-server/adserver/server.py
+++ b/components/alibi-detect-server/adserver/server.py
@@ -63,7 +63,6 @@ class CEServer(object):
         self.event_type = event_type
         self.event_source = event_source
         self.seldon_metrics = SeldonMetrics(
-            worker_id_func=lambda: str(uuid.uuid1()),
             extra_default_labels=DEFAULT_LABELS,
         )
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
All the metrics from the `alibi-detect-server` are unable to be used as-is for monitoring and alerting across the span of multiple events.

The use of a UUID means every request is treated as a new timeseries by Prometheus because the labels are different every time.
Furthermore, it means metrics, whether gauges or counters, can never be reset, which is painful for alerting.

The default worker ID function--the process ID for the worker--will be consistent across requests, which mitigates both of the aforementioned issues.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Fixed alibi-detect-server metrics to allow effective alerting by providing a consistent set of labels across every event.
```

