### PR TITLE
Clarify use of SCv1 in Helm chart descriptions + fix typo

### DIFF
--- a/helm-charts/README.md.tpl
+++ b/helm-charts/README.md.tpl
@@ -18,7 +18,7 @@ helm repo update
 {{- $appCharts := list "seldon-core-operator" "seldon-core-analytics" "seldon-core-loadtesting" -}}
 {{ if has .Name $appCharts }}
 
-Onca that's done, you should then be able to deploy the chart as:
+Once that's done, you should then be able to deploy the chart as:
 
 ```bash
 kubectl create namespace seldon-system

--- a/helm-charts/seldon-abtest/Chart.yaml
+++ b/helm-charts/seldon-abtest/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: seldon-abtest
-description: Chart to deploy an AB test in Seldon Core. Allows you to split traffic between two models.
+description: Chart to deploy an AB test in Seldon Core v1. Allows you to split traffic between two models.
 version: 0.2.0
 home: https://github.com/SeldonIO/seldon-core
 sources:

--- a/helm-charts/seldon-benchmark-workflow/Chart.yaml
+++ b/helm-charts/seldon-benchmark-workflow/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: Seldon Benchmark Workflow
+description: Seldon Core v1 Benchmark Workflow
 keywords:
 - kubernetes
 - machine-learning

--- a/helm-charts/seldon-core-loadtesting/Chart.yaml
+++ b/helm-charts/seldon-core-loadtesting/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: seldon-core-loadtesting
-description: Loadtesting for seldon core
+description: Loadtesting for Seldon Core v1
 version: 0.2.0
 home: https://github.com/SeldonIO/seldon-core
 sources:

--- a/helm-charts/seldon-core-operator/Chart.yaml
+++ b/helm-charts/seldon-core-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 1.15.0-dev
-description: Seldon Core CRD and controller helm chart for Kubernetes.
+description: Seldon Core v1 CRD and controller Helm chart for Kubernetes.
 keywords:
 - kubernetes
 - machine-learning

--- a/helm-charts/seldon-mab/Chart.yaml
+++ b/helm-charts/seldon-mab/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: seldon-mab
 description: |
-  Chart to deploy a multi-armed bandits router over two Seldon deployments, so
-  that traffic is sent to the best performing model.
+  Chart to deploy a multi-armed bandits router over two Seldon Core v1 deployments,
+  so that traffic is sent to the best performing model.
   You will need to utilize both the `predict` and `send_feedback` API methods.
 version: 0.2.0
 home: https://github.com/SeldonIO/seldon-core

--- a/helm-charts/seldon-od-model/Chart.yaml
+++ b/helm-charts/seldon-od-model/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: seldon-od-model
-description: Chart to deploy an outlier detector as a single Seldon model. 
+description: Chart to deploy an outlier detector as a single model with Seldon Core v1.
 version: 0.2.0
 home: https://github.com/SeldonIO/seldon-core
 sources:

--- a/helm-charts/seldon-od-transformer/Chart.yaml
+++ b/helm-charts/seldon-od-transformer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: seldon-od-transformer
-description: Chart to deploy an outlier detector as a transformer in an inference graph. 
+description: Chart to deploy an outlier detector as a transformer in a Seldon Core v1 inference graph.
 version: 0.2.0
 home: https://github.com/SeldonIO/seldon-core
 sources:

--- a/helm-charts/seldon-openvino/Chart.yaml
+++ b/helm-charts/seldon-openvino/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: seldon-openvino
-description: Proxy integration to deploy models optimized for Intel OpenVINO in Seldon Core
+description: Proxy integration to deploy models optimized for Intel OpenVINO in Seldon Core v1
 version: 0.1
 deprecated: true
 sources:

--- a/helm-charts/seldon-single-model/Chart.yaml
+++ b/helm-charts/seldon-single-model/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: seldon-single-model
-description: Chart to deploy a machine learning model in Seldon Core.
+description: Chart to deploy a machine learning model in Seldon Core v1.
 version: 0.2.0
 home: https://github.com/SeldonIO/seldon-core
 sources:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR fixes two things:
* It clarifies this Helm chart is for Core v1, as Core v2 now also exists but has completely separate Helm charts.
* It fixes a capitalisation typo referring to Helm, as this is a proper noun in that affected usage.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
