### PR TITLE
add tar to wrapper image as it is missing after move to ubi-minimal

### DIFF
--- a/wrappers/s2i/python/Dockerfile.conda
+++ b/wrappers/s2i/python/Dockerfile.conda
@@ -7,6 +7,7 @@ RUN microdnf update -y && \
     microdnf install -y \
       wget \
       bzip2 \
+      tar \
       ca-certificates \
       curl-minimal
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

`tar` is not included in `ubi-minimal` base images - this PR re-adds it

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/SeldonIO/seldon-core/issues/4457

**Special notes for your reviewer**:
