### PR TITLE
Decompress prediction events before logging to kafka topics

### DIFF
--- a/executor/logger/worker.go
+++ b/executor/logger/worker.go
@@ -113,6 +113,12 @@ func getCEType(logReq LogRequest) (string, error) {
 }
 
 func (w *Worker) sendKafkaEvent(logReq LogRequest) error {
+
+	data, err := payload.DecompressBytes(*logReq.Bytes, logReq.ContentEncoding)
+	if err != nil {
+		return fmt.Errorf("while creating kafka transport: %s", err)
+	}
+
 	reqType, err := getCEType(logReq)
 	if err != nil {
 		return err
@@ -130,7 +136,7 @@ func (w *Worker) sendKafkaEvent(logReq LogRequest) error {
 	w.Log.Info("kafkaHeaders is", "kafkaHeaders", kafkaHeaders)
 	err = w.Producer.Produce(&kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: &w.KafkaTopic, Partition: kafka.PartitionAny},
-		Value:          *logReq.Bytes,
+		Value:          data,
 		Headers:        kafkaHeaders,
 	}, nil)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Related to https://github.com/SeldonIO/seldon-core/issues/3749 but for kafka events. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4004

**Special notes for your reviewer**:
We should for the produce kafka events without gzip compression - event if they come as such, e.g. from Triton server.