### PR TITLE
Retry ModelFailed models

### DIFF
--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -404,7 +404,7 @@ func (s *Server) Subscribe(request *pb.AgentSubscribeRequest, stream pb.AgentSer
 			s.mutex.Lock()
 			delete(s.agents, ServerKey{serverName: request.ServerName, replicaIdx: request.ReplicaIdx})
 			s.mutex.Unlock()
-			s.removeServerReplicaImpl(request.GetServerName(), int(request.GetReplicaIdx())) // this is non-blocking beyond rescheduling
+			s.removeServerReplicaImpl(request.GetServerName(), int(request.GetReplicaIdx())) // this is non-blocking beyond rescheduling models on removed server
 			return nil
 		}
 	}

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -80,10 +80,12 @@ func (s *SimpleScheduler) Schedule(modelKey string) error {
 }
 
 func (s *SimpleScheduler) ScheduleFailedModels() ([]string, error) {
-	s.muFailedModels.RLock()
-	defer s.muFailedModels.RUnlock()
+	failedModels, err := s.getFailedModels()
+	if err != nil {
+		return nil, err
+	}
 	var updatedModels []string
-	for modelName := range s.failedModels {
+	for _, modelName := range failedModels {
 		err := s.scheduleToServer(modelName)
 		if err != nil {
 			s.logger.Debugf("Failed to schedule failed model %s", modelName)

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -31,12 +31,10 @@ import (
 )
 
 type SimpleScheduler struct {
-	muFailedModels  sync.RWMutex
 	muSortAndUpdate sync.Mutex
 	store           store.ModelStore
 	logger          log.FieldLogger
 	SchedulerConfig
-	failedModels map[string]bool
 }
 
 type SchedulerConfig struct {
@@ -62,21 +60,12 @@ func NewSimpleScheduler(logger log.FieldLogger,
 		store:           store,
 		logger:          logger.WithField("Name", "SimpleScheduler"),
 		SchedulerConfig: schedulerConfig,
-		failedModels:    make(map[string]bool),
 	}
 	return s
 }
 
 func (s *SimpleScheduler) Schedule(modelKey string) error {
-	err := s.scheduleToServer(modelKey)
-	// Set model state using error
-	if err != nil {
-		s.muFailedModels.Lock()
-		defer s.muFailedModels.Unlock()
-		s.failedModels[modelKey] = true
-		return err
-	}
-	return nil
+	return s.scheduleToServer(modelKey)
 }
 
 func (s *SimpleScheduler) ScheduleFailedModels() ([]string, error) {
@@ -96,25 +85,23 @@ func (s *SimpleScheduler) ScheduleFailedModels() ([]string, error) {
 	return updatedModels, nil
 }
 
-
 func (s *SimpleScheduler) getFailedModels() ([]string, error) {
 	models, err := s.store.GetModels()
 	if err != nil {
 		return nil, err
 	}
-	var failedModels []string 
+	var failedModels []string
 	for _, model := range models {
 		version := model.GetLatest()
 		if version != nil {
-			versionState := version.ModelState() 
+			versionState := version.ModelState()
 			if versionState.State == store.ModelFailed || versionState.State == store.ScheduleFailed {
 				failedModels = append(failedModels, model.Name)
-			} 
+			}
 		}
 	}
 	return failedModels, nil
 }
-
 
 // TODO - clarify non shared models should not be scheduled
 func (s *SimpleScheduler) scheduleToServer(modelName string) error {
@@ -144,7 +131,6 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 				logger.Warnf("Failed to unschedule model replicas for model %s on server %s", modelName, latestModel.Server())
 			}
 		}
-		delete(s.failedModels, modelName) // Ensure model removed from failed models if its there
 	} else {
 		var debugTrail []string
 		var filteredServers []*store.ServerSnapshot

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -94,6 +94,26 @@ func (s *SimpleScheduler) ScheduleFailedModels() ([]string, error) {
 	return updatedModels, nil
 }
 
+
+func (s *SimpleScheduler) getFailedModels() ([]string, error) {
+	models, err := s.store.GetModels()
+	if err != nil {
+		return nil, err
+	}
+	var failedModels []string 
+	for _, model := range models {
+		version := model.GetLatest()
+		if version != nil {
+			versionState := version.ModelState() 
+			if versionState.State == store.ModelFailed || versionState.State == store.ScheduleFailed {
+				failedModels = append(failedModels, model.Name)
+			} 
+		}
+	}
+	return failedModels, nil
+}
+
+
 // TODO - clarify non shared models should not be scheduled
 func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 	logger := s.logger.WithField("func", "scheduleToServer")

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -370,6 +370,7 @@ func (m *MemoryStore) updateLoadedModelsImpl(
 	}
 
 	// in cases where we did have a previous ScheduleFailed, we need to reflect the change here
+	// this could be in the cases where we are scaling down a model and the new replica count can be all deployed
 	if updated || modelVersion.state.State == ScheduleFailed {
 		logger.Debugf("Updating model status for model %s server %s", modelKey, serverKey)
 		modelVersion.server = serverKey


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Retry `ModelFailed` when a new agent comes online. We already retry on `ScheduleFailed`. 

We clean up `failedModels` data structure and search the underlying store instead.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4553

**Special notes for your reviewer**:
