### PR TITLE
Add UTF-8 support for Flask jsonify

### DIFF
--- a/python/seldon_core/wrapper.py
+++ b/python/seldon_core/wrapper.py
@@ -201,6 +201,7 @@ def _set_flask_app_configs(app):
         "DEBUG",
         "EXPLAIN_TEMPLATE_LOADING",
         "JSONIFY_PRETTYPRINT_REGULAR",
+        "JSON_AS_ASCII",
         "JSON_SORT_KEYS",
         "PROPAGATE_EXCEPTIONS",
         "PRESERVE_CONTEXT_ON_EXCEPTION",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Make Flask jsonify encoding configurable, that is, add UTF-8 support for Flask jsonify

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4261

**Special notes for your reviewer**:
