### PR TITLE
v2: Fix model load order and delete rclone folders

### DIFF
--- a/samples/examples/pandasquery/pandasquery/model.py
+++ b/samples/examples/pandasquery/pandasquery/model.py
@@ -18,6 +18,7 @@ from mlserver.codecs import PandasCodec
 from mlserver.errors import MLServerError
 import pandas as pd
 from fastapi import status
+from mlserver.logging import logger
 
 QUERY_KEY = "query"
 
@@ -31,6 +32,7 @@ class ModelParametersMissing(MLServerError):
 class PandasQueryRuntime(MLModel):
 
   async def load(self) -> bool:
+    logger.info("Loading with settings %s", self.settings)
     if self.settings.parameters is None or \
       self.settings.parameters.extra is None:
       raise ModelParametersMissing(self.name, "no settings.parameters.extra found")

--- a/scheduler/pkg/agent/repository/model_repository.go
+++ b/scheduler/pkg/agent/repository/model_repository.go
@@ -138,6 +138,12 @@ func (r *V2ModelRepository) DownloadModelVersion(modelName string,
 		return nil, err
 	}
 
+	// Purge rclone path now we have loaded successfully
+	err = r.rcloneClient.PurgeLocal(rclonePath)
+	if err != nil {
+		return nil, err
+	}
+
 	return &modelVersionFolder, nil
 }
 


### PR DESCRIPTION
- Delete rclone folder after model loaded successfully with an rclone /operations/purge
- Remove model repository directory only after model unloaded sucessfully - was causing unload issues with MLServer custom model.py models that need to be read on unload to ensure correct python module is unloaded.