### PR TITLE
Add envs for starting zookeeper and prometheus with specific versions

### DIFF
--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -6,8 +6,10 @@ DATAFLOW_IMG ?= ${DOCKERHUB_USERNAME}/seldon-dataflow-engine:${CUSTOM_IMAGE_TAG}
 ENVOY_IMG ?= ${DOCKERHUB_USERNAME}/seldon-envoy:${CUSTOM_IMAGE_TAG}
 # Grafana image only used for Docker compose not k8s
 GRAFANA_IMG ?= ${DOCKERHUB_USERNAME}/seldon-grafana:${CUSTOM_IMAGE_TAG}
+PROMETHEUS_IMG ?= prom/prometheus:latest
 HODOMETER_IMG ?= ${DOCKERHUB_USERNAME}/seldon-hodometer:${CUSTOM_IMAGE_TAG}
 KAFKA_IMG ?= docker.io/bitnami/kafka:3.3
+ZOOKEEPER_IMG ?= docker.io/bitnami/zookeeper:3.8
 MLSERVER_IMG ?= seldonio/mlserver:1.2.3
 MODELGATEWAY_IMG ?= ${DOCKERHUB_USERNAME}/seldon-modelgateway:${CUSTOM_IMAGE_TAG}
 OTELCOL_IMG ?= otel/opentelemetry-collector-contrib-dev:latest
@@ -243,6 +245,8 @@ DOCKER_COMPOSE_IMAGES = \
 	DATAFLOW_IMAGE_AND_TAG=${DATAFLOW_IMG} \
 	HODOMETER_IMAGE_AND_TAG=${HODOMETER_IMG} \
 	KAFKA_IMAGE_AND_TAG=${KAFKA_IMG} \
+	PROMETHEUS_IMAGE_AND_TAG=${PROMETHEUS_IMG} \
+	ZK_IMAGE_AND_TAG=${ZOOKEEPER_IMG} \
 	OTELCOL_IMG=${OTELCOL_IMG}
 
 DOCKER_COMPOSE_ENV = \

--- a/scheduler/all-base.yaml
+++ b/scheduler/all-base.yaml
@@ -143,7 +143,7 @@ services:
       - otel-collector
 
   prometheus:
-    image: prom/prometheus:latest
+    image: "${PROMETHEUS_IMAGE_AND_TAG}"
 
   rclone-mlserver:
     build:
@@ -203,7 +203,7 @@ services:
       stack: 67108864
 
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.8
+    image: ${ZK_IMAGE_AND_TAG}
     volumes:
       - "zookeeper_data:/bitnami"
     environment:


### PR DESCRIPTION
This is a change to allow users to set specific versions for zookeeper and prometheus at docker compose startup similar to the other services we have.
