### PR TITLE
Migrate dataflow engine to UBI9 base image

### DIFF
--- a/scheduler/Dockerfile.dataflow
+++ b/scheduler/Dockerfile.dataflow
@@ -14,7 +14,7 @@ RUN gradle build --no-daemon --info
 ################################################################################
 
 # Some dependencies require glibc, which Alpine does not provide
-FROM gcr.io/distroless/java17-debian11:latest-amd64
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
 USER 1000
 

--- a/scheduler/Dockerfile.dataflow
+++ b/scheduler/Dockerfile.dataflow
@@ -16,8 +16,6 @@ RUN gradle build --no-daemon --info
 # Some dependencies require glibc, which Alpine does not provide
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-USER 1000
-
 WORKDIR /app
 COPY --from=builder /build/src/data-flow/build/libs/*.jar .
 COPY scheduler/data-flow/opentelemetry-javaagent.jar opentelemetry-javaagent.jar

--- a/scheduler/Dockerfile.dataflow
+++ b/scheduler/Dockerfile.dataflow
@@ -16,6 +16,11 @@ RUN gradle build --no-daemon --info
 # Some dependencies require glibc, which Alpine does not provide
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
+# Run update to pickup any necessary security updates
+USER root
+RUN microdnf update -y
+USER default
+
 WORKDIR /app
 COPY --from=builder /build/src/data-flow/build/libs/*.jar .
 COPY scheduler/data-flow/opentelemetry-javaagent.jar opentelemetry-javaagent.jar


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR changes the base container image for the SCv2 dataflow engine from `distroless/java-17` to `ubi9/openjdk-17`.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
Checks on the UBI9 OpenJDK base image:
* Java is located at `/usr/bin/java` (so no need to update image entrypoint)
* GLIBC is available, which is required for some dependencies, e.g. Kafka Streams (for `librdkafka` or similar)
* There is a default, non-root user set (although this user is in the root group)
```
$ docker run --rm -it registry.access.redhat.com/ubi9/openjdk-17-runtime:latest bash
[default@b3581214b70d ~]$ /usr/bin/java -version
openjdk version "17.0.6" 2023-01-17 LTS
OpenJDK Runtime Environment (Red_Hat-17.0.6.0.10-3.el9_1) (build 17.0.6+10-LTS)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.6.0.10-3.el9_1) (build 17.0.6+10-LTS, mixed mode, sharing)

[default@b3581214b70d ~]$ ldd --version ldd
ldd (GNU libc) 2.34
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.

[default@b3581214b70d ~]$ id
uid=185(default) gid=0(root) groups=0(root),185(default)
``` 

Testing:
- [X] Docker Compose
  ```
  $ make start-scheduler-host
  $ make start-dataflow-engine-host
  $ docker logs scv2-dataflow-1 2>&1 
  ```
- [X] Kubernetes cluster (node image `v1.23.14-gke.1800`)
- [x] `kind` cluster
  I did a minimal setup with:
  ```
  $ ansible-playbook playbooks/kind-cluster.yaml
  $ ansible-playbook playbooks/setup-ecosystem.yaml -e install_kafka=yes -e install_prometheus=yes -e install_certmanager=yes -e install_jaeger=no -e install_opentelemetry=no
  $ ansible-playbook playbooks/setup-seldon.yaml -e seldon_install_servers=no
  
  $ seldon pipeline load -f ../samples/pipelines/iris.yaml --scheduler-host 172.18.255.2:9004
  $ seldon pipeline list --scheduler-host 172.18.255.2:9004
  pipeline	state		reason
  --------	-----		------
  iris-pipeline	PipelineReady	created pipeline
  ```
  I then checked logs for the dataflow engine, which showed it had loaded the pipeline and rebalanced. 