### PR TITLE
Fix for hard-coded service account name in rolebindings

### DIFF
--- a/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-sas-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-manager-sas-rolebinding.yaml
@@ -16,7 +16,7 @@ roleRef:
   name: seldon-manager-sas-role-{{ include "seldon.namespace" . }}
 subjects:
 - kind: ServiceAccount
-  name: seldon-manager
+  name: '{{ .Values.serviceAccount.name }}'
   namespace: '{{ include "seldon.namespace" . }}'
 {{- end }}
 {{- end }}

--- a/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-webhook-rolebinding.yaml
+++ b/helm-charts/seldon-core-operator/templates/clusterrolebinding_seldon-webhook-rolebinding.yaml
@@ -15,7 +15,7 @@ roleRef:
   name: seldon-webhook-role-{{ include "seldon.namespace" . }}
 subjects:
 - kind: ServiceAccount
-  name: seldon-manager
+  name: '{{ .Values.serviceAccount.name }}'
   namespace: '{{ include "seldon.namespace" . }}'
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
There is a problem with the service account name usage in templates. It's not possible to change the name from the default "seldon-manager" to something else, because in deployment phase this error occurs:
`"Error creating: pods "seldon-controller-manager-xxx-" is forbidden: error looking up service account xxx/seldon-manager: serviceaccount "seldon-manager" not found".`
So the fix is to use the name from the `serviceAccount.name` variable defined in values.yaml instead of the hard-coded one.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
