### PR TITLE
Upgrading docker compose CLI command

### DIFF
--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -277,7 +277,7 @@ ifneq ($(DOCKER_COMPOSE_BUILD_IMAGES),)
 	DOCKER_COMPOSE_BUILD_IMAGES := --build
 endif
 
-DOCKER_COMPOSE_BASE_COMMAND = docker-compose --env-file env.all -f all-base.yaml
+DOCKER_COMPOSE_BASE_COMMAND = docker compose --env-file env.all -f all-base.yaml
 ifeq ($(GPU_ENABLED),1)
 	DOCKER_COMPOSE_BASE_COMMAND := $(DOCKER_COMPOSE_BASE_COMMAND) -f all-gpu.yaml
 endif


### PR DESCRIPTION
Not sure if this is necessary but it actually took me some time to figure it out as I was sure that I have `docker compose` already installed. According to the [Docker documentation](https://docs.docker.com/compose/reference/) the spaced version looks like the newer one and maybe the makefile should be updated for that.

