### PR TITLE
Use timer instead of time.After to prevent memory leaks in logger

### DIFF
--- a/executor/logger/collector.go
+++ b/executor/logger/collector.go
@@ -1,7 +1,7 @@
 package logger
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 	"time"
 )
 
@@ -19,10 +19,12 @@ var (
 )
 
 func QueueLogRequest(req LogRequest) error {
+	timer := time.NewTimer(time.Duration(writeTimeoutMilliseconds) * time.Millisecond)
+	defer timer.Stop()
 	select {
 	case workQueue <- req:
 		return nil
-	case <-time.After(time.Duration(writeTimeoutMilliseconds) * time.Millisecond):
+	case <-timer.C:
 		return errors.New("timed out waiting to queue log request: buffer is full")
 	}
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

A kind person at gophercon pointed out that our usage of `time.After` here could lead to a memory leak. This can happen because the actual timer in `time.After` is not cleaned up until the timer fires. This can be after the work has been accepted on the work queue. In our default setup the timer is only 2s which should be mostly fine, but it is user configurable so this could end up as a memory leak (ex. you set the timer to 1h, and send 1mil requests - you end up with 1 mil timers sitting there for 1h even though the work has been processed).

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
