### PR TITLE
Issue #3968: Allow hostNetwork=true for seldon operator

### DIFF
--- a/helm-charts/seldon-core-operator/README.md
+++ b/helm-charts/seldon-core-operator/README.md
@@ -117,3 +117,5 @@ helm install seldon-core-operator seldonio/seldon-core-operator --namespace seld
 | storageInitializer.memoryRequest | string | `"100Mi"` |  |
 | usageMetrics.enabled | bool | `false` |  |
 | webhook.port | int | `4443` |  |
+| metrics.port | int | `8080` |  |
+| hostNetwork | bool | `false` |  |

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -25,6 +25,7 @@ spec:
 {{- toYaml . | nindent 8}}
 {{- end }}
         prometheus.io/scrape: 'true'
+        prometheus.io/port: '{{ .Values.metrics.port }}'
         sidecar.istio.io/inject: 'false'
       labels:
         app: seldon
@@ -140,7 +141,7 @@ spec:
         - containerPort: {{ .Values.webhook.port }}
           name: webhook-server
           protocol: TCP
-        - containerPort: 8080
+        - containerPort: {{ .Values.metrics.port }}
           name: metrics
           protocol: TCP
         resources:
@@ -167,3 +168,4 @@ spec:
           defaultMode: 420
           secretName: seldon-webhook-server-cert
 {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -42,7 +42,6 @@ spec:
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)
         - '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
-        - '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
 {{- with .Values.manager.containerSecurityContext }}
 {{- toYaml . | nindent 8}}
 {{- end }}

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -157,7 +157,7 @@ spec:
           name: cert
           readOnly: true
 {{- end }}
-      hostNetwork: '{{ .Values.hostNetwork }}'
+      hostNetwork: {{ .Values.hostNetwork }}
       securityContext:
         runAsUser: {{ .Values.managerUserID }}
       serviceAccountName: '{{ .Values.serviceAccount.name }}'

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -24,8 +24,8 @@ spec:
 {{- with .Values.manager.annotations }}
 {{- toYaml . | nindent 8}}
 {{- end }}
-        prometheus.io/scrape: 'true'
         prometheus.io/port: '{{ .Values.metrics.port }}'
+        prometheus.io/scrape: 'true'
         sidecar.istio.io/inject: 'false'
       labels:
         app: seldon
@@ -41,6 +41,7 @@ spec:
         - --create-resources=$(MANAGER_CREATE_RESOURCES)
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)
+        - '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
         - '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
 {{- with .Values.manager.containerSecurityContext }}
 {{- toYaml . | nindent 8}}
@@ -157,6 +158,7 @@ spec:
           name: cert
           readOnly: true
 {{- end }}
+      hostNetwork: '{{ .Values.hostNetwork }}'
       securityContext:
         runAsUser: {{ .Values.managerUserID }}
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
@@ -168,4 +170,3 @@ spec:
           defaultMode: 420
           secretName: seldon-webhook-server-cert
 {{- end }}
-      hostNetwork: {{ .Values.hostNetwork }}

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -2,7 +2,7 @@
 # Below are the default values when installing Seldon Core
 
 # Defaults to .Release.Namespace
-namespaceOverride: "" 
+namespaceOverride: ""
 
 # ## Ingress Options
 # You are able to choose between Istio and Ambassador
@@ -69,6 +69,7 @@ executor:
     workQueueSize: 10000
     writeTimeoutMs: 2000
 
+
 # ## Seldon Core Controller Manager Options
 image:
   pullPolicy: IfNotPresent
@@ -101,13 +102,18 @@ storageInitializer:
   memoryRequest: 100Mi
 usageMetrics:
   enabled: false
+# In scenarios like EKS with non-standard CNI plugin like calico, the control plane cannot reach the webhook
+# hence it is needed to set hostNetwork: true
+hostNetwork: false
 webhook:
-  port: 4443
+  port: 4443 # If 'hostNetwork: true' you might need to change this port if it is already used by the node
+metrics: # these are the metrics exposed by the controller pod
+  port: 8080 # If 'hostNetwork: true' you might need to change this port if it is already used by the node
 
 # ## Predictive Unit Values
 predictiveUnit:
   httpPort: 9000
-  grpcPort: 9500  
+  grpcPort: 9500
   metricsPortName: metrics
   # If you would like to add extra environment variables to the init container to make available
   #   secrets such as cloud credentials, you can provide a default secret name that will be loaded
@@ -135,7 +141,7 @@ predictor_servers:
       seldon:
         defaultImageVersion: "1.14.0-dev"
         image: seldonio/tfserving-proxy
-      tensorflow: 
+      tensorflow:
         defaultImageVersion: 2.1.0
         image:  tensorflow/serving
   XGBOOST_SERVER:

