### PR TITLE
v2: Remove need for ONESHELL in go lint

### DIFF
--- a/components/tls/Makefile
+++ b/components/tls/Makefile
@@ -7,20 +7,12 @@ test:
 .GOLANGCILINT_VERSION := v1.48.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
-.PHONY: .install-golangci-lint
-.ONESHELL: .install-golangci-lint
-.install-golangci-lint:
-	@installed=false
-	if [ -e "${.GOLANGCILINT_PATH}/golangci-lint" ]; then
-		installed=true
-	fi
-	if ! $${installed}; then
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+${.GOLANGCILINT_PATH}/golangci-lint: 
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sh -s -- -b ${.GOLANGCILINT_PATH} ${.GOLANGCILINT_VERSION}
-	fi
 
 .PHONY: lint
-lint: .install-golangci-lint
+lint: ${.GOLANGCILINT_PATH}/golangci-lint
 	gofmt -w pkg
 	${.GOLANGCILINT_PATH}/golangci-lint run --fix
 

--- a/hodometer/Makefile
+++ b/hodometer/Makefile
@@ -24,20 +24,12 @@ RELEASE_TYPE ?= pre-release
 .GOLANGCILINT_VERSION := v1.48.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
-.PHONY: .install-golangci-lint
-.ONESHELL: .install-golangci-lint
-.install-golangci-lint:
-	@installed=false
-	if [ -e "${.GOLANGCILINT_PATH}/golangci-lint" ]; then
-		installed=true
-	fi
-	if ! $${installed}; then
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+${.GOLANGCILINT_PATH}/golangci-lint: 
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sh -s -- -b ${.GOLANGCILINT_PATH} ${.GOLANGCILINT_VERSION}
-	fi
 
 .PHONY: lint
-lint: .install-golangci-lint
+lint: ${.GOLANGCILINT_PATH}/golangci-lint
 	gofmt -w cmd
 	gofmt -w pkg
 	${.GOLANGCILINT_PATH}/golangci-lint run --fix

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -65,21 +65,12 @@ vet: ## Run go vet against code.
 .GOLANGCILINT_VERSION := v1.48.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
-.PHONY: .install-golangci-lint
-.ONESHELL: .install-golangci-lint
-.install-golangci-lint:
-	@installed=false
-	if [ -e "${.GOLANGCILINT_PATH}/golangci-lint" ]; then
-		installed=true
-	fi
-	if ! $${installed}; then
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+${.GOLANGCILINT_PATH}/golangci-lint: 
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sh -s -- -b ${.GOLANGCILINT_PATH} ${.GOLANGCILINT_VERSION}
-	fi
-
 
 .PHONY: lint
-lint: .install-golangci-lint
+lint: ${.GOLANGCILINT_PATH}/golangci-lint
 	${.GOLANGCILINT_PATH}/golangci-lint run --fix
 
 .PHONY: test

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -69,20 +69,12 @@ build: build-go build-jvm
 .GOLANGCILINT_VERSION := v1.48.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
-.PHONY: .install-golangci-lint
-#.ONESHELL: .install-golangci-lint
-.install-golangci-lint:
-	@installed=false
-	if [ -e "${.GOLANGCILINT_PATH}/golangci-lint" ]; then
-		installed=true
-	fi
-	if ! $${installed}; then
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+${.GOLANGCILINT_PATH}/golangci-lint: 
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sh -s -- -b ${.GOLANGCILINT_PATH} ${.GOLANGCILINT_VERSION}
-	fi
 
 .PHONY: lint
-lint: .install-golangci-lint
+lint: ${.GOLANGCILINT_PATH}/golangci-lint
 	gofmt -w pkg
 	gofmt -w cmd
 	${.GOLANGCILINT_PATH}/golangci-lint run --fix


### PR DESCRIPTION
Removes the need to use the [ONESHELL](https://www.gnu.org/software/make/manual/html_node/One-Shell.html) directive in Makefiles for Go lint download. ONESHELL is a global directive for the entire Makefile and causes issues in getting the go license updates to run as it stops normal error failure during Makefile runs, i.e. an error code from a command should stop the Make run.

From docs:

> Even with this special feature, however, makefiles with .ONESHELL will behave differently in ways that could be noticeable. For example, normally if any line in the recipe fails, that causes the rule to fail and no more recipe lines are processed. Under .ONESHELL a failure of any but the final recipe line will not be noticed by make. You can modify .SHELLFLAGS to add the -e option to the shell which will cause any failure anywhere in the command line to cause the shell to fail, but this could itself cause your recipe to behave differently. Ultimately you may need to harden your recipe lines to allow them to work with .ONESHELL.