### PR TITLE
limit changelog to current version

### DIFF
--- a/create-changelog
+++ b/create-changelog
@@ -5,8 +5,9 @@ set -o errexit
 set -o pipefail
 
 STARTUP_DIR="$( cd "$( dirname "$0" )" && pwd )"
+CURRENT_VERSION="$( cat version.txt )"
 
 docker run --rm -it \
     -v $STARTUP_DIR:/work \
     -w /work node \
-    bash -c "set -x && npm install -g auto-changelog && auto-changelog"
+    bash -c "set -x && npm install -g auto-changelog && auto-changelog --ending-version v$CURRENT_VERSION"


### PR DESCRIPTION
Improvement added to `v1.15.0-release` branch - making sure it lands on master.

This is required so we do not include v2 release changes in v1 changelog.