### PR TITLE
enh: Add support to configure PrepackedTriton with no storage initialiser

### DIFF
--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -71,6 +71,7 @@ const (
 	ANNOTATION_SEPARATE_ENGINE         = "seldon.io/engine-separate-pod"
 	ANNOTATION_HEADLESS_SVC            = "seldon.io/headless-svc"
 	ANNOTATION_NO_ENGINE               = "seldon.io/no-engine"
+	ANNOTATION_NO_STOARGE_INITIALIZER  = "seldon.io/no-storage-initializer"
 	ANNOTATION_CUSTOM_SVC_NAME         = "seldon.io/svc-name"
 	ANNOTATION_LOGGER_WORK_QUEUE_SIZE  = "seldon.io/executor-logger-queue-size"
 	ANNOTATION_LOGGER_WRITE_TIMEOUT_MS = "seldon.io/executor-logger-write-timeout-ms"

--- a/operator/constants/constants.go
+++ b/operator/constants/constants.go
@@ -24,8 +24,14 @@ const (
 	GrpcPortName          = "grpc"
 	HttpPortName          = "http"
 
-	TritonDefaultGrpcPort = 2001
-	TritonDefaultHttpPort = 2000
+	TritonDefaultGrpcPort      = 2001
+	TritonDefaultHttpPort      = 2000
+	TritonArgGrpcPort          = "--grpc-port="
+	TritonArgHttpPort          = "--http-port="
+	TritonArgModelRepository   = "--model-repository="
+	TritonArgModelControlMode  = "--model-control-mode="
+	TritonArgLoadModel         = "--load-model="
+	TritonArgStrictModelConfig = "--strict-model-config="
 
 	KFServingProbeLivePath  = "/v2/health/live"
 	KFServingProbeReadyPath = "/v2/health/ready"

--- a/operator/controllers/model_initializer_injector_test.go
+++ b/operator/controllers/model_initializer_injector_test.go
@@ -2,12 +2,13 @@ package controllers
 
 import (
 	"context"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 func TestStorageInitalizerInjector(t *testing.T) {

--- a/operator/controllers/seldondeployment_prepackaged_servers_test.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers_test.go
@@ -1170,18 +1170,18 @@ var _ = Describe("Create a prepacked triton server with seldon.io/no-storage-ini
 		Expect(len(depFetched.Spec.Template.Spec.Containers[0].Args)).Should(Equal(7))
 		for _, c := range depFetched.Spec.Template.Spec.Containers {
 			if c.Name == modelName {
-				for idx, arg := range c.Args {
-					if arg == constants.TritonArgModelRepository {
-						Expect(c.Args[idx+1]).To(Equal(modelUri))
+				for _, arg := range c.Args {
+					if strings.Index(arg, constants.TritonArgModelRepository) == 0 {
+						Expect(arg).To(Equal(constants.TritonArgModelRepository + modelUri))
 					}
-					if arg == constants.TritonArgModelControlMode {
-						Expect(c.Args[idx+1]).To(Equal("explicit"))
+					if strings.Index(arg, constants.TritonArgModelControlMode) == 0 {
+						Expect(arg).To(Equal(constants.TritonArgModelControlMode + "explicit"))
 					}
-					if arg == constants.TritonArgLoadModel {
-						Expect(c.Args[idx+1]).To(Equal("model1"))
+					if strings.Index(arg, constants.TritonArgLoadModel) == 0 {
+						Expect(arg).To(Equal(constants.TritonArgLoadModel + "model1"))
 					}
-					if arg == constants.TritonArgStrictModelConfig {
-						Expect(c.Args[idx+1]).To(Equal("true"))
+					if strings.Index(arg, constants.TritonArgStrictModelConfig) == 0 {
+						Expect(arg).To(Equal(constants.TritonArgStrictModelConfig + "true"))
 					}
 				}
 			}

--- a/operator/controllers/seldondeployment_prepackaged_servers_test.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers_test.go
@@ -2,6 +2,10 @@ package controllers
 
 import (
 	"context"
+	"strconv"
+	"strings"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
@@ -12,9 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var _ = Describe("Create a prepacked sklearn server", func() {
@@ -1051,6 +1052,143 @@ var _ = Describe("Create a prepacked mlflow server with existing container", fun
 		Expect(len(depFetched.Spec.Template.Spec.Containers)).Should(Equal(2))
 
 		Expect(k8sClient.Delete(context.Background(), instance)).Should(Succeed())
+	})
+
+})
+
+var _ = Describe("Create a prepacked triton server with seldon.io/no-storage-initializer annotation", func() {
+	const timeout = time.Second * 30
+	const interval = time.Second * 1
+	const name = "pp1"
+	const sdepName = "prepack12"
+	envExecutorUser = "2"
+	By("Creating a resource")
+	It("should create a resource with no storage initializer but triton args", func() {
+		Expect(k8sClient).NotTo(BeNil())
+		var modelType = machinelearningv1.MODEL
+		modelName := "classifier"
+		modelUri := "s3://mybucket/mymodel"
+		var impl = machinelearningv1.PredictiveUnitImplementation(constants.PrePackedServerTriton)
+		key := types.NamespacedName{
+			Name:      sdepName,
+			Namespace: "default",
+		}
+		instance := &machinelearningv1.SeldonDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+			},
+			Spec: machinelearningv1.SeldonDeploymentSpec{
+				Annotations: map[string]string{
+					"seldon.io/no-storage-initializer": "true",
+				},
+				Name:     name,
+				Protocol: machinelearningv1.ProtocolV2,
+				Predictors: []machinelearningv1.PredictorSpec{
+					{
+						Annotations: map[string]string{
+							"seldon.io/no-engine": "true",
+						},
+						Name: "p1",
+						ComponentSpecs: []*machinelearningv1.SeldonPodSpec{
+							{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name: modelName,
+										},
+									},
+								},
+							},
+						},
+						Graph: machinelearningv1.PredictiveUnit{
+							Name:           modelName,
+							ModelURI:       modelUri,
+							Type:           &modelType,
+							Implementation: &impl,
+							Endpoint:       &machinelearningv1.Endpoint{Type: machinelearningv1.REST},
+							Parameters: []machinelearningv1.Parameter{
+								{
+									Name:  "model_control_mode",
+									Type:  machinelearningv1.STRING,
+									Value: "explicit",
+								},
+								{
+									Name:  "load_model",
+									Type:  machinelearningv1.STRING,
+									Value: "model1",
+								},
+								{
+									Name:  "strict_model_config",
+									Type:  machinelearningv1.STRING,
+									Value: "true",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		configMapName := types.NamespacedName{Name: "seldon-config",
+			Namespace: "seldon-system"}
+
+		configResult := &corev1.ConfigMap{}
+		const timeout = time.Second * 30
+		Eventually(func() error { return k8sClient.Get(context.TODO(), configMapName, configResult) }, timeout).
+			Should(Succeed())
+
+		// Run Defaulter
+		instance.Default()
+
+		Expect(k8sClient.Create(context.Background(), instance)).Should(Succeed())
+		//time.Sleep(time.Second * 5)
+
+		fetched := &machinelearningv1.SeldonDeployment{}
+		Eventually(func() error {
+			err := k8sClient.Get(context.Background(), key, fetched)
+			return err
+		}, timeout, interval).Should(BeNil())
+		Expect(fetched.Name).Should(Equal(sdepName))
+
+		predictor := instance.Spec.Predictors[0]
+		sPodSpec, idx := utils.GetSeldonPodSpecForPredictiveUnit(&predictor, predictor.Graph.Name)
+		depName := machinelearningv1.GetDeploymentName(instance, predictor, sPodSpec, idx)
+		depKey := types.NamespacedName{
+			Name:      depName,
+			Namespace: "default",
+		}
+		depFetched := &appsv1.Deployment{}
+		Eventually(func() error {
+			err := k8sClient.Get(context.Background(), depKey, depFetched)
+			return err
+		}, timeout, interval).Should(BeNil())
+		Expect(len(depFetched.Spec.Template.Spec.InitContainers)).To(Equal(0)) // no storage
+		Expect(len(depFetched.Spec.Template.Spec.Containers)).Should(Equal(1)) // no engine
+
+		// Check we have 7 args total (server, http, grpc, model_uri, model_control_mode, load_model, strict_model_config)
+		Expect(len(depFetched.Spec.Template.Spec.Containers[0].Args)).Should(Equal(7))
+		for _, c := range depFetched.Spec.Template.Spec.Containers {
+			if c.Name == modelName {
+				for idx, arg := range c.Args {
+					if arg == constants.TritonArgModelRepository {
+						Expect(c.Args[idx+1]).To(Equal(modelUri))
+					}
+					if arg == constants.TritonArgModelControlMode {
+						Expect(c.Args[idx+1]).To(Equal("explicit"))
+					}
+					if arg == constants.TritonArgLoadModel {
+						Expect(c.Args[idx+1]).To(Equal("model1"))
+					}
+					if arg == constants.TritonArgStrictModelConfig {
+						Expect(c.Args[idx+1]).To(Equal("true"))
+					}
+				}
+			}
+		}
+
+		//j, _ := json.Marshal(depFetched)
+		//fmt.Println(string(j))
 	})
 
 })


### PR DESCRIPTION
```release-note
Added support to configure PrepackedTriton for no storage initialiser, instead passing start up args to load explicit models. 
```

**What this PR does / why we need it**:
When using the prepackaged Triton Inference server with a cloud based model repository, the storage initialiser will clone the full path to the registry which may contain a large number of models.  To support multiple models with an object store Triton supports [model mangement](https://github.com/triton-inference-server/server/blob/main/docs/model_management.md) capabilities be `explicit` about which models to load.  It also has native support to download these models from the object store without need to the storage initializer.

This PR adds the following:
1. A new `ANNOTATION_NO_STOARGE_INITIALIZER` on the deploy spec to not create storage initializer, but instead pass down the ModelUri directly to Triton, along with any secrets configured.
2. Support for passing Parameters set on the PredictiveUint to set as constant args to Triton Inference Server
3. Tests to validate (1) and (2) as passed

**Which issue(s) this PR fixes**:
Fixes #4203 

**Special notes for your reviewer**:
I ran pre-commit checks for all files and noticed some changes out of the scope of the files I touched, so left these alone.
