### PR TITLE
Add support for passing nodeSelector & tolerations to Orchestrator

### DIFF
--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -160,7 +160,10 @@ spec:
           readOnly: true
 {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
-      nodeSelector: {{ .Values.manager.nodeSelector }}
+      nodeSelector:
+{{- with .Values.manager.nodeSelector }}
+{{- toYaml . | nindent 8}}
+{{- end }}
       priorityClassName: '{{ .Values.manager.priorityClassName }}'
       securityContext:
         runAsUser: {{ .Values.managerUserID }}

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -160,11 +160,13 @@ spec:
           readOnly: true
 {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
+      nodeSelector: '{{ .Values.manager.nodeSelector }}'
       priorityClassName: '{{ .Values.manager.priorityClassName }}'
       securityContext:
         runAsUser: {{ .Values.managerUserID }}
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
       terminationGracePeriodSeconds: 10
+      tolerations: '{{ .Values.manager.tolerations }}'
 {{- if not .Values.managerCreateResources }}
       volumes:
       - name: cert

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -160,13 +160,13 @@ spec:
           readOnly: true
 {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
-      nodeSelector: '{{ .Values.manager.nodeSelector }}'
+      nodeSelector: {{ .Values.manager.nodeSelector }}
       priorityClassName: '{{ .Values.manager.priorityClassName }}'
       securityContext:
         runAsUser: {{ .Values.managerUserID }}
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
       terminationGracePeriodSeconds: 10
-      tolerations: '{{ .Values.manager.tolerations }}'
+      tolerations: {{ .Values.manager.tolerations }}
 {{- if not .Values.managerCreateResources }}
       volumes:
       - name: cert

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -172,3 +172,15 @@ spec:
           defaultMode: 420
           secretName: seldon-webhook-server-cert
 {{- end }}
+{{- if .Values.manager.nodeSelector }}
+{{- with .Values.manager.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if .Values.manager.tolerations }}
+{{- with .Values.manager.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end }}

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -172,15 +172,3 @@ spec:
           defaultMode: 420
           secretName: seldon-webhook-server-cert
 {{- end }}
-{{- if .Values.manager.nodeSelector }}
-{{- with .Values.manager.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- end }}
-{{- if .Values.manager.tolerations }}
-{{- with .Values.manager.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- end }}

--- a/helm-charts/seldon-core-operator/templates/webhook.yaml
+++ b/helm-charts/seldon-core-operator/templates/webhook.yaml
@@ -34,7 +34,9 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
+{{- if not .Values.certManager.enabled }}
     caBundle: '{{ $ca.Cert | b64enc }}'
+{{- end }}
     service:
       name: seldon-webhook-service
       namespace: '{{ include "seldon.namespace" . }}'

--- a/helm-charts/seldon-core-operator/templates/webhook.yaml
+++ b/helm-charts/seldon-core-operator/templates/webhook.yaml
@@ -34,9 +34,7 @@ webhooks:
   - v1
   - v1beta1
   clientConfig:
-{{- if not .Values.certManager.enabled }}
     caBundle: '{{ $ca.Cert | b64enc }}'
-{{- end }}
     service:
       name: seldon-webhook-service
       namespace: '{{ include "seldon.namespace" . }}'

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -89,6 +89,8 @@ manager:
   containerSecurityContext: {}
   deploymentNameAsPrefix: false
   priorityClassName:
+  nodeSelector: []
+  tolerations: {}
 rbac:
   configmap:
     create: true

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -89,8 +89,8 @@ manager:
   containerSecurityContext: {}
   deploymentNameAsPrefix: false
   priorityClassName:
-  nodeSelector: []
-  tolerations: {}
+  nodeSelector: {}
+  tolerations: []
 rbac:
   configmap:
     create: true

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -137,5 +137,5 @@ spec:
             cpu: 100m
             memory: 200Mi
       terminationGracePeriodSeconds: 10
-      nodeSelector: []
-      tolerations: {}
+      nodeSelector: {}
+      tolerations: []

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -137,3 +137,5 @@ spec:
             cpu: 100m
             memory: 200Mi
       terminationGracePeriodSeconds: 10
+      nodeSelector: []
+      tolerations: {}

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -184,6 +184,14 @@ if __name__ == "__main__":
                     "memory"
                 ] = helm_value("manager.memoryLimit")
 
+                # NodeSelection & tolerations
+                res["spec"]["template"]["spec"]["nodeSelector"] = helm_value(
+                    "manager.nodeSelector"
+                )
+                res["spec"]["template"]["spec"]["tolerations"] = helm_value(
+                    "manager.tolerations"
+                )
+
                 for env in res["spec"]["template"]["spec"]["containers"][0]["env"]:
                     if env["name"] in HELM_ENV_SUBST:
                         env["value"] = helm_value(HELM_ENV_SUBST[env["name"]])

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -493,6 +493,14 @@ if __name__ == "__main__":
             fdata = fdata.replace(
                 "'{{ .Values.managerUserID }}'", "{{ .Values.managerUserID }}"
             )
+            # make sure nodeSelector is not quoted as its a map
+            fdata = fdata.replace(
+                "'{{ .Values.manager.nodeSelector }}'", "{{ .Values.manager.nodeSelector }}"
+            )
+            # make sure tolerations is not quoted as its a list
+            fdata = fdata.replace(
+                "'{{ .Values.manager.tolerations }}'", "{{ .Values.manager.tolerations }}"
+            )
 
             if not kind == "namespace":
                 if (


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding support for passing nodeSelector & tolerations to the deployment of the Seldon orchestrator. Hopefully, this is something useful.

**Which issue(s) this PR fixes**:

Fixes #3852

**Special notes for your reviewer**:
