### PR TITLE
use ubuntu-latest for GHA

### DIFF
--- a/.github/workflows/alibidetect_tests.yml
+++ b/.github/workflows/alibidetect_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/python-builder:0.6
 
     steps:
@@ -22,7 +22,7 @@ jobs:
           make -C components/alibi-detect-server lint
 
   python-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/python-builder:0.6
 
     steps:

--- a/.github/workflows/alibiexplainer_tests.yml
+++ b/.github/workflows/alibiexplainer_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/python-builder:0.6
 
     steps:
@@ -23,7 +23,7 @@ jobs:
 
   python-tests:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/python-builder:0.6
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   docs-lint:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/core-builder:0.27
 
     steps:
@@ -20,7 +20,7 @@ jobs:
 
   docs-build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/core-builder:0.27
 
     steps:

--- a/.github/workflows/executor_lint.yml
+++ b/.github/workflows/executor_lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   executor-lint:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/core-builder:0.27
 
     steps:

--- a/.github/workflows/executor_tests.yml
+++ b/.github/workflows/executor_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   executor-tests:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/core-builder:0.27
 
     steps:

--- a/.github/workflows/operator_lint.yml
+++ b/.github/workflows/operator_lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   operator-lint:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/core-builder:0.27
 
     steps:

--- a/.github/workflows/operator_tests.yml
+++ b/.github/workflows/operator_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   operator-tests:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/core-builder:0.27
 
     steps:

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   python-lint:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/python-builder:0.5
 
     steps:

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   python-tests:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: seldonio/python-builder:0.5
 
     steps:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Ubuntu 18.04 environment for GHA has been deprecated according to error message, e.g. [here](https://github.com/SeldonIO/seldon-core/actions/runs/3846080345). This bumps these tasks to use `ubuntu-latest` (20.04) as in some other actions we already have.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/SeldonIO/seldon-core/issues/4549

**Special notes for your reviewer**:
