### PR TITLE
Update rclone to 1.62.2

### DIFF
--- a/scheduler/Dockerfile.rclone
+++ b/scheduler/Dockerfile.rclone
@@ -1,4 +1,4 @@
-FROM rclone/rclone:1.61.1 as builder
+FROM rclone/rclone:1.62.2 as builder
 
 RUN mkdir /licenses && wget -O /licenses/license.txt https://raw.githubusercontent.com/rclone/rclone/master/COPYING
 


### PR DESCRIPTION
Fixes some CVEs in previous image with updated GO libs.