### PR TITLE
Dont hold a global lock when publishing to `EventHub`

### DIFF
--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -419,9 +419,6 @@ func (s *Server) StopAgentStreams() {
 }
 
 func (s *Server) syncMessage(request *pb.AgentSubscribeRequest, stream pb.AgentService_SubscribeServer) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	s.logger.Debugf("Add Server Replica %+v with config %+v", request, request.ReplicaConfig)
 	err := s.store.AddServerReplica(request)
 	if err != nil {

--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -111,8 +111,6 @@ func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersio
 }
 
 func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	modelVersion.state = ModelStatus{
 		State:               ScheduleFailed,
 		Reason:              reason,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

We should not be holding any locks when we publish to the `eventHub`. This ensures that there is no potential deadlock as we can block while publishing an message in high load scenarions.

This PR removes a couple of global locks towards this object.

There are still places where this can happen though but let as future PR:

- (Agent) Server `Sync` grabbing a model lock while doing `UpdateModelState` : https://github.com/SeldonIO/seldon-core/blob/3165f0fa252ba6f44e224a477ad63dd7a781fa54/scheduler/pkg/agent/server.go#L232-L279
- VersionCleaner `cleanupOldVersions` grabbing a model lock while doing `UnloadVersionModels` : https://github.com/SeldonIO/seldon-core/blob/3165f0fa252ba6f44e224a477ad63dd7a781fa54/scheduler/pkg/scheduler/cleaner/versions.go#L59-L76
- (Agent) Server `AgentEvent` grabbing a model lock while doing `UpdateModelState`: https://github.com/SeldonIO/seldon-core/blob/3165f0fa252ba6f44e224a477ad63dd7a781fa54/scheduler/pkg/agent/server.go#L323-L344
**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
