### PR TITLE
Bump version of golint

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.16.4'
+          go-version: '^1.19'
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '~1.19.0'
 
       - name: Setup Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '~1.19.0'
       - name: test-operator
         run: make -C operator test
       - name: test-scheduler

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.16.4'
+          go-version: '^1.19'
       - name: test-operator
         run: make -C operator test
       - name: test-scheduler

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,26 +16,27 @@ jobs:
         with:
           version: v1.51.2
           working-directory: operator
-          # NOTE: We need to skip the pkg cache until the following issue is
-          # resolved (same applies to the other steps):
+          # NOTE: We need to skip caching completely until the following issues
+          # are resolved (same applies to the other steps):
           # https://github.com/golangci/golangci-lint-action/issues/677
-          skip-pkg-cache: true
+          # https://github.com/golangci/golangci-lint-action/issues/496
+          skip-cache: true
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: scheduler
-          skip-pkg-cache: true
+          skip-cache: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: hodometer
-          skip-pkg-cache: true
+          skip-cache: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.51.2
           working-directory: components/tls
-          skip-pkg-cache: true
+          skip-cache: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.51.2
           working-directory: operator
           # NOTE: We need to skip caching completely until the following issues
           # are resolved (same applies to the other steps):
@@ -24,19 +24,19 @@ jobs:
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.51.2
           working-directory: scheduler
           skip-cache: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.51.2
           working-directory: hodometer
           skip-cache: true
       - name: lint-tls
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.51.2
           working-directory: components/tls
           skip-cache: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '1.19'
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,25 +14,25 @@ jobs:
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          version: v1.51.0
           working-directory: operator
           skip-go-installation: true
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          version: v1.51.0
           working-directory: scheduler
           skip-go-installation: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          version: v1.51.0
           working-directory: hodometer
           skip-go-installation: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.48.0
+          version: v1.51.0
           working-directory: components/tls
           skip-go-installation: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,25 +14,25 @@ jobs:
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.0
+          version: v1.51.2
           working-directory: operator
           skip-go-installation: true
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.0
+          version: v1.51.2
           working-directory: scheduler
           skip-go-installation: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.0
+          version: v1.51.2
           working-directory: hodometer
           skip-go-installation: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.51.0
+          version: v1.51.2
           working-directory: components/tls
           skip-go-installation: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,22 +17,26 @@ jobs:
           version: v1.51.2
           working-directory: operator
           skip-go-installation: true
+          skip-build-cache: true
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: scheduler
           skip-go-installation: true
+          skip-build-cache: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: hodometer
           skip-go-installation: true
+          skip-build-cache: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.51.2
           working-directory: components/tls
           skip-go-installation: true
+          skip-build-cache: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18.5'
+          go-version: '^1.19'
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,27 +16,19 @@ jobs:
         with:
           version: v1.51.2
           working-directory: operator
-          # NOTE: We need to skip caching completely until the following issues
-          # are resolved (same applies to the other steps):
-          # https://github.com/golangci/golangci-lint-action/issues/677
-          # https://github.com/golangci/golangci-lint-action/issues/496
-          skip-cache: true
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: scheduler
-          skip-cache: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: hodometer
-          skip-cache: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: components/tls
-          skip-cache: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '~1.19.0'
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,19 +16,26 @@ jobs:
         with:
           version: v1.51.2
           working-directory: operator
+          # NOTE: We need to skip caching packages until the following issue is
+          # resolved (same applies to the other steps):
+          # https://github.com/golangci/golangci-lint-action/issues/677
+          skip-pkg-cache: true
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: scheduler
+          skip-pkg-cache: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: hodometer
+          skip-pkg-cache: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: components/tls
+          skip-pkg-cache: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,27 +16,26 @@ jobs:
         with:
           version: v1.51.2
           working-directory: operator
