### PR TITLE
Fix model delete hang when FailedSchedule

### DIFF
--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -298,7 +298,7 @@ func (m *MemoryStore) updateLoadedModelsImpl(
 			modelKey, version, modelVersion.GetVersion(),
 		)
 	}
-	
+
 	if serverKey == "" {
 		// nothing to do for a model that doesnt have a server, proceed with sending an event for downstream
 		return &coordinator.ModelEventMsg{ModelName: modelVersion.GetMeta().GetName(), ModelVersion: modelVersion.GetVersion()}, nil

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -298,6 +298,12 @@ func (m *MemoryStore) updateLoadedModelsImpl(
 			modelKey, version, modelVersion.GetVersion(),
 		)
 	}
+	
+	if serverKey == "" {
+		// nothing to do for a model that doesnt have a server, proceed with sending an event for downstream
+		return &coordinator.ModelEventMsg{ModelName: modelVersion.GetMeta().GetName(), ModelVersion: modelVersion.GetVersion()}, nil
+	}
+
 	server, ok := m.store.servers[serverKey]
 	if !ok {
 		return nil, fmt.Errorf("failed to find server %s", serverKey)

--- a/scheduler/pkg/store/memory_test.go
+++ b/scheduler/pkg/store/memory_test.go
@@ -631,6 +631,28 @@ func TestUpdateLoadedModels(t *testing.T) {
 			},
 			expectedStates: map[int]ReplicaStatus{0: {State: LoadRequested}},
 		},
+		{
+			name: "DeleteFailedSchedulerModel",
+			store: &LocalSchedulerStore{
+				models: map[string]*Model{"model": {
+					versions: []*ModelVersion{
+						{
+							modelDefn: &pb.Model{ModelSpec: &pb.ModelSpec{MemoryBytes: &memBytes}},
+							server:    "",
+							version:   1,
+							replicas:  map[int]ReplicaStatus{},
+						},
+					},
+				}},
+				servers: map[string]*Server{},
+			},
+			modelKey:       "model",
+			version:        1,
+			serverKey:      "",
+			replicas:       []*ServerReplica{},
+			isModelDeleted: true,
+			expectedStates: map[int]ReplicaStatus{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR fixes a bug that when the model fails scheduling (i.e. no server is assigned) then it gets stuck when deleting it afterwards. The reason being is that previously when we delete a model that has no server associated, we did not send an update status event. Therefore the controller never received a `ModelTerminated` status change and therefore got stuck in the finaliser during the delete process.

The fix is to allow an event to published with state change of deleted models even if they have no associated server.