### PR TITLE
Update cache folder and bump MLServer image

### DIFF
--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -163,7 +163,7 @@ predictor_servers:
   HUGGINGFACE_SERVER:
     protocols:
       v2:
-        defaultImageVersion: "1.1.0.dev3-huggingface"
+        defaultImageVersion: "1.1.0.dev5-huggingface"
         image: seldonio/mlserver
   TEMPO_SERVER:
     protocols:

--- a/operator/config/manager/configmap.yaml
+++ b/operator/config/manager/configmap.yaml
@@ -77,7 +77,7 @@ data:
           "protocols" : {
             "v2": {
               "image": "seldonio/mlserver",
-              "defaultImageVersion": "1.1.0.dev3-huggingface"
+              "defaultImageVersion": "1.1.0.dev5-huggingface"
               }
             }
         },

--- a/operator/controllers/mlserver.go
+++ b/operator/controllers/mlserver.go
@@ -23,7 +23,7 @@ const (
 
 	MLServerParallelWorkersEnv         = "MLSERVER_PARALLEL_WORKERS"
 	MLServerParallelWorkersEnvDefault  = "0"
-	MLServerHuggingFaceCacheEnv        = "TRANSFORMERS_CACHE"
+	MLServerHuggingFaceCacheEnv        = "XDG_CACHE_HOME"
 	MLServerHuggingFaceCacheEnvDefault = "/opt/mlserver"
 	MLServerHTTPPortEnv                = "MLSERVER_HTTP_PORT"
 	MLServerGRPCPortEnv                = "MLSERVER_GRPC_PORT"


### PR DESCRIPTION
Part of https://github.com/SeldonIO/MLServer/issues/576

* Bumps mlserver to 1.1.0-dev5
* Updates cache folder to top level XDG as per https://github.com/huggingface/optimum/issues/186