### PR TITLE
Correct typo in `cifar10_drift.ipynb`

### DIFF
--- a/components/drift-detection/cifar10/cifar10_drift.ipynb
+++ b/components/drift-detection/cifar10/cifar10_drift.ipynb
@@ -278,7 +278,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a Knative trigger to forward logging events to our Outlier Detector."
+    "Create a Knative trigger to forward logging events to our Drift Detector."
    ]
   },
   {


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects a minor typo in `cifar10_drift.ipynb`. The detector was referred to as an "Outlier" detector instead of "Drift" detector.

**Special notes for your reviewer**:
