### PR TITLE
Images update

### DIFF
--- a/components/rclone-storage-initializer/Dockerfile
+++ b/components/rclone-storage-initializer/Dockerfile
@@ -19,5 +19,8 @@ ENV RCLONE_CONFIG_GS_ANONYMOUS true
 # Do not set to '2' by default, as this may leak sensitive values
 ENV RCLONE_VERBOSE 1
 
+# Run update to pickup any necessary security updates
+RUN microdnf update -y
+
 USER 8888
 ENTRYPOINT ["rclone", "copy"]

--- a/executor/Dockerfile.executor.redhat
+++ b/executor/Dockerfile.executor.redhat
@@ -68,5 +68,8 @@ RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Cri
 # Copy openapi spec and swagger UI files
 COPY --from=builder /openapi/ /openapi/
 
+# Run update to pickup any necessary security updates
+RUN microdnf update -y
+
 USER 8888
 ENTRYPOINT ["/executor"]

--- a/marketplaces/redhat/Makefile
+++ b/marketplaces/redhat/Makefile
@@ -3,23 +3,10 @@ SHELL := /bin/bash
 VERSION ?= $(shell cat ../../version.txt)
 MLSERVER_VERSION ?= 1.2.0.dev12
 
-IMG_MLSERVER ?= docker.io/seldonio/mlserver:${MLSERVER_VERSION}
 IMG_MLSERVER_SC ?= docker.io/seldonio/mlserver-sc:${VERSION}
 IMG_MLSERVER_SC_SLIM ?= docker.io/seldonio/mlserver-sc-slim:${VERSION}
 
 redhat-image-scan: scan-mlserver scan-mlserver-sc scan-mlserver-sc-slim
-
-# password can be found at: https://connect.redhat.com/projects/63566bb9822ce8cef9ba27fc/overview
-project-mlserver=63566bb9822ce8cef9ba27fc
-scan-mlserver:
-	docker pull ${IMG_MLSERVER}
-	source ~/.config/seldon/seldon-core/redhat-image-passwords.sh && \
-		echo $${rh_mlserver} | docker login -u redhat-isv-containers+${project-mlserver}-robot quay.io --password-stdin
-	docker tag ${IMG_MLSERVER} quay.io/redhat-isv-containers/${project-mlserver}:${MLSERVER_VERSION}
-	docker push quay.io/redhat-isv-containers/${project-mlserver}:${MLSERVER_VERSION}
-	source ~/.config/seldon/seldon-core/redhat-image-passwords.sh && \
-		preflight check container quay.io/redhat-isv-containers/${project-mlserver}:${MLSERVER_VERSION} --docker-config=${HOME}/.docker/config.json --certification-project-id=${project-mlserver} --pyxis-api-token=$${pyxis_api_token} --submit
-
 
 # password can be found at: https://connect.redhat.com/projects/635670d3624969b495b6936f/overview
 project-mlserver-sc=635670d3624969b495b6936f

--- a/marketplaces/redhat/scan-images.py
+++ b/marketplaces/redhat/scan-images.py
@@ -34,7 +34,6 @@ def scan_images(debug=False):
         "components/storage-initializer",
         "components/rclone-storage-initializer",
         "servers/tfserving",
-        "marketplaces/redhat",
     ]
 
     for path in paths:

--- a/operator/Dockerfile.redhat
+++ b/operator/Dockerfile.redhat
@@ -61,5 +61,9 @@ COPY generated/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_se
 COPY generated/v1_service_seldon-webhook-service.yaml /tmp/operator-resources/service.yaml
 COPY generated/v1_configmap_seldon-config.yaml /tmp/operator-resources/configmap.yaml
 COPY generated/apiextensions.k8s.io_v1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml /tmp/operator-resources/crd-v1.yaml
+
+# Run update to pickup any necessary security updates
+RUN microdnf update -y
+
 USER 8888
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This adds `microdnf update` to Operator, Executor and Rclone Storage Intiializer images to make sure that latest CVE patches are applied in Red Hat images.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

As MLServer Red Hat images are mainly being pushed to Red Hat registry directly from MLServer repository the relevant code from Makefile has been removed (with exception of two SC images).