### PR TITLE
V2: TLS Kafka

### DIFF
--- a/components/tls/pkg/tls/util.go
+++ b/components/tls/pkg/tls/util.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	EnvSecurityProtocolSuffix = "_SECURITY_PROTOCOL"
+	SecurityProtocolTLS       = "TLS"
 	SecurityProtocolSSL       = "SSL"
 	SecurityProtocolPlaintxt  = "PLAINTEXT"
 	SecurityProtocolSASLSSL   = "SASL_SSL"

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
@@ -64,19 +64,19 @@ fun getKafkaAdminProperties(params: KafkaStreamsParams): KafkaAdminProperties {
                     params.security.certConfig.brokerSecret != "") {
                 K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
             }
-             if (params.security.certConfig.clientSecret != "") {
-            val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
+            if (params.security.certConfig.clientSecret != "") {
+                val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
 
-            this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
-            this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-            this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
+                this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
+                this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
+                this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
             }
 
-             if (params.security.certConfig.brokerSecret != "") {
-            val keyStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
+            if (params.security.certConfig.brokerSecret != "") {
+                val keyStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
 
-            this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
-            this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
+                this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
+                this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
             }
         } else if (params.security.securityProtocol == SecurityProtocol.SASL_SSL) {
             this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = params.security.certConfig.endpointIdentificationAlgorithm
@@ -115,7 +115,7 @@ fun getKafkaProperties(params: KafkaStreamsParams): KafkaProperties {
                     params.security.certConfig.brokerSecret != "") {
                 K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
             }
-             if (params.security.certConfig.clientSecret != "") {
+            if (params.security.certConfig.clientSecret != "") {
                 val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
 
                 this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
@@ -123,7 +123,7 @@ fun getKafkaProperties(params: KafkaStreamsParams): KafkaProperties {
                 this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
             }
 
-             if (params.security.certConfig.brokerSecret != "") {
+            if (params.security.certConfig.brokerSecret != "") {
                 val keyStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
 
                 this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
@@ -60,17 +60,24 @@ fun getKafkaAdminProperties(params: KafkaStreamsParams): KafkaAdminProperties {
         this[StreamsConfig.SECURITY_PROTOCOL_CONFIG] = params.security.securityProtocol.toString()
         if (params.security.securityProtocol == SecurityProtocol.SSL) {
             this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = params.security.certConfig.endpointIdentificationAlgorithm
-            if (params.security.certConfig.clientSecret != "" &&
+            if (params.security.certConfig.clientSecret != "" ||
                     params.security.certConfig.brokerSecret != "") {
                 K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
             }
+             if (params.security.certConfig.clientSecret != "") {
             val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
 
             this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
             this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
             this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
+            }
+
+             if (params.security.certConfig.brokerSecret != "") {
+            val keyStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
+
             this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
             this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
+            }
         } else if (params.security.securityProtocol == SecurityProtocol.SASL_SSL) {
             this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = params.security.certConfig.endpointIdentificationAlgorithm
             if (params.security.certConfig.brokerSecret != "") {
@@ -104,17 +111,24 @@ fun getKafkaProperties(params: KafkaStreamsParams): KafkaProperties {
         this[StreamsConfig.SECURITY_PROTOCOL_CONFIG] = params.security.securityProtocol.toString()
         if (params.security.securityProtocol == SecurityProtocol.SSL) {
             this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = params.security.certConfig.endpointIdentificationAlgorithm
-            if (params.security.certConfig.clientSecret != "" &&
-                params.security.certConfig.brokerSecret != "") {
+             if (params.security.certConfig.clientSecret != "" ||
+                    params.security.certConfig.brokerSecret != "") {
                 K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
             }
-            val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
+             if (params.security.certConfig.clientSecret != "") {
+                val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
 
-            this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
-            this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-            this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-            this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
-            this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
+                this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
+                this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
+                this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
+            }
+
+             if (params.security.certConfig.brokerSecret != "") {
+                val keyStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
+
+                this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
+                this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
+            }    
         } else if (params.security.securityProtocol == SecurityProtocol.SASL_SSL) {
             this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = params.security.certConfig.endpointIdentificationAlgorithm
             if (params.security.certConfig.brokerSecret != "") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR adds support for plain TLS Kafka communication.
Currently communication to a Kafka cluster is only possible with client authentication, e.g. using mTLS or SASL.
This PR makes changes to the existing code to facilitate plain tls support.

**Which issue(s) this PR fixes**:
With this PR client certificate information becomes optional and support for plain TLS is added when communicating with the Kafka cluster.
This allows for unauthenticated cluster access.

A new TLS Security Protocol 'TLS' is added. However, we suggest do refactor the existing code to

- either distinguish mTLS and TLS based on provided parameters
- or rename the existing protocol 'SecurityProtocolSSL' to 'SecurityProtocolMTLS'

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
This is an initial request. If the general concept and direction suits you, we can make the changes proposed above as well as update the required documentation.
