### PR TITLE
Fix check for separate annotation pid

### DIFF
--- a/operator/apis/machinelearning.seldon.io/v1/defaults.go
+++ b/operator/apis/machinelearning.seldon.io/v1/defaults.go
@@ -134,7 +134,7 @@ func (r *SeldonDeploymentSpec) setContainerPredictiveUnitDefaults(compSpecIdx in
 
 	// Set ports and hostname in predictive unit so engine can read it from SDep
 	// if this is the first componentSpec then it's the one to put the engine in - note using outer loop counter here
-	if _, hasSeparateEnginePod := r.Annotations[ANNOTATION_SEPARATE_ENGINE]; compSpecIdx == 0 && !hasSeparateEnginePod {
+	if compSpecIdx == 0 && !HasSeparateEnginePod(*r) {
 		pu.Endpoint.ServiceHost = constants.DNSLocalHost
 	} else {
 		containerServiceValue := GetContainerServiceName(mldepName, *p, con)

--- a/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
+++ b/operator/apis/machinelearning.seldon.io/v1/seldondeployment_types.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"os"
 	"strconv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -83,6 +84,10 @@ const (
 var (
 	envDeploymentNameAsPrefix = os.Getenv(ENV_DEPLOYMENT_NAME_AS_PREFIX)
 )
+
+func HasSeparateEnginePod(spec SeldonDeploymentSpec) bool {
+	return strings.ToLower(spec.Annotations[ANNOTATION_SEPARATE_ENGINE]) == "true"
+}
 
 func hash(text string) string {
 	hasher := md5.New()

--- a/operator/controllers/selddondeployment_controller_components_test.go
+++ b/operator/controllers/selddondeployment_controller_components_test.go
@@ -1,0 +1,105 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	machinelearningv1 "github.com/seldonio/seldon-core/operator/apis/machinelearning.seldon.io/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func createSeldonDeploymentWithPredictorsWithAnnotation(name string, namespace string, addAnnotation bool, engineSeparatePod bool) *machinelearningv1.SeldonDeployment {
+	envExecutorImage = "seldonio/executor:0.1"
+	modelType := machinelearningv1.MODEL
+	instance := &machinelearningv1.SeldonDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: machinelearningv1.SeldonDeploymentSpec{
+			Predictors: []machinelearningv1.PredictorSpec{
+				{
+					Name: "p1",
+					ComponentSpecs: []*machinelearningv1.SeldonPodSpec{
+						{
+							Metadata: machinelearningv1.ObjectMeta{},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Image: "seldonio/mock_classifier:1.0",
+										Name:  "classifier",
+									},
+								},
+							},
+						},
+					},
+					Graph: machinelearningv1.PredictiveUnit{
+						Name: "classifier",
+						Type: &modelType,
+					},
+					Traffic: 70,
+				},
+				{
+					Name: "p2",
+					ComponentSpecs: []*machinelearningv1.SeldonPodSpec{
+						{
+							Metadata: machinelearningv1.ObjectMeta{},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Image: "seldonio/mock_classifier:1.0",
+										Name:  "classifier",
+									},
+								},
+							},
+						},
+					},
+					Graph: machinelearningv1.PredictiveUnit{
+						Name: "classifier",
+						Type: &modelType,
+					},
+					Traffic: 30,
+				},
+			},
+		},
+	}
+	if addAnnotation {
+		instance.Spec.Annotations = map[string]string{"seldon.io/engine-separate-pod": fmt.Sprintf("%v", engineSeparatePod)}
+	}
+	return instance
+}
+
+func TestEngineSeparatePodAnnotation(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	name := "test"
+	namespace := "default"
+
+	logger := ctrl.Log.WithName("controllers").WithName("SeldonDeployment")
+	reconciler := &SeldonDeploymentReconciler{
+		Log: logger,
+	}
+
+	// With separte engine annotation true
+	instance := createSeldonDeploymentWithPredictorsWithAnnotation(name, namespace, true, true)
+	instance.Spec.DefaultSeldonDeployment(name, namespace)
+	_, err := reconciler.createComponents(context.TODO(), instance, nil, logger)
+	g.Expect(err).To(BeNil())
+
+	// With separte engine annotation false
+	instance = createSeldonDeploymentWithPredictorsWithAnnotation(name, namespace, true, false)
+	instance.Spec.DefaultSeldonDeployment(name, namespace)
+	_, err = reconciler.createComponents(context.TODO(), instance, nil, logger)
+	g.Expect(err).To(BeNil())
+
+	// No annotations
+	instance = createSeldonDeploymentWithPredictorsWithAnnotation(name, namespace, false, false)
+	instance.Spec.DefaultSeldonDeployment(name, namespace)
+	_, err = reconciler.createComponents(context.TODO(), instance, nil, logger)
+	g.Expect(err).To(BeNil())
+
+}

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -459,7 +459,7 @@ func (r *SeldonDeploymentReconciler) createComponents(ctx context.Context, mlDep
 			certSecretRefName = predictorCertConfig.CertSecretName
 		}
 		// Add engine deployment if separate
-		hasSeparateEnginePod := strings.ToLower(mlDep.Spec.Annotations[machinelearningv1.ANNOTATION_SEPARATE_ENGINE]) == "true"
+		hasSeparateEnginePod := machinelearningv1.HasSeparateEnginePod(mlDep.Spec)
 		if hasSeparateEnginePod && !noEngine {
 			deploy, err := createEngineDeployment(mlDep, &p, pSvcName, engine_http_port, engine_grpc_port)
 			if err != nil {


### PR DESCRIPTION
The webhook defaulter was not checking the value but just the existence of this annotation.
Add a central test that can be used by two places in code.

Fixes: #4710 