### PR TITLE
Added fix for clashing zombie webhook in integration tests

### DIFF
--- a/testing/scripts/test_operator_updates.py
+++ b/testing/scripts/test_operator_updates.py
@@ -72,6 +72,9 @@ def test_namespace_update(namespace, seldon_version):
 
     assert_model_during_op(_install_namespace_scoped, "mymodel", namespace)
 
+    # Delete all resources (webhooks, etc.) before deleting namespace
+    retry_run(f"helm delete seldon --namespace {namespace}")
+
 
 @pytest.mark.sequential
 @pytest.mark.parametrize("seldon_version", SELDON_VERSIONS_TO_TEST, indirect=True)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes issue addressed initially via #4256

**Special notes for your reviewer**:

All relevant tests now passing for `test_operator_updates.py`:

![image](https://user-images.githubusercontent.com/1447507/183422118-d5506072-16da-43a2-99c5-d3fd4dfb5b7d.png)

