### PR TITLE
Enable GPU for docker-compose deployment

### DIFF
--- a/docs/source/contents/getting-started/docker-installation/index.md
+++ b/docs/source/contents/getting-started/docker-installation/index.md
@@ -16,7 +16,7 @@ From the project root run:
 make deploy-local
 ```
 
-This will run with `latest` images for the componnets.
+This will run with `latest` images for the components.
 
 Note: Triton and MLServer are large images at present (11G and 9G respectively) so will take time to download on first usage.
 
@@ -28,6 +28,14 @@ To run a particular release set the environment variable `CUSTOM_IMAGE_TAG` to t
 export CUSTOM_IMAGE_TAG=0.2.0
 make deploy-local
 ```
+
+### GPU support
+
+To enable GPU on servers: 
+
+1. Make sure that `nvidia-container-runtime` is installed, follow [link](https://docs.docker.com/config/containers/resource_constraints/#gpu)
+2. Enable GPU: `export GPU_ENABLED=1`
+
 
 ### Local Models
 

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -15,6 +15,7 @@ PIPELINEGATEWAY_IMG ?= ${DOCKERHUB_USERNAME}/seldon-pipelinegateway:${CUSTOM_IMA
 RCLONE_IMG ?= ${DOCKERHUB_USERNAME}/seldon-rclone:${CUSTOM_IMAGE_TAG}
 SCHEDULER_IMG ?= ${DOCKERHUB_USERNAME}/seldon-scheduler:${CUSTOM_IMAGE_TAG}
 TRITON_IMG ?= nvcr.io/nvidia/tritonserver:22.05-py3
+GPU_ENABLED ?= 0
 
 KIND_NAME=ansible
 
@@ -277,6 +278,10 @@ ifneq ($(DOCKER_COMPOSE_BUILD_IMAGES),)
 endif
 
 DOCKER_COMPOSE_BASE_COMMAND = docker-compose --env-file env.all -f all-base.yaml
+ifeq ($(GPU_ENABLED),1)
+	DOCKER_COMPOSE_BASE_COMMAND := $(DOCKER_COMPOSE_BASE_COMMAND) -f all-gpu.yaml
+endif
+
 DOCKER_COMPOSE_INTERNAL = -f all-internal.yaml
 DOCKER_COMPOSE_HOST = -f all-host-network.yaml
 

--- a/scheduler/all-gpu.yaml
+++ b/scheduler/all-gpu.yaml
@@ -1,0 +1,8 @@
+version: "3.9"
+
+services:
+  triton:
+     runtime: nvidia
+      
+  mlserver:
+     runtime: nvidia


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR enables GPU usage in local deployment. To enable GPU support set the envar `GPU_ENABLED=1` (default is 0)

Currently all GPUs on the system is going to be used for triton and mlserver.

Although it looks like mlserver does not have cuda drivers installed in the image used by default.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
