### PR TITLE
Add resource generic load, unload, status to CLI

### DIFF
--- a/operator/cmd/seldon/cli/load.go
+++ b/operator/cmd/seldon/cli/load.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"k8s.io/utils/env"
+
+	"github.com/seldonio/seldon-core/operator/v2/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+func createLoad() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "load",
+		Short: "load resources",
+		Long:  `load resources`,
+		Args:  cobra.MinimumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+
+			schedulerHostIsSet := flags.Changed(flagSchedulerHost)
+			schedulerHost, err := flags.GetString(flagSchedulerHost)
+			if err != nil {
+				return err
+			}
+			authority, err := flags.GetString(flagAuthority)
+			if err != nil {
+				return err
+			}
+			filename, err := flags.GetString(flagFile)
+			if err != nil {
+				return err
+			}
+			showRequest, err := flags.GetBool(flagShowRequest)
+			if err != nil {
+				return err
+			}
+			showResponse, err := flags.GetBool(flagShowResponse)
+			if err != nil {
+				return err
+			}
+
+			schedulerClient, err := cli.NewSchedulerClient(schedulerHost, schedulerHostIsSet, authority)
+			if err != nil {
+				return err
+			}
+
+			var dataFile []byte
+			if filename != "" {
+				dataFile = loadFile(filename)
+			}
+			err = schedulerClient.Load(dataFile, showRequest, showResponse)
+			return err
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolP(flagShowRequest, "r", false, "show request")
+	flags.BoolP(flagShowResponse, "o", false, "show response")
+	flags.String(flagSchedulerHost, env.GetString(envScheduler, defaultSchedulerHost), helpSchedulerHost)
+	flags.String(flagAuthority, "", helpAuthority)
+	flags.StringP(flagFile, "f", "", "model manifest file (YAML)")
+
+	return cmd
+}

--- a/operator/cmd/seldon/cli/root.go
+++ b/operator/cmd/seldon/cli/root.go
@@ -106,11 +106,16 @@ func GetCmd() *cobra.Command {
 	cmdConfigRemove := createConfigRemove()
 	cmdConfigList := createConfigList()
 
+	// Generic commands
+	cmdLoad := createLoad()
+	cmdUnload := createUnload()
+	cmdStatus := createStatus()
+
 	var rootCmd = &cobra.Command{Use: "seldon", SilenceErrors: false, SilenceUsage: true}
 
 	rootCmd.DisableAutoGenTag = true
 
-	rootCmd.AddCommand(cmdModel, cmdServer, cmdExperiment, cmdPipeline, cmdConfig)
+	rootCmd.AddCommand(cmdModel, cmdServer, cmdExperiment, cmdPipeline, cmdConfig, cmdLoad, cmdUnload, cmdStatus)
 	cmdModel.AddCommand(cmdModelLoad, cmdModelUnload, cmdModelStatus, cmdModelInfer, cmdModelMeta, cmdModelList)
 	cmdServer.AddCommand(cmdServerStatus, cmdServerList)
 	cmdExperiment.AddCommand(cmdExperimentStart, cmdExperimentStop, cmdExperimentStatus, cmdExperimentList)

--- a/operator/cmd/seldon/cli/status.go
+++ b/operator/cmd/seldon/cli/status.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"k8s.io/utils/env"
+
+	"github.com/seldonio/seldon-core/operator/v2/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+func createStatus() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <pipelineName>",
+		Short: "status of a pipeline",
+		Long:  `status of a pipeline`,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+
+			schedulerHostIsSet := flags.Changed(flagSchedulerHost)
+			schedulerHost, err := flags.GetString(flagSchedulerHost)
+			if err != nil {
+				return err
+			}
+			authority, err := flags.GetString(flagAuthority)
+			if err != nil {
+				return err
+			}
+			showRequest, err := flags.GetBool(flagShowRequest)
+			if err != nil {
+				return err
+			}
+			showResponse, err := flags.GetBool(flagShowResponse)
+			if err != nil {
+				return err
+			}
+			waitCondition, err := flags.GetBool(flagWaitCondition)
+			if err != nil {
+				return err
+			}
+			filename, err := flags.GetString(flagFile)
+			if err != nil {
+				return err
+			}
+			var dataFile []byte
+			if filename != "" {
+				dataFile = loadFile(filename)
+			}
+			schedulerClient, err := cli.NewSchedulerClient(schedulerHost, schedulerHostIsSet, authority)
+			if err != nil {
+				return err
+			}
+
+			err = schedulerClient.Status(dataFile, showRequest, showResponse, waitCondition)
+			return err
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolP(flagShowRequest, "r", false, "show request")
+	flags.BoolP(flagShowResponse, "o", false, "show response")
+	flags.String(flagSchedulerHost, env.GetString(envScheduler, defaultSchedulerHost), helpSchedulerHost)
+	flags.String(flagAuthority, "", helpAuthority)
+	flags.BoolP(flagWaitCondition, "w", false, "wait for resources to be ready")
+	flags.StringP(flagFile, "f", "", "model manifest file (YAML)")
+
+	return cmd
+}

