### PR TITLE
Add progress deadline support for SDeps

### DIFF
--- a/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
+++ b/helm-charts/seldon-core-operator/templates/customresourcedefinition_v1_seldondeployments.machinelearning.seldon.io.yaml
@@ -6169,6 +6169,9 @@ spec:
                       type: object
                     name:
                       type: string
+                    progressDeadlineSeconds:
+                      format: int32
+                      type: integer
                     replicas:
                       format: int32
                       type: integer
@@ -12543,6 +12546,9 @@ spec:
                       type: object
                     name:
                       type: string
+                    progressDeadlineSeconds:
+                      format: int32
+                      type: integer
                     replicas:
                       format: int32
                       type: integer
@@ -18917,6 +18923,9 @@ spec:
                       type: object
                     name:
                       type: string
+                    progressDeadlineSeconds:
+                      format: int32
+                      type: integer
                     replicas:
                       format: int32
                       type: integer

--- a/helm-charts/seldon-core-operator/templates/webhook.yaml
+++ b/helm-charts/seldon-core-operator/templates/webhook.yaml
@@ -4,20 +4,6 @@
 {{- $cert := genSignedCert "seldon-webhook-service" nil $altNames 365 $ca -}}
 ---
 
-{{- if not .Values.certManager.enabled }}
-apiVersion: v1
-data:
-  ca.crt: '{{ $ca.Cert | b64enc }}'
-  tls.crt: '{{ $cert.Cert | b64enc }}'
-  tls.key: '{{ $cert.Key | b64enc }}'
-kind: Secret
-metadata:
-  name: seldon-webhook-server-cert
-  namespace: '{{ include "seldon.namespace" . }}'
-type: kubernetes.io/tls
-{{- end }}
----
-
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -43,38 +29,6 @@ webhooks:
       path: /validate-machinelearning-seldon-io-v1-seldondeployment
   failurePolicy: Fail
   name: v1.vseldondeployment.kb.io
