### PR TITLE
Retry on server load fail

### DIFF
--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -59,7 +59,7 @@ const (
 	// period for subservice ready "cron"
 	periodReadySubService = 60 * time.Second
 	// number of retries for loading a model onto a server
-	maxLoadRetryCount = 3
+	maxLoadRetryCount = 6
 	// number of retries for unloading a model onto a server
 	maxUnloadRetryCount = 1
 )

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -278,7 +278,7 @@ func main() {
 			maxElapsedTimeReadySubServiceBeforeStart,
 			maxElapsedTimeReadySubServiceAfterStart,
 			maxLoadRetryCount,
-			maxLoadRetryCount,
+			maxUnloadRetryCount,
 		),
 		logger,
 		modelRepository,

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -58,6 +58,10 @@ const (
 	maxElapsedTimeReadySubServiceBeforeStart = 15 * time.Minute // 15 mins is the default MaxElapsedTime
 	// period for subservice ready "cron"
 	periodReadySubService = 60 * time.Second
+	// number of retries for loading a model onto a server
+	maxLoadRetryCount = 3
+	// number of retries for unloading a model onto a server
+	maxUnloadRetryCount = 1
 )
 
 func makeDirs() (string, string, error) {
@@ -273,6 +277,8 @@ func main() {
 			periodReadySubService,
 			maxElapsedTimeReadySubServiceBeforeStart,
 			maxElapsedTimeReadySubServiceAfterStart,
+			maxLoadRetryCount,
+			maxLoadRetryCount,
 		),
 		logger,
 		modelRepository,

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -59,7 +59,7 @@ const (
 	// period for subservice ready "cron"
 	periodReadySubService = 60 * time.Second
 	// number of retries for loading a model onto a server
-	maxLoadRetryCount = 6
+	maxLoadRetryCount = 10
 	// number of retries for unloading a model onto a server
 	maxUnloadRetryCount = 1
 )

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -535,7 +535,7 @@ func (c *Client) LoadModel(request *agent.ModelOperationMessage) error {
 	}
 	logger.Infof("Chose path %s for model %s:%d", *chosenVersionPath, modelName, modelVersion)
 
-	// TODO: do we need the actual protos being sent
+	// TODO: consider whether we need the actual protos being sent to `LoadModelVersion`?
 	modifiedModelVersionRequest := getModifiedModelVersion(modelWithVersion, pinnedModelVersion, request.GetModelVersion())
 	err = c.stateManager.LoadModelVersion(modifiedModelVersionRequest)
 	if err != nil {

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -540,7 +540,7 @@ func (c *Client) LoadModel(request *agent.ModelOperationMessage) error {
 	loaderFn := func() error {
 		return c.stateManager.LoadModelVersion(modifiedModelVersionRequest)
 	}
-	if err := fnWithRetry(loaderFn, 3, logger); err != nil {
+	if err := backoffWithMaxNumRetry(loaderFn, 3, logger); err != nil {
 		c.sendModelEventError(modelName, modelVersion, agent.ModelEventMessage_LOAD_FAILED, err)
 		return err
 	}
@@ -580,7 +580,7 @@ func (c *Client) UnloadModel(request *agent.ModelOperationMessage) error {
 	unloaderFn := func() error {
 		return c.stateManager.UnloadModelVersion(modifiedModelVersionRequest)
 	}
-	if err := fnWithRetry(unloaderFn, 3, logger); err != nil {
+	if err := backoffWithMaxNumRetry(unloaderFn, 3, logger); err != nil {
 		c.sendModelEventError(modelName, modelVersion, agent.ModelEventMessage_UNLOAD_FAILED, err)
 		return err
 	}

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -204,7 +204,7 @@ func TestClientCreate(t *testing.T) {
 			drainerServicePort, _ := getFreePort()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client,
 				test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -355,7 +355,7 @@ func TestLoadModel(t *testing.T) {
 			drainerServicePort, _ := getFreePort()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 			mockAgentV2Server := &mockAgentV2Server{models: []string{}}
@@ -493,7 +493,7 @@ parameters:
 			drainerServicePort, _ := getFreePort()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository,
 				v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService,
@@ -635,7 +635,7 @@ func TestUnloadModel(t *testing.T) {
 			drainerServicePort, _ := getFreePort()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 			mockAgentV2Server := &mockAgentV2Server{models: []string{}}
@@ -693,7 +693,7 @@ func TestClientClose(t *testing.T) {
 	drainerServicePort, _ := getFreePort()
 	drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 	client := NewClient(
-		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute),
+		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 		logger, modelRepository, v2Client,
 		&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 		rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -792,7 +792,7 @@ func TestAgentStopOnSubServicesFailure(t *testing.T) {
 				_ = drainerService.Start()
 			}()
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart, 1, 1),
 				logger, modelRepository, v2Client,
 				&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -88,7 +88,7 @@ func isReadyChecker(
 	return nil
 }
 
-func fnWithRetry(fn func() error, count uint8, logger log.FieldLogger) error {
+func backoffWithMaxNumRetry(fn func() error, count uint8, logger log.FieldLogger) error {
 	backoffWithMax := backoff.NewExponentialBackOff()
 	backoffWithMax.MaxElapsedTime = 15 * time.Minute // default
 
@@ -98,29 +98,29 @@ func fnWithRetry(fn func() error, count uint8, logger log.FieldLogger) error {
 		logger.WithError(err).Errorf("Retry op #%d", i)
 		i++
 	}
-	return backoff.RetryNotify(fn, NewBackOffWithMaxCount(count, backoffWithMax), logFailure)
+	return backoff.RetryNotify(fn, newBackOffWithMaxCount(count, backoffWithMax), logFailure)
 }
 
-// BackOffWithMaxCount is a backoff policy that retries up to a max count
-type BackOffWithMaxCount struct {
+// backOffWithMaxCount is a backoff policy that retries up to a max count
+type backOffWithMaxCount struct {
 	backoffPolicy backoff.BackOff
 	maxCount      uint8
 	currentCount  uint8
 }
 
-func NewBackOffWithMaxCount(maxCount uint8, backOffPolicy backoff.BackOff) *BackOffWithMaxCount {
-	return &BackOffWithMaxCount{
+func newBackOffWithMaxCount(maxCount uint8, backOffPolicy backoff.BackOff) *backOffWithMaxCount {
+	return &backOffWithMaxCount{
 		maxCount:      maxCount,
 		backoffPolicy: backOffPolicy,
 		currentCount:  0,
 	}
 }
 
-func (b *BackOffWithMaxCount) Reset() {
+func (b *backOffWithMaxCount) Reset() {
 	b.backoffPolicy.Reset()
 }
 
-func (b *BackOffWithMaxCount) NextBackOff() time.Duration {
+func (b *backOffWithMaxCount) NextBackOff() time.Duration {
 	if b.currentCount >= b.maxCount {
 		return backoff.Stop
 	} else {

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -87,3 +87,31 @@ func isReadyChecker(
 	}
 	return nil
 }
+
+// BackOffWithMaxCount is a backoff policy that retries up to a max count
+type BackOffWithMaxCount struct {
+	backoffPolicy backoff.BackOff
+	maxCount      uint8
+	currentCount  uint8
+}
+
+func NewBackOffWithMaxCount(maxCount uint8, backOffPolicy backoff.BackOff) *BackOffWithMaxCount {
+	return &BackOffWithMaxCount{
+		maxCount:      maxCount,
+		backoffPolicy: backOffPolicy,
+		currentCount:  0,
+	}
+}
+
+func (b *BackOffWithMaxCount) Reset() {
+	b.backoffPolicy.Reset()
+}
+
+func (b *BackOffWithMaxCount) NextBackOff() time.Duration {
+	if b.currentCount >= b.maxCount {
+		return backoff.Stop
+	} else {
+		b.currentCount++
+		return b.backoffPolicy.NextBackOff()
+	}
+}

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -90,8 +90,6 @@ func isReadyChecker(
 
 func backoffWithMaxNumRetry(fn func() error, count uint8, logger log.FieldLogger) error {
 	backoffWithMax := backoff.NewExponentialBackOff()
-	backoffWithMax.MaxElapsedTime = 15 * time.Minute // default
-
 	// Wait for model repo to be ready
 	i := 0
 	logFailure := func(err error, delay time.Duration) {

--- a/scheduler/pkg/agent/client_utils_test.go
+++ b/scheduler/pkg/agent/client_utils_test.go
@@ -63,7 +63,7 @@ func TestBackOffPolicyWithMax(t *testing.T) {
 				return test.err
 			}
 			count := uint8(0)
-			policyWithMax := NewBackOffWithMaxCount(test.count, &policy)
+			policyWithMax := newBackOffWithMaxCount(test.count, &policy)
 			logFailure := func(err error, delay time.Duration) {
 				logger.WithError(err).Errorf("retry")
 				count++
@@ -102,7 +102,7 @@ func TestFnWrapperWithMax(t *testing.T) {
 			fn := func() error {
 				return fmt.Errorf("error")
 			}
-			_ = fnWithRetry(fn, test.count, logger)
+			_ = backoffWithMaxNumRetry(fn, test.count, logger)
 			// if we are here we are done
 		})
 	}

--- a/scheduler/pkg/agent/client_utils_test.go
+++ b/scheduler/pkg/agent/client_utils_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 Seldon Technologies Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/cenkalti/backoff/v4"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestBackOffPolicyWithMax(t *testing.T) {
+	t.Logf("Started")
+	logger := log.New()
+	log.SetLevel(log.DebugLevel)
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name  string
+		count uint8
+	}
+	tests := []test{
+		{
+
+			name:  "simple",
+			count: 3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy := backoff.ZeroBackOff{}
+			fn := func() error {
+				return fmt.Errorf("err")
+			}
+			count := uint8(0)
+			policyWithMax := NewBackOffWithMaxCount(test.count, &policy)
+			logFailure := func(err error, delay time.Duration) {
+				logger.WithError(err).Errorf("retry")
+				count++
+			}
+
+			//TODO make retry configurable
+			_ = backoff.RetryNotify(fn, policyWithMax, logFailure)
+			g.Expect(count).To(Equal(test.count))
+		})
+	}
+}

--- a/scheduler/pkg/scheduler/filters/replicamemory.go
+++ b/scheduler/pkg/scheduler/filters/replicamemory.go
@@ -37,7 +37,7 @@ func isModelReplicaLoadedOnServerReplica(model *store.ModelVersion, replica *sto
 }
 
 func (r AvailableMemoryReplicaFilter) Filter(model *store.ModelVersion, replica *store.ServerReplica) bool {
-	mem := math.Max(0, float64(replica.GetAvailableMemory()-replica.GetReservedMemory()))
+	mem := math.Max(0, float64(replica.GetAvailableMemory())-float64(replica.GetReservedMemory()))
 	return model.GetRequiredMemory() <= uint64(mem) || isModelReplicaLoadedOnServerReplica(model, replica)
 }
 

--- a/scheduler/pkg/scheduler/filters/replicamemory_test.go
+++ b/scheduler/pkg/scheduler/filters/replicamemory_test.go
@@ -59,6 +59,7 @@ func TestReplicaMemoryFilter(t *testing.T) {
 		{name: "NoMemorySpecified", model: getTestModelWithMemory(nil, "", -1), server: getTestServerReplicaWithMemory(200, 0, "server1", 0), expected: true},
 		{name: "NotEnoughMemory", model: getTestModelWithMemory(&memory, "", -1), server: getTestServerReplicaWithMemory(50, 0, "server1", 0), expected: false},
 		{name: "NotEnoughMemoryWithReserved", model: getTestModelWithMemory(&memory, "", -1), server: getTestServerReplicaWithMemory(200, 150, "server1", 0), expected: false},
+		{name: "NotEnoughMemoryWithReservedOverflow", model: getTestModelWithMemory(&memory, "", -1), server: getTestServerReplicaWithMemory(200, 250, "server1", 0), expected: false},
 		{name: "ModelAlreadyLoaded", model: getTestModelWithMemory(&memory, "server1", 0), server: getTestServerReplicaWithMemory(0, 0, "server1", 0), expected: true}, // note not enough memory on server replica
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR adds the ability to retry loading / unloading models onto a server (control plane) with max number of attempts. This is different from the current usage of retries with backoff as we also cap retries with a number of attempts given that different models will have different latencies for loading / unloading.

We only do this on the control plane to get around the issue where we are loading an inference model and an associated explainer concurrently. So if an explainer tries to load first, it might fail if the underlying inference model has not loaded yet. With retries this should be able to eventually load the explainer.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4623 

**Special notes for your reviewer**:
