### PR TITLE
Remove last dot from constant

### DIFF
--- a/operator/constants/constants.go
+++ b/operator/constants/constants.go
@@ -20,7 +20,7 @@ const (
 	FirstHttpPortNumber   = int32(9000)
 	FirstGrpcPortNumber   = int32(9500)
 	DNSLocalHost          = "localhost"
-	DNSClusterLocalSuffix = ".svc.cluster.local."
+	DNSClusterLocalSuffix = ".svc.cluster.local"
 	GrpcPortName          = "grpc"
 	HttpPortName          = "http"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

It looks like having that last dot at the end of the FQDN causes issues with Istio. That is, `my-model.seldon.svc.cluster.local.` doesn't seem to work (whereas `my-model.seldon.svc.cluster.local` does).
This PR removes that last dot.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
