### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/alibidetect_tests.yml
+++ b/.github/workflows/alibidetect_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-18.04

--- a/.github/workflows/alibiexplainer_tests.yml
+++ b/.github/workflows/alibiexplainer_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-18.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   docs-lint:
 

--- a/.github/workflows/executor_lint.yml
+++ b/.github/workflows/executor_lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   executor-lint:
 

--- a/.github/workflows/executor_tests.yml
+++ b/.github/workflows/executor_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   executor-tests:
 

--- a/.github/workflows/operator_lint.yml
+++ b/.github/workflows/operator_lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   operator-lint:
 

--- a/.github/workflows/operator_tests.yml
+++ b/.github/workflows/operator_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   operator-tests:
 

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   python-lint:
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   python-tests:
 

--- a/.github/workflows/security_tests.yml
+++ b/.github/workflows/security_tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   security-python:
 
@@ -89,6 +92,8 @@ jobs:
 
   security-image-python-sklearn:
 
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
     - name: security-image-python-sklearn
@@ -101,6 +106,8 @@ jobs:
 
   security-image-python-mlflow:
 
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
     - name: security-image-python-mlflow
@@ -113,6 +120,8 @@ jobs:
 
   security-image-python-xgboost:
 
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
     - name: security-image-python-xgboost


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
