### PR TITLE
Inject storage initializer on not prepacked server

### DIFF
--- a/operator/controllers/model_initializer_injector.go
+++ b/operator/controllers/model_initializer_injector.go
@@ -123,18 +123,8 @@ func (mi *ModelInitialiser) InjectModelInitializer(deployment *appsv1.Deployment
 		return deployment, fmt.Errorf("Invalid configuration: cannot find container: %s", containerName)
 	}
 
-	ModelInitializerVolumeName := userContainer.Name + "-" + ModelInitializerVolumeSuffix
-	//kubernetes names limited to 63
-	if len(ModelInitializerVolumeName) > 63 {
-		ModelInitializerVolumeName = ModelInitializerVolumeName[0:63]
-		ModelInitializerVolumeName = strings.TrimSuffix(ModelInitializerVolumeName, "-")
-	}
-
-	ModelInitializerContainerName := userContainer.Name + "-" + ModelInitializerContainerSuffix
-	if len(ModelInitializerContainerName) > 63 {
-		ModelInitializerContainerName = ModelInitializerContainerName[0:63]
-		ModelInitializerContainerName = strings.TrimSuffix(ModelInitializerContainerName, "-")
-	}
+	ModelInitializerVolumeName := utils.GetNameWithSuffix(userContainer.Name, ModelInitializerVolumeSuffix)
+	ModelInitializerContainerName := utils.GetNameWithSuffix(userContainer.Name, ModelInitializerContainerSuffix)
 
 	// TODO: KFServing does a check for an annotation before injecting - not doing that for now
 	podSpec := &deployment.Spec.Template.Spec

--- a/operator/utils/utils.go
+++ b/operator/utils/utils.go
@@ -151,3 +151,13 @@ func GetEnvAsBool(key string, fallback bool) bool {
 func IsEmptyTLS(p *machinelearningv1.PredictorSpec) bool {
 	return p.SSL == nil || len(p.SSL.CertSecretName) == 0
 }
+
+func GetNameWithSuffix(name string, suffix string) string {
+	volumeName := name + "-" + suffix
+	// kubernetes names limited to 63
+	if len(volumeName) > 63 {
+		volumeName = volumeName[0:63]
+		volumeName = strings.TrimSuffix(volumeName, "-")
+	}
+	return volumeName
+}


### PR DESCRIPTION
 
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

```release-note
Added Storage Initializers on not prepacked server.
```

**What this PR does / why we need it**:

Enable storage initalizer inject when `modelUri` set in graph on not prepacked server.

**Which issue(s) this PR fixes**: 
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4251

**Special notes for your reviewer**:

A test already added.