### PR TITLE
Add runAsUid for Istio CNI DNS proxy

### DIFF
--- a/doc/source/ingress/openshift.md
+++ b/doc/source/ingress/openshift.md
@@ -37,7 +37,7 @@ spec:
       value: 'true'
 ```
 
-2. In the case of using Istio CNI, you may need to configure the `runAsUid` correctly when using MinIO. e.g£º
+2. In the case of using Istio CNI, you may need to configure the `runAsUid` correctly when using MinIO. e.g:
 ```yaml
 spec:
   predictors:

--- a/doc/source/ingress/openshift.md
+++ b/doc/source/ingress/openshift.md
@@ -37,6 +37,16 @@ spec:
       value: 'true'
 ```
 
+2. In the case of using Istio CNI, you may need to configure the `runAsUid` correctly when using MinIO. e.g£º
+```yaml
+spec:
+  predictors:
+  - graph:
+      modelUri: "s3://minio.default.svc.cluster.local:9000/model/"
+      name: "*****"
+      runAsUid: 1337
+```
+
 
 ### Namespace Seldon Core Install
 

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -304,6 +304,7 @@ type Explainer struct {
 	StorageInitializerImage string             `json:"storageInitializerImage,omitempty" protobuf:"bytes,8,opt,name=storageInitializerImage"`
 	Replicas                *int32             `json:"replicas,omitempty" protobuf:"string,9,opt,name=replicas"`
 	InitParameters          string             `json:"initParameters,omitempty" protobuf:"string,10,opt,name=initParameters"`
+	RunAsUid                *int64             `json:"runAsUid,omitempty" protobuf:"bytes,11,opt,name=runAsUid"`
 }
 
 // ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1" ObjectMeta.
@@ -602,6 +603,7 @@ type PredictiveUnit struct {
 	EnvSecretRefName        string                        `json:"envSecretRefName,omitempty" protobuf:"bytes,10,opt,name=envSecretRefName"`
 	StorageInitializerImage string                        `json:"storageInitializerImage,omitempty" protobuf:"bytes,11,opt,name=storageInitializerImage"`
 	Logger                  *Logger                       `json:"logger,omitempty" protobuf:"bytes,12,opt,name=logger"`
+	RunAsUid                *int64                        `json:"runAsUid,omitempty" protobuf:"bytes,13,opt,name=runAsUid"`
 }
 
 type LoggerMode string

--- a/operator/controllers/seldondeployment_explainers.go
+++ b/operator/controllers/seldondeployment_explainers.go
@@ -258,7 +258,7 @@ func (ei *ExplainerInitialiser) createExplainer(mlDep *machinelearningv1.SeldonD
 			envSecretRefName := extractExplainerEnvSecretRefName(p.Explainer)
 
 			mi := NewModelInitializer(ei.ctx, ei.clientset)
-			deploy, err = mi.InjectModelInitializer(deploy, explainerContainer.Name, p.Explainer.ModelUri, p.Explainer.ServiceAccountName, envSecretRefName, p.Explainer.StorageInitializerImage)
+			deploy, err = mi.InjectModelInitializer(deploy, explainerContainer.Name, p.Explainer.ModelUri, p.Explainer.ServiceAccountName, envSecretRefName, p.Explainer.StorageInitializerImage, p.Explainer.RunAsUid)
 			if err != nil {
 				return err
 			}

--- a/operator/controllers/seldondeployment_prepackaged_servers.go
+++ b/operator/controllers/seldondeployment_prepackaged_servers.go
@@ -123,7 +123,7 @@ func (pi *PrePackedInitialiser) addTFServerContainer(mlDepSpec *machinelearningv
 	envSecretRefName := extractEnvSecretRefName(pu)
 
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err := mi.InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
+	_, err := mi.InjectModelInitializer(deploy, tfServingContainer.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage, pu.RunAsUid)
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func (pi *PrePackedInitialiser) addTritonServer(mlDepSpec *machinelearningv1.Sel
 
 	if !noStorage {
 		mi := NewModelInitializer(pi.ctx, pi.clientset)
-		_, err := mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
+		_, err := mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage, pu.RunAsUid)
 		if err != nil {
 			return err
 		}
@@ -278,7 +278,7 @@ func (pi *PrePackedInitialiser) addMLServerDefault(pu *machinelearningv1.Predict
 	envSecretRefName := extractEnvSecretRefName(pu)
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
 
-	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
+	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage, pu.RunAsUid)
 	if err != nil {
 		return err
 	}
@@ -344,7 +344,7 @@ func (pi *PrePackedInitialiser) addModelDefaultServers(mlDepSepc *machinelearnin
 	envSecretRefName := extractEnvSecretRefName(pu)
 
 	mi := NewModelInitializer(pi.ctx, pi.clientset)
-	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage)
+	_, err = mi.InjectModelInitializer(deploy, c.Name, pu.ModelURI, pu.ServiceAccountName, envSecretRefName, pu.StorageInitializerImage, pu.RunAsUid)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

I used MinIO to save a TF model in OpenShift. When using Istio CNI, the initcontainer could not be able to access the MinIO service. 
I checked the Istio documentation and found that we need to specify `runAsuser` in the rclone initcontainer in order to handle the internal service correctly.
https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers
![image](https://user-images.githubusercontent.com/12069428/206711124-220cfde1-8a9f-4583-807f-09ace6fdd774.png)


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # N/A

**Special notes for your reviewer**:
N/A