--- a/operator/config/default/manager_prometheus_metrics_patch.yaml
+++ b/operator/config/default/manager_prometheus_metrics_patch.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
+        prometheus.io/port: '8080'
     spec:
       containers:
       # Expose the prometheus metrics on default port

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         control-plane: seldon-controller-manager
     spec:
+      hostNetwork: false
       serviceAccountName: manager
       securityContext:
         runAsUser: 8888
@@ -38,7 +39,7 @@ spec:
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)
         env:
         - name: MANAGER_LEADER_ELECTION_ID
-          value: "a33bd623.machinelearning.seldon.io"        
+          value: "a33bd623.machinelearning.seldon.io"
         - name: MANAGER_LOG_LEVEL
           value: "INFO"
         - name: WATCH_NAMESPACE
@@ -46,22 +47,22 @@ spec:
         - name: RELATED_IMAGE_EXECUTOR
           value: ""
         - name: RELATED_IMAGE_STORAGE_INITIALIZER
-          value: ""          
+          value: ""
         - name: RELATED_IMAGE_SKLEARNSERVER
-          value: ""          
+          value: ""
         - name: RELATED_IMAGE_XGBOOSTSERVER
-          value: ""          
+          value: ""
         - name: RELATED_IMAGE_MLFLOWSERVER
-          value: ""          
+          value: ""
         - name: RELATED_IMAGE_TFPROXY
-          value: ""          
+          value: ""
         - name: RELATED_IMAGE_TENSORFLOW
-          value: ""          
+          value: ""
         - name: RELATED_IMAGE_EXPLAINER
-          value: ""          
+          value: ""
         - name: RELATED_IMAGE_MOCK_CLASSIFIER
-          value: ""          
-        - name: MANAGER_CREATE_RESOURCES          
+          value: ""
+        - name: MANAGER_CREATE_RESOURCES
           value: "false"
         - name: POD_NAMESPACE
           valueFrom:
@@ -100,7 +101,7 @@ spec:
         - name: EXECUTOR_SERVER_PORT
           value: "8000"
         - name: EXECUTOR_CONTAINER_USER
-          value: "8888"          
+          value: "8888"
         - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
           value: default
         - name: EXECUTOR_SERVER_METRICS_PORT_NAME

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -465,7 +465,11 @@ if __name__ == "__main__":
                     re.M,
                 )
 
-            # make sure metric is not quoted as its an int
+            # make sure hostNetwork is not quoted as its a bool
+            fdata = fdata.replace(
+                "'{{ .Values.hostNetwork }}'", "{{ .Values.hostNetwork }}"
+            )
+            # make sure metrics.port is not quoted as its an int
             fdata = fdata.replace(
                 "containerPort: '{{ .Values.metrics.port }}'", "containerPort: {{ .Values.metrics.port }}"
             )

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -219,10 +219,6 @@ if __name__ == "__main__":
                     if portSpec["name"] == "metrics":
                         portSpec["containerPort"] = helm_value("metrics.port")
 
-                res["spec"]["template"]["spec"]["containers"][0]["args"].append(
-                    '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
-                )
-
                 # Networking
                 res["spec"]["template"]["spec"]["hostNetwork"] = helm_value("hostNetwork")
 

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -211,6 +211,21 @@ if __name__ == "__main__":
                     '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
                 )
 
+                # Update metrics port
+                res["spec"]["template"]["metadata"]["annotations"]["prometheus.io/port"] = helm_value('metrics.port')
+                for portSpec in res["spec"]["template"]["spec"]["containers"][0][
+                    "ports"
+                ]:
+                    if portSpec["name"] == "metrics":
+                        portSpec["containerPort"] = helm_value("metrics.port")
+
+                res["spec"]["template"]["spec"]["containers"][0]["args"].append(
+                    '{{- if .Values.singleNamespace }}--namespace={{ include "seldon.namespace" . }}{{- end }}'
+                )
+
+                # Networking
+                res["spec"]["template"]["spec"]["hostNetwork"] = helm_value("hostNetwork")
+
             if kind == "configmap" and name == "seldon-config":
                 res["data"]["credentials"] = helm_value_json("credentials")
                 res["data"]["predictor_servers"] = helm_value_json(
@@ -454,6 +469,10 @@ if __name__ == "__main__":
                     re.M,
                 )
 
+            # make sure metric is not quoted as its an int
+            fdata = fdata.replace(
+                "containerPort: '{{ .Values.metrics.port }}'", "containerPort: {{ .Values.metrics.port }}"
+            )
             # make sure webhook is not quoted as its an int
             fdata = fdata.replace(
                 "'{{ .Values.webhook.port }}'", "{{ .Values.webhook.port }}"


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
It allows to set hostNetwork for seldon core operator.
It is needed for EKS clusters with CNI plugin such as calico in order to allow communication from the control plane to the operator webhook

**Which issue(s) this PR fixes**:
Fixes #3968

**Special notes for your reviewer**:
