### PR TITLE
Operator sets seldondeployment to failed when deployment not progressing

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -153,7 +153,9 @@ create-client: test
 docker-build: test generate-resources
 	docker build . -t ${IMG}
 
-
+# Build the docker image without testing
+docker-build-no-test: generate-resources
+	docker build . -t ${IMG}
 
 # Push the docker image
 docker-push:

--- a/operator/README.md
+++ b/operator/README.md
@@ -86,7 +86,6 @@ You should delete the Operator running in the cluster at this point.
 
 Use the Makefile in the `./helm` directory. Ensure you have `pyyaml` in your python environment.
 
-
 # Openshift
 
 see [here](openshift.md)

--- a/operator/bundle/manifests/seldon-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/seldon-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ spec:
   customresourcedefinitions:
     owned:
     - description: A seldon engine deployment
-      displayName: Seldon Delpoyment
+      displayName: Seldon Deployment
       kind: SeldonDeployment
       name: seldondeployments.machinelearning.seldon.io
       resources:

--- a/operator/config/crd/kustomization.yaml
+++ b/operator/config/crd/kustomization.yaml
@@ -24,7 +24,7 @@ patchesStrategicMerge:
 # but be aware issue means we can't support k8s <1.12 https://github.com/knative/eventing-contrib/issues/114
 #- patches/preserve_ukn_fields.yaml
 
-# Seldon addtion
+# Seldon addition
 # Allow graphs up to a set number of levels. Recursive openApi Validation is not presently supported in CRDs.
 - patches/graph_children.yaml
 

--- a/operator/config/manifests/bases/seldon-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/seldon-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ spec:
   customresourcedefinitions:
     owned:
     - description: A seldon engine deployment
-      displayName: Seldon Delpoyment
+      displayName: Seldon Deployment
       kind: SeldonDeployment
       name: seldondeployments.machinelearning.seldon.io
       resources:

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -1438,9 +1438,8 @@ func jsonEquals(a, b interface{}) (bool, error) {
 	return bytes.Equal(b1, b2), nil
 }
 
