### PR TITLE
Ensure x-request-id header matches kafka key

### DIFF
--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -196,6 +196,7 @@ func (km *KafkaManager) Infer(ctx context.Context, resourceName string, isModel 
 	}
 	logger.Debugf("Produce on topic %s with key %s", outputTopic, key)
 	kafkaHeaders := append(headers, kafka.Header{Key: resources.SeldonPipelineHeader, Value: []byte(resourceName)})
+	kafkaHeaders = addRequestIdToKafkaHeadersIfMissing(kafkaHeaders, requestId)
 
 	msg := &kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: &outputTopic, Partition: kafka.PartitionAny},


### PR DESCRIPTION
- [x] Ensure we set x-request-id kafka header when we create a new kafka produce in pipelinegateway thus ensuring a new one won't be generated
- [x] make kafka headers lowercase when converting from http headers which will be in canonical form, e.g. X-Request-ID -> x-request-id