### PR TITLE
Pass down ports info to MLServer

### DIFF
--- a/examples/transformers/v2-protocol/README.ipynb
+++ b/examples/transformers/v2-protocol/README.ipynb
@@ -253,14 +253,7 @@
     "                securityContext:\n",
     "                  # Workaround for multi-user bug in custom images in MLServer:\n",
     "                  # https://github.com/SeldonIO/MLServer/issues/388\n",
-    "                  runAsUser: 1000\n",
-    "                ports:\n",
-    "                  - containerPort: 8080\n",
-    "                    name: http\n",
-    "                    protocol: TCP\n",
-    "                  - containerPort: 8081\n",
-    "                    name: grpc\n",
-    "                    protocol: TCP\n"
+    "                  runAsUser: 1000\n"
    ]
   },
   {
@@ -306,7 +299,7 @@
     "%%bash\n",
     "curl localhost:8003/seldon/models/gpt2/v2/models/infer \\\n",
     "    -H 'Content-Type: application/json' \\\n",
-    "    -d '{\"inputs\": [{\"name\": \"sentences\", \"datatype\": \"BYTES\", \"shape\": [1, 11], \"data\": \"hello world\"}]}' \\\n",
+    "    -d '{\"inputs\": [{\"name\": \"sentences\", \"datatype\": \"BYTES\", \"shape\": [1, 11], \"data\": [\"hello world\"]}]}' \\\n",
     "    | python -m json.tool "
    ]
   },
@@ -335,7 +328,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.8"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/examples/transformers/v2-protocol/seldondeployment.yaml
+++ b/examples/transformers/v2-protocol/seldondeployment.yaml
@@ -21,10 +21,3 @@ spec:
                   # Workaround for multi-user bug in custom images in MLServer:
                   # https://github.com/SeldonIO/MLServer/issues/388
                   runAsUser: 1000
-                ports:
-                  - containerPort: 8080
-                    name: http
-                    protocol: TCP
-                  - containerPort: 8081
-                    name: grpc
-                    protocol: TCP

--- a/operator/controllers/mlserver.go
+++ b/operator/controllers/mlserver.go
@@ -61,11 +61,7 @@ func mergeMLServerContainer(existing *v1.Container, mlServer *v1.Container) *v1.
 	}
 
 	for _, envVar := range existing.Env {
-		if utils.HasEnvVar(mlServer.Env, envVar.Name) {
-			mlServer.Env = utils.SetEnvVar(mlServer.Env, envVar)
-		} else {
-			mlServer.Env = append(mlServer.Env, envVar)
-		}
+		mlServer.Env = utils.SetEnvVar(mlServer.Env, envVar, true)
 	}
 	existing.Env = mlServer.Env
 

--- a/operator/controllers/seldondeployment_controller_test.go
+++ b/operator/controllers/seldondeployment_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -119,6 +120,29 @@ var _ = Describe("Create a Seldon Deployment", func() {
 		}, TestTimout, interval).Should(BeNil())
 		Expect(len(depFetched.Spec.Template.Spec.Containers)).Should(Equal(2))
 		Expect(*depFetched.Spec.Replicas).To(Equal(int32(1)))
+
+		// Check port envs have been added
+		containers := depFetched.Spec.Template.Spec.Containers
+		httpPort := strconv.Itoa(int(constants.FirstHttpPortNumber))
+		grpcPort := strconv.Itoa(int(constants.FirstGrpcPortNumber))
+		Expect(containers[0].Env).To(ContainElements(
+			v1.EnvVar{
+				Name:  machinelearningv1.ENV_PREDICTIVE_UNIT_HTTP_SERVICE_PORT,
+				Value: httpPort,
+			},
+			v1.EnvVar{
+				Name:  machinelearningv1.ENV_PREDICTIVE_UNIT_GRPC_SERVICE_PORT,
+				Value: grpcPort,
+			},
+			v1.EnvVar{
+				Name:  MLServerHTTPPortEnv,
+				Value: httpPort,
+			},
+			v1.EnvVar{
+				Name:  MLServerGRPCPortEnv,
+				Value: grpcPort,
+			},
+		))
 
 		//Update Deployment as pods not created with test client.
 		depUpdated := depFetched.DeepCopy()

--- a/operator/controllers/seldondeployment_prepackaged_servers.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers.go
@@ -305,12 +305,11 @@ func (pi *PrePackedInitialiser) addModelDefaultServers(mlDepSepc *machinelearnin
 	}
 
 	if len(params) > 0 {
-		if !utils.HasEnvVar(c.Env, machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS) {
-			c.Env = append(c.Env, v1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS, Value: string(paramStr)})
-		} else {
-			c.Env = utils.SetEnvVar(c.Env, v1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS, Value: string(paramStr)})
+		paramsEnvVar := v1.EnvVar{
+			Name:  machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS,
+			Value: string(paramStr),
 		}
-
+		c.Env = utils.SetEnvVar(c.Env, paramsEnvVar, true)
 	}
 
 	// Add container to deployment
@@ -368,12 +367,11 @@ func SetUriParamsForTFServingProxyContainer(pu *machinelearningv1.PredictiveUnit
 	parameters = append(parameters, modelNameParam)
 
 	if len(parameters) > 0 {
-		if !utils.HasEnvVar(c.Env, machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS) {
-			c.Env = append(c.Env, v1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS, Value: utils.GetPredictiveUnitAsJson(parameters)})
-		} else {
-			c.Env = utils.SetEnvVar(c.Env, v1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS, Value: utils.GetPredictiveUnitAsJson(parameters)})
+		parametersEnvVar := v1.EnvVar{
+			Name:  machinelearningv1.ENV_PREDICTIVE_UNIT_PARAMETERS,
+			Value: utils.GetPredictiveUnitAsJson(parameters),
 		}
-
+		c.Env = utils.SetEnvVar(c.Env, parametersEnvVar, true)
 	}
 }
 

--- a/operator/utils/utils.go
+++ b/operator/utils/utils.go
@@ -105,7 +105,7 @@ func HasEnvVar(envVars []v1.EnvVar, name string) bool {
 	return false
 }
 
-func SetEnvVar(envVars []v1.EnvVar, newVar v1.EnvVar) (newEnvVars []v1.EnvVar) {
+func SetEnvVar(envVars []v1.EnvVar, newVar v1.EnvVar, override bool) (newEnvVars []v1.EnvVar) {
 	found := false
 	index := 0
 	for i, envVar := range envVars {
@@ -114,11 +114,14 @@ func SetEnvVar(envVars []v1.EnvVar, newVar v1.EnvVar) (newEnvVars []v1.EnvVar) {
 			index = i
 		}
 	}
-	if found {
+
+	if found && override {
 		newEnvVars = append(envVars[:index])
 		newEnvVars = append(newEnvVars, newVar)
 		newEnvVars = append(newEnvVars, envVars[index+1:]...)
-	} else {
+	}
+
+	if !found {
 		newEnvVars = envVars
 		newEnvVars = append(newEnvVars, newVar)
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR ensures that ports assigned to each container are also passed down to custom MLServer images through env vars. Previously, only the V1 wrapper env vars were added. 

It's worth noting that this is only relevant for non-prepackaged servers.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3753 

**Special notes for your reviewer**:
