### PR TITLE
Fix golang version in security tests

### DIFF
--- a/.github/workflows/security_tests_v2.yml
+++ b/.github/workflows/security_tests_v2.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         skip-pkg-cache: true
       run: |
-        make -C operator fmt
+        # make -C operator fmt
         snyk test --file=operator/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-scheduler:
@@ -36,7 +36,7 @@ jobs:
       with:
         skip-pkg-cache: true
       run: |
-        make -C scheduler lint
+        # make -C scheduler lint
         snyk test --file=scheduler/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-image-operator:

--- a/.github/workflows/security_tests_v2.yml
+++ b/.github/workflows/security_tests_v2.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   security-operator:
     runs-on: ubuntu-latest
-    container: snyk/snyk:golang
+    container: snyk/snyk:golang-1.19
     steps:
     - uses: actions/checkout@v2
     - name: security-golang
@@ -25,7 +25,7 @@ jobs:
 
   security-scheduler:
     runs-on: ubuntu-latest
-    container: snyk/snyk:golang
+    container: snyk/snyk:golang-1.19
     steps:
     - uses: actions/checkout@v2
     - name: security-golang

--- a/.github/workflows/security_tests_v2.yml
+++ b/.github/workflows/security_tests_v2.yml
@@ -19,7 +19,9 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        GOFLAGS: “-buildvcs=false”
       run: |
+        make -C operator fmt
         snyk test --file=operator/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-scheduler:
@@ -30,7 +32,9 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        GOFLAGS: “-buildvcs=false”
       run: |
+        make -C scheduler lint
         snyk test --file=scheduler/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-image-operator:

--- a/.github/workflows/security_tests_v2.yml
+++ b/.github/workflows/security_tests_v2.yml
@@ -19,10 +19,7 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        skip-pkg-cache: true
       run: |
-        # make -C operator fmt
         snyk test --file=operator/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-scheduler:
@@ -33,10 +30,7 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        skip-pkg-cache: true
       run: |
-        # make -C scheduler lint
         snyk test --file=scheduler/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-image-operator:

--- a/.github/workflows/security_tests_v2.yml
+++ b/.github/workflows/security_tests_v2.yml
@@ -19,6 +19,8 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        skip-pkg-cache: true
       run: |
         make -C operator fmt
         snyk test --file=operator/go.mod --fail-on=upgradable --severity-threshold=high
@@ -31,6 +33,8 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        skip-pkg-cache: true
       run: |
         make -C scheduler lint
         snyk test --file=scheduler/go.mod --fail-on=upgradable --severity-threshold=high

--- a/.github/workflows/security_tests_v2.yml
+++ b/.github/workflows/security_tests_v2.yml
@@ -19,7 +19,7 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        GOFLAGS: “-buildvcs=false”
+        GOFLAGS: "-buildvcs=false"
       run: |
         make -C operator fmt
         snyk test --file=operator/go.mod --fail-on=upgradable --severity-threshold=high
@@ -32,7 +32,7 @@ jobs:
     - name: security-golang
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        GOFLAGS: “-buildvcs=false”
+        GOFLAGS: "-buildvcs=false"
       run: |
         make -C scheduler lint
         snyk test --file=scheduler/go.mod --fail-on=upgradable --severity-threshold=high


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Fix `snyk` golang  image version to `1.19` in security tests. I have also disabled `buildvcs`

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
