### PR TITLE
Link how to install docker compose v2 from github releases

### DIFF
--- a/docs/source/contents/getting-started/docker-installation/index.md
+++ b/docs/source/contents/getting-started/docker-installation/index.md
@@ -4,7 +4,7 @@
 
  1. `git clone https://github.com/SeldonIO/seldon-core --branch=v2`
  2. Build [Seldon CLI](../cli.md)
- 3. Install [Docker Compose](https://docs.docker.com/compose/install/).
+ 3. Install [Docker Compose](https://docs.docker.com/compose/install/) (or directly from GitHub [release](https://github.com/docker/compose#linux) if not using Docker for Desktop).
  4. Install `make`. This will depend on your version of Linux, for example on Ubuntu run `sudo apt-get install build-essential`.
 
 
@@ -31,7 +31,7 @@ make deploy-local
 
 ### GPU support
 
-To enable GPU on servers: 
+To enable GPU on servers:
 
 1. Make sure that `nvidia-container-runtime` is installed, follow [link](https://docs.docker.com/config/containers/resource_constraints/#gpu)
 2. Enable GPU: `export GPU_ENABLED=1`
@@ -48,7 +48,7 @@ make deploy-local
 
 This folder will be mounted at `/mnt/models`. You can then specify models as shown below:
 
-```{literalinclude} ../../../../../samples/models/sklearn-iris-local.yaml 
+```{literalinclude} ../../../../../samples/models/sklearn-iris-local.yaml
 :language: yaml
 ```
 

--- a/docs/source/contents/getting-started/docker-installation/index.md
+++ b/docs/source/contents/getting-started/docker-installation/index.md
@@ -4,7 +4,7 @@
 
  1. `git clone https://github.com/SeldonIO/seldon-core --branch=v2`
  2. Build [Seldon CLI](../cli.md)
- 3. Install [Docker Compose](https://docs.docker.com/compose/install/) (or directly from GitHub [release](https://github.com/docker/compose#linux) if not using Docker for Desktop).
+ 3. Install [Docker Compose](https://docs.docker.com/compose/install/) (or directly from GitHub [release](https://github.com/docker/compose#linux) if not using Docker Desktop).
  4. Install `make`. This will depend on your version of Linux, for example on Ubuntu run `sudo apt-get install build-essential`.
 
 


### PR DESCRIPTION
This links docker compose GitHub repositories instruction  on how to install from GH releases (preferable for Compose V2 on Linux / Mac systems or whenever not using Docker for Desktop). It basically boils down to
```bash
DOCKER_COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)
DESTINATION=${HOME}/.docker/cli-plugins
mkdir -p ${DESTINATION}
curl -L "https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o ${DESTINATION}/docker-compose
chmod +x ${DESTINATION}/docker-compose
```
but linking upstream resource seems preferable. 