### PR TITLE
Do not report scaling events if not set by scheduler

### DIFF
--- a/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
+++ b/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
@@ -84,9 +84,20 @@ func TestStatsAnalyserSmoke(t *testing.T) {
 	ch := service.GetEventChannel()
 
 	t.Logf("Test lags")
+
+	// add the models, note only 0,1,3
+	err = service.AddModel(dummyModelPrefix + "0")
+	g.Expect(err).To(BeNil())
+	err = service.AddModel(dummyModelPrefix + "1")
+	g.Expect(err).To(BeNil())
+	err = service.AddModel(dummyModelPrefix + "3")
+	g.Expect(err).To(BeNil())
+
 	err = lags.Set(dummyModelPrefix+"0", lagThresholdDefault-1)
 	g.Expect(err).To(BeNil())
 	err = lags.Set(dummyModelPrefix+"1", lagThresholdDefault+1)
+	g.Expect(err).To(BeNil())
+	err = lags.Set(dummyModelPrefix+"2", lagThresholdDefault+1) //  model 2 not added so will not get returned to ch
 	g.Expect(err).To(BeNil())
 	event := <-ch
 	g.Expect(event.StatsData.ModelName).To(Equal(dummyModelPrefix + "1"))
@@ -95,6 +106,8 @@ func TestStatsAnalyserSmoke(t *testing.T) {
 
 	t.Logf("Test last used")
 	err = lastUsed.Set(dummyModelPrefix+"3", uint32(time.Now().Unix())-lastUsedThresholdSecondsDefault)
+	g.Expect(err).To(BeNil())
+	err = lastUsed.Set(dummyModelPrefix+"4", uint32(time.Now().Unix())-lastUsedThresholdSecondsDefault) // model 4 not added
 	g.Expect(err).To(BeNil())
 	event = <-ch
 	g.Expect(event.StatsData.ModelName).To(Equal(dummyModelPrefix + "3"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

In cases where the model is not going to autoscale (set by scheduler) we do not want agent to report events for it.
We always track stats for models regardless on agent side on the data plane and therefore the change here is to not publish any scaling events back to scheduler if not needed.

However we still keep stats in the agent about all models as we might need to enable scaling later and it will incur extra overheads on the inference path if we want to check whether to collect stats for the model.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4631

**Special notes for your reviewer**:
