### PR TITLE
Sorted metric tags to avoid duplicate prom data with gRPC requests

### DIFF
--- a/python/seldon_core/metrics.py
+++ b/python/seldon_core/metrics.py
@@ -200,7 +200,7 @@ class SeldonMetrics:
 
     @staticmethod
     def _generate_tags_key(tags):
-        return "_".join(["-".join(i) for i in tags.items()])
+        return "_".join(["-".join(i) for i in sorted(tags.items())])
 
     @staticmethod
     def _update_hist(x, vals, sumv):

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -64,7 +64,7 @@ def handle_raw_custom_metrics(
         metrics = seldon_message_to_json(msg.meta).get("metrics", [])
         for metric in metrics:
             metric["tags"] = dict(sorted(metric["tags"].items(), key=lambda item: item[1]))
-        
+
         if metrics and not INCLUDE_METRICS_IN_CLIENT_RESPONSE:
             del msg.meta.metrics[:]
     elif isinstance(msg, dict):

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -62,7 +62,8 @@ def handle_raw_custom_metrics(
         # proto to json extracts dictionary in no particular order
         # sorting tags it here to ensure unique key in metrics.py _generate_tags_key
         metrics = seldon_message_to_json(msg.meta).get("metrics", [])
-        metrics["tags"] = dict(sorted(metrics["tags"].items(), key=lambda item: item[1]))
+        for metric in metrics:
+            metric["tags"] = dict(sorted(metric["tags"].items(), key=lambda item: item[1]))
         if metrics and not INCLUDE_METRICS_IN_CLIENT_RESPONSE:
             del msg.meta.metrics[:]
     elif isinstance(msg, dict):

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -59,11 +59,7 @@ def handle_raw_custom_metrics(
     """
     metrics = []
     if is_proto:
-        # proto to json extracts dictionary in no particular order
-        # sorting tags it here to ensure unique key in metrics.py _generate_tags_key
         metrics = seldon_message_to_json(msg.meta).get("metrics", [])
-        for metric in metrics:
-            metric["tags"] = dict(sorted(metric["tags"].items(), key=lambda item: item[1]))
 
         if metrics and not INCLUDE_METRICS_IN_CLIENT_RESPONSE:
             del msg.meta.metrics[:]

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -59,7 +59,10 @@ def handle_raw_custom_metrics(
     """
     metrics = []
     if is_proto:
-        metrics = seldon_message_to_json(msg.meta).get("metrics", [])
+        # proto to json extracts dictionary in no particular order
+        # sorting it here to ensure unique key in metrics.py _generate_tags_key
+        unordered_metrics = seldon_message_to_json(msg.meta).get("metrics", [])
+        metrics = dict(sorted(unordered_metrics.items(), key=lambda item: item[1])
         if metrics and not INCLUDE_METRICS_IN_CLIENT_RESPONSE:
             del msg.meta.metrics[:]
     elif isinstance(msg, dict):

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -60,9 +60,9 @@ def handle_raw_custom_metrics(
     metrics = []
     if is_proto:
         # proto to json extracts dictionary in no particular order
-        # sorting it here to ensure unique key in metrics.py _generate_tags_key
-        unordered_metrics = seldon_message_to_json(msg.meta).get("metrics", [])
-        metrics = dict(sorted(unordered_metrics.items(), key=lambda item: item[1])
+        # sorting tags it here to ensure unique key in metrics.py _generate_tags_key
+        metrics = seldon_message_to_json(msg.meta).get("metrics", [])
+        metrics["tags"] = dict(sorted(metrics["tags"].items(), key=lambda item: item[1])
         if metrics and not INCLUDE_METRICS_IN_CLIENT_RESPONSE:
             del msg.meta.metrics[:]
     elif isinstance(msg, dict):

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -60,7 +60,6 @@ def handle_raw_custom_metrics(
     metrics = []
     if is_proto:
         metrics = seldon_message_to_json(msg.meta).get("metrics", [])
-
         if metrics and not INCLUDE_METRICS_IN_CLIENT_RESPONSE:
             del msg.meta.metrics[:]
     elif isinstance(msg, dict):

--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -62,7 +62,7 @@ def handle_raw_custom_metrics(
         # proto to json extracts dictionary in no particular order
         # sorting tags it here to ensure unique key in metrics.py _generate_tags_key
         metrics = seldon_message_to_json(msg.meta).get("metrics", [])
-        metrics["tags"] = dict(sorted(metrics["tags"].items(), key=lambda item: item[1])
+        metrics["tags"] = dict(sorted(metrics["tags"].items(), key=lambda item: item[1]))
         if metrics and not INCLUDE_METRICS_IN_CLIENT_RESPONSE:
             del msg.meta.metrics[:]
     elif isinstance(msg, dict):

--- a/python/tests/test_runtime_metrics_tags.py
+++ b/python/tests/test_runtime_metrics_tags.py
@@ -106,7 +106,7 @@ def test_generate_tags_key():
     # initializing two different kinds of dictionary
     insertion_order = OrderedDict({'b': 'b', 'a': 'a'})
     sorted_order = {'a': 'a', 'b': 'b'}
-    # assert the items in the list will differ based on order
+    # assert the items in the list differ based on order
     assert list(insertion_order.items()) != list(sorted_order.items())
 
     insertion_order_tag = SeldonMetrics._generate_tags_key(insertion_order)

--- a/python/tests/test_runtime_metrics_tags.py
+++ b/python/tests/test_runtime_metrics_tags.py
@@ -104,8 +104,8 @@ def verify_seldon_metrics(data, mycounter_value, histogram_entries, method):
 
 def test_generate_tags_key():
     # initializing two different kinds of dictionary
-    insertion_order = OrderedDict({'b': 'b', 'a': 'a'})
-    sorted_order = {'a': 'a', 'b': 'b'}
+    insertion_order = OrderedDict({"b": "b", "a": "a"})
+    sorted_order = {"a": "a", "b": "b"}
     # assert the items in the list differ based on order
     assert list(insertion_order.items()) != list(sorted_order.items())
 

--- a/python/tests/test_runtime_metrics_tags.py
+++ b/python/tests/test_runtime_metrics_tags.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import pytest
 from google.protobuf import json_format
+from collections import OrderedDict
 
 from seldon_core.flask_utils import SeldonMicroserviceException
 from seldon_core.metrics import (
@@ -85,6 +86,8 @@ def verify_seldon_metrics(data, mycounter_value, histogram_entries, method):
     base_tags_key = SeldonMetrics._generate_tags_key(expected_base_tags)
     expected_custom_tags = {"mytag": "mytagvalue", "method": method}
     custom_tags_key = SeldonMetrics._generate_tags_key(expected_custom_tags)
+    expected_tags_key = f"method-{method}_mytag-mytagvalue"
+    assert custom_tags_key == expected_tags_key
     assert data["GAUGE", "runtime_gauge", base_tags_key]["value"] == 42
     assert data["GAUGE", "mygauge", base_tags_key]["value"] == 100
     assert data["GAUGE", "customtag", custom_tags_key]["value"] == 200
@@ -97,6 +100,19 @@ def verify_seldon_metrics(data, mycounter_value, histogram_entries, method):
     assert np.allclose(
         data["TIMER", "mytimer", base_tags_key]["value"][1], np.sum(histogram_entries)
     )
+
+
+def test_generate_tags_key():
+    # initializing two different kinds of dictionary
+    insertion_order = OrderedDict({'b': 'b', 'a': 'a'})
+    sorted_order = {'a': 'a', 'b': 'b'}
+    # assert the items in the list will differ based on order
+    assert list(insertion_order.items()) != list(sorted_order.items())
+
+    insertion_order_tag = SeldonMetrics._generate_tags_key(insertion_order)
+    sorted_order_tag = SeldonMetrics._generate_tags_key(sorted_order)
+    # same tag generated irrespective of order
+    assert insertion_order_tag == sorted_order_tag
 
 
 @pytest.mark.parametrize("cls", [UserObject])

--- a/python/tests/test_runtime_metrics_tags.py
+++ b/python/tests/test_runtime_metrics_tags.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import os
+from collections import OrderedDict
 
 import numpy as np
 import pytest
 from google.protobuf import json_format
-from collections import OrderedDict
 
 from seldon_core.flask_utils import SeldonMicroserviceException
 from seldon_core.metrics import (


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
To ensure no duplication of metrics occur in prometheus due to non-unique temp keys dependent on "tags" of custom metrics.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3968 

**Special notes for your reviewer**:
