### PR TITLE
 Adding tests to explicitly state expected behaviour of v2 protocol chaining in REST

### DIFF
--- a/executor/api/rest/kfserving_test.go
+++ b/executor/api/rest/kfserving_test.go
@@ -1,0 +1,84 @@
+package rest
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/seldonio/seldon-core/executor/api/payload"
+)
+
+func TestChainKFServingInputs(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var dataStr = []byte(`{"inputs":[{"name":"features","datatype":"BYTES","shape":[1,1],"data":["hello"]}]}`)
+
+	var input interface{}
+	err := json.Unmarshal(dataStr, &input)
+	g.Expect(err).To(BeNil())
+
+	inputPayload := payload.BytesPayload{Msg: dataStr, ContentType: ContentTypeJSON}
+
+	outputPayload, err := ChainKFserving(&inputPayload)
+	g.Expect(err).To(BeNil())
+
+	var output interface{}
+	outputStr, err := outputPayload.GetBytes()
+	g.Expect(err).To(BeNil())
+	err = json.Unmarshal(outputStr, &output)
+
+	inputMap := input.(map[string]interface{})
+	outputMap := output.(map[string]interface{})
+
+	g.Expect(inputMap["inputs"]).To(Equal(outputMap["inputs"]))
+}
+
+func TestChainKFServingOutputs(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var dataStr = []byte(`{"outputs":[{"name":"features","datatype":"BYTES","shape":[1,1],"data":["hello"]}]}`)
+
+	var input interface{}
+	err := json.Unmarshal(dataStr, &input)
+	g.Expect(err).To(BeNil())
+
+	inputPayload := payload.BytesPayload{Msg: dataStr, ContentType: ContentTypeJSON}
+
+	outputPayload, err := ChainKFserving(&inputPayload)
+	g.Expect(err).To(BeNil())
+
+	var output interface{}
+	outputStr, err := outputPayload.GetBytes()
+	g.Expect(err).To(BeNil())
+	err = json.Unmarshal(outputStr, &output)
+
+	inputMap := input.(map[string]interface{})
+	outputMap := output.(map[string]interface{})
+
+	g.Expect(inputMap["outputs"]).To(Equal(outputMap["inputs"]))
+}
+
+func TestChainKFServingParams(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var dataStr = []byte(`{"parameters": {"key": "value"},"outputs":[{"name":"features","datatype":"BYTES","shape":[1,1],"data":["hello"]}]}`)
+
+	var input interface{}
+	err := json.Unmarshal(dataStr, &input)
+	g.Expect(err).To(BeNil())
+
+	inputPayload := payload.BytesPayload{Msg: dataStr, ContentType: ContentTypeJSON}
+
+	outputPayload, err := ChainKFserving(&inputPayload)
+	g.Expect(err).To(BeNil())
+
+	var output interface{}
+	outputStr, err := outputPayload.GetBytes()
+	g.Expect(err).To(BeNil())
+	err = json.Unmarshal(outputStr, &output)
+
+	inputMap := input.(map[string]interface{})
+	outputMap := output.(map[string]interface{})
+
+	g.Expect(inputMap["parameters"]).To(Equal(outputMap["parameters"]))
+}

--- a/executor/api/rest/kfserving_test.go
+++ b/executor/api/rest/kfserving_test.go
@@ -31,6 +31,7 @@ func TestChainKFServingInputs(t *testing.T) {
 	outputMap := output.(map[string]interface{})
 
 	g.Expect(inputMap["inputs"]).To(Equal(outputMap["inputs"]))
+	g.Expect(outputMap["outputs"]).To(BeNil())
 }
 
 func TestChainKFServingOutputs(t *testing.T) {
@@ -56,6 +57,7 @@ func TestChainKFServingOutputs(t *testing.T) {
 	outputMap := output.(map[string]interface{})
 
 	g.Expect(inputMap["outputs"]).To(Equal(outputMap["inputs"]))
+	g.Expect(outputMap["outputs"]).To(BeNil())
 }
 
 func TestChainKFServingParams(t *testing.T) {
@@ -81,4 +83,5 @@ func TestChainKFServingParams(t *testing.T) {
 	outputMap := output.(map[string]interface{})
 
 	g.Expect(inputMap["parameters"]).To(Equal(outputMap["parameters"]))
+	g.Expect(outputMap["outputs"]).To(BeNil())
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Following #4054 adding unit tests to REST to reflect the expected behaviour of chaining for v2 protocol explicitly

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
