### PR TITLE
Small CLI Updates

### DIFF
--- a/operator/cmd/seldon/cli/experiment_stop.go
+++ b/operator/cmd/seldon/cli/experiment_stop.go
@@ -53,17 +53,9 @@ func createExperimentStop() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			filename, err := flags.GetString(flagFile)
+			fileBytes, experimentName, err := extractFileOrName(flags, args)
 			if err != nil {
 				return err
-			}
-			var fileBytes []byte
-			if filename != "" {
-				fileBytes = loadFile(filename)
-			}
-			experimentName := ""
-			if len(args) > 0 {
-				experimentName = args[0]
 			}
 			err = schedulerClient.StopExperiment(experimentName, fileBytes, showRequest, showResponse)
 			return err

--- a/operator/cmd/seldon/cli/experiment_stop.go
+++ b/operator/cmd/seldon/cli/experiment_stop.go
@@ -28,7 +28,6 @@ func createExperimentStop() *cobra.Command {
 		Use:   "stop <experimentName>",
 		Short: "stop an experiment",
 		Long:  `stop an experiment`,
-		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
 
@@ -54,9 +53,19 @@ func createExperimentStop() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			experimentName := args[0]
-			err = schedulerClient.StopExperiment(experimentName, showRequest, showResponse)
+			filename, err := flags.GetString(flagFile)
+			if err != nil {
+				return err
+			}
+			var fileBytes []byte
+			if filename != "" {
+				fileBytes = loadFile(filename)
+			}
+			experimentName := ""
+			if len(args) > 0 {
+				experimentName = args[0]
+			}
+			err = schedulerClient.StopExperiment(experimentName, fileBytes, showRequest, showResponse)
 			return err
 		},
 	}
@@ -66,6 +75,7 @@ func createExperimentStop() *cobra.Command {
 	flags.BoolP(flagShowResponse, "o", true, "show response")
 	flags.String(flagSchedulerHost, env.GetString(envScheduler, defaultSchedulerHost), helpSchedulerHost)
 	flags.String(flagAuthority, "", helpAuthority)
+	flags.StringP(flagFile, "f", "", "experiment manifest file (YAML)")
 
 	return cmd
 }

--- a/operator/cmd/seldon/cli/file.go
+++ b/operator/cmd/seldon/cli/file.go
@@ -19,6 +19,8 @@ package cli
 import (
 	"fmt"
 	"os"
+
+	"github.com/spf13/pflag"
 )
 
 func loadFile(filename string) []byte {
@@ -28,4 +30,22 @@ func loadFile(filename string) []byte {
 		os.Exit(-1)
 	}
 	return dat
+}
+
+// Utility method to extract file bytes or name of resource
+func extractFileOrName(flags *pflag.FlagSet, args []string) ([]byte, string, error) {
+	filename, err := flags.GetString(flagFile)
+	if err != nil {
+		return nil, "", err
+	}
+	var fileBytes []byte
+	name := ""
+	if filename != "" {
+		fileBytes = loadFile(filename)
+	} else {
+		if len(args) > 0 {
+			name = args[0]
+		}
+	}
+	return fileBytes, name, nil
 }

--- a/operator/cmd/seldon/cli/model_unload.go
+++ b/operator/cmd/seldon/cli/model_unload.go
@@ -28,7 +28,6 @@ func createModelUnload() *cobra.Command {
 		Use:   "unload <modelName>",
 		Short: "unload a model",
 		Long:  `unload a model`,
-		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
 
@@ -49,14 +48,25 @@ func createModelUnload() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			modelName := args[0]
+			filename, err := flags.GetString(flagFile)
+			if err != nil {
+				return err
+			}
+			var fileBytes []byte
+			if filename != "" {
+				fileBytes = loadFile(filename)
+			}
+			modelName := ""
+			if len(args) > 0 {
+				modelName = args[0]
+			}
 
 			schedulerClient, err := cli.NewSchedulerClient(schedulerHost, schedulerHostIsSet, authority)
 			if err != nil {
 				return err
 			}
 
-			err = schedulerClient.UnloadModel(modelName, showRequest, showResponse)
+			err = schedulerClient.UnloadModel(modelName, fileBytes, showRequest, showResponse)
 			return err
 		},
 	}
