### PR TITLE
Bugfix: reference pipeline fields after handling error

### DIFF
--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -471,14 +471,13 @@ func (p *IncrementalProcessor) addPipeline(pipelineName string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	pip, err := p.pipelineHandler.GetPipeline(pipelineName)
-	logger.Debugf("Handling pipeline %s deleted %v", pip.Name, pip.Deleted)
 	if err != nil {
 		logger.WithError(err).Errorf("Failed to get pipeline %s", pipelineName)
 		return err
-	} else {
-		if pip.Deleted {
-			return p.removePipeline(pip)
-		}
+	}
+	logger.Debugf("Handling pipeline %s deleted %v", pip.Name, pip.Deleted)
+	if pip.Deleted {
+		return p.removePipeline(pip)
 	}
 	routeName := getPipelineRouteName(pip.Name)
 	p.xdsCache.RemovePipelineRoute(routeName)


### PR DESCRIPTION
**What this PR does / why we need it**:
A panic occurs if there is an issue retrieving a pipeline specified in an experiment.
```
│ time="2023-01-05T10:44:16Z" level=info msg="Scheduler server running on 9004 mtls:false" source=SchedulerServer                                      │
│ time="2023-01-05T10:44:16Z" level=info msg="Not starting scheduler mTLS server" func=StartGrpcServers source=SchedulerServer                         │
│ time="2023-01-05T10:44:16Z" level=info msg="Experiment income-debug-experiment sync - calling for pipeline income-debug" func=experimentSync source= │
│ EnvoyServer                                                                                                                                          │
│ time="2023-01-05T10:44:16Z" level=debug msg="Received sync for experiment income-v2-experiment" func=handleExperimentEvents source=EnvoyServer       │
│ panic: runtime error: invalid memory address or nil pointer dereference                                                                              │
│ [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x192fcbe]                                                                              │
│ goroutine 156 [running]:                                                                                                                             │
│ github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/processor.(*IncrementalProcessor).addPipeline(0xc0007445b0, {0xc000ef48b0, 0xc})              │
│     /build/scheduler/pkg/envoy/processor/incremental.go:474 +0x13e                                                                                   │
│ github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/processor.(*IncrementalProcessor).experimentUpdate(0xc0007445b0, 0xc000219500)                │
│     /build/scheduler/pkg/envoy/processor/incremental.go:525 +0x13b                                                                                   │
│ github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/processor.(*IncrementalProcessor).handleExperimentEvents.func1()                              │
│     /build/scheduler/pkg/envoy/processor/incremental.go:165 +0x1f6                                                                                   │
│ created by github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/processor.(*IncrementalProcessor).handleExperimentEvents                           │
│     /build/scheduler/pkg/envoy/processor/incremental.go:153 +0x1ab    
```

**Which issue(s) this PR fixes**:
No issues opened for this

**Special notes for your reviewer**:
