### PR TITLE
Allow ServerConfig and Server labels and annotations to be passed to StatefulSet

### DIFF
--- a/operator/controllers/reconcilers/server_reconciler.go
+++ b/operator/controllers/reconcilers/server_reconciler.go
@@ -125,7 +125,7 @@ func (s *ServerReconciler) createStatefulSetReconciler(server *mlopsv1alpha1.Ser
 	updateCapabilities(server.Spec.ExtraCapabilities, podSpec)
 
 	// Reconcile ReplicaSet
-	statefulSetReconciler := statefulset.NewStatefulSetReconciler(s.ReconcilerConfig, server.ObjectMeta, podSpec, serverConfig.Spec.VolumeClaimTemplates, &server.Spec.ScalingSpec)
+	statefulSetReconciler := statefulset.NewStatefulSetReconciler(s.ReconcilerConfig, server.ObjectMeta, podSpec, serverConfig.Spec.VolumeClaimTemplates, &server.Spec.ScalingSpec, serverConfig.ObjectMeta)
 	return statefulSetReconciler, nil
 }
 

--- a/operator/controllers/reconcilers/statefulset/statefulset_reconciler_test.go
+++ b/operator/controllers/reconcilers/statefulset/statefulset_reconciler_test.go
@@ -326,9 +326,12 @@ func TestToStatefulSet(t *testing.T) {
 					},
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels:    map[string]string{constants.ServerLabelNameKey: "foo", constants.AppKey: constants.ServerLabelValue},
-							Name:      "foo",
-							Namespace: "default",
+							Labels: map[string]string{constants.ServerLabelNameKey: "foo",
+								constants.AppKey: constants.ServerLabelValue,
+								"l1":             "l1val"},
+							Annotations: map[string]string{"a1": "a1val"},
+							Name:        "foo",
+							Namespace:   "default",
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{

--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -42,3 +42,30 @@ func RemoveStr(slice []string, s string) (result []string) {
 func GetStatefulSetReplicaName(name string, replicaIdx int) string {
 	return fmt.Sprintf("%s-%d", name, replicaIdx)
 }
+
+func MergeMaps(child map[string]string, parent map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range child {
+		merged[k] = v
+	}
+	for k, v := range parent {
+		if _, ok := child[k]; !ok {
+			merged[k] = v
+		}
+
+	}
+	return merged
+}
+
+func HasMappings(expected map[string]string, found map[string]string) bool {
+	for k, v := range expected {
+		if v2, ok := found[k]; ok {
+			if v != v2 {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}

--- a/operator/pkg/utils/utils_test.go
+++ b/operator/pkg/utils/utils_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMergeMaps(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name     string
+		m1       map[string]string
+		m2       map[string]string
+		expected map[string]string
+	}
+
+	tests := []test{
+		{
+			name:     "same mappings",
+			m1:       map[string]string{"a": "a"},
+			m2:       map[string]string{},
+			expected: map[string]string{"a": "a"},
+		},
+		{
+			name:     "different mappings",
+			m1:       map[string]string{"a": "a"},
+			m2:       map[string]string{"b": "b"},
+			expected: map[string]string{"a": "a", "b": "b"},
+		},
+		{
+			name:     "overrides",
+			m1:       map[string]string{"a": "2"},
+			m2:       map[string]string{"a": "1"},
+			expected: map[string]string{"a": "2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m3 := MergeMaps(test.m1, test.m2)
+			for k, v := range test.expected {
+				g.Expect(m3[k]).To(Equal(v))
+			}
+		})
+	}
+}
+
+func TestHasMappings(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name     string
+		m1       map[string]string
+		m2       map[string]string
+		expected bool
+	}
+
+	tests := []test{
+		{
+			name:     "same mappings",
+			m1:       map[string]string{"a": "a"},
+			m2:       map[string]string{"a": "a"},
+			expected: true,
+		},
+		{
+			name:     "subset",
+			m1:       map[string]string{"a": "a"},
+			m2:       map[string]string{"a": "a", "b": "b"},
+			expected: true,
+		},
+		{
+			name:     "fail value",
+			m1:       map[string]string{"a": "a"},
+			m2:       map[string]string{"a": "b", "b": "b"},
+			expected: false,
+		},
+		{
+			name:     "fail key",
+			m1:       map[string]string{"a": "a"},
+			m2:       map[string]string{"c": "c", "b": "b"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g.Expect(HasMappings(test.m1, test.m2)).To(Equal(test.expected))
+		})
+	}
+}


### PR DESCRIPTION
- ServerConfig and Server annotations and labels added to StatefulSet and StatefulSet Pod Template
- Server values override any from ServerConfig

Fixes #4542 
