### PR TITLE
Added Triton's config route

### DIFF
--- a/executor/api/client/client.go
+++ b/executor/api/client/client.go
@@ -17,6 +17,7 @@ const (
 	SeldonFeedbackPath        = "/send-feedback"
 	SeldonStatusPath          = "/health/status"
 	SeldonMetadataPath        = "/metadata"
+	SeldonConfigPath          = "/config"
 )
 
 type SeldonApiClient interface {
@@ -32,6 +33,7 @@ type SeldonApiClient interface {
 	Metadata(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error)
 	// Return model's metadata decoded to payload.ModelMetadata (to build GraphMetadata)
 	ModelMetadata(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.ModelMetadata, error)
+	Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error)
 	Unmarshall(msg []byte, contentType string) (payload.SeldonPayload, error)
 	Marshall(out io.Writer, msg payload.SeldonPayload) error
 	CreateErrorPayload(err error) payload.SeldonPayload

--- a/executor/api/grpc/kfserving/client.go
+++ b/executor/api/grpc/kfserving/client.go
@@ -178,6 +178,10 @@ func (s *KFServingGrpcClient) Metadata(ctx context.Context, modelName string, ho
 	return &resPayload, nil
 }
 
+func (kc *KFServingGrpcClient) Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	panic("Not implemented")
+}
+
 func (s *KFServingGrpcClient) Unmarshall(msg []byte, contentType string) (payload.SeldonPayload, error) {
 	panic("implement me")
 }

--- a/executor/api/grpc/seldon/client.go
+++ b/executor/api/grpc/seldon/client.go
@@ -260,3 +260,7 @@ func (s *SeldonMessageGrpcClient) ModelMetadata(ctx context.Context, modelName s
 	}
 	return output, nil
 }
+
+func (s *SeldonMessageGrpcClient) Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	panic("Not implemented")
+}

--- a/executor/api/grpc/tensorflow/client.go
+++ b/executor/api/grpc/tensorflow/client.go
@@ -161,6 +161,10 @@ func (s *TensorflowGrpcClient) ModelMetadata(ctx context.Context, modelName stri
 	return payload.ModelMetadata{}, status.Errorf(codes.Unimplemented, "ModelMetadata not implemented")
 }
 
+func (kc *TensorflowGrpcClient) Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	panic("Not implemented")
+}
+
 func (s *TensorflowGrpcClient) Feedback(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
 	panic("implement me")
 }

--- a/executor/api/grpc/tensorflow/server_test.go
+++ b/executor/api/grpc/tensorflow/server_test.go
@@ -119,6 +119,11 @@ func (s TestTensorflowClient) TransformOutput(ctx context.Context, modelName str
 func (s TestTensorflowClient) Feedback(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
 	panic("not implemented")
 }
+
+func (s TestTensorflowClient) Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	panic("not implemented")
+}
+
 func TestPredict(t *testing.T) {
 	t.Logf("Started")
 	g := NewGomegaWithT(t)

--- a/executor/api/kafka/client.go
+++ b/executor/api/kafka/client.go
@@ -142,6 +142,10 @@ func (kc *KafkaClient) Metadata(ctx context.Context, modelName string, host stri
 	panic("Not implemented")
 }
 
+func (kc *KafkaClient) Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	panic("Not implemented")
+}
+
 func (kc *KafkaClient) CreateErrorPayload(err error) payload.SeldonPayload {
 	panic("Not implemented")
 }

--- a/executor/api/metric/constants.go
+++ b/executor/api/metric/constants.go
@@ -18,6 +18,7 @@ const (
 	StatusHttpServiceName     = "status"
 	MetadataHttpServiceName   = "metadata"
 	FeedbackHttpServiceName   = "feedback"
+	ConfigHttpServiceName     = "config"
 )
 
 var (

--- a/executor/api/rest/client.go
+++ b/executor/api/rest/client.go
@@ -277,6 +277,8 @@ func (smc *JSONRestClient) modifyMethod(method string, modelName string) string 
 			return "/v2/models/" + modelName + "/ready"
 		case client.SeldonMetadataPath:
 			return "/v2/models/" + modelName
+		case client.SeldonConfigPath:
+			return "/v2/models/" + modelName + "/config"
 		}
 	default:
 		return method
@@ -338,6 +340,10 @@ func (smc *JSONRestClient) ModelMetadata(ctx context.Context, modelName string, 
 		return payload.ModelMetadata{}, err
 	}
 	return modelMetadata, nil
+}
+
+func (smc *JSONRestClient) Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	return smc.call(ctx, modelName, smc.modifyMethod(client.SeldonConfigPath, modelName), host, port, msg, meta)
 }
 
 func (smc *JSONRestClient) Chain(ctx context.Context, modelName string, msg payload.SeldonPayload) (payload.SeldonPayload, error) {

--- a/executor/api/rest/constants.go
+++ b/executor/api/rest/constants.go
@@ -4,7 +4,7 @@ const (
 	TracingPredictionsName = "predictions"
 	TracingStatusName      = "status"
 	TracingMetadataName    = "metadata"
-	TracingConfigName      = "condig"
+	TracingConfigName      = "config"
 
 	LoggingRestClientName = "RestClient"
 )

--- a/executor/api/rest/constants.go
+++ b/executor/api/rest/constants.go
@@ -4,6 +4,7 @@ const (
 	TracingPredictionsName = "predictions"
 	TracingStatusName      = "status"
 	TracingMetadataName    = "metadata"
+	TracingConfigName      = "condig"
 
 	LoggingRestClientName = "RestClient"
 )

--- a/executor/api/test/seldonmessage_test_client.go
+++ b/executor/api/test/seldonmessage_test_client.go
@@ -67,6 +67,10 @@ func (s SeldonMessageTestClient) ModelMetadata(ctx context.Context, modelName st
 	return output, nil
 }
 
+func (s SeldonMessageTestClient) Config(ctx context.Context, modelName string, host string, port int32, msg payload.SeldonPayload, meta map[string][]string) (payload.SeldonPayload, error) {
+	return msg, nil
+}
+
 func (s SeldonMessageTestClient) Chain(ctx context.Context, modelName string, msg payload.SeldonPayload) (payload.SeldonPayload, error) {
 	return msg, nil
 }

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -412,6 +412,10 @@ func (p *PredictorProcess) Metadata(node *v1.PredictiveUnit, modelName string, m
 	}
 }
 
+func (p *PredictorProcess) Config(node *v1.PredictiveUnit, modelName string, msg payload.SeldonPayload) (payload.SeldonPayload, error) {
+	return p.Client.Config(p.Ctx, modelName, node.Endpoint.ServiceHost, p.getPort(node), msg, p.Meta.Meta)
+}
+
 func (p *PredictorProcess) GraphMetadata(spec *v1.PredictorSpec) (*GraphMetadata, error) {
 	metadataMap, err := p.ModelMetadataMap(&spec.Graph)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR adds the /v2/models/{model}/config route that Triton supports.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3648 

**Special notes for your reviewer**:
I do not know how to run tests or add new tests.
I looked into existing tests in similar places, they all use the v1 endpoint which is not relevant here.
If v2 endpoints aren't even tested anyway, can this be approved without new tests as well?
If not, can a maintainer help me add them?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
Otherwise, enter your extended release note in the block below.
For more information on release notes see: 
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html#release-notes
-->
```release-note
Added Triton's config route
```

