### PR TITLE
fix(agent): Use type from storage config and enforce name matches config

### DIFF
--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -250,7 +250,7 @@ func (r *RCloneClient) createUriWithConfig(uri string, rawConfig []byte) (string
 
 	var sb strings.Builder
 	sb.WriteString(":")
-	sb.WriteString(remoteName)
+	sb.WriteString(config.Type)
 	for k, v := range config.Parameters {
 		sb.WriteString(",")
 		sb.WriteString(k)

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -242,7 +242,7 @@ func (r *RCloneClient) createUriWithConfig(uri string, rawConfig []byte) (string
 
 	if config.Name != remoteName {
 		return "", fmt.Errorf(
-			"storage provider name from URI (%s) does not match secret (%s); are you using the right secret?",
+			"name from URI (%s) does not match secret (%s); are you using the right storage config?",
 			remoteName,
 			config.Name,
 		)

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -229,29 +229,29 @@ func (r *RCloneClient) parseRcloneConfig(config []byte) (*RcloneConfigCreate, er
 }
 
 // Creating a connection string with https://rclone.org/docs/#connection-strings
-func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, error) {
+func (r *RCloneClient) createUriWithConfig(uri string, rawConfig []byte) (string, error) {
 	remoteName, err := getRemoteName(uri)
 	if err != nil {
 		return "", err
 	}
 
-	parsed, err := r.parseRcloneConfig(config)
+	config, err := r.parseRcloneConfig(rawConfig)
 	if err != nil {
 		return "", err
 	}
 
-	if parsed.Name != remoteName {
+	if config.Name != remoteName {
 		return "", fmt.Errorf(
 			"storage provider name from URI (%s) does not match secret (%s); are you using the right secret?",
 			remoteName,
-			parsed.Name,
+			config.Name,
 		)
 	}
 
 	var sb strings.Builder
 	sb.WriteString(":")
 	sb.WriteString(remoteName)
-	for k, v := range parsed.Parameters {
+	for k, v := range config.Parameters {
 		sb.WriteString(",")
 		sb.WriteString(k)
 		sb.WriteString("=")

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -240,6 +240,14 @@ func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, e
 		return "", err
 	}
 
+	if parsed.Name != remoteName {
+		return "", fmt.Errorf(
+			"storage provider name from URI (%s) does not match secret (%s)",
+			remoteName,
+			parsed.Name,
+		)
+	}
+
 	var sb strings.Builder
 	sb.WriteString(":")
 	sb.WriteString(remoteName)

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -258,12 +258,12 @@ func (r *RCloneClient) createUriWithConfig(uri string, rawConfig []byte) (string
 
 		if strings.ContainsAny(v, ":,") {
 			sb.WriteString(`"`)
-			v = strings.Replace(v, `"`, `""`, -1)
-		}
-
-		sb.WriteString(v)
-		if strings.ContainsAny(v, ":,") {
+			sb.WriteString(
+				strings.Replace(v, `"`, `""`, -1),
+			)
 			sb.WriteString(`"`)
+		} else {
+			sb.WriteString(v)
 		}
 	}
 

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -230,7 +230,7 @@ func (r *RCloneClient) parseRcloneConfig(config []byte) (*RcloneConfigCreate, er
 
 // Creating a connection string with https://rclone.org/docs/#connection-strings
 func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, error) {
-	remote, err := getRemoteName(uri)
+	remoteName, err := getRemoteName(uri)
 	if err != nil {
 		return "", err
 	}
@@ -242,7 +242,7 @@ func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, e
 
 	var sb strings.Builder
 	sb.WriteString(":")
-	sb.WriteString(remote)
+	sb.WriteString(remoteName)
 	for k, v := range parsed.Parameters {
 		sb.WriteString(",")
 		sb.WriteString(k)
@@ -259,7 +259,7 @@ func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, e
 		}
 	}
 
-	return strings.Replace(uri, remote, sb.String(), 1), nil
+	return strings.Replace(uri, remoteName, sb.String(), 1), nil
 }
 
 func (r *RCloneClient) Config(config []byte) (string, error) {

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -242,7 +242,7 @@ func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, e
 
 	if parsed.Name != remoteName {
 		return "", fmt.Errorf(
-			"storage provider name from URI (%s) does not match secret (%s)",
+			"storage provider name from URI (%s) does not match secret (%s); are you using the right secret?",
 			remoteName,
 			parsed.Name,
 		)


### PR DESCRIPTION
# Why
## Motivation
There are two ways of providing storage configs for models to the Core v2 agent:
* Directly via the model spec's `.spec.storageConfig` field, which creates an ad-hoc config for Rclone.
* Via the agent's config file (or configmap), which then automatically loads all such configs into Rclone.

These mechanisms currently behave somewhat differently.

When use pre-configured configs (not specific to a given model), the assumption is that the model uses a `storageUri` with a scheme matching a known config.  For example, Rclone might have config for a remote called `gs` and the model might have a storage URI like `gs://seldon-models/mlserver/iris`.

When using  ad-hoc configs, the agent currently assumes the URI scheme (`gs` in this example) is the Rclone `type` of the remote.  However, we _require_ storage configs to already have a type and, in fact, a name. 

This PR brings the ad-hoc behaviour in line with that of the pre-configured configs.  The type from the config is used as the Rclone type and the name is expected to match the URI scheme, as Rclone would normally expect.  This is simpler, consistent, and avoids confusion about what to call a remote depending on how a config is used.

## Issues
N/A

# What
## Changes
* Add check that URI scheme matches remote name from storage config for ad-hoc configs.
* Use config `Type` as Rclone type for ad-hoc configs.

## Testing
I have a simple Core v2 setup with MinIO as an S3 provider.  I have set up a storage secret in line with this.
The basic model looks like this:
```yaml
apiVersion: mlops.seldon.io/v1alpha1
kind: Model
metadata:
  namespace: seldon
  name: iris
spec:
  storageUri: minio://models/iris
  secretName: minio-scv2
  memory: 100Ki
  requirements: ['sklearn', 'python']
```
```yaml
name: minio
type: s3
parameters:
  provider: minio
  access_key_id: XXX
  secret_access_key: XXX
  env_auth: false
  endpoint: http://minio.minio-system.svc.cluster.local:9000
```

- [X] Valid config secret but non-matching URI fails.
  - `"name from URI (s3) does not match secret (minio); are you using the right storage config?"`
- [X] Valid config secret and matching URI works.
  - `seldon model infer iris '{"id": "test", "inputs": [{"name": "predict", "shape": [1, 4], "datatype": "FP32", "data": [[4, 0.1, 2.4, 3.3]]}]}' --inference-host XXX`