### PR TITLE
Skip request logging if skip header is present

### DIFF
--- a/components/alibi-explain-server/alibiexplainer/utils.py
+++ b/components/alibi-explain-server/alibiexplainer/utils.py
@@ -138,6 +138,7 @@ def _grpc(arr: np.array, predictor_host: str, tf_data_type: Optional[str]) -> np
     else:
         datadef = prediction_pb2.DefaultData(tftensor=tf.make_tensor_proto(arr))
     request = prediction_pb2.SeldonMessage(data=datadef)
-    response = stub.Predict(request=request)
+    request_metadata = ((SELDON_SKIP_LOGGING_HEADER, "true"),)
+    response = stub.Predict(request=request, metadata=request_metadata)
     arr_resp = tf.make_ndarray(response.data.tftensor)
     return arr_resp

--- a/components/alibi-explain-server/poetry.lock
+++ b/components/alibi-explain-server/poetry.lock
@@ -1206,6 +1206,22 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "requests-mock"
+version = "1.9.3"
+description = "Mock out responses from the requests package"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+requests = ">=2.3,<3"
+six = "*"
+
+[package.extras]
+fixture = ["fixtures"]
+test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
+
+[[package]]
 name = "requests-oauthlib"
 version = "1.3.1"
 description = "OAuthlib authentication support for Requests."
