### PR TITLE
docs: update GUNICOR_THREADS default value in the docs

### DIFF
--- a/doc/source/python/python_server.rst
+++ b/doc/source/python/python_server.rst
@@ -100,8 +100,8 @@ orchestrator so GRPC requests would no longer work. An example of this would be 
 Threads
 -------
 
-By default, Seldon will process your model's incoming requests using a
-pool of **10 threads per worker process**. You can increase this number
+By default, Seldon will process your model's incoming requests using 
+**1 thread per worker process**. You can increase this number
 through the ``GUNICORN_THREADS`` environment variable. This variable can
 be controlled directly through the ``SeldonDeployment`` CRD.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR updates some outdated documentation. Since seldon-core 1.10 the default `GUNICORN_WORKERS` value is set to 1 not to 10.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

None.

**Special notes for your reviewer**:
