### PR TITLE
Upgrade to go 1.19.7 in Docker builds

### DIFF
--- a/hodometer/Dockerfile.hodometer
+++ b/hodometer/Dockerfile.hodometer
@@ -1,6 +1,4 @@
-FROM golang:1.18-alpine as builder
-
-RUN apk add --upgrade make
+FROM golang:1.19.4-buster as builder
 
 WORKDIR /build
 # Copy the Go Modules manifests
@@ -19,6 +17,7 @@ ARG GIT_COMMIT
 ARG RELEASE_TYPE
 ARG BUILD_VERSION
 
+RUN apt-get install make
 RUN make build-hodometer
 
 ################################################################################

--- a/hodometer/Dockerfile.hodometer
+++ b/hodometer/Dockerfile.hodometer
@@ -1,4 +1,4 @@
-FROM golang:1.19.4-buster as builder
+FROM golang:1.19.7-buster as builder
 
 WORKDIR /build
 # Copy the Go Modules manifests

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.3 as builder
+FROM golang:1.19.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.4 as builder
+FROM golang:1.19.7 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/scheduler/Dockerfile.agent
+++ b/scheduler/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine as builder
+FROM golang:1.19.4-alpine as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.agent
+++ b/scheduler/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM golang:1.19.4-alpine as builder
+FROM golang:1.19.7-alpine as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.modelgateway
+++ b/scheduler/Dockerfile.modelgateway
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-buster as builder
+FROM golang:1.19.4-buster as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.modelgateway
+++ b/scheduler/Dockerfile.modelgateway
@@ -1,4 +1,4 @@
-FROM golang:1.19.4-buster as builder
+FROM golang:1.19.7-buster as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.pipelinegateway
+++ b/scheduler/Dockerfile.pipelinegateway
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-buster as builder
+FROM golang:1.19.4-buster as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.pipelinegateway
+++ b/scheduler/Dockerfile.pipelinegateway
@@ -1,4 +1,4 @@
-FROM golang:1.19.4-buster as builder
+FROM golang:1.19.7-buster as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.scheduler
+++ b/scheduler/Dockerfile.scheduler
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-buster as builder
+FROM golang:1.19.4-buster as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.scheduler
+++ b/scheduler/Dockerfile.scheduler
@@ -1,4 +1,4 @@
-FROM golang:1.19.4-buster as builder
+FROM golang:1.19.7-buster as builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
 See [here](https://groups.google.com/g/golang-announce/c/3-TpUx48iQY) and [here](https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E)