--- a/operator/cmd/seldon/cli/unload.go
+++ b/operator/cmd/seldon/cli/unload.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"k8s.io/utils/env"
+
+	"github.com/seldonio/seldon-core/operator/v2/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+func createUnload() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unload resources",
+		Short: "unload resources",
+		Long:  `unload resources`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+
+			schedulerHostIsSet := flags.Changed(flagSchedulerHost)
+			schedulerHost, err := flags.GetString(flagSchedulerHost)
+			if err != nil {
+				return err
+			}
+			authority, err := flags.GetString(flagAuthority)
+			if err != nil {
+				return err
+			}
+			showRequest, err := flags.GetBool(flagShowRequest)
+			if err != nil {
+				return err
+			}
+			showResponse, err := flags.GetBool(flagShowResponse)
+			if err != nil {
+				return err
+			}
+			filename, err := flags.GetString(flagFile)
+			if err != nil {
+				return err
+			}
+			var dataFile []byte
+			if filename != "" {
+				dataFile = loadFile(filename)
+			}
+
+			schedulerClient, err := cli.NewSchedulerClient(schedulerHost, schedulerHostIsSet, authority)
+			if err != nil {
+				return err
+			}
+
+			err = schedulerClient.Unload(dataFile, showRequest, showResponse)
+			return err
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolP(flagShowRequest, "r", false, "show request")
+	flags.BoolP(flagShowResponse, "o", false, "show response")
+	flags.String(flagSchedulerHost, env.GetString(envScheduler, defaultSchedulerHost), helpSchedulerHost)
+	flags.String(flagAuthority, "", helpAuthority)
+	flags.StringP(flagFile, "f", "", "model manifest file (YAML)")
+
+	return cmd
+}

--- a/operator/config/crd/bases/mlops.seldon.io_pipelines.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_pipelines.yaml
@@ -37,7 +37,42 @@ spec:
           spec:
             description: PipelineSpec defines the desired state of Pipeline
             properties:
+              input:
+                description: External inputs to this pipeline, optional
+                properties:
+                  externalInputs:
+                    description: Previous external pipeline steps to receive data
+                      from
+                    items:
+                      type: string
+                    type: array
+                  externalTriggers:
+                    description: Triggers required to activate inputs
+                    items:
+                      type: string
+                    type: array
+                  joinType:
+                    description: One of inner (default), outer, or any (see above
+                      for details)
+                    type: string
+                  joinWindowMs:
+                    description: msecs to wait for messages from multiple inputs to
+                      arrive before joining the inputs
+                    format: int32
+                    type: integer
+                  tensorMap:
+                    additionalProperties:
+                      type: string
+                    description: Map of tensor name conversions to use e.g. output1
+                      -> input1
+                    type: object
+                  triggersJoinType:
+                    description: One of inner (default), outer, or any (see above
+                      for details)
+                    type: string
+                type: object
               output:
+                description: Synchronous output from this pipeline, optional
                 properties:
                   joinWindowMs:
                     description: msecs to wait for messages from multiple inputs to

