### PR TITLE
chore: update setuptools version to 65.5.1

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -35,7 +35,7 @@ setup(
         "grpcio-opentracing >= 1.1.4, < 1.2.0",
         "grpcio-reflection < 1.35.0",
         "gunicorn >= 19.9.0, < 20.2.0",
-        "setuptools >= 41.0.0",
+        "setuptools >= 65.5.1",
         "prometheus_client >= 0.7.1, < 0.9.0",
         "werkzeug >= 2.1.1, < 2.3",
         "cryptography >= 3.4, < 3.5",

--- a/servers/mlflowserver/models/elasticnet_wine/Makefile
+++ b/servers/mlflowserver/models/elasticnet_wine/Makefile
@@ -6,7 +6,7 @@ model: env train
 
 env:
 	python3 -m venv .env
-	./.env/bin/pip install --upgrade pip==22.1.2 setuptools==62.4.0
+	./.env/bin/pip install --upgrade pip==22.1.2 setuptools==65.5.1
 	./.env/bin/pip install -r requirements.txt
 
 train:

--- a/wrappers/s2i/python/Dockerfile
+++ b/wrappers/s2i/python/Dockerfile
@@ -22,7 +22,7 @@ RUN microdnf update -y && \
     conda install -c conda-forge --yes python=$PYTHON_VERSION conda=$CONDA_VERSION
 
 # Pin pip and setuptools
-RUN pip install pip==22.1.2 setuptools==63.1.0
+RUN pip install pip==22.1.2 setuptools==65.5.1
 
 RUN mkdir microservice
 WORKDIR /microservice


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Update the `setuptools` package version to resolve Snyk vulnerability warning.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4558 

**Special notes for your reviewer**:
The specific version of `setuptools` that was mentioned in the issue description (`setuptools@57.5.0`) was not present in the repo, so I have updated the version at all the places where setuptools was being used.