### PR TITLE
[SCv2] Improve inference docs re routing and headers

### DIFF
--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -167,9 +167,9 @@ Seldon works around this limitation by introducing _virtual_ endpoints for pipel
 Virtual means that Seldon understands them, but v2 protocol-compatible components like inference servers do not.
 
 Use the following rules for paths to route to models and pipelines:
-* For models, use the path prefix `/v2/models/` and the model name.
+* For models, use the path prefix `/v2/models/{model name}`.
   This is normal usage of the inference v2 protocol.
-* For pipelines, use the path prefix `/v2/pipelines/` and the pipeline name.
+* For pipelines, use the path prefix `/v2/pipelines/{pipeline name}`.
   Otherwise calling pipelines looks just like the inference v2 protocol for models.
   Do **not** use any suffix for the pipeline name as you would for routing headers.
 ````

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -56,6 +56,8 @@ If you are using a service mesh like Istio or Ambassador, you will need to use t
 
 ### Request Routing
 
+#### Seldon Routes
+
 Seldon needs to determine where to route requests to, as models and pipelines might have the same name.
 There are two ways of doing this: header-based routing (preferred) and path-based routing.
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -3,7 +3,7 @@
 This section will discuss how to make inference calls against your Seldon models or pipelines.
 
 You can make synchronous inference requests via REST or gRPC or asynchronous requests via Kafka topics.
-The content of your request should be an [inference V2 protocol payload](../apis/inference/v2.md):
+The content of your request should be an [inference v2 protocol payload](../apis/inference/v2.md):
 * REST payloads will generally be in the JSON v2 protocol format.
 * gRPC and Kafka payloads **must** be in the Protobuf v2 protocol format.
 
@@ -240,7 +240,7 @@ print("result is:", result.as_numpy("predict"))
 
 ## Asynchronous Requests
 
-The Seldon architecture uses Kafka and therefore asynchronous requests can be sent by pushing V2 protocol payloads to the appropriate topic.
+The Seldon architecture uses Kafka and therefore asynchronous requests can be sent by pushing inference v2 protocol payloads to the appropriate topic.
 Topics have the following form:
 
 ```

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -11,8 +11,8 @@ The content of your request should be an [inference v2 protocol payload](../apis
 
 For making synchronous requests, the process will generally be:
 1. Find the appropriate service endpoint (IP address and port) for accessing the installation of Seldon Core v2.
-1. Determine the appropriate headers/metadata for the request.
-1. Make requests via REST or gRPC.
+2. Determine the appropriate headers/metadata for the request.
+3. Make requests via REST or gRPC.
 
 ### Find the Seldon Service Endpoint
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -1,6 +1,6 @@
 # Inference
 
-This section will discuss how to make inference calls against your seldon models or pipelines.
+This section will discuss how to make inference calls against your Seldon models or pipelines.
 
 You can make synchronous inference requests via REST or gRPC or asynchronous requests via Kafka topics.
 
@@ -27,7 +27,7 @@ Seldon routes requests to to the correct enpoint via headers in HTTP calls. You 
 
 The content of your request should be a [V2 protocol payload](../apis/inference/v2.md).
 
-The `seldon` CLI can be used to easily send requests to your deployed resources. See the [examples](../examples/index) and the [seldon CLI docs](../cli/index.md).
+The `seldon` CLI can be used to easily send requests to your deployed resources. See the [examples](../examples/index) and the [Seldon CLI docs](../cli/index.md).
 
 An example curl request might look like for a Model called `iris`:
 
@@ -101,7 +101,7 @@ It may be useful to send metadata alongside your inference. If using Kafka direc
  * For REST requests add HTTP headers prefixe with `X-`
  * For gRPC requests add meatdata with keys starting with `X-`
 
-You can also do this with the seldon CLI by setting headers with the `--header` argument (and also showing response headers with the `--show-headers` argument)
+You can also do this with the Seldon CLI by setting headers with the `--header` argument (and also showing response headers with the `--show-headers` argument)
 
 ```
 seldon pipeline infer --show-headers --header X-foo=bar tfsimples \

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -111,7 +111,7 @@ You might want to use a mixture of these methods; the choice is yours.
 
 ````{tab} Virtual Hosts
 
