### PR TITLE
Pointing links at v2 latest

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,10 +4,10 @@ Seldon Core
 .. image:: ./_static/scv2_banner.png
    :alt: Seldon Core V2 logo
    :align: center
-   :target: https://docs.seldon.io/projects/seldon-core/en/v2.0.0/index.html
+   :target: https://docs.seldon.io/projects/seldon-core/en/v2/index.html
 
 .. important::
-   `Seldon Core V2 <https://docs.seldon.io/projects/seldon-core/en/v2.0.0/index.html>`_ **is now available** (in alpha). Check out the `docs here <https://docs.seldon.io/projects/seldon-core/en/v2.0.0/index.html>`_ and make sure to leave feedback on `our slack community <https://join.slack.com/t/seldondev/shared_invite/zt-vejg6ttd-ksZiQs3O_HOtPQsen_labg>`_ and `submit bugs or feature requests on the repo <https://github.com/SeldonIO/seldon-core/issues/new/choose>`_.
+   `Seldon Core V2 <https://docs.seldon.io/projects/seldon-core/en/v2/index.html>`_ **is now available** (in alpha). Check out the `docs here <https://docs.seldon.io/projects/seldon-core/en/v2/index.html>`_ and make sure to leave feedback on `our slack community <https://join.slack.com/t/seldondev/shared_invite/zt-vejg6ttd-ksZiQs3O_HOtPQsen_labg>`_ and `submit bugs or feature requests on the repo <https://github.com/SeldonIO/seldon-core/issues/new/choose>`_.
 
 
 .. These are hidden links, which are not linked anywhere but may still be


### PR DESCRIPTION
Forgot to include the doc index in https://github.com/SeldonIO/seldon-core/pull/4637

Currently only github readme points at v2 latest docs build.