### PR TITLE
feat(dataflow): Add missing filter for requests without input tensors

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Joiner.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Joiner.kt
@@ -171,6 +171,8 @@ class Joiner(
             .filterForPipeline(topic.pipelineName)
             .unmarshallInferenceV2Response()
             .convertToRequest(topic.pipelineName, topic.topicName, tensorsByTopic?.get(topic), tensorRenaming)
+            // handle cases where there are no tensors we want
+            .filter { _, value -> value.inputsList.size != 0 }
             .marshallInferenceV2Request()
     }
 


### PR DESCRIPTION

Missing filter for joining pipelines when there are no tensor matches.