### PR TITLE
Set allowPrivilegeEscalation to false for the service orchestrator

### DIFF
--- a/operator/controllers/seldondeployment_engine.go
+++ b/operator/controllers/seldondeployment_engine.go
@@ -337,7 +337,8 @@ func createEngineContainer(mlDep *machinelearningv1.SeldonDeployment, p *machine
 	}
 
 	if engineUser != nil {
-		c.SecurityContext = &corev1.SecurityContext{RunAsUser: engineUser}
+		escalationDefault := false
+		c.SecurityContext = &corev1.SecurityContext{RunAsUser: engineUser, AllowPrivilegeEscalation: &escalationDefault}
 	}
 
 	// Environment vars if specified


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
The executor/service orchestrator container does not need privilege escalation. As a security best practice and to allow for
runnning seldon in more restricted environments this PR sets the securityContext.allowPrivilegeEscalation property to false.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4409

**Special notes for your reviewer**:


<sup>The program was tested solely for our own use cases, which might differ from yours.</sup>
<sup>Winfried Umbrath winfried.umbrath@mercedes-benz.com, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>