### PR TITLE
Don't hardcode UID for Triton containers

### DIFF
--- a/operator/controllers/seldondeployment_prepackaged_servers.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers.go
@@ -135,8 +135,6 @@ func (pi *PrePackedInitialiser) addTritonServer(mlDepSpec *machinelearningv1.Sel
 	c := utils.GetContainerForDeployment(deploy, pu.Name)
 	existing := c != nil
 
-	tritonUser := int64(1000)
-
 	cServer := &v1.Container{
 		Name: pu.Name,
 		Args: []string{
@@ -179,9 +177,6 @@ func (pi *PrePackedInitialiser) addTritonServer(mlDepSpec *machinelearningv1.Sel
 			PeriodSeconds:       10,
 			SuccessThreshold:    1,
 			FailureThreshold:    3,
-		},
-		SecurityContext: &v1.SecurityContext{
-			RunAsUser: &tritonUser,
 		},
 		VolumeMounts: []v1.VolumeMount{
 			{

--- a/operator/controllers/seldondeployment_prepackaged_servers_test.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers_test.go
@@ -845,8 +845,9 @@ var _ = Describe("Create a prepacked triton server", func() {
 		}, timeout, interval).Should(BeNil())
 		Expect(fetched.Name).Should(Equal(sdepName))
 
-		sPodSpec, idx := utils.GetSeldonPodSpecForPredictiveUnit(&instance.Spec.Predictors[0], instance.Spec.Predictors[0].Graph.Name)
-		depName := machinelearningv1.GetDeploymentName(instance, instance.Spec.Predictors[0], sPodSpec, idx)
+		predictor := instance.Spec.Predictors[0]
+		sPodSpec, idx := utils.GetSeldonPodSpecForPredictiveUnit(&predictor, predictor.Graph.Name)
+		depName := machinelearningv1.GetDeploymentName(instance, predictor, sPodSpec, idx)
 		depKey := types.NamespacedName{
 			Name:      depName,
 			Namespace: "default",
@@ -859,6 +860,9 @@ var _ = Describe("Create a prepacked triton server", func() {
 		Expect(len(depFetched.Spec.Template.Spec.Containers)).Should(Equal(2))
 		Expect(depFetched.Spec.Template.Spec.SecurityContext).ToNot(BeNil())
 		Expect(*depFetched.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(2)))
+
+		container := utils.GetContainerForDeployment(depFetched, predictor.Graph.Name)
+		Expect(container.SecurityContext).To(BeNil())
 
 		Expect(k8sClient.Delete(context.Background(), instance)).Should(Succeed())
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Remove current hardcoded UID (`1000`) in Triton container. This ensures that the Triton pre-packaged server can be used in OpenShift clusters.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3019

**Special notes for your reviewer**:
