### PR TITLE
Fix grpc connection retry to control and data plane services

### DIFF
--- a/scheduler/pkg/agent/rproxy.go
+++ b/scheduler/pkg/agent/rproxy.go
@@ -132,7 +132,9 @@ func (t *lazyModelLoadTransport) RoundTrip(req *http.Request) (*http.Response, e
 	// this is likely to increase latency for genuine bad requests as we will retry twice
 	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusBadRequest {
 		internalModelName := req.Header.Get(resources.SeldonInternalModelHeader)
-		t.loader(internalModelName)
+		if v2Err := t.loader(internalModelName); v2Err != nil {
+			t.logger.WithError(v2Err).Warnf("cannot load model %s", internalModelName)
+		}
 
 		req2 := req.Clone(req.Context())
 

--- a/scheduler/pkg/agent/rproxy_grpc.go
+++ b/scheduler/pkg/agent/rproxy_grpc.go
@@ -237,7 +237,9 @@ func (rp *reverseGRPCProxy) ModelInfer(ctx context.Context, r *v2.ModelInferRequ
 	opts := append(rp.callOptions, grpc.Trailer(&trailer))
 	resp, err := rp.getV2GRPCClient().ModelInfer(ctx, r, opts...)
 	if retryForLazyReload(err) {
-		rp.stateManager.v2Client.LoadModel(internalModelName)
+		if v2Err := rp.stateManager.v2Client.LoadModel(internalModelName); v2Err != nil {
+			rp.logger.WithError(v2Err).Warnf("error loading model %s", internalModelName)
+		}
 		resp, err = rp.getV2GRPCClient().ModelInfer(ctx, r, opts...)
 	}
 
@@ -269,7 +271,9 @@ func (rp *reverseGRPCProxy) ModelMetadata(ctx context.Context, r *v2.ModelMetada
 
 	resp, err := rp.getV2GRPCClient().ModelMetadata(ctx, r)
 	if retryForLazyReload(err) {
-		rp.stateManager.v2Client.LoadModel(internalModelName)
+		if v2Err := rp.stateManager.v2Client.LoadModel(internalModelName); v2Err != nil {
+			rp.logger.WithError(v2Err).Warnf("error loading model %s", internalModelName)
+		}
 		resp, err = rp.getV2GRPCClient().ModelMetadata(ctx, r)
 	}
 	return resp, err
@@ -289,7 +293,9 @@ func (rp *reverseGRPCProxy) ModelReady(ctx context.Context, r *v2.ModelReadyRequ
 
 	resp, err := rp.getV2GRPCClient().ModelReady(ctx, r)
 	if retryForLazyReload(err) {
-		rp.stateManager.v2Client.LoadModel(internalModelName)
+		if v2Err := rp.stateManager.v2Client.LoadModel(internalModelName); v2Err != nil {
+			rp.logger.WithError(v2Err).Warnf("error loading model %s", internalModelName)
+		}
 		resp, err = rp.getV2GRPCClient().ModelReady(ctx, r)
 	}
 	return resp, err

--- a/scheduler/pkg/agent/v2.go
+++ b/scheduler/pkg/agent/v2.go
@@ -85,6 +85,13 @@ type V2Err struct {
 	errCode int
 }
 
+func (v2err *V2Err) Error() string {
+	if v2err != nil {
+		return v2err.err.Error()
+	}
+	return ""
+}
+
 func (v *V2Err) IsNotFound() bool {
 	if v.isGrpc {
 		return v.errCode == int(codes.NotFound)

--- a/scheduler/pkg/agent/v2.go
+++ b/scheduler/pkg/agent/v2.go
@@ -29,14 +29,14 @@ import (
 	"strconv"
 	"time"
 
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -104,6 +104,7 @@ var ErrServerNotReady = errors.New("Server not ready")
 func getV2GrpcConnection(host string, plainTxtPort int) (*grpc.ClientConn, error) {
 	retryOpts := []grpc_retry.CallOption{
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(util.GrpcRetryBackoffMillisecs * time.Millisecond)),
+		grpc_retry.WithMax(util.GrpcRetryMaxCount),
 	}
 
 	opts := []grpc.DialOption{

--- a/scheduler/pkg/agent/v2_test.go
+++ b/scheduler/pkg/agent/v2_test.go
@@ -289,5 +289,7 @@ func TestGrpcV2WithRetry(t *testing.T) {
 		g.Expect(err).To(BeNil())
 		time.Sleep(100 * time.Millisecond)
 	}
+
+	// stop server
 	isActive.Store(false)
 }

--- a/scheduler/pkg/agent/v2_test.go
+++ b/scheduler/pkg/agent/v2_test.go
@@ -247,7 +247,7 @@ func TestGrpcV2WithError(t *testing.T) {
 }
 
 func TestGrpcV2WithRetry(t *testing.T) {
-	// note: we keep starting and stopping the service to simulate transient communication errors
+	// note: we delay starting the server to simulate transient errors
 	g := NewGomegaWithT(t)
 	mockMLServer := &mockGRPCMLServer{}
 	backEndGRPCPort, err := getFreePort()
@@ -276,7 +276,7 @@ func TestGrpcV2WithRetry(t *testing.T) {
 	}()
 	defer mockMLServer.stop()
 
-	// make sure that we can still get to the server
+	// make sure that we can still get to the server, this will require retries as the server starts after 0.5s
 	for i := 0; i < 20; i++ {
 		err = v2Client.Ready()
 		g.Expect(err).To(BeNil())

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -86,6 +86,7 @@ func (kc *KafkaSchedulerClient) ConnectToScheduler(host string, plainTxtPort int
 		transCreds = kc.certificateStore.CreateClientTransportCredentials()
 		port = tlsPort
 	}
+	// note: retry is done in the caller
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transCreds),
 	}

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -101,7 +101,6 @@ func (kc *KafkaSchedulerClient) ConnectToScheduler(host string, plainTxtPort int
 		return err
 	}
 	kc.conn = conn
-	logger.Info("Connected to scheduler")
 	return nil
 }
 

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -22,8 +22,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
-
 	"github.com/cenkalti/backoff/v4"
 	seldontls "github.com/seldonio/seldon-core/components/tls/v2/pkg/tls"
 
@@ -76,9 +74,7 @@ func (kc *KafkaSchedulerClient) ConnectToScheduler(host string, plainTxtPort int
 			return err
 		}
 	}
-	retryOpts := []grpc_retry.CallOption{
-		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(util.GrpcRetryBackoffMillisecs * time.Millisecond)),
-	}
+
 	var transCreds credentials.TransportCredentials
 	var port int
 	if kc.certificateStore == nil {
@@ -92,8 +88,6 @@ func (kc *KafkaSchedulerClient) ConnectToScheduler(host string, plainTxtPort int
 	}
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transCreds),
-		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(retryOpts...)),
-		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(retryOpts...)),
 	}
 	logger.Infof("Connecting to scheduler at %s:%d", host, port)
 	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", host, port), opts...)
@@ -114,7 +108,7 @@ func (kc *KafkaSchedulerClient) Stop() {
 func (kc *KafkaSchedulerClient) Start() error {
 	logger := kc.logger.WithField("func", "Start")
 	// We keep trying to connect to scheduler.
-	// If SubscribeModelEvents returns we try to start connecing again.
+	// If SubscribeModelEvents returns we try to start connecting again.
 	// Only stop if asked to via the keepRunning flag.
 	// We allow the subscribeModelEvents to return nil on EOF to allow a new Exponential backoff to be started
 	// rather than return an error and continue the current Exponential backoff with might have reached large intervals

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -87,7 +87,7 @@ func NewInferWorker(consumer *InferKafkaHandler, logger log.FieldLogger, tracePr
 		callOptions: opts,
 		topicNamer:  topicNamer,
 	}
-	// Create HTTP and gRPC clients
+	// Create gRPC clients
 	grpcClient, err := iw.getGrpcClient(consumer.consumerConfig.InferenceServerConfig.Host, consumer.consumerConfig.InferenceServerConfig.GrpcPort)
 	if err != nil {
 		return nil, err
@@ -113,6 +113,7 @@ func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceSer
 	logger := iw.logger.WithField("func", "getGrpcClient")
 	retryOpts := []grpc_retry.CallOption{
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(util.GrpcRetryBackoffMillisecs * time.Millisecond)),
+		grpc_retry.WithMax(util.GrpcRetryMaxCount),  // retry envoy connection
 	}
 	var creds credentials.TransportCredentials
 	if iw.consumer.tlsClientOptions.TLS {

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -113,7 +113,7 @@ func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceSer
 	logger := iw.logger.WithField("func", "getGrpcClient")
 	retryOpts := []grpc_retry.CallOption{
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(util.GrpcRetryBackoffMillisecs * time.Millisecond)),
-		grpc_retry.WithMax(util.GrpcRetryMaxCount),  // retry envoy connection
+		grpc_retry.WithMax(util.GrpcRetryMaxCount), // retry envoy connection
 	}
 	var creds credentials.TransportCredentials
 	if iw.consumer.tlsClientOptions.TLS {

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -20,6 +20,6 @@ import "time"
 
 const (
 	GrpcRetryBackoffMillisecs         = 100
-	GrpcRetryMaxCount                 = 6 // around 12s in total wait duration
+	GrpcRetryMaxCount                 = 5 // around 3.2s in total wait duration
 	EnvoyUpdateDefaultBatchWaitMillis = 250 * time.Millisecond
 )

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -20,5 +20,6 @@ import "time"
 
 const (
 	GrpcRetryBackoffMillisecs         = 100
+	GrpcRetryMaxCount                 = 6 // around 12s in total wait duration
 	EnvoyUpdateDefaultBatchWaitMillis = 250 * time.Millisecond
 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR introduces MaxRetry (default 5) for grpc services:
- agent <-> model server (control plane)
- modelgateway <-> envoy (data plane inference from kafka)

Currently the grpc codes that are going to be retried are `Unavailable` and `Resource_Exhausted`. These are the default.

We also remove `grpc_retry` options for stream connections to scheduler as the retry logic is already handled by the callers.


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4547

**Special notes for your reviewer**:
