### PR TITLE
Ensure request is chained before payload is logged

### DIFF
--- a/executor/licenses/dep.txt
+++ b/executor/licenses/dep.txt
@@ -228,7 +228,6 @@ github.com/jstemmer/go-junit-report
 github.com/jtolds/gls
 github.com/julienschmidt/httprouter
 github.com/jung-kurt/gofpdf
-github.com/kedacore/keda
 github.com/kedacore/keda/v2
 github.com/kelseyhightower/envconfig
 github.com/kisielk/errcheck
@@ -401,7 +400,6 @@ google.golang.org/protobuf
 gopkg.in/alecthomas/kingpin.v2
 gopkg.in/check.v1
 gopkg.in/errgo.v2
-gopkg.in/evanphx/json-patch.v4
 gopkg.in/fsnotify.v1
 gopkg.in/inf.v0
 gopkg.in/ini.v1

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -100,6 +100,11 @@ func (p *PredictorProcess) transformInput(node *v1.PredictiveUnit, msg payload.S
 	modelName := p.getModelName(node)
 
 	if callModel || callTransformInput {
+		msg, err := p.Client.Chain(p.Ctx, modelName, msg)
+		if err != nil {
+			return nil, err
+		}
+
 		//Log Request
 		if node.Logger != nil && (node.Logger.Mode == v1.LogRequest || node.Logger.Mode == v1.LogAll) {
 			err := p.logPayload(node.Name, node.Logger, payloadLogger.InferenceRequest, msg, puid)
@@ -108,10 +113,6 @@ func (p *PredictorProcess) transformInput(node *v1.PredictiveUnit, msg payload.S
 			}
 		}
 
-		msg, err := p.Client.Chain(p.Ctx, modelName, msg)
-		if err != nil {
-			return nil, err
-		}
 		p.RoutingMutex.Lock()
 		p.Routing[node.Name] = -1
 		p.RoutingMutex.Unlock()

--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -152,6 +152,11 @@ func (p *PredictorProcess) transformOutput(node *v1.PredictiveUnit, msg payload.
 	modelName := p.getModelName(node)
 
 	if callClient {
+		msg, err := p.Client.Chain(p.Ctx, modelName, msg)
+		if err != nil {
+			return nil, err
+		}
+
 		//Log Request
 		if node.Logger != nil && (node.Logger.Mode == v1.LogRequest || node.Logger.Mode == v1.LogAll) {
 			err := p.logPayload(node.Name, node.Logger, payloadLogger.InferenceRequest, msg, puid)
@@ -160,10 +165,6 @@ func (p *PredictorProcess) transformOutput(node *v1.PredictiveUnit, msg payload.
 			}
 		}
 
-		msg, err := p.Client.Chain(p.Ctx, modelName, msg)
-		if err != nil {
-			return nil, err
-		}
 		tmsg, err := p.Client.TransformOutput(p.Ctx, modelName, node.Endpoint.ServiceHost, p.getPort(node), msg, p.Meta.Meta)
 		if tmsg != nil && err == nil {
 			// Log Response


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Ensure responsed is chained to the next request before logging the request. Otherwise, we will log as "request" the response from the previous model in the inference graph. In the V2 payload, since the request and response have different fields, this currently ends up in an error later on at the request logger. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