-// Create Deployments specified in components.
-func (r *SeldonDeploymentReconciler) createDeployments(components *components, instance *machinelearningv1.SeldonDeployment, log logr.Logger) (bool, error) {
-	// TODO(user) refactor ready variable to be less confusing
+// Create Deployments specified in components, returns ready, progressing, error.
+func (r *SeldonDeploymentReconciler) createDeployments(components *components, instance *machinelearningv1.SeldonDeployment, log logr.Logger) (bool, bool, error) {
 	ready := true
 	var lastSuccessfulCondition *apis.Condition
 	for _, deploy := range components.deployments {
@@ -1448,7 +1447,7 @@ func (r *SeldonDeploymentReconciler) createDeployments(components *components, i
 		log.Info("Scheme", "r.scheme", r.Scheme)
 		log.Info("createDeployments", "deploy", deploy)
 		if err := ctrl.SetControllerReference(instance, deploy, r.Scheme); err != nil {
-			return ready, err
+			return ready, true, err
 		}
 
 		// TODO(user): Change this for the object type created by your controller
@@ -1460,11 +1459,11 @@ func (r *SeldonDeploymentReconciler) createDeployments(components *components, i
 			log.Info("Creating Deployment", "namespace", deploy.Namespace, "name", deploy.Name)
 			err = r.Create(context.TODO(), deploy)
 			if err != nil {
-				return ready, err
+				return ready, true, err
 			}
 			r.Recorder.Eventf(instance, corev1.EventTypeNormal, constants.EventsCreateDeployment, "Created Deployment %q", deploy.GetName())
 		} else if err != nil {
-			return ready, err
+			return ready, true,  err
 		} else {
 			identical := true
 			if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec, found.Spec.Template.Spec) {
@@ -1479,7 +1478,7 @@ func (r *SeldonDeploymentReconciler) createDeployments(components *components, i
 
 				err = r.Update(context.TODO(), found)
 				if err != nil {
-					return ready, err
+					return ready, true, err
 				}
 
 				// Check if what came back from server modulo the defaults applied by k8s is the same or not
@@ -1531,7 +1530,7 @@ func (r *SeldonDeploymentReconciler) createDeployments(components *components, i
 						progressingCondition := getDeploymentCondition(found, appsv1.DeploymentProgressing)
 						if progressingCondition.IsFalse() && availableCondition.IsFalse() {
 							log.Info("Deployment is not progressing, returning failed status", "name", found.Name)
-							return false, fmt.Errorf("deployment %s is not progressing and not available: (%s)", found.Name, progressingCondition.GetMessage())
+							return false, false, nil
 						}
 					}
 					ready = false
@@ -1550,7 +1549,7 @@ func (r *SeldonDeploymentReconciler) createDeployments(components *components, i
 	if ready {
 		instance.Status.SetCondition(machinelearningv1.DeploymentsReady, lastSuccessfulCondition)
 	}
-	return ready, nil
+	return ready, true, nil
 }
 
 func getDeploymentCondition(deployment *appsv1.Deployment, conditionType appsv1.DeploymentConditionType) *apis.Condition {
@@ -1817,13 +1816,12 @@ func (r *SeldonDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	deploymentsReady, err := r.createDeployments(components, instance, log)
+	deploymentsReady, deploymentsProgressing, err := r.createDeployments(components, instance, log)
 	if err != nil {
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, constants.EventsInternalError, err.Error())
 		r.updateStatusForError(instance, err, log)
 		return ctrl.Result{}, err
 	}
-
 	if deploymentsReady {
 		err := r.completeServiceCreation(instance, components, log)
 		if err != nil {
@@ -1833,13 +1831,21 @@ func (r *SeldonDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	if deploymentsReady && servicesReady && hpasReady && pdbsReady && (!withKedaSupport || kedaScaledObjectsReady) {
+	switch {
+	// Everything is available - happy case.
+	case deploymentsReady && servicesReady && hpasReady && pdbsReady && (!withKedaSupport || kedaScaledObjectsReady):
 		instance.Status.State = machinelearningv1.StatusStateAvailable
 		instance.Status.Description = ""
-	} else {
+	// Deployment is not ready and no longer progressing - set status to failed.
+	case !deploymentsProgressing && !deploymentsReady:
+		instance.Status.State = machinelearningv1.StatusStateFailed
+		instance.Status.Description = "Deployment is no longer progressing and not available."
+	// Everything else is still creating.
+	default:
 		instance.Status.State = machinelearningv1.StatusStateCreating
 		instance.Status.Description = ""
 	}
+
 	err = r.updateStatus(instance, log)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/operator/licenses/license.txt
+++ b/operator/licenses/license.txt
@@ -14855,7 +14855,7 @@ recommend that a file or class name and description of purpose be included on
 the same "printed page" as the copyright notice for easier identification within
 third-party archives.
 
-   Copyright 2014 Unknwon
+   Copyright 2014 Unknown
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/operator/utils/k8s/webhook.go
+++ b/operator/utils/k8s/webhook.go
@@ -69,7 +69,7 @@ func (wc *WebhookCreator) CreateValidatingWebhookConfigurationFromFile(ctx conte
 		vwc.Webhooks[idx].ClientConfig.Service.Namespace = namespace
 
 		//Remove namespace exclusion if watchNamespace
-		//TODO change to add a namespace selector if the initalizer adds a label to namespace
+		//TODO change to add a namespace selector if the initializer adds a label to namespace
 		if watchNamespace {
 			vwc.Webhooks[idx].NamespaceSelector = nil
 		}


### PR DESCRIPTION
Improves operator to return an error (sets seldondeployment status to failed) when underlying deployment is not available and no longer progressing. Verified it works in my cloud cluster.