@@ -66,6 +76,7 @@ func createModelUnload() *cobra.Command {
 	flags.BoolP(flagShowResponse, "o", true, "show response")
 	flags.String(flagSchedulerHost, env.GetString(envScheduler, defaultSchedulerHost), helpSchedulerHost)
 	flags.String(flagAuthority, "", helpAuthority)
+	flags.StringP(flagFile, "f", "", "model manifest file (YAML)")
 
 	return cmd
 }

--- a/operator/cmd/seldon/cli/model_unload.go
+++ b/operator/cmd/seldon/cli/model_unload.go
@@ -48,17 +48,9 @@ func createModelUnload() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			filename, err := flags.GetString(flagFile)
+			fileBytes, modelName, err := extractFileOrName(flags, args)
 			if err != nil {
 				return err
-			}
-			var fileBytes []byte
-			if filename != "" {
-				fileBytes = loadFile(filename)
-			}
-			modelName := ""
-			if len(args) > 0 {
-				modelName = args[0]
 			}
 
 			schedulerClient, err := cli.NewSchedulerClient(schedulerHost, schedulerHostIsSet, authority)

--- a/operator/cmd/seldon/cli/pipeline_inspect.go
+++ b/operator/cmd/seldon/cli/pipeline_inspect.go
@@ -30,6 +30,7 @@ const (
 	flagRequestId    = "request-id"
 	flagOutputFormat = "format"
 	flagVerbose      = "verbose"
+	flagTruncate     = "truncate"
 	flagNamespace    = "namespace"
 )
 
@@ -68,6 +69,10 @@ func createPipelineInspect() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			truncateData, err := flags.GetBool(flagTruncate)
+			if err != nil {
+				return err
+			}
 			namespace, err := flags.GetString(flagNamespace)
 			if err != nil {
 				return err
@@ -77,7 +82,7 @@ func createPipelineInspect() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = kc.InspectStep(string(data), offset, requestId, format, verbose, namespace)
+			err = kc.InspectStep(string(data), offset, requestId, format, verbose, truncateData, namespace)
 			return err
 		},
 	}
@@ -89,6 +94,7 @@ func createPipelineInspect() *cobra.Command {
 	flags.String(flagSchedulerHost, env.GetString(envScheduler, defaultSchedulerHost), helpSchedulerHost)
 	flags.String(flagOutputFormat, cli.InspectFormatRaw, fmt.Sprintf("inspect output format: raw or json. Default %s", cli.InspectFormatRaw))
 	flags.String(flagNamespace, "", fmt.Sprintf("Kubernetes namespace. Default %s", cli.DefaultNamespace))
-	flags.Bool(flagVerbose, false, "display more details, such as headers")
+	flags.BoolP(flagVerbose, "v", false, "display more details, such as headers")
+	flags.BoolP(flagTruncate, "t", false, "truncate data")
 	return cmd
 }