@@ -1821,7 +1837,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<3.8"
-content-hash = "6c57ba7f2fded3781116c3df704c952ad0232ed0a5a40afccea479a75e359663"
+content-hash = "5c7700b29ec3138fc1221f49d1cd4497ad1ed5f5cd2dc309165ec6d42c56e999"
 
 [metadata.files]
 absl-py = [
@@ -2888,6 +2904,10 @@ regex = [
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+requests-mock = [
+    {file = "requests-mock-1.9.3.tar.gz", hash = "sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba"},
+    {file = "requests_mock-1.9.3-py2.py3-none-any.whl", hash = "sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970"},
 ]
 requests-oauthlib = [
     {file = "requests-oauthlib-1.3.1.tar.gz", hash = "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"},

--- a/components/alibi-explain-server/pyproject.toml
+++ b/components/alibi-explain-server/pyproject.toml
@@ -33,6 +33,8 @@ black = "21.7b0"
 isort = "5.9.0"
 types-requests = "2.26.0"
 gsutil = "5.5"
+requests-mock = "1.9.3"
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/components/alibi-explain-server/tests/test_utils.py
+++ b/components/alibi-explain-server/tests/test_utils.py
@@ -1,0 +1,40 @@
+import pytest
+import numpy as np
+
+from requests_mock import Mocker
+
+from alibiexplainer.utils import (
+    construct_predict_fn,
+    Protocol,
+    SELDON_SKIP_LOGGING_HEADER,
+    SELDON_PREDICTOR_URL_FORMAT,
+    TENSORFLOW_PREDICTOR_URL_FORMAT,
+)
+
+
+@pytest.mark.parametrize("protocol", [Protocol.seldon_http, Protocol.tensorflow_http])
+def test_construct_predict_fn(protocol: str, requests_mock: Mocker):
+    predictor_host = "fake-endpoint.com"
+    model_name = "foo"
+    predictor_endpoint = SELDON_PREDICTOR_URL_FORMAT.format(predictor_host)
+    if protocol == Protocol.tensorflow_http:
+        predictor_endpoint = TENSORFLOW_PREDICTOR_URL_FORMAT.format(
+            predictor_host, model_name
+        )
+
+    res_value = [[7]]
+    requests_mock.post(
+        predictor_endpoint,
+        json={"data": {"ndarray": res_value}, "predictions": res_value},
+    )
+
+    predict_fn = construct_predict_fn(
+        predictor_host, model_name=model_name, protocol=protocol
+    )
+
+    res = predict_fn(arr=[[0, 1, 2, 3]])
+
+    assert res == np.array(res_value)
+    assert requests_mock.call_count == 1
+    assert SELDON_SKIP_LOGGING_HEADER in requests_mock.last_request.headers
+    assert requests_mock.last_request.headers[SELDON_SKIP_LOGGING_HEADER] == "true"

--- a/components/alibi-explain-server/tests/test_utils.py
+++ b/components/alibi-explain-server/tests/test_utils.py
@@ -1,14 +1,13 @@
-import pytest
 import numpy as np
-
+import pytest
 from requests_mock import Mocker
 
 from alibiexplainer.utils import (
-    construct_predict_fn,
-    Protocol,
-    SELDON_SKIP_LOGGING_HEADER,
     SELDON_PREDICTOR_URL_FORMAT,
+    SELDON_SKIP_LOGGING_HEADER,
     TENSORFLOW_PREDICTOR_URL_FORMAT,
+    Protocol,
+    construct_predict_fn,
 )
 
 

--- a/executor/api/payload/metadata.go
+++ b/executor/api/payload/metadata.go
@@ -1,7 +1,12 @@
 package payload
 
+import (
+	"strings"
+)
+
 const (
-	SeldonPUIDHeader = "Seldon-Puid"
+	SeldonPUIDHeader        = "Seldon-Puid"
+	SeldonSkipLoggingHeader = "Seldon-Skip-Logging"
 )
 
 type MetaData struct {
@@ -18,4 +23,24 @@ func NewFromMap(m map[string][]string) *MetaData {
 		}
 	}
 	return &meta
+}
+
+func (m *MetaData) GetAsBoolean(key string, def bool) bool {
+	values, ok := m.Meta[key]
+	if !ok {
+		return def
+	}
+
+	trueValues := []string{"true", "on", "1"}
+	for _, val := range values {
+		lowVal := strings.ToLower(val)
+		for _, trueVal := range trueValues {
+			if lowVal == trueVal {
+				// If any element of the list matches, we'll return true
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/executor/api/payload/metadata_test.go
+++ b/executor/api/payload/metadata_test.go
@@ -14,3 +14,75 @@ func TestNewFromtMeta(t *testing.T) {
 
 	g.Expect(meta.Meta[k][0]).To(Equal(v))
 }
+
+func TestGetAsBoolean(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		val      []string
+		def      bool
+		expected bool
+	}{
+		{
+			val:      []string{"true"},
+			def:      false,
+			expected: true,
+		},
+		{
+			val:      []string{"on"},
+			def:      false,
+			expected: true,
+		},
+		{
+			val:      []string{"1"},
+			def:      false,
+			expected: true,
+		},
+		{
+			val:      []string{"TRUE", "0"},
+			def:      false,
+			expected: true,
+		},
+		{
+			val:      []string{"false", "1"},
+			def:      false,
+			expected: true,
+		},
+		{
+			val:      []string{"false"},
+			def:      true,
+			expected: false,
+		},
+		{
+			val:      []string{"0"},
+			def:      true,
+			expected: false,
+		},
+		{
+			val:      []string{"asdasd"},
+			def:      true,
+			expected: false,
+		},
+		{
+			val:      []string{},
+			def:      true,
+			expected: true,
+		},
+		{
+			val:      []string{},
+			def:      false,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		m := map[string][]string{}
+		if len(test.val) > 0 {
+			m["foo"] = test.val
+		}
+		meta := NewFromMap(m)
+
+		asBool := meta.GetAsBoolean("foo", test.def)
+		g.Expect(asBool).To(Equal(test.expected))
+	}
+}

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -375,7 +375,6 @@ func (p *PredictorProcess) getLogUrl(logger *v1.Logger) (*url.URL, error) {
 func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqType payloadLogger.LogRequestType, msg payload.SeldonPayload, puid string) error {
 	skipLogging := p.Meta.GetAsBoolean(payload.SeldonSkipLoggingHeader, false)
 	if skipLogging {
-		// TODO: log info message
 		p.Log.Info("Skip logging request with PUID", puid)
 		return nil
 	}

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -375,7 +375,7 @@ func (p *PredictorProcess) getLogUrl(logger *v1.Logger) (*url.URL, error) {
 func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqType payloadLogger.LogRequestType, msg payload.SeldonPayload, puid string) error {
 	skipLogging := p.Meta.GetAsBoolean(payload.SeldonSkipLoggingHeader, false)
 	if skipLogging {
-		p.Log.Info("Skip logging request with PUID", puid)
+		p.Log.Info("Skipped logging request with", "PUID", puid)
 		return nil
 	}
 

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -373,6 +373,13 @@ func (p *PredictorProcess) getLogUrl(logger *v1.Logger) (*url.URL, error) {
 }
 
 func (p *PredictorProcess) logPayload(nodeName string, logger *v1.Logger, reqType payloadLogger.LogRequestType, msg payload.SeldonPayload, puid string) error {
+	skipLogging := p.Meta.GetAsBoolean(payload.SeldonSkipLoggingHeader, false)
+	if skipLogging {
+		// TODO: log info message
+		p.Log.Info("Skip logging request with PUID", puid)
+		return nil
+	}
+
 	data, err := msg.GetBytes()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR introduces the `Seldon-Skip-Logging` header, which can be used to tell the executor **not to** forward the request / response down to the request logger (and further down the Knative pipeline). Additionally, it also updates the explainer server so that explain requests include this header.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3257 

**Special notes for your reviewer**:
