### PR TITLE
Release v1.13.1 for OpenShift

### DIFF
--- a/components/rclone-storage-initializer/Dockerfile.redhat
+++ b/components/rclone-storage-initializer/Dockerfile.redhat
@@ -1,0 +1,20 @@
+FROM rclone/rclone:1.56.2 as builder
+
+RUN mkdir /licenses && wget -O /licenses/license.txt https://raw.githubusercontent.com/rclone/rclone/master/COPYING
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+LABEL name="Rclone Storage Initializer" \
+      vendor="Seldon Technologies" \
+      version="1.13.1" \
+      release="1" \
+      summary="Storage Initializer for Seldon Core" \
+      description="Allows Seldon Core to download artifacts from cloud and local storage to a local volume"
+
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /licenses/ /licenses/
+
+ENV RCLONE_CONFIG_GS_TYPE google cloud storage
+ENV RCLONE_CONFIG_GS_ANONYMOUS true
+
+
+ENTRYPOINT ["rclone", "copy", "-vv"]

--- a/components/rclone-storage-initializer/Makefile
+++ b/components/rclone-storage-initializer/Makefile
@@ -12,3 +12,22 @@ docker-push:
 
 kind-load: docker-build
 	kind load docker-image seldonio/${IMAGE}:${VERSION} --name ${KIND_NAME}
+
+
+docker-build-redhat:
+	docker build --file=Dockerfile.redhat --force-rm=true -t seldonio/${IMAGE}-ubi8:${VERSION} .
+
+docker-push-redhat:
+	docker push seldonio/${IMAGE}-ubi8:${VERSION}
+
+kind-load-redhat:
+	kind load docker-image seldonio/${IMAGE}-ubi8:${VERSION} --name ${KIND_NAME}
+
+
+scan=ospid-622b6fcf8a65f13d3bd4172f
+redhat-image-scan:
+	# docker pull seldonio/${IMAGE}-ubi8:${VERSION}
+	source ~/.config/seldon/seldon-core/redhat-image-passwords.sh && \
+		echo $${rh_password_rclone_storage_initializer} | docker login -u unused scan.connect.redhat.com --password-stdin
+	docker tag seldonio/${IMAGE}-ubi8:${VERSION} scan.connect.redhat.com/${scan}/${IMAGE}:${VERSION}
+	docker push scan.connect.redhat.com/${scan}/${IMAGE}:${VERSION}

--- a/marketplaces/redhat/scan-images.py
+++ b/marketplaces/redhat/scan-images.py
@@ -33,6 +33,7 @@ def scan_images(debug=False):
     "servers/tfserving_proxy",
     "components/alibi-explain-server",
     "components/storage-initializer",
+    "components/rclone-storage-initializer",
     "servers/tfserving",
     ]
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -271,8 +271,8 @@ recreate_bundle:
 	rm -fr bundle
 	kustomize build config/manifests | operator-sdk --verbose generate bundle --default-channel stable --version ${VERSION} --channels stable
 	python hack/csv_hack.py bundle/manifests/seldon-operator.clusterserviceversion.yaml ${VERSION}
-	echo '  com.redhat.openshift.versions: "v4.8"' >> bundle/metadata/annotations.yaml
-	echo 'LABEL com.redhat.openshift.versions=v4.8' >> bundle.Dockerfile
+	echo '  com.redhat.openshift.versions: "v4.8-v4.9"' >> bundle/metadata/annotations.yaml
+	echo 'LABEL com.redhat.openshift.versions=v4.8-v4.9' >> bundle.Dockerfile
 
 create_bundle_image:
 	docker build . -f bundle.Dockerfile -t quay.io/seldon/seldon-operator:v${VERSION}
@@ -312,18 +312,21 @@ scorecard:
 #
 
 # Change to local checkout
