### PR TITLE
Fix CLI config bug and extend help

### DIFF
--- a/operator/cmd/seldon/cli/config_activate.go
+++ b/operator/cmd/seldon/cli/config_activate.go
@@ -23,9 +23,9 @@ import (
 
 func createConfigActivate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "activate",
-		Short: "activate config",
-		Long:  `activate config`,
+		Use:   "activate <key>",
+		Short: "activate config for given key",
+		Long:  `activate config for given key`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configKey := args[0]

--- a/operator/cmd/seldon/cli/config_add.go
+++ b/operator/cmd/seldon/cli/config_add.go
@@ -23,9 +23,9 @@ import (
 
 func createConfigAdd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add",
-		Short: "add config",
-		Long:  `add config`,
+		Use:   "add <key> <path>",
+		Short: "add config for given path under the supplied key",
+		Long:  `add config for given path under the supplied key. You should provide the full path to the config file`,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configKey := args[0]

--- a/operator/cmd/seldon/cli/config_deactivate.go
+++ b/operator/cmd/seldon/cli/config_deactivate.go
@@ -23,9 +23,9 @@ import (
 
 func createConfigDeactivate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "deactivate",
-		Short: "deactivate config",
-		Long:  `deactivate config`,
+		Use:   "deactivate <key>",
+		Short: "deactivate config for given key",
+		Long:  `deactivate config for given key`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configKey := args[0]

--- a/operator/cmd/seldon/cli/config_remove.go
+++ b/operator/cmd/seldon/cli/config_remove.go
@@ -23,9 +23,9 @@ import (
 
 func createConfigRemove() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove",
-		Short: "remove config",
-		Long:  `remove config`,
+		Use:   "remove <key>",
+		Short: "remove config for given key",
+		Long:  `remove config for given key`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configKey := args[0]

--- a/operator/pkg/cli/configs.go
+++ b/operator/pkg/cli/configs.go
@@ -51,6 +51,9 @@ func LoadSeldonCLIConfigs() (*SeldonCLIConfigs, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load CLI configs from %s: %s", path, err.Error())
 	}
+	if cfg.Configs == nil {
+		cfg.Configs = map[string]string{}
+	}
 	return &cfg, nil
 }
 


### PR DESCRIPTION
- Handle empty map when loading an empty json config which can cause a nil pointer exception
- add CLI help for config sub command help