### PR TITLE
Adding protocol info to executor payload logging worker

### DIFF
--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -81,7 +81,7 @@ var (
 	kafkaWorkers      = flag.Int("kafka_workers", 4, "Number of kafka workers")
 	logKafkaBroker    = flag.String("log_kafka_broker", "", "The kafka log broker")
 	logKafkaTopic     = flag.String("log_kafka_topic", "", "The kafka log topic")
-	fullHealthChecks = flag.Bool("full_health_checks",false, "Full health checks via chosen protocol API")
+	fullHealthChecks  = flag.Bool("full_health_checks", false, "Full health checks via chosen protocol API")
 	debug             = flag.Bool(
 		"debug",
 		util.GetEnvAsBool(debugEnvVar, debugDefault),
@@ -309,7 +309,7 @@ func main() {
 	setupLogger()
 	logger := logf.Log.WithName("entrypoint")
 
-	logger.Info("Full health checks ","value", fullHealthChecks)
+	logger.Info("Full health checks ", "value", fullHealthChecks)
 
 	// Set runtime.GOMAXPROCS to respect container limits if the env var GOMAXPROCS is not set or is invalid, preventing CPU throttling.
 	undo, err := maxprocs.Set(maxprocs.Logger(func(format string, a ...interface{}) {
@@ -350,7 +350,7 @@ func main() {
 	}
 
 	//Start Logger Dispacther
-	err = loghandler.StartDispatcher(*logWorkers, *logWorkBufferSize, *logWriteTimeoutMs, logger, *sdepName, *namespace, *predictorName, *logKafkaBroker, *logKafkaTopic)
+	err = loghandler.StartDispatcher(*logWorkers, *logWorkBufferSize, *logWriteTimeoutMs, logger, *sdepName, *namespace, *predictorName, *logKafkaBroker, *logKafkaTopic, *protocol)
 	if err != nil {
 		log.Fatal("Failed to start log dispatcher", err)
 	}

--- a/executor/logger/dispatcher.go
+++ b/executor/logger/dispatcher.go
@@ -11,7 +11,7 @@ const (
 	ENV_LOGGER_KAFKA_TOPIC  = "LOGGER_KAFKA_TOPIC"
 )
 
-func StartDispatcher(nworkers int, logBufferSize int, writeTimeoutMs int, log logr.Logger, sdepName string, namespace string, predictorName string, kafkaBroker string, kafkaTopic string) error {
+func StartDispatcher(nworkers int, logBufferSize int, writeTimeoutMs int, log logr.Logger, sdepName string, namespace string, predictorName string, kafkaBroker string, kafkaTopic string, protocol string) error {
 	if kafkaBroker == "" {
 		kafkaBroker = os.Getenv(ENV_LOGGER_KAFKA_BROKER)
 	}
@@ -29,7 +29,7 @@ func StartDispatcher(nworkers int, logBufferSize int, writeTimeoutMs int, log lo
 	// Now, create all of our workers.
 	for i := 0; i < nworkers; i++ {
 		log.Info("Starting", "worker", i+1)
-		worker, err := NewWorker(i+1, workQueue, log, sdepName, namespace, predictorName, kafkaBroker, kafkaTopic)
+		worker, err := NewWorker(i+1, workQueue, log, sdepName, namespace, predictorName, kafkaBroker, kafkaTopic, protocol)
 		if err != nil {
 			return err
 		}

--- a/executor/logger/log_memory_benchmark_test.go
+++ b/executor/logger/log_memory_benchmark_test.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"github.com/seldonio/seldon-core/executor/api"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -25,7 +26,7 @@ var processedChan = make(chan bool, 100)
 func BenchmarkLoggerMemoryUsage(b *testing.B) {
 	serverPort := startSlowLogListener()
 
-	err := StartDispatcher(5, DefaultWorkQueueSize, DefaultWriteTimeoutMilliseconds, logf.Log.WithName("test"), "test-name", "test-namespace", "test-predictor", "", "")
+	err := StartDispatcher(5, DefaultWorkQueueSize, DefaultWriteTimeoutMilliseconds, logf.Log.WithName("test"), "test-name", "test-namespace", "test-predictor", "", "", api.ProtocolSeldon)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/executor/predictor/predictor_process_test.go
+++ b/executor/predictor/predictor_process_test.go
@@ -9,10 +9,9 @@ import (
 	"net/url"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/gomega"
+	"github.com/seldonio/seldon-core/executor/api"
 	"github.com/seldonio/seldon-core/executor/api/grpc"
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
 	"github.com/seldonio/seldon-core/executor/api/payload"
@@ -20,6 +19,7 @@ import (
 	"github.com/seldonio/seldon-core/executor/logger"
 	v1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const (
@@ -461,7 +461,7 @@ func TestModelWithLogRequests(t *testing.T) {
 
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
-	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "")
+	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "", api.ProtocolSeldon)
 
 	model := v1.MODEL
 	graph := &v1.PredictiveUnit{
@@ -509,7 +509,7 @@ func TestModelWithLogRequestsAtDefaultedUrl(t *testing.T) {
 
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
-	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "")
+	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "", api.ProtocolSeldon)
 
 	model := v1.MODEL
 	graph := &v1.PredictiveUnit{
@@ -552,7 +552,7 @@ func TestModelWithLogResponses(t *testing.T) {
 
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
-	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "")
+	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "", api.ProtocolSeldon)
 
 	model := v1.MODEL
 	graph := &v1.PredictiveUnit{
@@ -606,7 +606,7 @@ func TestModelRequestSkipsLogging(t *testing.T) {
 
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
-	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "")
+	logger.StartDispatcher(1, logger.DefaultWorkQueueSize, logger.DefaultWriteTimeoutMilliseconds, log, "", "", "", "", "", api.ProtocolSeldon)
 
 	model := v1.MODEL
 	graph := &v1.PredictiveUnit{


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds a payload information along with the request logging functionality in the seldon core executor. Having this additional information allow for efficient filtering/processing in downstreams apps that consumes this information. 


**Special notes for your reviewer**:
New cloud event header created -> protocol (seldon,tensorflow, v2)
New kafka message header created -> protocol (seldon,tensorflow, v2)