### PR TITLE
Make verbosity configurable and not leak sensitive values

### DIFF
--- a/components/rclone-storage-initializer/Dockerfile
+++ b/components/rclone-storage-initializer/Dockerfile
@@ -10,4 +10,7 @@ LABEL name="Storage Initializer (rclone based)" \
 ENV RCLONE_CONFIG_GS_TYPE google cloud storage
 ENV RCLONE_CONFIG_GS_ANONYMOUS true
 
-ENTRYPOINT ["rclone", "copy", "-vv"]
+# Do not set to '2' by default, as this may leak sensitive values
+ENV RCLONE_VERBOSE=1
+
+ENTRYPOINT ["rclone", "copy"]

--- a/components/rclone-storage-initializer/Dockerfile
+++ b/components/rclone-storage-initializer/Dockerfile
@@ -11,6 +11,6 @@ ENV RCLONE_CONFIG_GS_TYPE google cloud storage
 ENV RCLONE_CONFIG_GS_ANONYMOUS true
 
 # Do not set to '2' by default, as this may leak sensitive values
-ENV RCLONE_VERBOSE=1
+ENV RCLONE_VERBOSE 1
 
 ENTRYPOINT ["rclone", "copy"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce verbose logging, which leaks sensitive values like secrets/keys, but, make it configurable via `RCLONE_VERBOSE`.

**Which issue(s) this PR fixes**:
Fixes #4247

**Special notes for your reviewer**:
