### PR TITLE
Enabling optional grpc server on python level only

### DIFF
--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -341,7 +341,7 @@ def main():
     parser.add_argument(
         "--grpc-workers",
         type=int,
-        default=os.environ.get("GRPC_WORKERS", default="1"),
+        default=os.environ.get("GRPC_WORKERS", default="0"),
         help="Number of GPRC workers.",
     )
 
@@ -533,7 +533,7 @@ def main():
             for worker in workers:
                 worker.join()
 
-    server2_func = grpc_prediction_server
+    server2_func = grpc_prediction_server if args.grpc_workers > 0 else None
 
     def rest_metrics_server():
         app = seldon_microservice.get_metrics_microservice(seldon_metrics)

--- a/python/seldon_core/microservice.py
+++ b/python/seldon_core/microservice.py
@@ -341,7 +341,7 @@ def main():
     parser.add_argument(
         "--grpc-workers",
         type=int,
-        default=os.environ.get("GRPC_WORKERS", default="0"),
+        default=os.environ.get("GRPC_WORKERS", default="1"),
         help="Number of GPRC workers.",
     )
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

* [x] Allow for grpc server to be disabled 
* [x] Test that all non-grpc integration tests still pass when disabled
* [x] Add documentation to outline how to enable/disable this

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4031

**Special notes for your reviewer**:

From integration tests it seems that only GRPC tests actually fail so we should be able to introduce this as a feasible "base soltuion" with the premise that it would have the grpc service enabled.

The integration tests actually fail for two reasons, namely 1) the expected reason of requests failing when sent as GRPC, but also 2) when setting the `node` as grpc explicitly, the ready check actually fails so the pod does not go up - this latter shouldn't be necessary but the documentation should encompass this.
