### PR TITLE
added tag for s2i python image

### DIFF
--- a/doc/source/wrappers/s2i.md
+++ b/doc/source/wrappers/s2i.md
@@ -16,7 +16,7 @@ The general work flow is:
 
     ```bash
     s2i build https://github.com/seldonio/seldon-core.git \
-        --context-dir=wrappers/s2i/python/test/model-template-app seldonio/seldon-core-s2i-python3 \
+        --context-dir=wrappers/s2i/python/test/model-template-app seldonio/seldon-core-s2i-python3:1.13.1 \
         seldon-core-template-model
     ```
 


### PR DESCRIPTION
The previous build command would pull the `latest` tag which hasn't been updated in ages. I've added the most recent version but maybe in future we make sure we overwrite latest each time we update the base image?

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
