### PR TITLE
fix(helm-chart): improve compatibility with existing RBAC

### DIFF
--- a/helm-charts/seldon-core-operator/templates/role_seldon1-manager-role.yaml
+++ b/helm-charts/seldon-core-operator/templates/role_seldon1-manager-role.yaml
@@ -227,19 +227,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - v1
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - v1
+  - ""
   resources:
   - services/status
   verbs:


### PR DESCRIPTION
This change choses the most compatible apiGroups for the seldon1-manager-role resource. This ensures that service accounts which do not have one of the two api versions can still install it. Or at least easily know which one they need.

closes #4420