### PR TITLE
Add optional manual commit to seldon kafka server

### DIFF
--- a/executor/api/kafka/server.go
+++ b/executor/api/kafka/server.go
@@ -287,7 +287,6 @@ func (ks *SeldonKafkaServer) Serve() error {
 				job := KafkaJob{
 					headers:    headers,
 					message:    e,
-					reqKey:     e.Key,
 					reqPayload: reqPayload,
 				}
 				// enqueue a job

--- a/executor/api/kafka/worker.go
+++ b/executor/api/kafka/worker.go
@@ -14,7 +14,6 @@ import (
 type KafkaJob struct {
 	headers    map[string][]string
 	message    *kafka.Message
-	reqKey     []byte
 	reqPayload payload.SeldonPayload
 }
 
@@ -65,7 +64,7 @@ func (ks *SeldonKafkaServer) processKafkaRequest(job *KafkaJob) {
 
 	err = ks.Producer.Produce(&kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: &ks.TopicOut, Partition: kafka.PartitionAny},
-		Key:            job.reqKey,
+		Key:            job.message.Key,
 		Value:          resBytes,
 		Headers:        kafkaHeaders,
 	}, nil)

--- a/executor/cmd/executor/main.go
+++ b/executor/cmd/executor/main.go
@@ -79,6 +79,7 @@ var (
 	kafkaTopicOut     = flag.String("kafka_output_topic", "", "The kafka output topic")
 	kafkaFullGraph    = flag.Bool("kafka_full_graph", false, "Use kafka for internal graph processing")
 	kafkaWorkers      = flag.Int("kafka_workers", 4, "Number of kafka workers")
+	kafkaAutoCommit   = flag.Bool("kafka_auto_commit", true, "Use auto committing in the kafka consumer")
 	logKafkaBroker    = flag.String("log_kafka_broker", "", "The kafka log broker")
 	logKafkaTopic     = flag.String("log_kafka_topic", "", "The kafka log topic")
 	fullHealthChecks  = flag.Bool("full_health_checks", false, "Full health checks via chosen protocol API")
@@ -285,6 +286,17 @@ func main() {
 			}
 		}
 
+		// Get Kafka Auto Commit
+		kafkaAutoCommitFromEnv := os.Getenv(kafka.ENV_KAFKA_AUTO_COMMIT)
+		if kafkaAutoCommitFromEnv != "" {
+			kafkaAutoCommitFromEnvBool, err := strconv.ParseBool(kafkaAutoCommitFromEnv)
+			if err != nil {
+				log.Fatalf("Failed to parse %s %s", kafka.ENV_KAFKA_AUTO_COMMIT, kafkaAutoCommitFromEnv)
+			} else {
+				*kafkaAutoCommit = kafkaAutoCommitFromEnvBool
+			}
+		}
+
 		//Kafka workers
 		kafkaWorkersFromEnv := os.Getenv(kafka.ENV_KAFKA_WORKERS)
 		if kafkaWorkersFromEnv != "" {
@@ -364,7 +376,7 @@ func main() {
 
 	if *serverType == "kafka" {
 		logger.Info("Starting kafka server")
-		kafkaServer, err := kafka.NewKafkaServer(*kafkaFullGraph, *kafkaWorkers, *sdepName, *namespace, *protocol, *transport, annotations, serverUrl, predictor, *kafkaBroker, *kafkaTopicIn, *kafkaTopicOut, logger, *fullHealthChecks)
+		kafkaServer, err := kafka.NewKafkaServer(*kafkaFullGraph, *kafkaWorkers, *sdepName, *namespace, *protocol, *transport, annotations, serverUrl, predictor, *kafkaBroker, *kafkaTopicIn, *kafkaTopicOut, logger, *fullHealthChecks, *kafkaAutoCommit)
 		if err != nil {
 			log.Fatalf("Failed to create kafka server: %v", err)
 		}


### PR DESCRIPTION
Signed-off-by: Emirhan Karagül <emirhan350z@gmail.com>

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**: This PR provides an optional flag to control auto commit behavior of kafka consumer. When no environment variable is set in the `svcOrchSpec`, the executor works as usual. If auto commit is disabled, the messages will be committed only after they have been processed and response has been sent to the output queue.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4097 

**Special notes for your reviewer**: As mentioned before, disabled auto commit might cause data duplication when `kafka_workers > 1`.
