### PR TITLE
Add bytes rawcontents correct handling and ensure headers are passed

### DIFF
--- a/operator/pkg/cli/infer.go
+++ b/operator/pkg/cli/infer.go
@@ -618,8 +618,7 @@ func updateResponseFromRawContents(res *v2_dataplane.ModelInferResponse) error {
 			output.Contents.Fp64Contents = make([]float64, getDataSize(output.Shape))
 			err = binary.Read(bytes.NewBuffer(rawOutput), binary.LittleEndian, &output.Contents.Fp64Contents)
 		case tyBytes:
-			output.Contents.BytesContents = make([][]byte, 1)
-			output.Contents.BytesContents[0] = rawOutput
+			output.Contents.BytesContents = convertRawBytesToByteContents(rawOutput)
 		}
 		if err != nil {
 			return err
@@ -628,6 +627,20 @@ func updateResponseFromRawContents(res *v2_dataplane.ModelInferResponse) error {
 	// Clear the raw contents now we have copied
 	res.RawOutputContents = nil
 	return nil
+}
+
+// Follows Triton client
+// see https://github.com/triton-inference-server/client/blob/6cc412c50ca4282cec6e9f62b3c2781be433dcc6/src/python/library/tritonclient/utils/__init__.py#L246-L273
+func convertRawBytesToByteContents(raw []byte) [][]byte {
+	var result [][]byte
+	for offset := uint32(0); offset < uint32(len(raw)); {
+		dataLen := binary.LittleEndian.Uint32(raw[offset : offset+4])
+		offset += 4
+		data := raw[offset : offset+dataLen]
+		result = append(result, data)
+		offset += dataLen
+	}
+	return result
 }
 
 func updateRequestFromRawContents(res *v2_dataplane.ModelInferRequest) error {

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -303,11 +303,11 @@ func (iw *InferWorker) restRequest(ctx context.Context, job *InferWork, maybeCon
 }
 
 // Add all external headers to request metadata
-func (iw *InferWorker) addMetadataToOutgoingContext(ctx context.Context, job *InferWork) context.Context {
+func addMetadataToOutgoingContext(ctx context.Context, job *InferWork, logger log.FieldLogger) context.Context {
 	for k, v := range job.headers {
 		if strings.HasPrefix(k, resources.ExternalHeaderPrefix) &&
 			k != resources.SeldonRouteHeader { // We don;t want to send x-seldon-route as this will confuse envoy
-			iw.logger.Debugf("Adding outgoing ctx metadata %s:%s", k, v)
+			logger.Debugf("Adding outgoing ctx metadata %s:%s", k, v)
 			ctx = metadata.AppendToOutgoingContext(ctx, k, v)
 		}
 	}
@@ -322,7 +322,7 @@ func (iw *InferWorker) grpcRequest(ctx context.Context, job *InferWork, req *v2.
 	req.ModelName = job.modelName
 	req.ModelVersion = fmt.Sprintf("%d", util.GetPinnedModelVersion())
 
-	ctx = iw.addMetadataToOutgoingContext(ctx, job)
+	ctx = addMetadataToOutgoingContext(ctx, job, logger)
 
 	var header, trailer metadata.MD
 	opts := append(iw.callOptions, grpc.Header(&header))


### PR DESCRIPTION
- Updates handling a v2 rawContents to ensure we can decode BYTES payloads correctly that are returned with rawContents which is an NVIDIA Triton extension where BYTES rawcontents are length encoded <len><bytes><len><bytes> where <len> is a 4 bytes unsigned little endian integer representing the number of bytes for the first element. This allows mixed length bytes to be returned in a single byte block and has also been implemented in MLServer also.
- ensure user headers are passed in grpc request - those starting with `x-` but ignoring the `x-seldon-route` which is used by us for direct envoy routing. This ensures grpc models can use user headers if needed.

Future PR should create a new shared library to stop duplicated code in CLI (operator) and Pipeliegateway (scheduler) projects.