--- a/operator/cmd/seldon/cli/pipeline_load.go
+++ b/operator/cmd/seldon/cli/pipeline_load.go
@@ -27,9 +27,9 @@ import (
 
 func createPipelineLoad() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "load",
-		Short: "load a pipeline",
-		Long:  `load a pipeline`,
+		Use:   "load -f <file>",
+		Short: "load a pipeline from a yaml file",
+		Long:  `load a pipeline from a yaml file`,
 		Args:  cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()

--- a/operator/cmd/seldon/cli/pipeline_unload.go
+++ b/operator/cmd/seldon/cli/pipeline_unload.go
@@ -48,17 +48,9 @@ func createPipelineUnload() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			filename, err := flags.GetString(flagFile)
+			fileBytes, pipelineName, err := extractFileOrName(flags, args)
 			if err != nil {
 				return err
-			}
-			var fileBytes []byte
-			if filename != "" {
-				fileBytes = loadFile(filename)
-			}
-			pipelineName := ""
-			if len(args) > 0 {
-				pipelineName = args[0]
 			}
 
 			schedulerClient, err := cli.NewSchedulerClient(schedulerHost, schedulerHostIsSet, authority)

--- a/operator/cmd/seldon/cli/pipeline_unload.go
+++ b/operator/cmd/seldon/cli/pipeline_unload.go
@@ -28,7 +28,6 @@ func createPipelineUnload() *cobra.Command {
 		Use:   "unload <pipelineName> or -f <filename>",
 		Short: "unload a pipeline",
 		Long:  `unload a pipeline`,
-		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
 

--- a/operator/pkg/cli/scheduler.go
+++ b/operator/pkg/cli/scheduler.go
@@ -414,7 +414,15 @@ func (sc *SchedulerClient) ListServers() error {
 	return nil
 }
 
-func (sc *SchedulerClient) UnloadModel(modelName string, showRequest bool, showResponse bool) error {
+func (sc *SchedulerClient) UnloadModel(modelName string, modelBytes []byte, showRequest bool, showResponse bool) error {
+	if len(modelBytes) > 0 && modelName == "" {
+		model := &mlopsv1alpha1.Model{}
+		err := unMarshallYamlStrict(modelBytes, model)
+		if err != nil {
+			return err
+		}
+		modelName = model.Name
+	}
 	req := &scheduler.UnloadModelRequest{
 		Model: &scheduler.ModelReference{
 			Name: modelName,
@@ -467,7 +475,15 @@ func (sc *SchedulerClient) StartExperiment(data []byte, showRequest bool, showRe
 	return nil
 }
 
-func (sc *SchedulerClient) StopExperiment(experimentName string, showRequest bool, showResponse bool) error {
+func (sc *SchedulerClient) StopExperiment(experimentName string, experimentBytes []byte, showRequest bool, showResponse bool) error {
+	if len(experimentBytes) > 0 && experimentName == "" {
+		experiment := &mlopsv1alpha1.Experiment{}
+		err := unMarshallYamlStrict(experimentBytes, experiment)
+		if err != nil {
+			return err
+		}
+		experimentName = experiment.Name
+	}
 	req := &scheduler.StopExperimentRequest{
 		Name: experimentName,
 	}

--- a/operator/pkg/cli/scheduler.go
+++ b/operator/pkg/cli/scheduler.go
@@ -629,7 +629,17 @@ func (sc *SchedulerClient) LoadPipeline(data []byte, showRequest bool, showRespo
 	return nil
 }
 
-func (sc *SchedulerClient) UnloadPipeline(pipelineName string, showRequest bool, showResponse bool) error {
+func (sc *SchedulerClient) UnloadPipeline(pipelineName string, pipelineBytes []byte, showRequest bool, showResponse bool) error {
+
+	if len(pipelineBytes) > 0 && pipelineName == "" {
+		pipeline := &mlopsv1alpha1.Pipeline{}
+		err := unMarshallYamlStrict(pipelineBytes, pipeline)
+		if err != nil {
+			return err
+		}
+		pipelineName = pipeline.Name
+	}
+
 	req := &scheduler.UnloadPipelineRequest{
 		Name: pipelineName,
 	}


### PR DESCRIPTION
- [x] Allow a `--truncate` option to not show data in `seldon inspect` as sometimes data can be very large and you want to just see outline of message
- [x] Allow `seldon pipeline unload` to take a `-f <filename>` like load and similar to k8s kubectl
- [x] Allow `seldon model unload` to take a `-f <filename>`
- [x] Allow `seldon experiment unload` to take a `-f <filename>`