-Virtual hosts are defined by the `Host` header for [HTTP/1](https://www.ietf.org/rfc/rfc2616.html#section-14.23) and the `:authority` pseudo-header for [HTTP/2](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1).
+Virtual hosts are defined by the `Host` header for [HTTP/1](https://www.rfc-editor.org/rfc/rfc7230#section-5.4) and the `:authority` pseudo-header for [HTTP/2](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1).
 These represent the same thing, and the HTTP/2 specification defines how to translate these when converting between protocol versions.
 
 Many tools and libraries treat these headers as special and have particular ways of handling them.

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -97,7 +97,7 @@ The response will appear on `seldon.seldon-mesh.model.iris.outputs`.
 
 For a local install if you have a pipeline `mypipeline`, you would be able to send a prediction request by pushing to the topic: `seldon.default.pipeline.mypipeline.inputs`. The response will appear on `seldon.default.pipeline.mypipeline.outputs`.
 
-For a Kubernetes install in `seldon-mesh` if you have a pipeline `pipeline`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.pipeline.mypipeline.inputs`. The response will appear on `seldon.seldon-mesh.pipeline.mypipeline.outputs`.
+For a Kubernetes install in `seldon-mesh` if you have a pipeline `mypipeline`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.pipeline.mypipeline.inputs`. The response will appear on `seldon.seldon-mesh.pipeline.mypipeline.outputs`.
 
 
 ## Pipeline Metadata

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -164,7 +164,7 @@ See the [examples](../examples/index) and the [Seldon CLI docs](../cli/index.md)
 
 The inference v2 protocol is only aware of models, thus has no concept of pipelines.
 Seldon works around this limitation by introducing _virtual_ endpoints for pipelines.
-Virtual means that Seldon understands them, but v2 protocol-compatible components like inference servers do not.
+Virtual means that Seldon understands them, but other v2 protocol-compatible components like inference servers do not.
 
 Use the following rules for paths to route to models and pipelines:
 * For models, use the path prefix `/v2/models/{model name}`.

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -32,7 +32,7 @@ The content of your request should be a [V2 protocol payload](../apis/inference/
 
 The `seldon` CLI can be used to easily send requests to your deployed resources. See the [examples](../examples/index) and the [Seldon CLI docs](../cli/index.md).
 
-An example curl request might look like for a Model called `iris`:
+An example curl request might look like for a model called `iris`:
 
 ```
 curl -v http://0.0.0.0:9000/v2/models/iris/infer -H "Content-Type: application/json" -H "seldon-model: iris"\
@@ -52,7 +52,7 @@ grpcurl -d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_con
 
 The above request was run from the project root folder allowing reference to the Protobuf manifests defined in the `apis/` folder.
 
-For Pipelines a synchronous request is possible if the Pipeline has an outputs section in the spec.
+For pipelines a synchronous request is possible if the pipeline has an outputs section in the spec.
 
 ### Using Python Tritonclient
 
@@ -86,18 +86,18 @@ seldon.<namespace>.<model|pipeline>.<name>.<inputs|outputs>
 
 ### Model Inference
 
-For a local install if you have a Model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.default.model.iris.inputs`.
+For a local install if you have a model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.default.model.iris.inputs`.
 The response will appear on `seldon.default.model.iris.outputs`.
 
-For a Kubernetes install in `seldon-mesh` if you have a Model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.model.iris.inputs`.
+For a Kubernetes install in `seldon-mesh` if you have a model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.model.iris.inputs`.
 The response will appear on `seldon.seldon-mesh.model.iris.outputs`.
 
 
 ### Pipeline Inference
 
-For a local install if you have a Pipeline `mypipeline`, you would be able to send a prediction request by pushing to the topic: `seldon.default.pipeline.mypipeline.inputs`. The response will appear on `seldon.default.pipeline.mypipeline.outputs`.
+For a local install if you have a pipeline `mypipeline`, you would be able to send a prediction request by pushing to the topic: `seldon.default.pipeline.mypipeline.inputs`. The response will appear on `seldon.default.pipeline.mypipeline.outputs`.
 
-For a Kubernetes install in `seldon-mesh` if you have a Pipeline `pipeline`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.pipeline.mypipeline.inputs`. The response will appear on `seldon.seldon-mesh.pipeline.mypipeline.outputs`.
+For a Kubernetes install in `seldon-mesh` if you have a pipeline `pipeline`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.pipeline.mypipeline.inputs`. The response will appear on `seldon.seldon-mesh.pipeline.mypipeline.outputs`.
 
 
 ## Pipeline Metadata

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -9,8 +9,10 @@ The content of your request should be an [inference V2 protocol payload](../apis
 
 ## Synchronous Requests
 
-1. Find the Seldon service endpoint
-2. Make requests via REST or gRPC
+For making synchronous requests, the process will generally be:
+1. Find the appropriate service endpoint (IP address and port) for accessing the installation of Seldon Core v2.
+1. Determine the appropriate headers/metadata for the request.
+2. Make requests via REST or gRPC.
 
 ### Find the Seldon Service Endpoint
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -192,7 +192,9 @@ No changes are required as the `seldon` CLI already understands how to set the a
 
 Note the header in the last line:
 
-```
+```{code-block}
+:emphasize-lines: 4
+
 curl -v http://0.0.0.0:9000/v2/models/iris/infer \
         -H "Content-Type: application/json" \
         -d '{"inputs": [{"name": "predict", "shape": [1, 4], "datatype": "FP32", "data": [[1, 2, 3, 4]]}]}' \
@@ -204,7 +206,9 @@ curl -v http://0.0.0.0:9000/v2/models/iris/infer \
 
 Note the `rpc-header` flag in the penultimate line:
 
-```
+```{code-block}
+:emphasize-lines: 6
+
 grpcurl \
 	-d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[1,4]}]}' \
 	-plaintext \
@@ -219,7 +223,9 @@ grpcurl \
 
 Note the `headers` dictionary in the `client.infer()` call:
 
-```python
+```{code-block}
+:emphasize-lines: 18
+
 import tritonclient.http as httpclient
 import numpy as np
 
@@ -234,7 +240,11 @@ inputs[0].set_data_from_numpy(
     binary_data=False,
 )
 
-result = client.infer("iris", inputs, headers={"Seldon-Model": "iris"})
+result = client.infer(
+    "iris",
+    inputs,
+    headers={"Seldon-Model": "iris"},
+)
 print("result is:", result.as_numpy("predict"))
 ```
 ````

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -111,6 +111,8 @@ You might want to use a mixture of these methods; the choice is yours.
 
 ````{tab} Virtual Hosts
 
+Virtual hosts are a way of differentiating between logical services accessed via the same physical machine(s).
+
 Virtual hosts are defined by the `Host` header for [HTTP/1](https://www.rfc-editor.org/rfc/rfc7230#section-5.4) and the `:authority` pseudo-header for [HTTP/2](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1).
 These represent the same thing, and the HTTP/2 specification defines how to translate these when converting between protocol versions.
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -99,8 +99,9 @@ curl -v http://0.0.0.0:9000/v2/models/iris/infer \
 An example `grpcurl` request might look like this:
 
 ```
-grpcurl -d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[1,4]}]}' \
-        -plaintext \
+grpcurl \
+	-d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[1,4]}]}' \
+	-plaintext \
 	-import-path apis \
 	-proto apis/mlops/v2_dataplane/v2_dataplane.proto \
 	0.0.0.0:9000 inference.GRPCInferenceService/ModelInfer

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -288,10 +288,16 @@ Be sure to check the documentation for how to set this with your preferred tools
 
 ````{tab} Subdomains
 
-Like virtual host names, subdomain names constitute a part of the overall host name.
-As such, specifying a subdomain name for requests will involve setting the appropriate host via the URI or headers.
+Subdomain names constitute a part of the overall host name.
+As such, specifying a subdomain name for requests will involve setting the appropriate host in the URI.
 
-For example, you may expose inference services in the namespaces `seldon-1` and `seldon-2` with the following, full-qualified domain names: `seldon-1.example.com` and `seldon-2.example.com`.
+For example, you may expose inference services in the namespaces `seldon-1` and `seldon-2` as in the following snippets:
+
+```
+curl https://seldon-1.example.com/v2/models/iris/infer ...
+
+seldon model infer --inference-host https://seldon-2.example.com/v2/models/iris/infer ...
+```
 
 Many popular ingresses support subdomain-based routing, including Istio and Nginx.
 Please refer to the documentation for your ingress of choice for further information.

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -157,14 +157,30 @@ You could use an exact match or a regex like `.*inference.*` to match this path,
 
 ### Make Inference Requests
 
-An example curl request might look like for a model called `iris`:
+Let us imagine making inference requests to a model called `iris`.
+Examples are given below for some common tools for making requests.
+
+```{tip}
+For pipelines, a synchronous request is possible if the pipeline has an `outputs` section defined in its spec.
+```
+
+`````{tabs}
+
+````{tab} cURL
+
+An example `curl` request might look like this:
 
 ```
-curl -v http://0.0.0.0:9000/v2/models/iris/infer -H "Content-Type: application/json" -H "seldon-model: iris"\
+curl -v http://0.0.0.0:9000/v2/models/iris/infer \
+        -H "Content-Type: application/json" \
+        -H "Seldon-Model: iris" \
         -d '{"inputs": [{"name": "predict", "shape": [1, 4], "datatype": "FP32", "data": [[1, 2, 3, 4]]}]}'
 ```
+````
 
-A request to the same model using `grpcurl` might look like:
+````{tab} grpcurl
+
+An example `grpcurl` request might look like this:
 
 ```
 grpcurl -d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[1,4]}]}' \
@@ -176,14 +192,13 @@ grpcurl -d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_con
 ```
 
 The above request was run from the project root folder allowing reference to the Protobuf manifests defined in the `apis/` folder.
+````
 
-For pipelines a synchronous request is possible if the pipeline has an outputs section in the spec.
+````{tab} Python tritonclient
 
-### Using Python Tritonclient
+You can use the Python [tritonclient](https://github.com/triton-inference-server/client) package to send inference requests.
 
-You can also use the Python [tritonclient](https://github.com/triton-inference-server/client) package to send inference requests.
-
-A short self-contained example corresponding to the above requests is:
+A short, self-contained example is:
 ```python
 import tritonclient.http as httpclient
 import numpy as np
@@ -194,11 +209,16 @@ client = httpclient.InferenceServerClient(
 )
 
 inputs = [httpclient.InferInput("predict", (1, 4), "FP64")]
-inputs[0].set_data_from_numpy(np.array([[1, 2, 3, 4]]).astype("float64"), binary_data=False)
+inputs[0].set_data_from_numpy(
+    np.array([[1, 2, 3, 4]]).astype("float64"),
+    binary_data=False,
+)
 
 result = client.infer("iris", inputs)
 print("result is:", result.as_numpy("predict"))
 ```
+````
+`````
 
 ## Asynchronous Requests
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -259,7 +259,7 @@ There are many ways to do this, but custom path prefixes will not work with gRPC
 This is because gRPC determines the path based on the Protobuf definition.
 Some gRPC implementations permit manipulating paths when sending requests, but this is by no means universal.
 
-If you want to expose your inference endpoints via gRPC and REST in a consistent way, you should use virtual hosts or headers.
+If you want to expose your inference endpoints via gRPC and REST in a consistent way, you should use virtual hosts, subdomains, or headers.
 
 The downside of using only paths is that you cannot differentiate between different installations of Seldon Core v2 or between traffic to Seldon and any other inference endpoints you may have exposed via the same ingress.
 
@@ -284,6 +284,17 @@ Some common ones are given below:
 * In Python, the `requests` library accepts the host as a normal header.
 
 Be sure to check the documentation for how to set this with your preferred tools and languages.
+````
+
+````{tab} Subdomains
+
+Like virtual host names, subdomain names constitute a part of the overall host name.
+As such, specifying a subdomain name for requests will involve setting the appropriate host via the URI or headers.
+
+For example, you may expose inference services in the namespaces `seldon-1` and `seldon-2` with the following, full-qualified domain names: `seldon-1.example.com` and `seldon-2.example.com`.
+
+Many popular ingresses support subdomain-based routing, including Istio and Nginx.
+Please refer to the documentation for your ingress of choice for further information.
 ````
 
 ````{tab} Headers

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -75,6 +75,19 @@ The `seldon` CLI is aware of these rules and can be used to easily send requests
 See the [examples](../examples/index) and the [Seldon CLI docs](../cli/index.md) for more information.
 ````
 
+````{tab} Paths
+
+The inference v2 protocol is only aware of models, thus has no concept of pipelines.
+Seldon works around this limitation by introducing _virtual_ endpoints for pipelines.
+Virtual means that Seldon understands them, but v2 protocol-compatible components like inference servers do not.
+
+Use the following rules for paths to route to models and pipelines:
+* For models, use the path prefix `/v2/models/` and the model name.
+  This is normal usage of the inference v2 protocol.
+* For pipelines, use the path prefix `/v2/pipelines/` and the pipeline name.
+  Otherwise calling pipelines looks just like the inference v2 protocol for models.
+  Do **not** use any suffix for the pipeline name as you would for routing headers.
+````
 
 `````
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -169,9 +169,11 @@ Virtual means that Seldon understands them, but v2 protocol-compatible component
 Use the following rules for paths to route to models and pipelines:
 * For models, use the path prefix `/v2/models/{model name}`.
   This is normal usage of the inference v2 protocol.
-* For pipelines, use the path prefix `/v2/pipelines/{pipeline name}`.
+* For pipelines, you can use the path prefix `/v2/pipelines/{pipeline name}`.
   Otherwise calling pipelines looks just like the inference v2 protocol for models.
   Do **not** use any suffix for the pipeline name as you would for routing headers.
+* For pipelines, you can also use the path prefix `/v2/models/{pipeline name}.pipeline`.
+  Again, this form looks just like the inference v2 protocol for models.
 ````
 
 `````

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -67,7 +67,7 @@ This `iris` model has the following schema, which can be set in a `model-setting
     "inputs": [
         {
             "name": "predict",
-            "datatype": "INT64",
+            "datatype": "FP32",
             "shape": [-1, 4]
         }
     ],

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -57,6 +57,33 @@ If you are using a service mesh like Istio or Ambassador, you will need to use t
 ### Make Inference Requests
 
 Let us imagine making inference requests to a model called `iris`.
+
+This `iris` model has the following schema, which can be set in a `model-settings.json` file for MLServer:
+
+```
+{
+    "name": "iris",
+    "implementation": "mlserver_sklearn.SKLearnModel",
+    "inputs": [
+        {
+            "name": "predict",
+            "datatype": "INT64",
+            "shape": [-1, 4]
+        }
+    ],
+    "outputs": [
+        {
+            "name": "predict",
+            "datatype": "INT64",
+            "shape": [-1, 1]
+        }
+    ],
+    "parameters": {
+        "version": "1"
+    }
+}
+```
+
 Examples are given below for some common tools for making requests.
 
 ```{tip}

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -111,7 +111,7 @@ You might want to use a mixture of these methods; the choice is yours.
 
 ````{tab} Virtual Hosts
 
-Virtual hosts are defined by the `Host` header for HTTP/1 and the `:authority` pseudo-header for HTTP/2.
+Virtual hosts are defined by the `Host` header for [HTTP/1](https://www.ietf.org/rfc/rfc2616.html#section-14.23) and the `:authority` pseudo-header for [HTTP/2](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1).
 These represent the same thing, and the HTTP/2 specification defines how to translate these when converting between protocol versions.
 
 Many tools and libraries treat these headers as special and have particular ways of handling them.

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -12,14 +12,14 @@ The content of your request should be an [inference V2 protocol payload](../apis
 For making synchronous requests, the process will generally be:
 1. Find the appropriate service endpoint (IP address and port) for accessing the installation of Seldon Core v2.
 1. Determine the appropriate headers/metadata for the request.
-2. Make requests via REST or gRPC.
+1. Make requests via REST or gRPC.
 
 ### Find the Seldon Service Endpoint
 
- 1. If you are running Seldon locally with Docker Compose, by default the endpoint will be `0.0.0.0:9000`
+1.  If you are running Seldon locally with Docker Compose, by default the endpoint will be `0.0.0.0:9000`
     * This is set by the `ENVOY_DATA_PORT` environment variable
- 2. If you are running in Kubernetes, Seldon creates a single `Service` called `seldon-mesh` in the namespace it is installed into, usually `seldon-mesh`.
-    If this is exposed via a load balancer, the appropriate address and port can be found via:
+1.  If you are running in Kubernetes, Seldon creates a single `Service` called `seldon-mesh` in the namespace it is installed into, by default also called `seldon-mesh`.
+    If this `Service` is exposed via a load balancer, the appropriate address and port can be found via:
 
      ```bash
      kubectl get svc seldon-mesh -n seldon-mesh -o jsonpath='{.status.loadBalancer.ingress[0].ip}'

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -11,8 +11,10 @@ You can make synchronous inference requests via REST or gRPC or asynchronous req
 
 ### Find the Seldon Service Endpoint
 
- 1. If you are running Seldon locally via Docker compose by default the endpoint will be `0.0.0.0:9000`
- 2. If you are running in Kubernetes Seldon creates a single Service `seldon-mesh` in the namespace Seldon is installed to, usually `seldon-mesh`. If this has be exposed via a load balancer this can be found via:
+ 1. If you are running Seldon locally with Docker Compose, by default the endpoint will be `0.0.0.0:9000`
+    * This is set by the `ENVOY_DATA_PORT` environment variable
+ 2. If you are running in Kubernetes, Seldon creates a single `Service` called `seldon-mesh` in the namespace it is installed into, usually `seldon-mesh`.
+    If this is exposed via a load balancer, the appropriate address and port can be found via:
 
      ```bash
      kubectl get svc seldon-mesh -n seldon-mesh -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
@@ -75,7 +77,8 @@ print("result is:", result.as_numpy("predict"))
 
 ## Asynchronous Requests
 
-The Seldon architetcure uses Kafka and therefore asynchronous requests can be sent by pushing V2 proto payloads to the appropriate topic.
+The Seldon architecture uses Kafka and therefore asynchronous requests can be sent by pushing V2 protocol payloads to the appropriate topic.
+Topics have the following form:
 
 ```
 seldon.<namespace>.<model|pipeline>.<name>.<inputs|outputs>

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -16,14 +16,32 @@ For making synchronous requests, the process will generally be:
 
 ### Find the Seldon Service Endpoint
 
-1.  If you are running Seldon locally with Docker Compose, by default the endpoint will be `0.0.0.0:9000`
-    * This is set by the `ENVOY_DATA_PORT` environment variable
-1.  If you are running in Kubernetes, Seldon creates a single `Service` called `seldon-mesh` in the namespace it is installed into, by default also called `seldon-mesh`.
-    If this `Service` is exposed via a load balancer, the appropriate address and port can be found via:
+`````{tabs}
 
-     ```bash
-     kubectl get svc seldon-mesh -n seldon-mesh -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-     ```
+````{tab} Docker Compose
+
+In the default Docker Compose setup, container ports are accessible from the host machine.
+This means you can use `localhost` or `0.0.0.0` as the hostname.
+
+The default port for sending inference requests to the Seldon system is `9000`.
+This is controlled by the `ENVOY_DATA_PORT` environment variable for Compose.
+
+Putting this together, you can send inference requests to `0.0.0.0:9000`.
+````
+
+````{tab} Kubernetes
+
+In Kubernetes, Seldon creates a single `Service` called `seldon-mesh` in the namespace it is installed into.
+By default, this namespace is also called `seldon-mesh`.
+
+If this `Service` is exposed via a load balancer, the appropriate address and port can be found via:
+
+```bash
+kubectl get svc seldon-mesh -n seldon-mesh -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+````
+
+`````
 
 ### Make Inference Requests
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -86,10 +86,6 @@ This `iris` model has the following schema, which can be set in a `model-setting
 
 Examples are given below for some common tools for making requests.
 
-```{tip}
-For pipelines, a synchronous request is possible if the pipeline has an `outputs` section defined in its spec.
-```
-
 `````{tabs}
 
 ````{group-tab} Seldon CLI
@@ -163,6 +159,10 @@ print("result is:", result.as_numpy("predict"))
 ```
 ````
 `````
+
+```{tip}
+For pipelines, a synchronous request is possible if the pipeline has an `outputs` section defined in its spec.
+```
 
 ### Request Routing
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -48,6 +48,8 @@ Inference requests can then be sent to `localhost:8080`.
 ```
 kubectl port-forward svc/seldon-mesh -n seldon-mesh 8080:80
 ```
+
+If you are using a service mesh like Istio or Ambassador, you will need to use the IP address of the service mesh ingress and determine the appropriate port.
 ````
 
 `````

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -3,6 +3,9 @@
 This section will discuss how to make inference calls against your Seldon models or pipelines.
 
 You can make synchronous inference requests via REST or gRPC or asynchronous requests via Kafka topics.
+The content of your request should be an [inference V2 protocol payload](../apis/inference/v2.md):
+* REST payloads will generally be in the JSON v2 protocol format.
+* gRPC and Kafka payloads **must** be in the Protobuf v2 protocol format.
 
 ## Synchronous Requests
 
@@ -27,8 +30,6 @@ You should set the header `seldon-model` as follows:
 
  * Models: use the model name, e.g. for a model named `mymodel` use `seldon-model: mymodel`
  * Pipelines: use the pipeline name with the suffix `.pipeline`, e.g. for a pipeline named `mypipeline` use `seldon-model: mypipeline.pipeline`
-
-The content of your request should be a [V2 protocol payload](../apis/inference/v2.md).
 
 The `seldon` CLI can be used to easily send requests to your deployed resources. See the [examples](../examples/index) and the [Seldon CLI docs](../cli/index.md).
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -166,6 +166,24 @@ For pipelines, a synchronous request is possible if the pipeline has an `outputs
 
 `````{tabs}
 
+````{tab} Seldon CLI
+
+An example `seldon` request might look like this:
+
+```
+seldon model infer iris \
+        '{"inputs": [{"name": "predict", "shape": [1, 4], "datatype": "FP32", "data": [[1, 2, 3, 4]]}]}'
+```
+
+The default inference mode is REST, but you can also send gRPC requests like this:
+
+```
+seldon model infer iris \
+        --inference-mode grpc \
+        '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[1,4]}]}'
+```
+````
+
 ````{tab} cURL
 
 An example `curl` request might look like this:

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -39,6 +39,15 @@ If this `Service` is exposed via a load balancer, the appropriate address and po
 ```bash
 kubectl get svc seldon-mesh -n seldon-mesh -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
+
+If you are not using a `LoadBalancer` for the `seldon-mesh` `Service`, you can still send inference requests.
+
+For development and testing purposes, you can port-forward the `Service` locally using the below.
+Inference requests can then be sent to `localhost:8080`.
+
+```
+kubectl port-forward svc/seldon-mesh -n seldon-mesh 8080:80
+```
 ````
 
 `````

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -222,7 +222,7 @@ import tritonclient.http as httpclient
 import numpy as np
 
 client = httpclient.InferenceServerClient(
-    url="172.19.255.9:80",
+    url="localhost:8080",
     verbose=False,
 )
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -247,6 +247,10 @@ Topics have the following form:
 seldon.<namespace>.<model|pipeline>.<name>.<inputs|outputs>
 ```
 
+```{note}
+If writing to a pipeline topic, you will need to include a Kafka header with the key `pipeline` and the value being the name of the pipeline.
+```
+
 ### Model Inference
 
 For a local install if you have a model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.default.model.iris.inputs`.

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -4,26 +4,27 @@ This section will discuss how to make inference calls against your Seldon models
 
 You can make synchronous inference requests via REST or gRPC or asynchronous requests via Kafka topics.
 
-## Synchronous requests
+## Synchronous Requests
 
-  1. Find the Seldon service endpoint
-  2. Make requests via REST or gRPC
+1. Find the Seldon service endpoint
+2. Make requests via REST or gRPC
 
-### Find Seldon service endpoint
+### Find the Seldon Service Endpoint
 
  1. If you are running Seldon locally via Docker compose by default the endpoint will be `0.0.0.0:9000`
  2. If you are running in Kubernetes Seldon creates a single Service `seldon-mesh` in the namespace Seldon is installed to, usually `seldon-mesh`. If this has be exposed via a load balancer this can be found via:
 
- ```bash
- kubectl get svc seldon-mesh -n seldon-mesh -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
- ```
+     ```bash
+     kubectl get svc seldon-mesh -n seldon-mesh -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+     ```
 
-### Make inference requests
+### Make Inference Requests
 
-Seldon routes requests to to the correct enpoint via headers in HTTP calls. You should set the header `seldon-model` as follow:
+Seldon routes requests to to the correct endpoint via headers in HTTP calls.
+You should set the header `seldon-model` as follows:
 
- * For Models: use the model name, e.g. for a Model names `mymodel`, `seldon-model: mymodel`
- * For Pipelines: use the Pipeline name with the suffix `.pipeline`, e.g. for a Pipeline named `mypipeline`, `seldon-model: mypipeline.pipeline`
+ * Models: use the model name, e.g. for a model named `mymodel` use `seldon-model: mymodel`
+ * Pipelines: use the pipeline name with the suffix `.pipeline`, e.g. for a pipeline named `mypipeline` use `seldon-model: mypipeline.pipeline`
 
 The content of your request should be a [V2 protocol payload](../apis/inference/v2.md).
 
@@ -36,7 +37,7 @@ curl -v http://0.0.0.0:9000/v2/models/iris/infer -H "Content-Type: application/j
         -d '{"inputs": [{"name": "predict", "shape": [1, 4], "datatype": "FP32", "data": [[1, 2, 3, 4]]}]}'
 ```
 
-A similar gRPC request using grpcurl to the same model might look like:
+A request to the same model using `grpcurl` might look like:
 
 ```
 grpcurl -d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[1,4]}]}' \
@@ -47,21 +48,21 @@ grpcurl -d '{"model_name":"iris","inputs":[{"name":"input","contents":{"fp32_con
 	0.0.0.0:9000 inference.GRPCInferenceService/ModelInfer
 ```
 
-The above request was run from the project root folder allowing reference to the protos defined in the apis folder.
+The above request was run from the project root folder allowing reference to the Protobuf manifests defined in the `apis/` folder.
 
 For Pipelines a synchronous request is possible if the Pipeline has an outputs section in the spec.
 
 ### Using Python Tritonclient
 
-You can also use Python [tritonclient](https://github.com/triton-inference-server/client) package to send inference requests.
+You can also use the Python [tritonclient](https://github.com/triton-inference-server/client) package to send inference requests.
 
-A short self-contained example corresponding to the above requests is
+A short self-contained example corresponding to the above requests is:
 ```python
 import tritonclient.http as httpclient
 import numpy as np
 
 client = httpclient.InferenceServerClient(
-    url=f"172.19.255.9:80",
+    url="172.19.255.9:80",
     verbose=False,
 )
 
@@ -72,7 +73,7 @@ result = client.infer("iris", inputs)
 print("result is:", result.as_numpy("predict"))
 ```
 
-## Asynchronous requests
+## Asynchronous Requests
 
 The Seldon architetcure uses Kafka and therefore asynchronous requests can be sent by pushing V2 proto payloads to the appropriate topic.
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -178,6 +178,28 @@ Use the following rules for paths to route to models and pipelines:
 
 `````
 
+Extending our examples from [above](#make-inference-requests), the requests may look like the below when using header-based routing.
+
+`````{tabs}
+
+````{tab} Seldon CLI
+
+````
+
+````{tab} cURL
+
+````
+
+````{tab} grpcurl
+
+````
+
+````{tab} Python tritonclient
+
+````
+
+`````
+
 #### Ingress Routes
 
 If you are using an ingress controller to make inference requests with Seldon, you will need to configure the routing rules correctly.

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -86,9 +86,11 @@ seldon.<namespace>.<model|pipeline>.<name>.<inputs|outputs>
 
 ### Model Inference
 
-For a local install if you have a Model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.default.model.iris.inputs`. The response will appear on `seldon.default.model.iris.outputs`.
+For a local install if you have a Model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.default.model.iris.inputs`.
+The response will appear on `seldon.default.model.iris.outputs`.
 
-For a Kubernetes install in `seldon-mesh` if you have a Model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.model.iris.inputs`. The response will appear on `seldon.seldon-mesh.model.iris.outputs`.
+For a Kubernetes install in `seldon-mesh` if you have a Model `iris`, you would be able to send a prediction request by pushing to the topic: `seldon.seldon-mesh.model.iris.inputs`.
+The response will appear on `seldon.seldon-mesh.model.iris.outputs`.
 
 
 ### Pipeline Inference
@@ -100,10 +102,13 @@ For a Kubernetes install in `seldon-mesh` if you have a Pipeline `pipeline`, you
 
 ## Pipeline Metadata
 
-It may be useful to send metadata alongside your inference. If using Kafka directly as described above you can attach kafka metadata to your request which will be passed oround the graph. When making synchronous requests to your pipeline with REST or gRPC you can also do this.
+It may be useful to send metadata alongside your inference.
 
- * For REST requests add HTTP headers prefixe with `X-`
- * For gRPC requests add meatdata with keys starting with `X-`
+If using Kafka directly as described above, you can attach Kafka metadata to your request, which will be passed around the graph.
+When making synchronous requests to your pipeline with REST or gRPC you can also do this.
+
+ * For REST requests add HTTP headers prefixed with `X-`
+ * For gRPC requests add metadata with keys starting with `X-`
 
 You can also do this with the Seldon CLI by setting headers with the `--header` argument (and also showing response headers with the `--show-headers` argument)
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -54,15 +54,32 @@ If you are using a service mesh like Istio or Ambassador, you will need to use t
 
 `````
 
+### Request Routing
+
+Seldon needs to determine where to route requests to, as models and pipelines might have the same name.
+There are two ways of doing this: header-based routing (preferred) and path-based routing.
+
+`````{tabs}
+
+````{tab} Headers
+
+Seldon can route requests to the correct endpoint via headers in HTTP calls, both for REST (HTTP/1.1) and gRPC (HTTP/2).
+
+Use the `Seldon-Model` header as follows:
+* For models, use the model name as the value.
+  For example, to send requests to a model named `foo` use the header `Seldon-Model: foo`.
+* For pipelines, use the pipeline name followed by `.pipeline` as the value.
+  For example, to send requests to a pipeline named `foo` use the header `Seldon-Model: foo.pipeline`.
+
+The `seldon` CLI is aware of these rules and can be used to easily send requests to your deployed resources.
+See the [examples](../examples/index) and the [Seldon CLI docs](../cli/index.md) for more information.
+````
+
+
+`````
+
+
 ### Make Inference Requests
-
-Seldon routes requests to to the correct endpoint via headers in HTTP calls.
-You should set the header `seldon-model` as follows:
-
- * Models: use the model name, e.g. for a model named `mymodel` use `seldon-model: mymodel`
- * Pipelines: use the pipeline name with the suffix `.pipeline`, e.g. for a pipeline named `mypipeline` use `seldon-model: mypipeline.pipeline`
-
-The `seldon` CLI can be used to easily send requests to your deployed resources. See the [examples](../examples/index) and the [Seldon CLI docs](../cli/index.md).
 
 An example curl request might look like for a model called `iris`:
 

--- a/docs/source/contents/inference/index.md
+++ b/docs/source/contents/inference/index.md
@@ -65,7 +65,7 @@ For pipelines, a synchronous request is possible if the pipeline has an `outputs
 
 `````{tabs}
 
-````{tab} Seldon CLI
+````{group-tab} Seldon CLI
 
 An example `seldon` request might look like this:
 
@@ -83,7 +83,7 @@ seldon model infer iris \
 ```
 ````
 
-````{tab} cURL
+````{group-tab} cURL
 
 An example `curl` request might look like this:
 
@@ -94,7 +94,7 @@ curl -v http://0.0.0.0:9000/v2/models/iris/infer \
 ```
 ````
 
-````{tab} grpcurl
+````{group-tab} grpcurl
 
 An example `grpcurl` request might look like this:
 
@@ -110,7 +110,7 @@ grpcurl \
 The above request was run from the project root folder allowing reference to the Protobuf manifests defined in the `apis/` folder.
 ````
 
-````{tab} Python tritonclient
+````{group-tab} Python tritonclient
 
 You can use the Python [tritonclient](https://github.com/triton-inference-server/client) package to send inference requests.
 
@@ -182,13 +182,13 @@ Extending our examples from [above](#make-inference-requests), the requests may 
 
 `````{tabs}
 
-````{tab} Seldon CLI
+````{group-tab} Seldon CLI
 
 No changes are required as the `seldon` CLI already understands how to set the appropriate gRPC and REST headers.
 
 ````
 
-````{tab} cURL
+````{group-tab} cURL
 
 Note the header in the last line:
 
@@ -200,7 +200,7 @@ curl -v http://0.0.0.0:9000/v2/models/iris/infer \
 ```
 ````
 
-````{tab} grpcurl
+````{group-tab} grpcurl
 
 Note the `rpc-header` flag in the penultimate line:
 
@@ -215,7 +215,7 @@ grpcurl \
 ```
 ````
 
-````{tab} Python tritonclient
+````{group-tab} Python tritonclient
 
 Note the `headers` dictionary in the `client.infer()` call:
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR achieves two things.  Firstly, it adds information on routing _to_ Core v2 via different methods (authority/virtual host headers, path matching, etc.).  Secondly, it improves the existing documentation on routing _through_ Core v2 with models and pipelines.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Special notes for your reviewer**:
