### PR TITLE
Increase idle connection of REST proxy to timeout to 30 minutes

### DIFF
--- a/scheduler/pkg/agent/rproxy.go
+++ b/scheduler/pkg/agent/rproxy.go
@@ -48,7 +48,7 @@ const (
 	disableKeepAlivesHTTP       = false
 	maxConnsPerHostHTTP         = 20
 	defaultTimeoutSeconds       = 5
-	idleConnTimeoutSeconds      = 60
+	idleConnTimeoutSeconds      = 60 * 30
 )
 
 type reverseHTTPProxy struct {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Increase default idle timeout of REST proxy to 30 minutes. This is the connection between agent and model server. Otherwise for a single inference requests that takes more than the default threshold (previously 1 minutes) the connection drops.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