--- a/operator/pkg/cli/generic.go
+++ b/operator/pkg/cli/generic.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	yaml2 "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func createDecoder(data []byte) *yaml2.YAMLOrJSONDecoder {
+	var reader io.Reader
+	if len(data) > 0 {
+		reader = bytes.NewReader(data)
+	} else {
+		reader = io.Reader(os.Stdin)
+	}
+	dec := yaml2.NewYAMLOrJSONDecoder(reader, 10)
+	return dec
+}
+
+func getNextResource(dec *yaml2.YAMLOrJSONDecoder) (string, string, []byte, bool, error) {
+	unstructuredObject := &unstructured.Unstructured{}
+	if err := dec.Decode(unstructuredObject); err != nil {
+		if errors.Is(err, io.EOF) {
+			return "", "", nil, false, nil
+		}
+		return "", "", nil, false, err
+	}
+	// Get the resource kind nad original bytes
+	gvk := unstructuredObject.GroupVersionKind()
+	data, err := unstructuredObject.MarshalJSON()
+	if err != nil {
+		return "", "", nil, false, err
+	}
+	return gvk.Kind, unstructuredObject.GetName(), data, true, nil
+}
+
+func (sc *SchedulerClient) Load(data []byte, showRequest bool, showResponse bool) error {
+	dec := createDecoder(data)
+	for {
+		kind, _, data, keepGoing, err := getNextResource(dec)
+		if !keepGoing {
+			return err
+		}
+		switch kind {
+		case "Model":
+			err = sc.LoadModel(data, showRequest, showResponse)
+		case "Pipeline":
+			err = sc.LoadPipeline(data, showRequest, showResponse)
+		case "Experiment":
+			err = sc.StartExperiment(data, showRequest, showResponse)
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (sc *SchedulerClient) Unload(data []byte, showRequest bool, showResponse bool) error {
+	dec := createDecoder(data)
+	for {
+		kind, _, data, keepGoing, err := getNextResource(dec)
+		if !keepGoing {
+			return err
+		}
+		switch kind {
+		case "Model":
+			err = sc.UnloadModel("", data, showRequest, showResponse)
+		case "Pipeline":
+			err = sc.UnloadPipeline("", data, showRequest, showResponse)
+		case "Experiment":
+			err = sc.StopExperiment("", data, showRequest, showResponse)
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (sc *SchedulerClient) Status(data []byte, showRequest bool, showResponse bool, wait bool) error {
+	dec := createDecoder(data)
+	for {
+		kind, name, _, keepGoing, err := getNextResource(dec)
+		if !keepGoing {
+			return err
+		}
+		waitCondition := ""
+		switch kind {
+		case "Model":
+			if wait {
+				waitCondition = "ModelAvailable"
+			}
+			err = sc.ModelStatus(name, showRequest, showResponse, waitCondition)
+		case "Pipeline":
+			if wait {
+				waitCondition = "PipelineReady"
+			}
+			err = sc.PipelineStatus(name, showRequest, showResponse, waitCondition)
+		case "Experiment":
+			err = sc.ExperimentStatus(name, showRequest, showResponse, wait)
+		}
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/operator/pkg/cli/scheduler.go
+++ b/operator/pkg/cli/scheduler.go
@@ -283,14 +283,8 @@ func (sc *SchedulerClient) ModelStatus(modelName string, showRequest bool, showR
 			return err
 		}
 	}
-	if !showResponse {
-		if len(res.Versions) > 0 {
-			modelStatus := res.Versions[0].State.GetState().String()
-			fmt.Printf("{\"%s\":\"%s\"}\n", modelName, modelStatus)
-		} else {
-			fmt.Println("Unknown")
-		}
-	} else {
+
+	if showResponse {
 		printProto(res)
 	}
 	return nil
@@ -540,8 +534,6 @@ func (sc *SchedulerClient) ExperimentStatus(experimentName string, showRequest b
 	}
 	if showResponse {
 		printProto(res)
-	} else {
-		fmt.Printf("%v", res.Active)
 	}
 	return nil
 }
@@ -715,13 +707,6 @@ func (sc *SchedulerClient) PipelineStatus(pipelineName string, showRequest bool,
 	}
 	if showResponse {
 		printProto(res)
-	} else {
-		if len(res.Versions) > 0 {
-			fmt.Printf("%v", res.Versions[0].State.Status.String())
-		} else {
-			fmt.Println("Unknown status")
-		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
- [x] Allow generic load, unload, status from stream or file

Examples:
Run kustomize to create a set of Seldon Core V2 artifacts and pipe to load:

`kustomize build config | seldon load`

Also, wait for a set of resources to be ready

`kustomize build config | seldon status -w`

A future PR can also allow for `-f` to take a folder rather than a file like kubectl.
