### PR TITLE
fix(helm-chart): remove keda rules from Role if disabled

### DIFF
--- a/helm-charts/seldon-core-operator/templates/role_seldon1-manager-role.yaml
+++ b/helm-charts/seldon-core-operator/templates/role_seldon1-manager-role.yaml
@@ -106,6 +106,7 @@ rules:
   - get
   - patch
   - update
+{{- if .Values.keda.enabled }}
 - apiGroups:
   - keda.sh
   resources:
@@ -138,6 +139,7 @@ rules:
   - get
   - patch
   - update
+{{ end -}}
 - apiGroups:
   - machinelearning.seldon.io
   resources:


### PR DESCRIPTION
No reason to have them in the role if keda support is disabled. I know it's also present in cluster roles and that things like ambassador and istio have the same problem, but I'm currently focussing on just keda.

closes #4422