-{{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
-{{- if not .Values.singleNamespace }}
-  namespaceSelector:
-    matchExpressions:
-    - key: seldon.io/controller-id
-      operator: DoesNotExist
-{{- if .Values.kubeflow }}
-    matchLabels:
-      serving.kubeflow.org/inferenceservice: enabled
-{{- end }}
-{{- end }}
-{{- end }}
-{{- if .Values.singleNamespace }}
-  namespaceSelector:
-    matchLabels:
-      seldon.io/controller-id: {{ include "seldon.namespace" . }}
-{{- end }}
-{{- if not .Values.kubeflow }}
-{{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
-{{- if not .Values.controllerId }}
-  objectSelector:
-    matchExpressions:
-    - key: seldon.io/controller-id
-      operator: DoesNotExist
-{{- end }}
-{{- end }}
-{{- if .Values.controllerId }}
-  objectSelector:
-    matchLabels:
-      seldon.io/controller-id: {{ .Values.controllerId }}
-{{- end }}
-{{- end }}
   rules:
   - apiGroups:
     - machinelearning.seldon.io
@@ -86,5 +40,19 @@ webhooks:
     resources:
     - seldondeployments
   sideEffects: None
+---
+
+{{- if not .Values.certManager.enabled }}
+apiVersion: v1
+data:
+  ca.crt: '{{ $ca.Cert | b64enc }}'
+  tls.crt: '{{ $cert.Cert | b64enc }}'
+  tls.key: '{{ $cert.Key | b64enc }}'
+kind: Secret
+metadata:
+  name: seldon-webhook-server-cert
+  namespace: '{{ include "seldon.namespace" . }}'
+type: kubernetes.io/tls
+{{- end }}
 
 {{- end }}

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -247,7 +247,7 @@ type PredictorSpec struct {
 	Explainer               *Explainer              `json:"explainer,omitempty" protobuf:"bytes,10,opt,name=explainer"`
 	Shadow                  bool                    `json:"shadow,omitempty" protobuf:"bytes,11,opt,name=shadow"`
 	SSL                     *SSL                    `json:"ssl,omitempty" protobuf:"bytes,12,opt,name=ssl"`
-	ProgressDeadlineSeconds int                     `json:"progressDeadlineSeconds,omitempty" protobuf:"bytes,13,opt,name=progressDeadlineSeconds"`
+	ProgressDeadlineSeconds *int32                  `json:"progressDeadlineSeconds,omitempty" protobuf:"bytes,13,opt,name=progressDeadlineSeconds"`
 }
 
 type Protocol string

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -235,18 +235,19 @@ type SSL struct {
 }
 
 type PredictorSpec struct {
-	Name            string                  `json:"name" protobuf:"string,1,opt,name=name"`
-	Graph           PredictiveUnit          `json:"graph" protobuf:"bytes,2,opt,name=predictiveUnit"`
-	ComponentSpecs  []*SeldonPodSpec        `json:"componentSpecs,omitempty" protobuf:"bytes,3,opt,name=componentSpecs"`
-	Replicas        *int32                  `json:"replicas,omitempty" protobuf:"string,4,opt,name=replicas"`
-	Annotations     map[string]string       `json:"annotations,omitempty" protobuf:"bytes,5,opt,name=annotations"`
-	EngineResources v1.ResourceRequirements `json:"engineResources,omitempty" protobuf:"bytes,6,opt,name=engineResources"`
-	Labels          map[string]string       `json:"labels,omitempty" protobuf:"bytes,7,opt,name=labels"`
-	SvcOrchSpec     SvcOrchSpec             `json:"svcOrchSpec,omitempty" protobuf:"bytes,8,opt,name=svcOrchSpec"`
-	Traffic         int32                   `json:"traffic,omitempty" protobuf:"bytes,9,opt,name=traffic"`
-	Explainer       *Explainer              `json:"explainer,omitempty" protobuf:"bytes,10,opt,name=explainer"`
-	Shadow          bool                    `json:"shadow,omitempty" protobuf:"bytes,11,opt,name=shadow"`
-	SSL             *SSL                    `json:"ssl,omitempty" protobuf:"bytes,12,opt,name=ssl"`
+	Name                    string                  `json:"name" protobuf:"string,1,opt,name=name"`
+	Graph                   PredictiveUnit          `json:"graph" protobuf:"bytes,2,opt,name=predictiveUnit"`
+	ComponentSpecs          []*SeldonPodSpec        `json:"componentSpecs,omitempty" protobuf:"bytes,3,opt,name=componentSpecs"`
+	Replicas                *int32                  `json:"replicas,omitempty" protobuf:"string,4,opt,name=replicas"`
+	Annotations             map[string]string       `json:"annotations,omitempty" protobuf:"bytes,5,opt,name=annotations"`
+	EngineResources         v1.ResourceRequirements `json:"engineResources,omitempty" protobuf:"bytes,6,opt,name=engineResources"`
+	Labels                  map[string]string       `json:"labels,omitempty" protobuf:"bytes,7,opt,name=labels"`
+	SvcOrchSpec             SvcOrchSpec             `json:"svcOrchSpec,omitempty" protobuf:"bytes,8,opt,name=svcOrchSpec"`
+	Traffic                 int32                   `json:"traffic,omitempty" protobuf:"bytes,9,opt,name=traffic"`
+	Explainer               *Explainer              `json:"explainer,omitempty" protobuf:"bytes,10,opt,name=explainer"`
+	Shadow                  bool                    `json:"shadow,omitempty" protobuf:"bytes,11,opt,name=shadow"`
+	SSL                     *SSL                    `json:"ssl,omitempty" protobuf:"bytes,12,opt,name=ssl"`
+	ProgressDeadlineSeconds int                     `json:"progressDeadlineSeconds,omitempty" protobuf:"bytes,13,opt,name=progressDeadlineSeconds"`
 }
 
 type Protocol string

--- a/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operator/config/crd/bases/machinelearning.seldon.io_seldondeployments.yaml
@@ -10171,6 +10171,9 @@ spec:
                       type: object
                     name:
                       type: string
+                    progressDeadlineSeconds:
+                      format: int32
+                      type: integer
                     replicas:
                       format: int32
                       type: integer
@@ -20607,6 +20610,9 @@ spec:
                       type: object
                     name:
                       type: string
+                    progressDeadlineSeconds:
+                      format: int32
+                      type: integer
                     replicas:
                       format: int32
                       type: integer
@@ -31043,6 +31049,9 @@ spec:
                       type: object
                     name:
                       type: string
+                    progressDeadlineSeconds:
+                      format: int32
+                      type: integer
                     replicas:
                       format: int32
                       type: integer

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -27,3 +27,45 @@ webhooks:
     resources:
     - seldondeployments
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-machinelearning-seldon-io-v1-seldondeployment
+  failurePolicy: Fail
+  name: v1.vseldondeployment.kb.io
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-machinelearning-seldon-io-v1-seldondeployment
+  failurePolicy: Fail
+  name: v1.vseldondeployment.kb.io
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+  sideEffects: None

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -914,7 +914,8 @@ func createDeploymentWithoutEngine(depName string, seldonId string, seldonPodSpe
 					Annotations: map[string]string{},
 				},
 			},
-			Strategy: appsv1.DeploymentStrategy{RollingUpdate: &appsv1.RollingUpdateDeployment{MaxUnavailable: &intstr.IntOrString{StrVal: "10%"}}},
+			Strategy:                appsv1.DeploymentStrategy{RollingUpdate: &appsv1.RollingUpdateDeployment{MaxUnavailable: &intstr.IntOrString{StrVal: "10%"}}},
+			ProgressDeadlineSeconds: p.ProgressDeadlineSeconds,
 		},
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Currently, Seldon Deployments do not support setting `progressDeadlineSeconds`, which is an optional setting used to control when a deployment is [marked as failed](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#failed-deployment).

This field is defined for deployments, not pods or containers, thus users cannot set this manually by overriding component specs in an SDep.

As `progressDeadlineSeconds` is optional in Kubernetes, with a default of 600 seconds, this change is backwards compatible -- any SDep not specifying this will use the Kubernetes default automatically.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4224 

**Special notes for your reviewer**:
