### PR TITLE
Add model_name when chaining requests

### DIFF
--- a/executor/api/grpc/kfserving/client.go
+++ b/executor/api/grpc/kfserving/client.go
@@ -112,11 +112,15 @@ func (s *KFServingGrpcClient) Chain(ctx context.Context, modelName string, msg p
 	switch v := msg.GetPayload().(type) {
 	case *inference.ModelInferRequest:
 		s.Log.Info("Identity chain")
+		if v.ModelName == "" {
+			v.ModelName = modelName
+		}
+
 		return msg, nil
 	case *inference.ModelInferResponse:
 		s.Log.Info("Chain!")
+
 		inputTensors := make([]*inference.ModelInferRequest_InferInputTensor, len(v.Outputs))
-		fmt.Println(len(inputTensors))
 		for idx, oTensor := range v.Outputs {
 			inputTensor := &inference.ModelInferRequest_InferInputTensor{
 				Name:       oTensor.Name,
@@ -127,6 +131,7 @@ func (s *KFServingGrpcClient) Chain(ctx context.Context, modelName string, msg p
 			}
 			inputTensors[idx] = inputTensor
 		}
+
 		pr := inference.ModelInferRequest{
 			ModelName: modelName,
 			Inputs:    inputTensors,

--- a/executor/api/grpc/kfserving/client.go
+++ b/executor/api/grpc/kfserving/client.go
@@ -116,7 +116,8 @@ func (s *KFServingGrpcClient) Chain(ctx context.Context, modelName string, msg p
 	case *inference.ModelInferResponse:
 		s.Log.Info("Chain!")
 		inputTensors := make([]*inference.ModelInferRequest_InferInputTensor, len(v.Outputs))
-		for _, oTensor := range v.Outputs {
+		fmt.Println(len(inputTensors))
+		for idx, oTensor := range v.Outputs {
 			inputTensor := &inference.ModelInferRequest_InferInputTensor{
 				Name:       oTensor.Name,
 				Datatype:   oTensor.Datatype,
@@ -124,10 +125,11 @@ func (s *KFServingGrpcClient) Chain(ctx context.Context, modelName string, msg p
 				Parameters: oTensor.Parameters,
 				Contents:   oTensor.Contents,
 			}
-			inputTensors = append(inputTensors, inputTensor)
+			inputTensors[idx] = inputTensor
 		}
 		pr := inference.ModelInferRequest{
-			Inputs: inputTensors,
+			ModelName: modelName,
+			Inputs:    inputTensors,
 		}
 		msg2 := payload.ProtoPayload{Msg: &pr}
 		return &msg2, nil

--- a/executor/api/grpc/kfserving/client_test.go
+++ b/executor/api/grpc/kfserving/client_test.go
@@ -52,6 +52,34 @@ func TestChain(t *testing.T) {
 			},
 		},
 		{
+			name: "ensure that request's model name is always set",
+			msg: &payload.ProtoPayload{
+				Msg: &inference.ModelInferRequest{
+					Inputs: []*inference.ModelInferRequest_InferInputTensor{
+						{
+							Name:     "input-1",
+							Datatype: "INT32",
+							Shape:    []int64{1},
+							Contents: &inference.InferTensorContents{IntContents: []int32{1}},
+						},
+					},
+				},
+			},
+			expected: &payload.ProtoPayload{
+				Msg: &inference.ModelInferRequest{
+					ModelName: nextModelName,
+					Inputs: []*inference.ModelInferRequest_InferInputTensor{
+						{
+							Name:     "input-1",
+							Datatype: "INT32",
+							Shape:    []int64{1},
+							Contents: &inference.InferTensorContents{IntContents: []int32{1}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "response should be chained",
 			msg: &payload.ProtoPayload{
 				Msg: &inference.ModelInferResponse{

--- a/executor/api/grpc/kfserving/client_test.go
+++ b/executor/api/grpc/kfserving/client_test.go
@@ -1,0 +1,95 @@
+package kfserving
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/seldonio/seldon-core/executor/api/grpc/kfserving/inference"
+	"github.com/seldonio/seldon-core/executor/api/payload"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestChain(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var prevModelName = "foo"
+	var nextModelName = "bar"
+
+	tests := []struct {
+		name     string
+		msg      payload.SeldonPayload
+		expected payload.SeldonPayload
+	}{
+		{
+			name: "request should be returned as-is",
+			msg: &payload.ProtoPayload{
+				Msg: &inference.ModelInferRequest{
+					ModelName: prevModelName,
+					Inputs: []*inference.ModelInferRequest_InferInputTensor{
+						{
+							Name:     "input-1",
+							Datatype: "INT32",
+							Shape:    []int64{1},
+							Contents: &inference.InferTensorContents{IntContents: []int32{1}},
+						},
+					},
+				},
+			},
+			expected: &payload.ProtoPayload{
+				Msg: &inference.ModelInferRequest{
+					ModelName: prevModelName,
+					Inputs: []*inference.ModelInferRequest_InferInputTensor{
+						{
+							Name:     "input-1",
+							Datatype: "INT32",
+							Shape:    []int64{1},
+							Contents: &inference.InferTensorContents{IntContents: []int32{1}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "response should be chained",
+			msg: &payload.ProtoPayload{
+				Msg: &inference.ModelInferResponse{
+					ModelName: prevModelName,
+					Outputs: []*inference.ModelInferResponse_InferOutputTensor{
+						{
+							Name:     "input-1",
+							Datatype: "INT32",
+							Shape:    []int64{1},
+							Contents: &inference.InferTensorContents{IntContents: []int32{1}},
+						},
+					},
+				},
+			},
+			expected: &payload.ProtoPayload{
+				Msg: &inference.ModelInferRequest{
+					ModelName: nextModelName,
+					Inputs: []*inference.ModelInferRequest_InferInputTensor{
+						{
+							Name:     "input-1",
+							Datatype: "INT32",
+							Shape:    []int64{1},
+							Contents: &inference.InferTensorContents{IntContents: []int32{1}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &KFServingGrpcClient{Log: logf.Log.WithName("SeldonGrpcClient")}
+			ctx := context.Background()
+
+			chained, err := client.Chain(ctx, nextModelName, tt.msg)
+			g.Expect(err).Should(BeNil())
+			g.Expect(chained).Should(Equal(tt.expected))
+		})
+	}
+}

--- a/testing/docker/mock-preprocessor/Makefile
+++ b/testing/docker/mock-preprocessor/Makefile
@@ -3,5 +3,8 @@
 build_image:
 	mlserver build . --tag seldonio/mock-preprocessor:0.1.0
 
+push_image:
+	docker push seldonio/mock-preprocessor:0.1.0
+
 kind_load_image: build_image
 	kind load -v 3 docker-image seldonio/mock-preprocessor:0.1.0

--- a/testing/docker/mock-preprocessor/Makefile
+++ b/testing/docker/mock-preprocessor/Makefile
@@ -1,0 +1,7 @@
+# Makefile for building and pushing fixed models docker images using for testing
+
+build_image:
+	mlserver build . --tag seldonio/mock-preprocessor:0.1.0
+
+kind_load_image: build_image
+	kind load -v 3 docker-image seldonio/mock-preprocessor:0.1.0

--- a/testing/docker/mock-preprocessor/model-settings.json
+++ b/testing/docker/mock-preprocessor/model-settings.json
@@ -1,0 +1,4 @@
+{
+  "name": "mock-preprocessor",
+  "implementation": "runtime.MockPreprocessor"
+}

--- a/testing/docker/mock-preprocessor/runtime.py
+++ b/testing/docker/mock-preprocessor/runtime.py
@@ -16,7 +16,7 @@ class MockPreprocessor(MLModel):
                     name="input-0",
                     shape=[1, 4],
                     datatype="FP32",
-                    data=[[0.1, 0.2, 0.3, 0.4]],
+                    data=[0.1, 0.2, 0.3, 0.4],
                 )
             ],
         )

--- a/testing/docker/mock-preprocessor/runtime.py
+++ b/testing/docker/mock-preprocessor/runtime.py
@@ -1,0 +1,22 @@
+from mlserver import MLModel
+from mlserver.types import InferenceRequest, InferenceResponse, ResponseOutput
+
+
+class MockPreprocessor(MLModel):
+    """
+    Mock runtime which returns the features for the next model on the graph.
+    """
+
+    async def predict(self, inference_request: InferenceRequest) -> InferenceResponse:
+        return InferenceResponse(
+            model_name=self.name,
+            model_version=self.version,
+            outputs=[
+                ResponseOutput(
+                    name="input-0",
+                    shape=[1, 4],
+                    datatype="FP32",
+                    data=[[0.1, 0.2, 0.3, 0.4]],
+                )
+            ],
+        )

--- a/testing/resources/graph-v2.yaml
+++ b/testing/resources/graph-v2.yaml
@@ -1,0 +1,30 @@
+apiVersion: machinelearning.seldon.io/v1
+kind: SeldonDeployment
+metadata:
+  name: graph-test
+spec:
+  protocol: kfserving
+  predictors:
+    - name: default
+      graph:
+        name: mock-preprocessor
+        children:
+          - name: model
+            implementation: SKLEARN_SERVER 
+            modelUri: gs://seldon-models/sklearn/iris-0.23.2/lr_model
+      componentSpecs:
+        - spec:
+            containers:
+              - name: mock-preprocessor
+                image: seldonio/mock-preprocessor:0.1.0
+                securityContext:
+                  # Workaround for multi-user bug in custom images in MLServer:
+                  # https://github.com/SeldonIO/MLServer/issues/388
+                  runAsUser: 1000
+                ports:
+                  - containerPort: 8080
+                    name: http
+                    protocol: TCP
+                  - containerPort: 8081
+                    name: grpc
+                    protocol: TCP

--- a/testing/scripts/Makefile
+++ b/testing/scripts/Makefile
@@ -30,6 +30,7 @@ kind_build_test_models:
 	make -C ../../examples/models/testing run_kind_load_all
 	make -C ../docker/fixed-model kind_load_images
 	make -C ../docker/echo-model kind_load_image
+	make -C ../docker/mock-preprocessor kind_load_image
 
 .PHONY: kind_build_prepackaged
 kind_build_prepackaged:

--- a/testing/scripts/conftest.py
+++ b/testing/scripts/conftest.py
@@ -7,6 +7,9 @@ from e2e_utils.install import delete_seldon, install_seldon
 from e2e_utils.s2i import create_s2i_image, kind_load_image
 from seldon_e2e_utils import clean_string, get_seldon_version, retry_run
 
+ROOT_PATH = os.path.dirname(os.path.dirname(__file__))
+RESOURCES_PATH = os.path.join(ROOT_PATH, "resources")
+
 
 def _to_python_bool(val):
     # From Flask's docs:

--- a/testing/scripts/dev_requirements.txt
+++ b/testing/scripts/dev_requirements.txt
@@ -16,3 +16,6 @@ tabulate==0.8.7
 
 # 2nd lvl dep on cov required to avoid sqllite dep
 coverage==4.5.4
+
+# Required to build mock test images
+mlserver==1.0.0.rc1

--- a/testing/scripts/e2e_utils/v2_protocol.py
+++ b/testing/scripts/e2e_utils/v2_protocol.py
@@ -41,7 +41,11 @@ def inference_request(
     return response.json()
 
 
-# TODO: Retry for gRPC errors
+@retry(
+    wait=wait_exponential(multiplier=1),
+    stop=stop_after_attempt(3),
+    retry=retry_if_exception_type(grpc.RpcError),
+)
 def inference_request_grpc(
     deployment_name: str,
     namespace: str,

--- a/testing/scripts/e2e_utils/v2_protocol.py
+++ b/testing/scripts/e2e_utils/v2_protocol.py
@@ -2,7 +2,12 @@ import requests
 import grpc
 
 from typing import Optional
-from tenacity import retry, retry_if_result, stop_after_attempt, wait_exponential
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 from google.protobuf.json_format import MessageToDict, ParseDict
 from mlserver.grpc.dataplane_pb2_grpc import GRPCInferenceServiceStub
 from mlserver.grpc.dataplane_pb2 import ModelInferRequest
@@ -10,15 +15,12 @@ from mlserver.grpc.dataplane_pb2 import ModelInferRequest
 from seldon_e2e_utils import API_AMBASSADOR
 
 
-def _is_transient_error(res):
-    to_retry = [404, 503, 504]
-    return res.status_code in to_retry
-
-
 @retry(
     wait=wait_exponential(multiplier=1),
     stop=stop_after_attempt(3),
-    retry=retry_if_result(_is_transient_error),
+    retry=retry_if_exception_type(
+        (requests.exceptions.ConnectionError, requests.exceptions.HTTPError)
+    ),
 )
 def inference_request(
     deployment_name: str,
@@ -39,6 +41,7 @@ def inference_request(
     return response.json()
 
 
+# TODO: Retry for gRPC errors
 def inference_request_grpc(
     deployment_name: str,
     namespace: str,

--- a/testing/scripts/e2e_utils/v2_protocol.py
+++ b/testing/scripts/e2e_utils/v2_protocol.py
@@ -1,5 +1,11 @@
 import requests
+import grpc
+
+from typing import Optional
 from tenacity import retry, retry_if_result, stop_after_attempt, wait_exponential
+from google.protobuf.json_format import MessageToDict, ParseDict
+from mlserver.grpc.dataplane_pb2_grpc import GRPCInferenceServiceStub
+from mlserver.grpc.dataplane_pb2 import ModelInferRequest
 
 from seldon_e2e_utils import API_AMBASSADOR
 
@@ -16,10 +22,36 @@ def _is_transient_error(res):
 )
 def inference_request(
     deployment_name: str,
-    model_name: str,
     namespace: str,
     payload: dict,
+    model_name: Optional[str] = None,
     host: str = API_AMBASSADOR,
-):
-    endpoint = f"http://{host}/seldon/{namespace}/{deployment_name}/v2/models/{model_name}/infer"
-    return requests.post(endpoint, json=payload)
+) -> dict:
+    root_endpoint = f"http://{host}/seldon/{namespace}/{deployment_name}"
+
+    endpoint = f"{root_endpoint}/v2/models/infer"
+    if model_name:
+        endpoint = f"{root_endpoint}/v2/models/{model_name}/infer"
+
+    response = requests.post(endpoint, json=payload)
+    response.raise_for_status()
+
+    return response.json()
+
+
+def inference_request_grpc(
+    deployment_name: str,
+    namespace: str,
+    payload: dict,
+    model_name: Optional[str] = None,
+    host: str = API_AMBASSADOR,
+) -> dict:
+    if model_name:
+        payload["model_name"] = model_name
+
+    with grpc.insecure_channel(host) as channel:
+        stub = GRPCInferenceServiceStub(channel)
+        request = ParseDict(payload, ModelInferRequest())
+        metadata = [("seldon", deployment_name), ("namespace", namespace)]
+        response = stub.ModelInfer(request=request, metadata=metadata)
+        return MessageToDict(response)

--- a/testing/scripts/e2e_utils/v2_protocol.py
+++ b/testing/scripts/e2e_utils/v2_protocol.py
@@ -1,16 +1,16 @@
-import requests
-import grpc
-
 from typing import Optional
+
+import grpc
+import requests
+from google.protobuf.json_format import MessageToDict, ParseDict
+from mlserver.grpc.dataplane_pb2 import ModelInferRequest
+from mlserver.grpc.dataplane_pb2_grpc import GRPCInferenceServiceStub
 from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
-from google.protobuf.json_format import MessageToDict, ParseDict
-from mlserver.grpc.dataplane_pb2_grpc import GRPCInferenceServiceStub
-from mlserver.grpc.dataplane_pb2 import ModelInferRequest
 
 from seldon_e2e_utils import API_AMBASSADOR
 

--- a/testing/scripts/test_graph.py
+++ b/testing/scripts/test_graph.py
@@ -1,12 +1,12 @@
 import os
 import time
+
 import pytest
+from conftest import RESOURCES_PATH
 
 from e2e_utils import v2_protocol
 from e2e_utils.models import deploy_model
 from seldon_e2e_utils import retry_run, wait_for_rollout, wait_for_status
-
-from conftest import RESOURCES_PATH
 
 
 @pytest.mark.parametrize("use_grpc", [True, False])

--- a/testing/scripts/test_graph.py
+++ b/testing/scripts/test_graph.py
@@ -1,0 +1,33 @@
+import os
+import time
+import pytest
+
+from e2e_utils import v2_protocol
+from e2e_utils.models import deploy_model
+from seldon_e2e_utils import retry_run, wait_for_rollout, wait_for_status
+
+from conftest import RESOURCES_PATH
+
+
+#  @pytest.mark.parametrize("use_grpc", [True, False])
+@pytest.mark.parametrize("use_grpc", [True])
+def test_graph_v2(namespace: str, use_grpc: bool):
+    sdep_name = "graph-test"
+    spec = os.path.join(RESOURCES_PATH, "graph-v2.yaml")
+    retry_run(f"kubectl apply -f {spec}  -n {namespace}")
+    wait_for_status(sdep_name, namespace)
+    wait_for_rollout(sdep_name, namespace)
+    time.sleep(1)
+
+    inference_request = (
+        v2_protocol.inference_request_grpc
+        if use_grpc
+        else v2_protocol.inference_request
+    )
+
+    response = inference_request(
+        deployment_name=sdep_name,
+        namespace=namespace,
+        payload={"inputs": []},
+    )
+    assert len(response["outputs"]) == 1

--- a/testing/scripts/test_graph.py
+++ b/testing/scripts/test_graph.py
@@ -9,8 +9,7 @@ from seldon_e2e_utils import retry_run, wait_for_rollout, wait_for_status
 from conftest import RESOURCES_PATH
 
 
-#  @pytest.mark.parametrize("use_grpc", [True, False])
-@pytest.mark.parametrize("use_grpc", [True])
+@pytest.mark.parametrize("use_grpc", [True, False])
 def test_graph_v2(namespace: str, use_grpc: bool):
     sdep_name = "graph-test"
     spec = os.path.join(RESOURCES_PATH, "graph-v2.yaml")

--- a/testing/scripts/test_prepackaged_servers.py
+++ b/testing/scripts/test_prepackaged_servers.py
@@ -80,7 +80,7 @@ class TestPrepack(object):
                 ]
             },
         )
-        assert r.status_code == 200
+        assert len(r["outputs"]) > 0
 
     # Test prepackaged server for tfserving
     def test_tfserving(self, namespace):
@@ -158,7 +158,7 @@ class TestPrepack(object):
                 ]
             },
         )
-        assert r.status_code == 200
+        assert len(r["outputs"]) > 0
 
     # Test prepackaged server for MLflow
     def test_mlflow(self, namespace):
@@ -301,7 +301,7 @@ class TestPrepack(object):
                 ],
             },
         )
-        assert r.status_code == 200
+        assert len(r["outputs"]) > 0
 
     # Test prepackaged Text SKLearn Alibi Explainer
     def test_text_alibi_explainer(self, namespace):


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

- Ensure that `model_name` is updated when chaining requests across a model graph.
- Ensure that `model_name` is present on the first request (i.e. so that it's not necessary that the user sends it on the initial request to the graph). 
- Add integration tests around inference graphs in the V2 protocol (for both REST and gRPC). 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3792

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
NONE
```

