### PR TITLE
v2: Change to ubi images for go applications

### DIFF
--- a/hodometer/Dockerfile.hodometer
+++ b/hodometer/Dockerfile.hodometer
@@ -23,7 +23,7 @@ RUN make build-hodometer
 
 ################################################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-micro 
+FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=builder /build/bin/hodometer /bin/hodometer
 
 ARG UID=1000

--- a/hodometer/Dockerfile.hodometer
+++ b/hodometer/Dockerfile.hodometer
@@ -23,7 +23,7 @@ RUN make build-hodometer
 
 ################################################################################
 
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-micro 
 COPY --from=builder /build/bin/hodometer /bin/hodometer
 
 ARG UID=1000

--- a/hodometer/Dockerfile.receiver
+++ b/hodometer/Dockerfile.receiver
@@ -18,7 +18,7 @@ RUN make build-receiver
 
 ################################################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-micro 
+FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=builder /build/bin/receiver /bin/receiver
 
 ARG UID=1000

--- a/hodometer/Dockerfile.receiver
+++ b/hodometer/Dockerfile.receiver
@@ -18,7 +18,7 @@ RUN make build-receiver
 
 ################################################################################
 
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-micro 
 COPY --from=builder /build/bin/receiver /bin/receiver
 
 ARG UID=1000

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -18,9 +18,7 @@ COPY operator/main.go main.go
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-micro 
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -18,7 +18,7 @@ COPY operator/main.go main.go
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro 
+FROM registry.access.redhat.com/ubi9/ubi-micro
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/scheduler/Dockerfile.agent
+++ b/scheduler/Dockerfile.agent
@@ -8,18 +8,10 @@ RUN apk add --no-cache make
 RUN make -C scheduler -o test-go build-agent
 
 # Copy binary
-# Need to be careful about: https://github.com/GoogleContainerTools/distroless/issues/718
-# for environments like Openshift that set a random UID
-# if we want to use FROM gcr.io/distroless/static:noroot
-# Keeping with Alpine at present to allow setting of volume permissions for Docker Compose use
-# both with shared and bind mounted volumes
-FROM alpine:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro
 
 RUN mkdir /mnt/agent && chmod o+rwx /mnt/agent
 VOLUME /mnt/agent
-
-RUN addgroup -S agent && adduser -S agent -G agent
-USER agent
 
 COPY --from=builder /build/scheduler/bin/agent /bin/agent
 ENTRYPOINT ["/bin/agent"]

--- a/scheduler/Dockerfile.modelgateway
+++ b/scheduler/Dockerfile.modelgateway
@@ -8,6 +8,6 @@ RUN apt-get install make
 RUN make -C scheduler -o test-go build-modelgateway
 
 # Kafka dependencies necessitate leaving CGo enabled and using a base image with C dependencies
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=builder /build/scheduler/bin/modelgateway /bin/modelgateway
 ENTRYPOINT ["/bin/modelgateway"]

--- a/scheduler/Dockerfile.pipelinegateway
+++ b/scheduler/Dockerfile.pipelinegateway
@@ -8,6 +8,6 @@ RUN apt-get install make
 RUN make -C scheduler -o test-go build-pipelinegateway
 
 # Kafka dependencies necessitate leaving CGo enabled and using a base image with C dependencies
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=builder /build/scheduler/bin/pipelinegateway /bin/pipelinegateway
 ENTRYPOINT ["/bin/pipelinegateway"]

--- a/scheduler/Dockerfile.scheduler
+++ b/scheduler/Dockerfile.scheduler
@@ -8,6 +8,6 @@ RUN apk add --no-cache make
 RUN make -C scheduler -o test-go build-scheduler
 
 # Copy binary
-FROM registry.access.redhat.com/ubi9/ubi-micro 
+FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=builder /build/scheduler/bin/scheduler /bin/scheduler
 ENTRYPOINT ["/bin/scheduler"]

--- a/scheduler/Dockerfile.scheduler
+++ b/scheduler/Dockerfile.scheduler
@@ -8,6 +8,6 @@ RUN apk add --no-cache make
 RUN make -C scheduler -o test-go build-scheduler
 
 # Copy binary
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-micro 
 COPY --from=builder /build/scheduler/bin/scheduler /bin/scheduler
 ENTRYPOINT ["/bin/scheduler"]


### PR DESCRIPTION
Part of #4613

Tested:

- [x] docker compose internal
- [x] docker compose host network
- [x] Kind k8s cluster