### PR TITLE
Fix possible SIGSEV after producer close in modelgateway

### DIFF
--- a/scheduler/pkg/kafka/gateway/consumer.go
+++ b/scheduler/pkg/kafka/gateway/consumer.go
@@ -161,6 +161,7 @@ func (kc *InferKafkaConsumer) setup() error {
 		}
 		kc.workers = append(kc.workers, worker)
 	}
+	kc.running.Store(true)
 	return nil
 }
 
@@ -285,7 +286,6 @@ func (kc *InferKafkaConsumer) Serve() {
 		go kc.workers[i].Start(jobChan, cancelChan)
 	}
 
-	kc.running.Store(true)
 	for run {
 		select {
 		case <-kc.done:

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -47,7 +47,7 @@ const (
 	defaultNumPartitions        = 1
 )
 
-type InferKafkaConsumer struct {
+type InferKafkaHandler struct {
 	logger            log.FieldLogger
 	mu                sync.RWMutex
 	loadedModels      map[string]bool
@@ -65,10 +65,10 @@ type InferKafkaConsumer struct {
 	numPartitions     int
 	tlsClientOptions  *util.TLSOptions
 	producerMu        sync.RWMutex
-	running           atomic.Bool
+	producerActive    atomic.Bool
 }
 
-func NewInferKafkaConsumer(logger log.FieldLogger, consumerConfig *ConsumerConfig, consumerName string) (*InferKafkaConsumer, error) {
+func NewInferKafkaHandler(logger log.FieldLogger, consumerConfig *ConsumerConfig, consumerName string) (*InferKafkaHandler, error) {
 	replicationFactor, err := util.GetIntEnvar(envDefaultReplicationFactor, defaultReplicationFactor)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func NewInferKafkaConsumer(logger log.FieldLogger, consumerConfig *ConsumerConfi
 	if err != nil {
 		return nil, err
 	}
-	ic := &InferKafkaConsumer{
+	ic := &InferKafkaHandler{
 		logger:            logger.WithField("source", "InferConsumer"),
 		done:              make(chan bool),
 		tracer:            consumerConfig.TraceProvider.GetTraceProvider().Tracer("Worker"),
@@ -97,7 +97,7 @@ func NewInferKafkaConsumer(logger log.FieldLogger, consumerConfig *ConsumerConfi
 	return ic, ic.setup()
 }
 
-func (kc *InferKafkaConsumer) setup() error {
+func (kc *InferKafkaHandler) setup() error {
 	logger := kc.logger.WithField("func", "setup")
 	var err error
 
@@ -119,6 +119,7 @@ func (kc *InferKafkaConsumer) setup() error {
 	if err != nil {
 		return err
 	}
+	kc.producerActive.Store(true)
 	logger.Infof("Created producer %s", kc.producer.String())
 
 	consumerConfig := config.CloneKafkaConfigMap(kc.consumerConfig.KafkaConfig.Consumer)
@@ -161,7 +162,6 @@ func (kc *InferKafkaConsumer) setup() error {
 		}
 		kc.workers = append(kc.workers, worker)
 	}
-	kc.running.Store(true)
 	return nil
 }
 
@@ -174,27 +174,30 @@ func collectHeaders(kheaders []kafka.Header) map[string]string {
 	return headers
 }
 
-func (kc *InferKafkaConsumer) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) error {
+func (kc *InferKafkaHandler) Produce(msg *kafka.Message, deliveryChan chan kafka.Event) error {
+	logger := kc.logger.WithField("func", "Produce")
 	kc.producerMu.RLock()
 	defer kc.producerMu.RUnlock()
-	if kc.running.Load() {
+	if kc.producerActive.Load() {
 		return kc.producer.Produce(msg, deliveryChan)
 	} else {
-		return fmt.Errorf("The infer producer %s is no longer running", kc.producer.String())
+		err := fmt.Errorf("The infer producer %s is no longer running", kc.producer.String())
+		logger.WithError(err).Error("Failed to produce kafka message")
+		return err
 	}
 }
 
-func (kc *InferKafkaConsumer) closeProducer() {
+func (kc *InferKafkaHandler) closeProducer() {
 	kc.producerMu.Lock()
 	defer kc.producerMu.Unlock()
 	kc.producer.Close()
 }
 
-func (kc *InferKafkaConsumer) Stop() {
+func (kc *InferKafkaHandler) Stop() {
 	close(kc.done)
 }
 
-func (kc *InferKafkaConsumer) subscribeTopics() error {
+func (kc *InferKafkaHandler) subscribeTopics() error {
 	topics := make([]string, len(kc.subscribedTopics))
 	idx := 0
 	for k := range kc.subscribedTopics {
@@ -205,13 +208,13 @@ func (kc *InferKafkaConsumer) subscribeTopics() error {
 	return err
 }
 
-func (kc *InferKafkaConsumer) GetNumModels() int {
+func (kc *InferKafkaHandler) GetNumModels() int {
 	kc.mu.RLock()
 	defer kc.mu.RUnlock()
 	return len(kc.loadedModels)
 }
 
-func (kc *InferKafkaConsumer) createTopics(topicNames []string) error {
+func (kc *InferKafkaHandler) createTopics(topicNames []string) error {
 	logger := kc.logger.WithField("func", "createTopics")
 	if kc.adminClient == nil {
 		logger.Warnf("Can't create topics %v as no admin client", topicNames)
@@ -239,7 +242,7 @@ func (kc *InferKafkaConsumer) createTopics(topicNames []string) error {
 	return nil
 }
 
-func (kc *InferKafkaConsumer) AddModel(modelName string) error {
+func (kc *InferKafkaHandler) AddModel(modelName string) error {
 	kc.mu.Lock()
 	defer kc.mu.Unlock()
 	kc.loadedModels[modelName] = true
@@ -260,7 +263,7 @@ func (kc *InferKafkaConsumer) AddModel(modelName string) error {
 	return nil
 }
 
-func (kc *InferKafkaConsumer) RemoveModel(modelName string) error {
+func (kc *InferKafkaHandler) RemoveModel(modelName string) error {
 	kc.mu.Lock()
 	defer kc.mu.Unlock()
 	delete(kc.loadedModels, modelName)
@@ -275,7 +278,7 @@ func (kc *InferKafkaConsumer) RemoveModel(modelName string) error {
 	return nil
 }
 
-func (kc *InferKafkaConsumer) Serve() {
+func (kc *InferKafkaHandler) Serve() {
 	logger := kc.logger.WithField("func", "Serve").WithField("consumerName", kc.consumerName)
 	run := true
 	// create a cancel and job channel
@@ -290,7 +293,7 @@ func (kc *InferKafkaConsumer) Serve() {
 		select {
 		case <-kc.done:
 			logger.Infof("Stopping")
-			kc.running.Store(false)
+			kc.producerActive.Store(false)
 			run = false
 		default:
 			ev := kc.consumer.Poll(pollTimeoutMillisecs)

--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -35,7 +35,7 @@ type ConsumerManager struct {
 	logger log.FieldLogger
 	mu     sync.Mutex
 	// all consumers we have
-	consumers       map[string]*InferKafkaConsumer
+	consumers       map[string]*InferKafkaHandler
 	consumerConfig  *ConsumerConfig
 	maxNumConsumers int
 }
@@ -52,12 +52,12 @@ func NewConsumerManager(logger log.FieldLogger, consumerConfig *ConsumerConfig, 
 	return &ConsumerManager{
 		logger:          logger.WithField("source", "ConsumerManager"),
 		consumerConfig:  consumerConfig,
-		consumers:       make(map[string]*InferKafkaConsumer),
+		consumers:       make(map[string]*InferKafkaHandler),
 		maxNumConsumers: maxNumConsumers,
 	}
 }
 
-func (cm *ConsumerManager) getInferKafkaConsumer(modelName string, create bool) (*InferKafkaConsumer, error) {
+func (cm *ConsumerManager) getInferKafkaConsumer(modelName string, create bool) (*InferKafkaHandler, error) {
 	logger := cm.logger.WithField("func", "getInferKafkaConsumer")
 	consumerBucketId := util.GetKafkaConsumerName(modelName, modelGatewayConsumerNamePrefix, cm.maxNumConsumers)
 	ic, ok := cm.consumers[consumerBucketId]
@@ -68,7 +68,7 @@ func (cm *ConsumerManager) getInferKafkaConsumer(modelName string, create bool) 
 
 	if !ok {
 		var err error
-		ic, err = NewInferKafkaConsumer(cm.logger, cm.consumerConfig, consumerBucketId)
+		ic, err = NewInferKafkaHandler(cm.logger, cm.consumerConfig, consumerBucketId)
 		if err != nil {
 			return nil, err
 		}
@@ -95,7 +95,7 @@ func (cm *ConsumerManager) AddModel(modelName string) error {
 	return nil
 }
 
-func (cm *ConsumerManager) stopEmptyConsumer(ic *InferKafkaConsumer) {
+func (cm *ConsumerManager) stopEmptyConsumer(ic *InferKafkaHandler) {
 	logger := cm.logger.WithField("func", "stopEmptyConsumer")
 	numModelsInConsumer := ic.GetNumModels()
 	if numModelsInConsumer == 0 {

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -244,7 +244,7 @@ func (iw *InferWorker) produce(ctx context.Context, job *InferWork, topic string
 	otel.GetTextMapPropagator().Inject(ctx, carrierOut)
 
 	deliveryChan := make(chan kafka.Event)
-	err := iw.consumer.producer.Produce(msg, deliveryChan)
+	err := iw.consumer.Produce(msg, deliveryChan)
 	if err != nil {
 		iw.logger.WithError(err).Errorf("Failed to produce response for model %s", topic)
 		return err

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -58,7 +58,7 @@ type InferWorker struct {
 	logger      log.FieldLogger
 	grpcClient  v2.GRPCInferenceServiceClient
 	httpClient  *http.Client
-	consumer    *InferKafkaConsumer
+	consumer    *InferKafkaHandler
 	tracer      trace.Tracer
 	callOptions []grpc.CallOption
 	topicNamer  *kafka2.TopicNamer
@@ -74,7 +74,7 @@ type V2Error struct {
 	Error string `json:"error"`
 }
 
-func NewInferWorker(consumer *InferKafkaConsumer, logger log.FieldLogger, traceProvider *seldontracer.TracerProvider, topicNamer *kafka2.TopicNamer) (*InferWorker, error) {
+func NewInferWorker(consumer *InferKafkaHandler, logger log.FieldLogger, traceProvider *seldontracer.TracerProvider, topicNamer *kafka2.TopicNamer) (*InferWorker, error) {
 	opts := []grpc.CallOption{
 		grpc.MaxCallSendMsgSize(math.MaxInt32),
 		grpc.MaxCallRecvMsgSize(math.MaxInt32),

--- a/scheduler/pkg/kafka/gateway/worker_test.go
+++ b/scheduler/pkg/kafka/gateway/worker_test.go
@@ -89,7 +89,7 @@ func TestRestRequest(t *testing.T) {
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
 			config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
-			ic, err := NewInferKafkaConsumer(logger, config, "dummy")
+			ic, err := NewInferKafkaHandler(logger, config, "dummy")
 			g.Expect(err).To(BeNil())
 			tn := kafka2.NewTopicNamer("default")
 			iw, err := NewInferWorker(ic, logger, tp, tn)
@@ -135,7 +135,7 @@ func TestProcessRequestRest(t *testing.T) {
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
 			config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
-			ic, err := NewInferKafkaConsumer(logger, config, "dummy")
+			ic, err := NewInferKafkaHandler(logger, config, "dummy")
 			g.Expect(err).To(BeNil())
 			tn := kafka2.NewTopicNamer("default")
 			iw, err := NewInferWorker(ic, logger, tp, tn)
@@ -201,14 +201,14 @@ func createInferWorkerWithMockConn(
 	logger log.FieldLogger,
 	serverConfig *InferenceServerConfig,
 	modelConfig *KafkaModelConfig,
-	g *WithT) (*InferKafkaConsumer, *InferWorker) {
+	g *WithT) (*InferKafkaHandler, *InferWorker) {
 	conn, _ := grpc.DialContext(context.TODO(), "", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return grpcServer.listener.Dial()
 	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 	g.Expect(err).To(BeNil())
 	config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: serverConfig, TraceProvider: tp, NumWorkers: 0}
-	ic, err := NewInferKafkaConsumer(logger, config, "dummy")
+	ic, err := NewInferKafkaHandler(logger, config, "dummy")
 	g.Expect(err).To(BeNil())
 	iw := &InferWorker{
 		logger:     logger,


### PR DESCRIPTION
[Its not allowed to use a producer after or during its closed](https://github.com/confluentinc/confluent-kafka-go/issues/909).
This PR wraps a lock around produce to ensure safe multi-goroutine use.