### PR TITLE
s2i usage fails with image version 1.15.0-dev

### DIFF
--- a/doc/source/python/python_wrapping_s2i.md
+++ b/doc/source/python/python_wrapping_s2i.md
@@ -16,7 +16,7 @@ In this guide, we illustrate the steps needed to wrap your own python model in a
 To check everything is working you can run
 
 ```bash
-s2i usage seldonio/seldon-core-s2i-python3:1.15.0-dev
+s2i usage seldonio/seldon-core-s2i-python3:1.15.0
 ```
 
 


### PR DESCRIPTION
running `s2i usage seldonio/seldon-core-s2i-python3:1.15.0-dev` fails with the following error[1]. Changing the version to the release version "1.15.0" works without issues. 

[1]
$ s2i usage seldonio/seldon-core-s2i-python3:1.15.0-dev  ERROR: An error occurred: failed to install [usage] ERROR: Suggested solution: set the scripts URL parameter with the location of the S2I scripts, or check if the image has the "io.openshift.s2i.scripts-url" label set ERROR: If the problem persists consult the docs at https://github.com/openshift/source-to-image/tree/master/docs. Eventually reach us on freenode #openshift or file an issue at https://github.com/openshift/source-to-image/issues providing us with a log from your build using log output level 3. bbalasub~$ s2i usage seldonio/seldon-core-s2i-python3:1.15.0-dev
ERROR: An error occurred: failed to install [usage]
ERROR: Suggested solution: set the scripts URL parameter with the location of the S2I scripts, or check if the image has the "io.openshift.s2i.scripts-url" label set
ERROR: If the problem persists consult the docs at https://github.com/openshift/source-to-image/tree/master/docs. Eventually reach us on freenode #openshift or file an issue at https://github.com/openshift/source-to-image/issues providing us with a log from your build using log output level 3.

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
