### PR TITLE
Update local-over-commit-test.ipynb

### DIFF
--- a/scheduler/notebooks/local-over-commit-test.ipynb
+++ b/scheduler/notebooks/local-over-commit-test.ipynb
@@ -42,7 +42,7 @@
    "id": "ebf5eb28",
    "metadata": {},
    "source": [
-    "By default if running locally there is 1 replica of `mlserver` with memory slots up to 10000000 MB (10GB) and 20% overcommit budget. We will load 11 `iris` models each requiring 1MB worth of memory slots as an example. These numbers allow for 10 models to be active at the same time and 1 model to be evicted to disk.  "
+    "By default if running locally there is 1 replica of `mlserver` with memory slots up to 10MB and 20% overcommit budget. We will load 11 `iris` models each requiring 1MB worth of memory slots as an example. These numbers allow for 10 models to be active at the same time and 1 model to be evicted to disk.  "
    ]
   },
   {


### PR DESCRIPTION
Update correct total memory slots of servers
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Update correct total memory slots for servers when running locally to 10 MB in notebook

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
