### PR TITLE
Updated cert-manager API version

### DIFF
--- a/examples/security/ssl_requests/README.ipynb
+++ b/examples/security/ssl_requests/README.ipynb
@@ -69,7 +69,7 @@
     "helm install \\\n",
     "  cert-manager jetstack/cert-manager \\\n",
     "  --namespace cert-manager \\\n",
-    "  --version v0.16.1 \\\n",
+    "  --version v1.6.1 \\\n",
     "  --set installCRDs=true"
    ]
   },
@@ -96,7 +96,7 @@
    "source": [
     "%%bash\n",
     "kubectl apply -f - << END\n",
-    "apiVersion: cert-manager.io/v1alpha2\n",
+    "apiVersion: cert-manager.io/v1\n",
     "kind: Issuer\n",
     "metadata:\n",
     "  name: selfsigned-issuer\n",
@@ -147,7 +147,7 @@
    "source": [
     "%%bash \n",
     "kubectl apply -f - << END\n",
-    "apiVersion: cert-manager.io/v1alpha3\n",
+    "apiVersion: cert-manager.io/v1\n",
     "kind: Certificate\n",
     "metadata:\n",
     "  name: sklearn-default-cert\n",

--- a/examples/security/ssl_requests/README.md
+++ b/examples/security/ssl_requests/README.md
@@ -12,7 +12,7 @@ kubectl create ns cert-manager
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v0.16.1 \
+  --version v1.6.1 \
   --set installCRDs=true
 ```
 
@@ -53,14 +53,13 @@ helm install \
 
     Error from server (AlreadyExists): namespaces "cert-manager" already exists
 
-
 #### Creating issuer so we can deploy certificates
 
 
 ```bash
 %%bash
 kubectl apply -f - << END
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -88,7 +87,7 @@ END
 ```bash
 %%bash 
 kubectl apply -f - << END
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: sklearn-default-cert

--- a/helm-charts/seldon-core-operator/templates/certificate_seldon-serving-cert.yaml
+++ b/helm-charts/seldon-core-operator/templates/certificate_seldon-serving-cert.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.certManager.enabled -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:

--- a/helm-charts/seldon-core-operator/templates/issuer_seldon-selfsigned-issuer.yaml
+++ b/helm-charts/seldon-core-operator/templates/issuer_seldon-selfsigned-issuer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.certManager.enabled -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -46,7 +46,7 @@ run: generate fmt vet manifests_all
 install-cert-manager:
 	kubectl create namespace cert-manager || echo "Namespace cert-manager-exists"
 	kubectl label namespace cert-manager cert-manager.io/disable-validation=true || echo "namespace cert-manager-already labelled"
-	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0/cert-manager.yaml
+	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 	kubectl rollout status deployment.apps/cert-manager -n cert-manager
 	kubectl rollout status deployment.apps/cert-manager-cainjector -n cert-manager
 	kubectl rollout status deployment.apps/cert-manager-webhook -n cert-manager

--- a/operator/config/certmanager/certificate.yaml
+++ b/operator/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -52,7 +52,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
@@ -60,7 +60,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates deprecated cert-manager API versions.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3887

