### PR TITLE
Fix: support models saved with mlflow=2 in mlflowserver conda_env_create

### DIFF
--- a/servers/mlflowserver/mlflowserver/conda_env_create.py
+++ b/servers/mlflowserver/mlflowserver/conda_env_create.py
@@ -47,11 +47,9 @@ def setup_env(model_folder):
 
     flavours = mlmodel["flavors"]
     pyfunc_flavour = flavours["python_function"]
-    mlflow_version = mlmodel["mlflow_version"]
-    if mlflow_version.startswith("2"):
-        env_file_name = pyfunc_flavour["env"]["conda"]
-    else:
-        env_file_name = pyfunc_flavour["env"]
+    env_file_name = pyfunc_flavour["env"]
+    if isinstance(env_file_name, dict):
+        env_file_name = env_file_name["conda"]
     env_file_path = os.path.join(model_folder, env_file_name)
     env_file_path = copy_env(env_file_path)
 

--- a/servers/mlflowserver/mlflowserver/conda_env_create.py
+++ b/servers/mlflowserver/mlflowserver/conda_env_create.py
@@ -47,7 +47,11 @@ def setup_env(model_folder):
 
     flavours = mlmodel["flavors"]
     pyfunc_flavour = flavours["python_function"]
-    env_file_name = pyfunc_flavour["env"]
+    mlflow_version = mlmodel["mlflow_version"]
+    if mlflow_version.startswith("2"):
+        env_file_name = pyfunc_flavour["env"]["conda"]
+    else:
+        env_file_name = pyfunc_flavour["env"]
     env_file_path = os.path.join(model_folder, env_file_name)
     env_file_path = copy_env(env_file_path)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR supports parsing `MLModel` files that were saved using `mlflow=2.* `. They introduced subfields for the environment in https://github.com/mlflow/mlflow/pull/6684. 

Here is an example of the differences between the `MLModel` files:

```yaml
### MLModel saved with mlflow=1
artifact_path: model
flavors:
  python_function:
    env: conda.yaml
    loader_module: mlflow.sklearn
    model_path: model.pkl
    predict_fn: predict
    python_version: 3.8.15
  sklearn:
    code: null
    pickled_model: model.pkl
    serialization_format: cloudpickle
    sklearn_version: 1.1.3
mlflow_version: 1.30.0
model_uuid: 9af999cad24d4f7e855ef3073a3f5163
run_id: 340709c027e3424bbe0e13e4803cad46
utc_time_created: '2022-12-02 15:47:51.018732'
```

```yaml
### MLModel saved with mlflow=2
artifact_path: model
flavors:
  python_function:
    env:
      conda: conda.yaml
      virtualenv: python_env.yaml
    loader_module: mlflow.sklearn
    model_path: model.pkl
    predict_fn: predict
    python_version: 3.8.15
  sklearn:
    code: null
    pickled_model: model.pkl
    serialization_format: cloudpickle
    sklearn_version: 1.1.3
mlflow_version: 2.0.1
model_uuid: 9649ad4b286e4b4fb52843a8c7146f64
run_id: fedf638f71a944eea4bf717008961a99
utc_time_created: '2022-12-09 20:26:51.455742'
```

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
I didn't see any related issues and the fix was easy enough to go directly to a PR.

**Special notes for your reviewer**:
I wanted to read `mlflow_version` from the `MLModel` file, but that field was only introduced in `mlflow=1.25` and the image is pinned to `mlflow<1.24.0`. So, I just added a check to see if the `env` field is a dictionary and if so, assumed that I would need to get the `conda` field.