### PR TITLE
 use Debian 11 for Executor & Operator images

### DIFF
--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -52,7 +52,7 @@ RUN chmod -R 660 /openapi/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian10:latest
+FROM gcr.io/distroless/base-debian11:latest
 WORKDIR /
 COPY --from=builder /workspace/executor .
 COPY licenses/license.txt licenses/license.txt

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -47,7 +47,7 @@ RUN wget -O mozilla-tls-observatory.tar.gz https://github.com/mozilla/tls-observ
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian10:latest
+FROM gcr.io/distroless/base-debian11:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY licenses/license.txt licenses/license.txt


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This is to address following CVEs:
- cve-2021-33574
- cve-2021-35942
- cve-2022-23218
- cve-2022-23219

present both in Executor and Operator images.


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
