### PR TITLE
Fix SSL modelgateway kafka admin client bug

### DIFF
--- a/docs/source/contents/getting-started/kubernetes-installation/tls/strimzi.md
+++ b/docs/source/contents/getting-started/kubernetes-installation/tls/strimzi.md
@@ -6,7 +6,7 @@ If you have installed Strimzi we have an example Helm chart to create a Kafka cl
 
 The Ansible `setup-ecosystem` playbook will also install Strimzi and this cluster. See [here](../ansible.md).
 
-## MTLS Example
+## mTLS Example
 
 Create a Kafka User `seldon` in the namespace seldon was installed. This assumes Strimzi Kafka cluster is installed in the same namespace or is running with cluster wide permissions. Our Ansible scripts to setup the ecosystem will also create this user if tls is active.
 

--- a/docs/source/contents/getting-started/kubernetes-installation/tls/strimzi.md
+++ b/docs/source/contents/getting-started/kubernetes-installation/tls/strimzi.md
@@ -1,13 +1,23 @@
 # Strimzi Example
 
-Create a Kafka User `seldon` in the namespace seldon was installed. This assumes Strimzi Kafka cluster is installed in the same namespace or is running with cluster wide permissions.
+## Cluster Setup
 
-```{literalinclude} ../../../../../../kafka/strimzi/user.yaml
+If you have installed Strimzi we have an example Helm chart to create a Kafka cluster for seldon and an associated user in `kafka/strimzi` folder.
+
+The Ansible `setup-ecosystem` playbook will also install Strimzi and this cluster. See [here](../ansible.md).
+
+## MTLS Example
+
+Create a Kafka User `seldon` in the namespace seldon was installed. This assumes Strimzi Kafka cluster is installed in the same namespace or is running with cluster wide permissions. Our Ansible scripts to setup the ecosystem will also create this user if tls is active.
+
+```{literalinclude} ../../../../../../k8s/samples/strimzi-example-tls-user.yaml
 :language: yaml
 ```
 
+If you don't have this user you can install it with:
+
 ```
-kubectl create -f kafka/strimzi/user.yaml -n seldon-mesh
+kubectl create -f k8s/samples/strimzi-example-tls-user.yaml -n seldon-mesh
 ```
 
 Install seldon with the Strimzi certificate secrets using a custom values file. This sets the secret created by Strimzi for the user created above (`seldon`) and targets the server certificate authority secret from the name of the cluster created on install of the Kafka cluster (`seldon-cluster-ca-cert`). 

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -149,6 +149,10 @@ func (kc *InferKafkaHandler) setup() error {
 		adminConfig := kafka.ConfigMap{
 			config.KafkaBootstrapServers: kc.consumerConfig.KafkaConfig.BootstrapServers,
 		}
+		err = config.AddKafkaSSLOptions(adminConfig)
+		if err != nil {
+			return err
+		}
 		kc.adminClient, err = kafka.NewAdminClient(&adminConfig)
 		if err != nil {
 			return err


### PR DESCRIPTION

- AdminClient was being created in modelgateway without adding possible SSL settings resulting in errors when testing with mTLS for Kafka.
- Updated docs for Strimzi mTLS
