### PR TITLE
Allow urllib3 >= 1.26.5

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -44,7 +44,7 @@ setup(
         # Addresses CVE PRISMA-2021-0020
         "click >= 8.0.0a1, < 8.1",
         # Addresses CVE CVE-2019-11236 and CVE-2020-26137 and SNYK-PYTHON-URLLIB3-1533435
-        "urllib3 == 1.26.5",
+        "urllib3 >= 1.26.5, < 1.27",
     ],
     extras_require=extras,
     entry_points={


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR allows urllib3 >= 1.26.5, < 1.27.
Our serving library depends on [sentry-sdk](https://github.com/getsentry/sentry-python)  which depends on [urllib3 >= 1.26.11](https://github.com/getsentry/sentry-python/blob/1.10.1/setup.py#L43).
If there is no specific reason to pin the version only to 1.26.5, I think it's OK to use >= 1.26.6 as well.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