-          skip-go-installation: true
-          skip-build-cache: true
+          # NOTE: We need to skip the pkg cache until the following issue is
+          # resolved (same applies to the other steps):
+          # https://github.com/golangci/golangci-lint-action/issues/677
+          skip-pkg-cache: true
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: scheduler
-          skip-go-installation: true
-          skip-build-cache: true
+          skip-pkg-cache: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
           working-directory: hodometer
-          skip-go-installation: true
-          skip-build-cache: true
+          skip-pkg-cache: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.51.2
           working-directory: components/tls
-          skip-go-installation: true
-          skip-build-cache: true
+          skip-pkg-cache: true
           args: --timeout 3m --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.51.1
           working-directory: operator
           # NOTE: We need to skip caching completely until the following issues
           # are resolved (same applies to the other steps):
@@ -24,19 +24,19 @@ jobs:
       - name: lint-scheduler
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.51.1
           working-directory: scheduler
           skip-cache: true
       - name: lint-hodometer
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.51.1
           working-directory: hodometer
           skip-cache: true
       - name: lint-tls
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.51.2
+          version: v1.51.1
           working-directory: components/tls
           skip-cache: true
           args: --timeout 3m --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.19'
+          go-version: '~1.19.0'
       - name: test-operator
         run: make -C operator test
       - name: test-scheduler

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.4'
+          go-version: '^1.19'
       - name: test-operator
         run: make -C operator test
       - name: test-scheduler

--- a/components/tls/Makefile
+++ b/components/tls/Makefile
@@ -4,7 +4,7 @@ GO_LDFLAGS := -s -w $(patsubst %,-X %, $(GO_BUILD_VARS))
 test:
 	go test ./pkg/... -coverprofile cover.out
 
-.GOLANGCILINT_VERSION := v1.51.0
+.GOLANGCILINT_VERSION := v1.51.2
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 

--- a/components/tls/Makefile
+++ b/components/tls/Makefile
@@ -4,7 +4,7 @@ GO_LDFLAGS := -s -w $(patsubst %,-X %, $(GO_BUILD_VARS))
 test:
 	go test ./pkg/... -coverprofile cover.out
 
-.GOLANGCILINT_VERSION := v1.48.0
+.GOLANGCILINT_VERSION := v1.51.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 

--- a/hodometer/Makefile
+++ b/hodometer/Makefile
@@ -21,7 +21,7 @@ RELEASE_TYPE ?= pre-release
 
 ################################################################################
 
-.GOLANGCILINT_VERSION := v1.48.0
+.GOLANGCILINT_VERSION := v1.51.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 

--- a/hodometer/Makefile
+++ b/hodometer/Makefile
@@ -21,7 +21,7 @@ RELEASE_TYPE ?= pre-release
 
 ################################################################################
 
-.GOLANGCILINT_VERSION := v1.51.0
+.GOLANGCILINT_VERSION := v1.51.2
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -62,7 +62,7 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-.GOLANGCILINT_VERSION := v1.48.0
+.GOLANGCILINT_VERSION := v1.51.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -62,7 +62,7 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-.GOLANGCILINT_VERSION := v1.51.0
+.GOLANGCILINT_VERSION := v1.51.2
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -68,7 +68,7 @@ build-jvm: build-dataflow-engine
 .PHONY: build
 build: build-go build-jvm
 
-.GOLANGCILINT_VERSION := v1.48.0
+.GOLANGCILINT_VERSION := v1.51.0
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -68,7 +68,7 @@ build-jvm: build-dataflow-engine
 .PHONY: build
 build: build-go build-jvm
 
-.GOLANGCILINT_VERSION := v1.51.0
+.GOLANGCILINT_VERSION := v1.51.2
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint: 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Bump version of `golangci-lint` from `1.48.0` to `1.51.2`.

On a [separate PR](https://github.com/SeldonIO/seldon-core/actions/runs/4322417104/jobs/7545502201), we saw the linter failing with a `143` error. It's unclear why that happened, but it could be related to https://github.com/golangci/golangci-lint-action/issues/552, where they suggest bumping the version of `golangci-lint` as a solution.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