-COMMUNITY_OPERATORS_FOLDER=~/work/seldon-core/redhat/community-operators
-UPSTREAM_OPERATORS_FOLDER=~/work/seldon-core/redhat/community-operators-prod
+# This should be paths to forks of
+# - https://github.com/k8s-operatorhub/community-operators
+# - https://github.com/redhat-openshift-ecosystem/community-operators-prod
+COMMUNITY_OPERATORS_FOLDER=~/work/red-hat/community-operators
+UPSTREAM_OPERATORS_FOLDER=~/work/red-hat/community-operators-prod
 
-update_community: 
-	cp -r bundle ${COMMUNITY_OPERATORS_FOLDER}/operators/seldon-operator/${VERSION}
+update_community:
+	cp -r bundle/. ${COMMUNITY_OPERATORS_FOLDER}/operators/seldon-operator/${VERSION}
 
 # Presently fails
 test_community:
-	cd ${COMMUNITY_OPERATORS_FOLDER} && export OP_TEST_DEBUG=3 &&  bash <(curl -sL https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/ci/latest/ci/scripts/opp.sh) kiwi,lemon,orange operators/seldon-operator/1.12.0
+	cd ${COMMUNITY_OPERATORS_FOLDER} && export OP_TEST_DEBUG=3 &&  bash <(curl -sL https://raw.githubusercontent.com/redhat-openshift-ecosystem/community-operators-pipeline/ci/latest/ci/scripts/opp.sh) kiwi,lemon,orange operators/seldon-operator/${VERSION}
 
 update_upstream:
-	cp -r bundle ${UPSTREAM_OPERATORS_FOLDER}/operators/seldon-operator/${VERSION}
+	cp -r bundle/. ${UPSTREAM_OPERATORS_FOLDER}/operators/seldon-operator/${VERSION}
 
 
 ###################################
@@ -349,16 +352,16 @@ redhat-image-scan:
 
 
 
-CERTIFIED_OPERATORS_FOLDER=/home/clive/work/seldon-core/redhat/certified-operators
+CERTIFIED_OPERATORS_FOLDER=~/work/red-hat/certified-operators
 
 #need to rename package in annotations.yaml to seldon-operator-certified
-update_certified: 
-	cp -r bundle-certified ${CERTIFIED_OPERATORS_FOLDER}/operators/seldon-operator-certified/${VERSION}
+update_certified:
+	cp -r bundle-certified/. ${CERTIFIED_OPERATORS_FOLDER}/operators/seldon-operator-certified/${VERSION}
 
 
-GIT_REPO_URL=git@github.com:cliveseldon/certified-operators.git
+GIT_REPO_URL=git@github.com:rafalskolasinski/certified-operators.git
 BUNDLE_PATH=operators/seldon-operator-certified/${VERSION}
-OPENSHIFT_PIPELINES_FOLDER=/home/clive/work/seldon-core/redhat/operator-pipelines
+OPENSHIFT_PIPELINES_FOLDER=~/work/red-hat/operator-pipelines
 run_certified_pipeline_basic:
 	cd ${OPENSHIFT_PIPELINES_FOLDER} && tkn pipeline start operator-ci-pipeline \
 		--param git_repo_url=${GIT_REPO_URL} \
@@ -406,8 +409,6 @@ run_certified_pipeline_submit:
 
 
 # Run last to prepare for future release
-PREV_VERSION=1.7.0
+PREV_VERSION=1.12.0
 update_config:
 	sed -i s#${PREV_VERSION}#${VERSION}# config/manifests/bases/seldon-operator.clusterserviceversion.yaml
-
-

--- a/operator/bundle-certified/manifests/seldon-operator-certified.clusterserviceversion.yaml
+++ b/operator/bundle-certified/manifests/seldon-operator-certified.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: AI/Machine Learning
     certified: 'false'
-    containerImage: registry.connect.redhat.com/seldonio/seldon-core-operator:1.12.0
+    containerImage: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:d5c5279a46623bbc8d6b03844e536a85deaf2ddea8d7b99d85db9d347726de0b
     createdAt: '2019-05-21 15:00:00'
     description: The Seldon operator for management, monitoring and operations of machine learning systems through the Seldon Engine. Once installed, the Seldon Operator provides multiple functions which facilitate the productisation, monitoring and maintenance of machine learning systems at scale.
     olm.skipRange: <1.12.0
@@ -56,14 +56,14 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/SeldonIO/seldon-core
     support: Clive Cox
-  name: seldon-operator.v1.12.0
+  name: seldon-operator.v1.13.1
   namespace: seldon-operator-system
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
     - description: A seldon engine deployment
-      displayName: Seldon Delpoyment
+      displayName: Seldon Deployment
       kind: SeldonDeployment
       name: seldondeployments.machinelearning.seldon.io
       resources:
@@ -436,6 +436,10 @@ spec:
                 command:
                 - /manager
                 env:
+                - name: MANAGER_CREATE_RESOURCES
+                  value: 'true'
+                - name: ENGINE_CONTAINER_USER
+                - name: EXECUTOR_CONTAINER_USER
                 - name: MANAGER_LEADER_ELECTION_ID
                   value: a33bd623.machinelearning.seldon.io
                 - name: MANAGER_LOG_LEVEL
@@ -445,27 +449,23 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_EXECUTOR
-                  value: registry.connect.redhat.com/seldonio/seldon-core-executor:1.12.0
-                - name: RELATED_IMAGE_ENGINE
-                  value: registry.connect.redhat.com/seldonio/seldon-engine:1.12.0
+                  value: registry.connect.redhat.com/seldonio/seldon-core-executor@sha256:c956375a292cc6ce08adbac8b3dcc90ecd284ac2d95726bc11fb2cffca7a0fd4
                 - name: RELATED_IMAGE_STORAGE_INITIALIZER
-                  value: registry.connect.redhat.com/seldonio/storage-initializer:1.12.0
+                  value: registry.connect.redhat.com/seldonio/storage-initializer@sha256:537100924c37956feaebebbe95116acca0f8f2dfe4ebde86736c6dceea3a3e49
                 - name: RELATED_IMAGE_SKLEARNSERVER
-                  value: registry.connect.redhat.com/seldonio/sklearnserver:1.12.0
+                  value: registry.connect.redhat.com/seldonio/sklearnserver@sha256:c40a1414196830d6c9b0e00e9d130926851c442f7cf861b4e30fe9f60be3175b
                 - name: RELATED_IMAGE_XGBOOSTSERVER
-                  value: registry.connect.redhat.com/seldonio/xgboostserver:1.12.0
+                  value: registry.connect.redhat.com/seldonio/xgboostserver@sha256:757b3a627adb6346eb6bd8a6676f2be240a610877ec48be52be6a02416d94d54
                 - name: RELATED_IMAGE_MLFLOWSERVER
-                  value: registry.connect.redhat.com/seldonio/mlflowserver:1.12.0
+                  value: registry.connect.redhat.com/seldonio/mlflowserver@sha256:bee42a780c485ff88fba3b767d52c6016fe4bf763686fcfabb83d0000c538c89
                 - name: RELATED_IMAGE_TFPROXY
-                  value: registry.connect.redhat.com/seldonio/tfproxy:1.12.0
+                  value: registry.connect.redhat.com/seldonio/tfproxy@sha256:8ff4254987e61418df2af773ef9668bd1553ded0afe0c8b213ee9fcec099401a
                 - name: RELATED_IMAGE_TENSORFLOW
-                  value: registry.connect.redhat.com/seldonio/tensorflow-serving:2.1.0
+                  value: registry.connect.redhat.com/seldonio/tensorflow-serving@sha256:a44a91ca1b2ac54ccde597404ad981843b3f10f8d835d675e43879d9f7d0120f
                 - name: RELATED_IMAGE_EXPLAINER
-                  value: registry.connect.redhat.com/seldonio/alibiexplainer:1.12.0
+                  value: registry.connect.redhat.com/seldonio/alibiexplainer@sha256:3ce53d3ba2a6dfe2a1b0ff8e21de9dc1637de50e183233cd58e6119f7db51cd1
                 - name: RELATED_IMAGE_MOCK_CLASSIFIER
-                  value: registry.connect.redhat.com/seldonio/mock-classifier:1.12.0
-                - name: MANAGER_CREATE_RESOURCES
-                  value: 'true'
+                  value: registry.connect.redhat.com/seldonio/mock-classifier@sha256:4365a1ef09bfe598c4881b6fe2b30019120ea3fece05ca95e6a91fd2382b639e
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -475,15 +475,6 @@ spec:
                   value: 'true'
                 - name: AMBASSADOR_SINGLE_NAMESPACE
                   value: 'false'
-                - name: ENGINE_CONTAINER_IMAGE_AND_VERSION
-                  value: docker.io/seldonio/engine:1.12.0
-                - name: ENGINE_CONTAINER_IMAGE_PULL_POLICY
-                  value: IfNotPresent
-                - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
-                  value: default
-                - name: ENGINE_CONTAINER_USER
-                - name: ENGINE_LOG_MESSAGES_EXTERNALLY
-                  value: 'false'
                 - name: PREDICTIVE_UNIT_HTTP_SERVICE_PORT
                   value: '9000'
                 - name: PREDICTIVE_UNIT_GRPC_SERVICE_PORT
@@ -491,12 +482,6 @@ spec:
                 - name: PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME
                 - name: PREDICTIVE_UNIT_METRICS_PORT_NAME
                   value: metrics
-                - name: ENGINE_SERVER_GRPC_PORT
-                  value: '5001'
-                - name: ENGINE_SERVER_PORT
-                  value: '8000'
-                - name: ENGINE_PROMETHEUS_PATH
-                  value: /prometheus
                 - name: ISTIO_ENABLED
                   value: 'false'
                 - name: KEDA_ENABLED
@@ -507,14 +492,13 @@ spec:
                 - name: USE_EXECUTOR
                   value: 'true'
                 - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
-                  value: seldonio/seldon-core-executor:1.12.0
+                  value: seldonio/seldon-core-executor:1.13.1
                 - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
                   value: IfNotPresent
                 - name: EXECUTOR_PROMETHEUS_PATH
                   value: /prometheus
                 - name: EXECUTOR_SERVER_PORT
                   value: '8000'
-                - name: EXECUTOR_CONTAINER_USER
                 - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
                   value: default
                 - name: EXECUTOR_SERVER_METRICS_PORT_NAME
@@ -534,17 +518,9 @@ spec:
                   value: '0.5'
                 - name: EXECUTOR_DEFAULT_MEMORY_LIMIT
                   value: 512Mi
-                - name: ENGINE_DEFAULT_CPU_REQUEST
-                  value: '0.5'
-                - name: ENGINE_DEFAULT_MEMORY_REQUEST
-                  value: 512Mi
-                - name: ENGINE_DEFAULT_CPU_LIMIT
-                  value: '0.5'
-                - name: ENGINE_DEFAULT_MEMORY_LIMIT
-                  value: 512Mi
                 - name: DEPLOYMENT_NAME_AS_PREFIX
                   value: 'false'
-                image: registry.connect.redhat.com/seldonio/seldon-core-operator:1.12.0
+                image: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:d5c5279a46623bbc8d6b03844e536a85deaf2ddea8d7b99d85db9d347726de0b
                 name: manager
                 ports:
                 - containerPort: 8443
@@ -630,7 +606,31 @@ spec:
   minKubeVersion: 1.16.0
   provider:
     name: Seldon Technologies
+  replaces: seldon-operator.v1.12.0
   selector:
     matchLabels:
       name: seldon-operator
-  version: 1.12.0
+  version: 1.13.1
+  relatedImages:
+  - name: seldon-core-operator-d5c5279a46623bbc8d6b03844e536a85deaf2ddea8d7b99d85db9d347726de0b-annotation
+    image: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:d5c5279a46623bbc8d6b03844e536a85deaf2ddea8d7b99d85db9d347726de0b
+  - name: manager
+    image: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:d5c5279a46623bbc8d6b03844e536a85deaf2ddea8d7b99d85db9d347726de0b
+  - name: executor
+    image: registry.connect.redhat.com/seldonio/seldon-core-executor@sha256:c956375a292cc6ce08adbac8b3dcc90ecd284ac2d95726bc11fb2cffca7a0fd4
+  - name: storage_initializer
+    image: registry.connect.redhat.com/seldonio/storage-initializer@sha256:537100924c37956feaebebbe95116acca0f8f2dfe4ebde86736c6dceea3a3e49
+  - name: sklearnserver
+    image: registry.connect.redhat.com/seldonio/sklearnserver@sha256:c40a1414196830d6c9b0e00e9d130926851c442f7cf861b4e30fe9f60be3175b
+  - name: xgboostserver
+    image: registry.connect.redhat.com/seldonio/xgboostserver@sha256:757b3a627adb6346eb6bd8a6676f2be240a610877ec48be52be6a02416d94d54
+  - name: mlflowserver
+    image: registry.connect.redhat.com/seldonio/mlflowserver@sha256:bee42a780c485ff88fba3b767d52c6016fe4bf763686fcfabb83d0000c538c89
+  - name: tfproxy
+    image: registry.connect.redhat.com/seldonio/tfproxy@sha256:8ff4254987e61418df2af773ef9668bd1553ded0afe0c8b213ee9fcec099401a
+  - name: tensorflow
+    image: registry.connect.redhat.com/seldonio/tensorflow-serving@sha256:a44a91ca1b2ac54ccde597404ad981843b3f10f8d835d675e43879d9f7d0120f
+  - name: explainer
+    image: registry.connect.redhat.com/seldonio/alibiexplainer@sha256:3ce53d3ba2a6dfe2a1b0ff8e21de9dc1637de50e183233cd58e6119f7db51cd1
+  - name: mock_classifier
+    image: registry.connect.redhat.com/seldonio/mock-classifier@sha256:4365a1ef09bfe598c4881b6fe2b30019120ea3fece05ca95e6a91fd2382b639e

--- a/operator/bundle-certified/metadata/annotations.yaml
+++ b/operator/bundle-certified/metadata/annotations.yaml
@@ -3,10 +3,10 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: seldon-operator
+  operators.operatorframework.io.bundle.package.v1: seldon-operator-certified
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.15.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
-  com.redhat.openshift.versions: "v4.8"
+  com.redhat.openshift.versions: "v4.8-v4.9"

--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -19,4 +19,4 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
-LABEL com.redhat.openshift.versions=v4.8
+LABEL com.redhat.openshift.versions=v4.8-v4.9

--- a/operator/bundle/manifests/seldon-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/seldon-operator.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: AI/Machine Learning
     certified: 'false'
-    containerImage: seldonio/seldon-core-operator:1.12.0
+    containerImage: seldonio/seldon-core-operator:1.13.1
     createdAt: '2019-05-21 15:00:00'
     description: The Seldon operator for management, monitoring and operations of machine learning systems through the Seldon Engine. Once installed, the Seldon Operator provides multiple functions which facilitate the productisation, monitoring and maintenance of machine learning systems at scale.
     olm.skipRange: <1.12.0
@@ -56,7 +56,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/SeldonIO/seldon-core
     support: Clive Cox
-  name: seldon-operator.v1.12.0
+  name: seldon-operator.v1.13.1
   namespace: seldon-operator-system
 spec:
   apiservicedefinitions: {}
@@ -436,6 +436,10 @@ spec:
                 command:
                 - /manager
                 env:
+                - name: MANAGER_CREATE_RESOURCES
+                  value: 'true'
+                - name: ENGINE_CONTAINER_USER
+                - name: EXECUTOR_CONTAINER_USER
                 - name: MANAGER_LEADER_ELECTION_ID
                   value: a33bd623.machinelearning.seldon.io
                 - name: MANAGER_LOG_LEVEL
@@ -445,7 +449,6 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_EXECUTOR
-                - name: RELATED_IMAGE_ENGINE
                 - name: RELATED_IMAGE_STORAGE_INITIALIZER
                 - name: RELATED_IMAGE_SKLEARNSERVER
                 - name: RELATED_IMAGE_XGBOOSTSERVER
@@ -454,8 +457,6 @@ spec:
                 - name: RELATED_IMAGE_TENSORFLOW
                 - name: RELATED_IMAGE_EXPLAINER
                 - name: RELATED_IMAGE_MOCK_CLASSIFIER
-                - name: MANAGER_CREATE_RESOURCES
-                  value: 'true'
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -465,15 +466,6 @@ spec:
                   value: 'true'
                 - name: AMBASSADOR_SINGLE_NAMESPACE
                   value: 'false'
-                - name: ENGINE_CONTAINER_IMAGE_AND_VERSION
-                  value: docker.io/seldonio/engine:1.12.0
-                - name: ENGINE_CONTAINER_IMAGE_PULL_POLICY
-                  value: IfNotPresent
-                - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
-                  value: default
-                - name: ENGINE_CONTAINER_USER
-                - name: ENGINE_LOG_MESSAGES_EXTERNALLY
-                  value: 'false'
                 - name: PREDICTIVE_UNIT_HTTP_SERVICE_PORT
                   value: '9000'
                 - name: PREDICTIVE_UNIT_GRPC_SERVICE_PORT
@@ -481,12 +473,6 @@ spec:
                 - name: PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME
                 - name: PREDICTIVE_UNIT_METRICS_PORT_NAME
                   value: metrics
-                - name: ENGINE_SERVER_GRPC_PORT
-                  value: '5001'
-                - name: ENGINE_SERVER_PORT
-                  value: '8000'
-                - name: ENGINE_PROMETHEUS_PATH
-                  value: /prometheus
                 - name: ISTIO_ENABLED
                   value: 'false'
                 - name: KEDA_ENABLED
@@ -497,14 +483,13 @@ spec:
                 - name: USE_EXECUTOR
                   value: 'true'
                 - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
-                  value: seldonio/seldon-core-executor:1.12.0
+                  value: seldonio/seldon-core-executor:1.13.1
                 - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
                   value: IfNotPresent
                 - name: EXECUTOR_PROMETHEUS_PATH
                   value: /prometheus
                 - name: EXECUTOR_SERVER_PORT
                   value: '8000'
-                - name: EXECUTOR_CONTAINER_USER
                 - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
                   value: default
                 - name: EXECUTOR_SERVER_METRICS_PORT_NAME
@@ -524,17 +509,9 @@ spec:
                   value: '0.5'
                 - name: EXECUTOR_DEFAULT_MEMORY_LIMIT
                   value: 512Mi
-                - name: ENGINE_DEFAULT_CPU_REQUEST
-                  value: '0.5'
-                - name: ENGINE_DEFAULT_MEMORY_REQUEST
-                  value: 512Mi
-                - name: ENGINE_DEFAULT_CPU_LIMIT
-                  value: '0.5'
-                - name: ENGINE_DEFAULT_MEMORY_LIMIT
-                  value: 512Mi
                 - name: DEPLOYMENT_NAME_AS_PREFIX
                   value: 'false'
-                image: docker.io/seldonio/seldon-core-operator:1.12.0
+                image: docker.io/seldonio/seldon-core-operator:1.13.1
                 name: manager
                 ports:
                 - containerPort: 8443
@@ -620,7 +597,8 @@ spec:
   minKubeVersion: 1.16.0
   provider:
     name: Seldon Technologies
+  replaces: seldon-operator.v1.12.0
   selector:
     matchLabels:
       name: seldon-operator
-  version: 1.12.0
+  version: 1.13.1

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -13,4 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: "v4.8"
+  com.redhat.openshift.versions: "v4.8-v4.9"

--- a/operator/config/manifests/bases/seldon-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/seldon-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
                     "spec": {
                       "containers": [
                         {
-                          "image": "seldonio/mock_classifier:1.12.0",
+                          "image": "seldonio/mock_classifier:1.13.1",
                           "name": "classifier"
                         }
                       ]
@@ -41,7 +41,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: AI/Machine Learning
     certified: "false"
-    containerImage: seldonio/seldon-core-operator:1.12.0
+    containerImage: seldonio/seldon-core-operator:1.13.1
     createdAt: "2019-05-21 15:00:00"
     description: The Seldon operator for management, monitoring and operations of
       machine learning systems through the Seldon Engine. Once installed, the Seldon
@@ -49,8 +49,8 @@ metadata:
       and maintenance of machine learning systems at scale.
     repository: https://github.com/SeldonIO/seldon-core
     support: Clive Cox
-    olm.skipRange: "<1.12.0"
-  name: seldon-operator.v1.12.0
+    olm.skipRange: "<1.13.1"
+  name: seldon-operator.v1.13.1
   namespace: seldon-operator-system
 spec:
   apiservicedefinitions: {}
@@ -665,7 +665,7 @@ spec:
                 - name: AMBASSADOR_SINGLE_NAMESPACE
                   value: "false"
                 - name: ENGINE_CONTAINER_IMAGE_AND_VERSION
-                  value: docker.io/seldonio/engine:1.12.0
+                  value: docker.io/seldonio/engine:1.13.1
                 - name: ENGINE_CONTAINER_IMAGE_PULL_POLICY
                   value: IfNotPresent
                 - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
@@ -692,7 +692,7 @@ spec:
                 - name: USE_EXECUTOR
                   value: "true"
                 - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
-                  value: seldonio/seldon-core-executor:1.12.0
+                  value: seldonio/seldon-core-executor:1.13.1
                 - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
                   value: IfNotPresent
                 - name: EXECUTOR_PROMETHEUS_PATH
@@ -707,7 +707,7 @@ spec:
                 - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT
                   value: http://default-broker
                 - name: DEFAULT_USER_ID
-                image: seldonio/seldon-core-operator:1.12.0
+                image: seldonio/seldon-core-operator:1.13.1
                 name: manager
                 ports:
                 - containerPort: 8443
@@ -783,4 +783,4 @@ spec:
   selector:
     matchLabels:
       name: seldon-operator
-  version: 1.12.0
+  version: 1.13.1

--- a/operator/config/openshift/patch_manager_env.yaml
+++ b/operator/config/openshift/patch_manager_env.yaml
@@ -7,12 +7,13 @@ spec:
   template:
     spec:
       securityContext:
+        $patch: delete
       containers:
       - env:
         - name: MANAGER_CREATE_RESOURCES
           value: "true"
         - name: ENGINE_CONTAINER_USER
-          value: ""          
+          value: ""
         - name: EXECUTOR_CONTAINER_USER
           value: ""
         name: manager

--- a/operator/openshift.md
+++ b/operator/openshift.md
@@ -27,7 +27,7 @@ spec:
         - name: MANAGER_CREATE_RESOURCES
           value: "true"
         - name: ENGINE_CONTAINER_USER
-          value: ""          
+          value: ""
         - name: EXECUTOR_CONTAINER_USER
           value: ""
         name: manager
@@ -59,7 +59,7 @@ Version: version.Version{OpmVersion:"1.12.3", GitCommit:"", BuildDate:"2020-09-1
 
 ### Quay
 
-Login to quay.io as seldon. Password in 1password. 
+Login to quay.io as seldon. Password in 1password.
 
 
 ## Version Update
@@ -91,7 +91,7 @@ Create a fork of https://github.com/k8s-operatorhub/community-operators
 
 Create a PR for community operator
 
-Update the Makefile locally for 
+Update the Makefile locally for
 
 ```
 COMMUNITY_OPERATORS_FOLDER=~/work/seldon-core/redhat/community-operators
@@ -118,7 +118,14 @@ git commit -s -m "Update Seldon Community Operator to 1.12.0"
 
 Push and create PR.
 
-if you need to redo and create a new commit. As they allow only 1 commit on the PR rebase and change previous commit to "FixUp" or "f" via:
+if you need to redo and create a new commit. As they allow only 1 commit the simplest option is to amend existing commit and force-push it with
+
+```
+git commit --amend
+git push -f
+```
+
+Other option is to do the rebase and change previous commit to "FixUp" or "f" via:
 
 ```
 git rebase -i HEAD~2
@@ -133,7 +140,7 @@ Create a fork of https://github.com/redhat-openshift-ecosystem/community-operato
 
 Create a PR for upstream operator
 
-Update the Makefile locally for 
+Update the Makefile locally for
 
 ```
 UPSTREAM_OPERATORS_FOLDER=~/work/seldon-core/redhat/community-operators-prod
@@ -208,7 +215,7 @@ With an openshift cluster authenticated first run the basic pipeline after follo
 make run_certified_pipeline_basic
 ```
 
-There may be an issue with the Tekton pipeline w.r.t TLSVERIFY: see [here](https://github.com/tektoncd/pipeline/issues/3243) and [here](https://bugzilla.redhat.com/show_bug.cgi?id=1879680). To allow the pipeline to run succesfully you will need to switch off TLSVERIFY by modifying [the buildah setps](https://github.com/cliveseldon/operator-pipelines/commit/72b2e12620a9a2d9a5f84b3f218d65f2e936a0ff). 
+There may be an issue with the Tekton pipeline w.r.t TLSVERIFY: see [here](https://github.com/tektoncd/pipeline/issues/3243) and [here](https://bugzilla.redhat.com/show_bug.cgi?id=1879680). To allow the pipeline to run succesfully you will need to switch off TLSVERIFY by modifying [the buildah setps](https://github.com/cliveseldon/operator-pipelines/commit/72b2e12620a9a2d9a5f84b3f218d65f2e936a0ff).
 
 When successful we can rerun but also with pinning. This failed last time but does create a pinned branch in your fork which can be used for a manual PR. For example, run with:
 

--- a/operator/openshift/tests/catalog-source-olm.yaml
+++ b/operator/openshift/tests/catalog-source-olm.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: seldon-core-catalog
+  namespace: olm
+spec:
+  sourceType: grpc
+  image: quay.io/seldon/test-catalog:latest
+  displayName: Seldon Core Catalog
+  updateStrategy:
+    registryPoll:
+      interval: 30m

--- a/operator/openshift/tests/operator-group-olm.yaml
+++ b/operator/openshift/tests/operator-group-olm.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: seldon-operatorgroup
+  namespace: default
+spec:
+  targetNamespaces:
+  - default

--- a/operator/openshift/tests/operator-subscription-olm.yaml
+++ b/operator/openshift/tests/operator-subscription-olm.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: seldon-operator-subscription
+  namespace: default
+spec:
+  channel: stable
+  name: seldon-operator
+  source: seldon-core-catalog
+  sourceNamespace: olm
+  startingCSV: seldon-operator.v1.13.1


### PR DESCRIPTION
Upgrade OpenShift release manifests. 

Work was carried in https://github.com/RafalSkolasinski/seldon-core/tree/v1.13.1-release-redhat

In here I squashed everything into a single commit https://github.com/RafalSkolasinski/seldon-core/tree/v1.13.1-release-redhat-rebase 

In branch that I open this PR I cherry picked that single commit on top of master.