### PR TITLE
Changing v2 links to point at latest docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ An open source platform to deploy your machine learning models on Kubernetes at 
 
 ## Seldon Core V2 Now Available
 
-[![scv2_image](https://raw.githubusercontent.com/SeldonIO/seldon-core/master/doc/source/_static/scv2_banner.png)](https://docs.seldon.io/projects/seldon-core/en/v2.0.0/index.html)
+[![scv2_image](https://raw.githubusercontent.com/SeldonIO/seldon-core/master/doc/source/_static/scv2_banner.png)](https://docs.seldon.io/projects/seldon-core/en/v2/index.html)
 
-[Seldon Core V2](https://docs.seldon.io/projects/seldon-core/en/v2.0.0/index.html) **is now available** (in alpha). Check out the [docs here](https://docs.seldon.io/projects/seldon-core/en/v2.0.0/index.html) and make sure to leave feedback on [our slack community](https://join.slack.com/t/seldondev/shared_invite/zt-vejg6ttd-ksZiQs3O_HOtPQsen_labg) and [submit bugs or feature requests on the repo](https://github.com/SeldonIO/seldon-core/issues/new/choose).
+[Seldon Core V2](https://docs.seldon.io/projects/seldon-core/en/v2/index.html) **is now available** (in alpha). Check out the [docs here](https://docs.seldon.io/projects/seldon-core/en/v2/index.html) and make sure to leave feedback on [our slack community](https://join.slack.com/t/seldondev/shared_invite/zt-vejg6ttd-ksZiQs3O_HOtPQsen_labg) and [submit bugs or feature requests on the repo](https://github.com/SeldonIO/seldon-core/issues/new/choose).
 
 Continue reading for info on Seldon Core V1...
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
