### PR TITLE
Pass through model name env var for MLServer

### DIFF
--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -780,7 +780,7 @@ func createContainerService(deploy *appsv1.Deployment,
 		}
 	}
 
-	// Add livecycle probe
+	// Add lifecycle probe
 	if con.Lifecycle == nil {
 		con.Lifecycle = &corev1.Lifecycle{PreStop: &corev1.Handler{Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "/bin/sleep 10"}}}}
 	}
@@ -816,6 +816,7 @@ func createContainerService(deploy *appsv1.Deployment,
 
 	con.Env = append(con.Env, []corev1.EnvVar{
 		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_ID, Value: con.Name},
+		corev1.EnvVar{Name: MLServerModelNameEnv, Value: con.Name},
 		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTIVE_UNIT_IMAGE, Value: con.Image},
 		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTOR_ID, Value: p.Name},
 		corev1.EnvVar{Name: machinelearningv1.ENV_PREDICTOR_LABELS, Value: string(labels)},

--- a/operator/controllers/seldondeployment_controller_test.go
+++ b/operator/controllers/seldondeployment_controller_test.go
@@ -144,6 +144,18 @@ var _ = Describe("Create a Seldon Deployment", func() {
 			},
 		))
 
+		// Check model's name is in there
+		Expect(containers[0].Env).To(ContainElements(
+			v1.EnvVar{
+				Name:  machinelearningv1.ENV_PREDICTIVE_UNIT_ID,
+				Value: containers[0].Name,
+			},
+			v1.EnvVar{
+				Name:  MLServerModelNameEnv,
+				Value: containers[0].Name,
+			},
+		))
+
 		//Update Deployment as pods not created with test client.
 		depUpdated := depFetched.DeepCopy()
 		depUpdated.Status.AvailableReplicas = replicas

--- a/testing/docker/mock-preprocessor/Makefile
+++ b/testing/docker/mock-preprocessor/Makefile
@@ -1,10 +1,10 @@
 # Makefile for building and pushing fixed models docker images using for testing
 
 build_image:
-	mlserver build . --tag seldonio/mock-preprocessor:0.1.0
+	mlserver build . --tag seldonio/mock-preprocessor:0.2.0
 
 push_image:
-	docker push seldonio/mock-preprocessor:0.1.0
+	docker push seldonio/mock-preprocessor:0.2.0
 
 kind_load_image: build_image
-	kind load -v 3 docker-image seldonio/mock-preprocessor:0.1.0
+	kind load -v 3 docker-image seldonio/mock-preprocessor:0.2.0

--- a/testing/docker/mock-preprocessor/model-settings.json
+++ b/testing/docker/mock-preprocessor/model-settings.json
@@ -1,4 +1,3 @@
 {
-  "name": "mock-preprocessor",
   "implementation": "runtime.MockPreprocessor"
 }

--- a/testing/resources/graph-v2.yaml
+++ b/testing/resources/graph-v2.yaml
@@ -3,7 +3,7 @@ kind: SeldonDeployment
 metadata:
   name: graph-test
 spec:
-  protocol: kfserving
+  protocol: v2
   predictors:
     - name: default
       graph:
@@ -16,15 +16,4 @@ spec:
         - spec:
             containers:
               - name: mock-preprocessor
-                image: seldonio/mock-preprocessor:0.1.0
-                securityContext:
-                  # Workaround for multi-user bug in custom images in MLServer:
-                  # https://github.com/SeldonIO/MLServer/issues/388
-                  runAsUser: 1000
-                ports:
-                  - containerPort: 8080
-                    name: http
-                    protocol: TCP
-                  - containerPort: 8081
-                    name: grpc
-                    protocol: TCP
+                image: seldonio/mock-preprocessor:0.2.0


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR ensures that the environment variables read by MLServer to set default values for the model settings are always set, regardless of whether the `SeldonDeployment` runs with a pre-packaged server or not. This ensures that `SeldonDeployment` workloads using custom MLServer images run out-of-the-box without having to also specify the `MLSERVER_MODEL_NAME` or `MLSERVER_MODEL_URI` variables.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3704

**Special notes for your reviewer**:
