### PR TITLE
feat(dataflow): Use raw contents in joins if any message uses raw contents

### DIFF
--- a/samples/pipeline-examples.ipynb
+++ b/samples/pipeline-examples.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "id": "f9e073d7",
    "metadata": {},
    "outputs": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "id": "997b4028",
    "metadata": {},
    "outputs": [
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "id": "3d017ede",
    "metadata": {},
    "outputs": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "following-winning",
    "metadata": {},
    "outputs": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "id": "artistic-kentucky",
    "metadata": {},
    "outputs": [
@@ -178,7 +178,7 @@
       "    {\r\n",
       "      \"pipeline\": {\r\n",
       "        \"name\": \"tfsimples\",\r\n",
-      "        \"uid\": \"cg4617kqieos73a7nuj0\",\r\n",
+      "        \"uid\": \"cgm2pdosogbs73emfvm0\",\r\n",
       "        \"version\": 1,\r\n",
       "        \"steps\": [\r\n",
       "          {\r\n",
@@ -206,7 +206,7 @@
       "        \"pipelineVersion\": 1,\r\n",
       "        \"status\": \"PipelineReady\",\r\n",
       "        \"reason\": \"created pipeline\",\r\n",
-      "        \"lastChangeTimestamp\": \"2023-03-08T10:17:03.193598898Z\",\r\n",
+      "        \"lastChangeTimestamp\": \"2023-04-04T13:57:11.631385497Z\",\r\n",
       "        \"modelsReady\": true\r\n",
       "      }\r\n",
       "    }\r\n",
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "id": "87f10a5c",
    "metadata": {},
    "outputs": [
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "id": "5c33133e",
    "metadata": {},
    "outputs": [
@@ -490,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 9,
    "id": "dimensional-hours",
    "metadata": {},
    "outputs": [
@@ -508,8 +508,393 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 10,
    "id": "outside-inspiration",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{}\n",
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon model unload tfsimple1\n",
+    "!seldon model unload tfsimple2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c6a8e27",
+   "metadata": {},
+   "source": [
+    "### Model Chaining from inputs\n",
+    "\n",
+    "Chain the output of one model into the next. Shows using the input and outputs and combining."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "7cbf98a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "apiVersion: mlops.seldon.io/v1alpha1\n",
+      "kind: Model\n",
+      "metadata:\n",
+      "  name: tfsimple1\n",
+      "spec:\n",
+      "  storageUri: \"gs://seldon-models/triton/simple\"\n",
+      "  requirements:\n",
+      "  - tensorflow\n",
+      "  memory: 100Ki\n",
+      "apiVersion: mlops.seldon.io/v1alpha1\n",
+      "kind: Model\n",
+      "metadata:\n",
+      "  name: tfsimple2\n",
+      "spec:\n",
+      "  storageUri: \"gs://seldon-models/triton/simple\"\n",
+      "  requirements:\n",
+      "  - tensorflow\n",
+      "  memory: 100Ki\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat ./models/tfsimple1.yaml\n",
+    "!cat ./models/tfsimple2.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "f0674da8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{}\n",
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon model load -f ./models/tfsimple1.yaml \n",
+    "!seldon model load -f ./models/tfsimple2.yaml "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "53ab8c9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{}\n",
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon model status tfsimple1 -w ModelAvailable | jq -M .\n",
+    "!seldon model status tfsimple2 -w ModelAvailable | jq -M ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "aa3c0927",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "apiVersion: mlops.seldon.io/v1alpha1\r\n",
+      "kind: Pipeline\r\n",
+      "metadata:\r\n",
+      "  name: tfsimples-input\r\n",
+      "spec:\r\n",
+      "  steps:\r\n",
+      "    - name: tfsimple1\r\n",
+      "    - name: tfsimple2\r\n",
+      "      inputs:\r\n",
+      "      - tfsimple1.inputs.INPUT0\r\n",
+      "      - tfsimple1.outputs.OUTPUT1\r\n",
+      "      tensorMap:\r\n",
+      "        tfsimple1.outputs.OUTPUT1: INPUT1\r\n",
+      "  output:\r\n",
+      "    steps:\r\n",
+      "    - tfsimple2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat ./pipelines/tfsimples-input.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "5c0aa3a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{}\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon pipeline load -f ./pipelines/tfsimples-input.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "0fc44852",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\r\n",
+      "  \"pipelineName\": \"tfsimples-input\",\r\n",
+      "  \"versions\": [\r\n",
+      "    {\r\n",
+      "      \"pipeline\": {\r\n",
+      "        \"name\": \"tfsimples-input\",\r\n",
+      "        \"uid\": \"cgm33165u83c73dgvr00\",\r\n",
+      "        \"version\": 1,\r\n",
+      "        \"steps\": [\r\n",
+      "          {\r\n",
+      "            \"name\": \"tfsimple1\"\r\n",
+      "          },\r\n",
+      "          {\r\n",
+      "            \"name\": \"tfsimple2\",\r\n",
+      "            \"inputs\": [\r\n",
+      "              \"tfsimple1.inputs.INPUT0\",\r\n",
+      "              \"tfsimple1.outputs.OUTPUT1\"\r\n",
+      "            ],\r\n",
+      "            \"tensorMap\": {\r\n",
+      "              \"tfsimple1.outputs.OUTPUT1\": \"INPUT1\"\r\n",
+      "            }\r\n",
+      "          }\r\n",
+      "        ],\r\n",
+      "        \"output\": {\r\n",
+      "          \"steps\": [\r\n",
+      "            \"tfsimple2.outputs\"\r\n",
+      "          ]\r\n",
+      "        },\r\n",
+      "        \"kubernetesMeta\": {}\r\n",
+      "      },\r\n",
+      "      \"state\": {\r\n",
+      "        \"pipelineVersion\": 1,\r\n",
+      "        \"status\": \"PipelineReady\",\r\n",
+      "        \"reason\": \"created pipeline\",\r\n",
+      "        \"lastChangeTimestamp\": \"2023-04-04T14:17:41.667004853Z\",\r\n",
+      "        \"modelsReady\": true\r\n",
+      "      }\r\n",
+      "    }\r\n",
+      "  ]\r\n",
+      "}\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon pipeline status tfsimples-input -w PipelineReady| jq -M ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "904cf65a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\r\n",
+      "  \"model_name\": \"\",\r\n",
+      "  \"outputs\": [\r\n",
+      "    {\r\n",
+      "      \"data\": [\r\n",
+      "        1,\r\n",
+      "        2,\r\n",
+      "        3,\r\n",
+      "        4,\r\n",
+      "        5,\r\n",
+      "        6,\r\n",
+      "        7,\r\n",
+      "        8,\r\n",
+      "        9,\r\n",
+      "        10,\r\n",
+      "        11,\r\n",
+      "        12,\r\n",
+      "        13,\r\n",
+      "        14,\r\n",
+      "        15,\r\n",
+      "        16\r\n",
+      "      ],\r\n",
+      "      \"name\": \"OUTPUT0\",\r\n",
+      "      \"shape\": [\r\n",
+      "        1,\r\n",
+      "        16\r\n",
+      "      ],\r\n",
+      "      \"datatype\": \"INT32\"\r\n",
+      "    },\r\n",
+      "    {\r\n",
+      "      \"data\": [\r\n",
+      "        1,\r\n",
+      "        2,\r\n",
+      "        3,\r\n",
+      "        4,\r\n",
+      "        5,\r\n",
+      "        6,\r\n",
+      "        7,\r\n",
+      "        8,\r\n",
+      "        9,\r\n",
+      "        10,\r\n",
+      "        11,\r\n",
+      "        12,\r\n",
+      "        13,\r\n",
+      "        14,\r\n",
+      "        15,\r\n",
+      "        16\r\n",
+      "      ],\r\n",
+      "      \"name\": \"OUTPUT1\",\r\n",
+      "      \"shape\": [\r\n",
+      "        1,\r\n",
+      "        16\r\n",
+      "      ],\r\n",
+      "      \"datatype\": \"INT32\"\r\n",
+      "    }\r\n",
+      "  ]\r\n",
+      "}\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon pipeline infer tfsimples-input \\\n",
+    "    '{\"inputs\":[{\"name\":\"INPUT0\",\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"datatype\":\"INT32\",\"shape\":[1,16]},{\"name\":\"INPUT1\",\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"datatype\":\"INT32\",\"shape\":[1,16]}]}' | jq -M ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "58a2f2ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\r\n",
+      "  \"outputs\": [\r\n",
+      "    {\r\n",
+      "      \"name\": \"OUTPUT0\",\r\n",
+      "      \"datatype\": \"INT32\",\r\n",
+      "      \"shape\": [\r\n",
+      "        \"1\",\r\n",
+      "        \"16\"\r\n",
+      "      ],\r\n",
+      "      \"contents\": {\r\n",
+      "        \"intContents\": [\r\n",
+      "          1,\r\n",
+      "          2,\r\n",
+      "          3,\r\n",
+      "          4,\r\n",
+      "          5,\r\n",
+      "          6,\r\n",
+      "          7,\r\n",
+      "          8,\r\n",
+      "          9,\r\n",
+      "          10,\r\n",
+      "          11,\r\n",
+      "          12,\r\n",
+      "          13,\r\n",
+      "          14,\r\n",
+      "          15,\r\n",
+      "          16\r\n",
+      "        ]\r\n",
+      "      }\r\n",
+      "    },\r\n",
+      "    {\r\n",
+      "      \"name\": \"OUTPUT1\",\r\n",
+      "      \"datatype\": \"INT32\",\r\n",
+      "      \"shape\": [\r\n",
+      "        \"1\",\r\n",
+      "        \"16\"\r\n",
+      "      ],\r\n",
+      "      \"contents\": {\r\n",
+      "        \"intContents\": [\r\n",
+      "          1,\r\n",
+      "          2,\r\n",
+      "          3,\r\n",
+      "          4,\r\n",
+      "          5,\r\n",
+      "          6,\r\n",
+      "          7,\r\n",
+      "          8,\r\n",
+      "          9,\r\n",
+      "          10,\r\n",
+      "          11,\r\n",
+      "          12,\r\n",
+      "          13,\r\n",
+      "          14,\r\n",
+      "          15,\r\n",
+      "          16\r\n",
+      "        ]\r\n",
+      "      }\r\n",
+      "    }\r\n",
+      "  ]\r\n",
+      "}\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon pipeline infer tfsimples-input --inference-mode grpc \\\n",
+    "    '{\"model_name\":\"simple\",\"inputs\":[{\"name\":\"INPUT0\",\"contents\":{\"int_contents\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},\"datatype\":\"INT32\",\"shape\":[1,16]},{\"name\":\"INPUT1\",\"contents\":{\"int_contents\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},\"datatype\":\"INT32\",\"shape\":[1,16]}]}' | jq -M ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "1cd53dd6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{}\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!seldon pipeline unload tfsimples-input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "91cce2e0",
    "metadata": {},
    "outputs": [
     {

--- a/samples/pipelines/tfsimples-input.yaml
+++ b/samples/pipelines/tfsimples-input.yaml
@@ -1,0 +1,16 @@
+apiVersion: mlops.seldon.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: tfsimples-input
+spec:
+  steps:
+    - name: tfsimple1
+    - name: tfsimple2
+      inputs:
+      - tfsimple1.inputs.INPUT0
+      - tfsimple1.outputs.OUTPUT1
+      tensorMap:
+        tfsimple1.outputs.OUTPUT1: INPUT1
+  output:
+    steps:
+    - tfsimple2

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Joiner.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Joiner.kt
@@ -192,8 +192,13 @@ class Joiner(
         if (right == null) {
             return left
         }
-        val leftRequest = V2Dataplane.ModelInferRequest.parseFrom(left)
-        val rightRequest = V2Dataplane.ModelInferRequest.parseFrom(right)
+        var leftRequest = V2Dataplane.ModelInferRequest.parseFrom(left)
+        var rightRequest = V2Dataplane.ModelInferRequest.parseFrom(right)
+        if (leftRequest.rawInputContentsCount > 0 && rightRequest.rawInputContentsCount == 0) {
+            rightRequest = convertRequestToRawInputContents(rightRequest)
+        } else if (rightRequest.rawInputContentsCount > 0 && leftRequest.rawInputContentsCount == 0) {
+            leftRequest = convertRequestToRawInputContents(leftRequest)
+        }
         val request = V2Dataplane.ModelInferRequest
             .newBuilder()
             .setId(leftRequest.id)
@@ -213,8 +218,13 @@ class Joiner(
         if (right == null) {
             return left
         }
-        val leftResponse = V2Dataplane.ModelInferResponse.parseFrom(left)
-        val rightResponse = V2Dataplane.ModelInferResponse.parseFrom(right)
+        var leftResponse = V2Dataplane.ModelInferResponse.parseFrom(left)
+        var rightResponse = V2Dataplane.ModelInferResponse.parseFrom(right)
+        if (leftResponse.rawOutputContentsCount > 0 && rightResponse.rawOutputContentsCount == 0) {
+            rightResponse = convertResponseToRawOutputContents(rightResponse)
+        } else if (rightResponse.rawOutputContentsCount > 0 && leftResponse.rawOutputContentsCount == 0) {
+            leftResponse = convertResponseToRawOutputContents(leftResponse)
+        }
         val response = V2Dataplane.ModelInferResponse
             .newBuilder()
             .setId(leftResponse.id)

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/StreamTransforms.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/StreamTransforms.kt
@@ -16,7 +16,6 @@ limitations under the License.
 
 package io.seldon.dataflow.kafka
 
-import com.google.protobuf.kotlin.toByteString
 import io.seldon.dataflow.kafka.headers.PipelineNameFilter
 import io.seldon.dataflow.kafka.headers.AlibiDetectRemover
 import io.seldon.dataflow.kafka.headers.PipelineHeaderSetter
@@ -94,7 +93,7 @@ fun KStream<String, ModelInferRequest>.batchMessages(batchProperties: Batch): KS
 }
 
 /**
- * Convert the output from one model (a response) to the input for another model (a request).
+ * Convert the output from one model (a response) to the input of another model (a request).
  */
 private fun convertToRequest(
     response: ModelInferResponse,
@@ -308,7 +307,7 @@ fun <T> KStream<T, ModelInferRequest>.convertToResponse(
 }
 
 /**
- * Convert the inout from one model (a request) to the output for another model (a response).
+ * Convert the input from one model (a request) to the output for another model (a response).
  */
 private fun convertToResponse(
     request: ModelInferRequest,

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/StreamTransforms.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/StreamTransforms.kt
@@ -16,6 +16,7 @@ limitations under the License.
 
 package io.seldon.dataflow.kafka
 
+import com.google.protobuf.kotlin.toByteString
 import io.seldon.dataflow.kafka.headers.PipelineNameFilter
 import io.seldon.dataflow.kafka.headers.AlibiDetectRemover
 import io.seldon.dataflow.kafka.headers.PipelineHeaderSetter
@@ -23,7 +24,6 @@ import io.seldon.mlops.chainer.ChainerOuterClass.PipelineTensorMapping
 import io.seldon.mlops.chainer.ChainerOuterClass.Batch
 import io.seldon.mlops.inference.v2.V2Dataplane.ModelInferRequest
 import io.seldon.mlops.inference.v2.V2Dataplane.ModelInferResponse
-import jdk.incubator.vector.VectorOperators.Test
 import org.apache.kafka.streams.kstream.KStream
 import org.apache.kafka.streams.kstream.ValueTransformerSupplier
 
@@ -308,7 +308,7 @@ fun <T> KStream<T, ModelInferRequest>.convertToResponse(
 }
 
 /**
- * Convert the output from one model (a response) to the input for another model (a request).
+ * Convert the inout from one model (a request) to the output for another model (a response).
  */
 private fun convertToResponse(
     request: ModelInferRequest,

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
@@ -2,6 +2,7 @@ package io.seldon.dataflow.kafka
 
 import com.google.protobuf.kotlin.toByteString
 import io.seldon.mlops.inference.v2.V2Dataplane
+import java.lang.UnsupportedOperationException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -100,7 +101,9 @@ fun convertRequestToRawInputContents(request: V2Dataplane.ModelInferRequest): V2
                         .toList()
                 }.toByteArray()
             }
-            DataType.FP16, // as data is stored as FP32 we treat the same. Its unclear if Triton would handdle this correctly though
+            DataType.FP16 -> {  // as data is stored as FP32 we treat the same. Its unclear if Triton would handle this correctly though
+                throw UnsupportedOperationException("FP16 is not presently supported in Pipeline joins")
+            }
             DataType.FP32 -> {
                 input.contents.fp32ContentsList.flatMap {
                     ByteBuffer
@@ -136,7 +139,7 @@ fun convertRequestToRawInputContents(request: V2Dataplane.ModelInferRequest): V2
         // Add raw contents
         builder.addRawInputContents(v.toByteString())
         // Clear the contents now we have added the raw inputs
-        builder.setInputs(idx, input.toBuilder().clearContents())
+        builder.getInputsBuilder(idx).clearContents()
     }
     return builder.build()
 }
@@ -230,7 +233,9 @@ fun convertResponseToRawOutputContents(request: V2Dataplane.ModelInferResponse):
                         .array().toList()
                 }.toByteArray()
             }
-            DataType.FP16, // Unclear if this is correct as will be stored as 4 byte floats so Triton may not handle this
+            DataType.FP16 -> {  // as data is stored as FP32 we treat the same. Its unclear if Triton would handle this correctly though
+                throw UnsupportedOperationException("FP16 is not presently supported in Pipeline joins")
+            }
             DataType.FP32 -> {
                 output.contents.fp32ContentsList.flatMap {
                     ByteBuffer
@@ -266,7 +271,7 @@ fun convertResponseToRawOutputContents(request: V2Dataplane.ModelInferResponse):
         // Add raw contents
         builder.addRawOutputContents(v.toByteString())
         // Clear the contents now we have added the raw outputs
-        builder.setOutputs(idx, output.toBuilder().clearContents())
+        builder.getOutputsBuilder(idx).clearContents()
     }
     return builder.build()
 }

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
@@ -12,70 +12,129 @@ enum class DataType {
 fun convertRequestToRawInputContents(request: V2Dataplane.ModelInferRequest): V2Dataplane.ModelInferRequest {
     val builder = request.toBuilder()
     request.inputsList.forEachIndexed { idx, input ->
-        when (DataType.valueOf(input.datatype)) {
+        val v = when (DataType.valueOf(input.datatype)) {
             DataType.UINT8 -> {
-                val v = input.contents.uintContentsList.flatMap { ByteBuffer.allocate(1)
-                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.uintContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(1)
+                        .put(it.toByte())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.UINT16 -> {
-                val v = input.contents.uintContentsList.flatMap { ByteBuffer.allocate(UShort.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+               input.contents.uintContentsList.flatMap {
+                   ByteBuffer
+                       .allocate(UShort.SIZE_BYTES)
+                       .order(ByteOrder.LITTLE_ENDIAN)
+                       .putShort(it.toShort())
+                       .array()
+                       .toList()
+               }.toByteArray()
             }
             DataType.UINT32 -> {
-                val v = input.contents.uintContentsList.flatMap { ByteBuffer.allocate(UInt.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.uintContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(UInt.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.UINT64 -> {
-                val v = input.contents.uint64ContentsList.flatMap { ByteBuffer.allocate(ULong.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.uint64ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(ULong.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putLong(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT8 -> {
-                val v = input.contents.intContentsList.flatMap { ByteBuffer.allocate(1)
-                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.intContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(1)
+                        .put(it.toByte())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT16 -> {
-                val v = input.contents.intContentsList.flatMap { ByteBuffer.allocate(Short.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.intContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Short.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putShort(it.toShort())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT32 -> {
-                val v = input.contents.intContentsList.flatMap { ByteBuffer.allocate(Int.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.intContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Int.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT64 -> {
-                val v = input.contents.int64ContentsList.flatMap { ByteBuffer.allocate(Long.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.int64ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Long.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putLong(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.BOOL -> {
-                val v = input.contents.boolContentsList.flatMap { ByteBuffer.allocate(1)
-                    .order(ByteOrder.LITTLE_ENDIAN).put(if (it) {1} else {0}) .array().toList() }.toByteArray()
+                input.contents.boolContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(1)
+                        .put(if (it) {1} else {0})
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
-            DataType.FP16, // Unclear if this is correct as will be stored as 4 byte floats
+            DataType.FP16, // as data is stored as FP32 we treat the same. Its unclear if Triton would handdle this correctly though
             DataType.FP32 -> {
-                val v = input.contents.fp32ContentsList.flatMap { ByteBuffer.allocate(Float.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putFloat(it).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.fp32ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Float.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putFloat(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.FP64 -> {
-                val v = input.contents.fp64ContentsList.flatMap { ByteBuffer.allocate(Double.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putDouble(it).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.fp64ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Double.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putDouble(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.BYTES -> {
-                val v = input.contents.bytesContentsList.flatMap { ByteBuffer.allocate(it.size() + 4)
-                    .order(ByteOrder.LITTLE_ENDIAN)
-                    .putInt(it.size())
-                    .put(it.toByteArray()).array().toList() }.toByteArray()
-                builder.addRawInputContents(v.toByteString())
+                input.contents.bytesContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(it.size() + Int.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(it.size())
+                        .put(it.toByteArray())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
         }
+        // Add raw contents
+        builder.addRawInputContents(v.toByteString())
         // Clear the contents now we have added the raw inputs
         builder.setInputs(idx, input.toBuilder().clearContents())
     }
@@ -85,71 +144,128 @@ fun convertRequestToRawInputContents(request: V2Dataplane.ModelInferRequest): V2
 fun convertResponseToRawOutputContents(request: V2Dataplane.ModelInferResponse): V2Dataplane.ModelInferResponse {
     val builder = request.toBuilder()
     request.outputsList.forEachIndexed { idx, output ->
-        when (DataType.valueOf(output.datatype)) {
+        val v = when (DataType.valueOf(output.datatype)) {
             DataType.UINT8 -> {
-                val v = output.contents.uintContentsList.flatMap { ByteBuffer.allocate(1)
-                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.uintContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(1)
+                        .put(it.toByte())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.UINT16 -> {
-                val v = output.contents.uintContentsList.flatMap { ByteBuffer.allocate(UShort.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.uintContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(UShort.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putShort(it.toShort())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.UINT32 -> {
-                val v = output.contents.uintContentsList.flatMap { ByteBuffer.allocate(UInt.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.uintContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(UInt.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.UINT64 -> {
-                val v = output.contents.uint64ContentsList.flatMap { ByteBuffer.allocate(ULong.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.uint64ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(ULong.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putLong(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT8 -> {
-                val v = output.contents.intContentsList.flatMap { ByteBuffer.allocate(1)
-                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.intContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(1)
+                        .put(it.toByte())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT16 -> {
-                val v = output.contents.intContentsList.flatMap { ByteBuffer.allocate(Short.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.intContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Short.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putShort(it.toShort())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT32 -> {
-                val v = output.contents.intContentsList.flatMap { ByteBuffer.allocate(Int.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.intContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Int.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.INT64 -> {
-                val v = output.contents.int64ContentsList.flatMap { ByteBuffer.allocate(Long.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.int64ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Long.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putLong(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.BOOL -> {
-                val v = output.contents.boolContentsList.flatMap { ByteBuffer.allocate(1)
-                    .order(ByteOrder.LITTLE_ENDIAN).put(if (it) {1} else {0}) .array().toList() }.toByteArray()
+                output.contents.boolContentsList.flatMap {
+                    ByteBuffer.allocate(1)
+                        .put(if (it) {1} else {0})
+                        .array().toList()
+                }.toByteArray()
             }
-            DataType.FP16, // Unclear if this is correct as will be stored as 4 byte floats
+            DataType.FP16, // Unclear if this is correct as will be stored as 4 byte floats so Triton may not handle this
             DataType.FP32 -> {
-                val v = output.contents.fp32ContentsList.flatMap { ByteBuffer.allocate(Float.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putFloat(it).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.fp32ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Float.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putFloat(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.FP64 -> {
-                val v = output.contents.fp64ContentsList.flatMap { ByteBuffer.allocate(Double.SIZE_BYTES)
-                    .order(ByteOrder.LITTLE_ENDIAN).putDouble(it).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.fp64ContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(Double.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putDouble(it)
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
             DataType.BYTES -> {
-                val v = output.contents.bytesContentsList.flatMap { ByteBuffer.allocate(it.size() + 4)
-                    .order(ByteOrder.LITTLE_ENDIAN)
-                    .putInt(it.size())
-                    .put(it.toByteArray()).array().toList() }.toByteArray()
-                builder.addRawOutputContents(v.toByteString())
+                output.contents.bytesContentsList.flatMap {
+                    ByteBuffer
+                        .allocate(it.size() + Int.SIZE_BYTES)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(it.size())
+                        .put(it.toByteArray())
+                        .array()
+                        .toList()
+                }.toByteArray()
             }
         }
-        // Clear the contents now we have added the raw inputs
+        // Add raw contents
+        builder.addRawOutputContents(v.toByteString())
+        // Clear the contents now we have added the raw outputs
         builder.setOutputs(idx, output.toBuilder().clearContents())
     }
     return builder.build()

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
@@ -101,9 +101,7 @@ fun convertRequestToRawInputContents(request: V2Dataplane.ModelInferRequest): V2
                         .toList()
                 }.toByteArray()
             }
-            DataType.FP16 -> {  // as data is stored as FP32 we treat the same. Its unclear if Triton would handle this correctly though
-                throw UnsupportedOperationException("FP16 is not presently supported in Pipeline joins")
-            }
+            DataType.FP16, // may need to handle this separately in future
             DataType.FP32 -> {
                 input.contents.fp32ContentsList.flatMap {
                     ByteBuffer
@@ -233,9 +231,7 @@ fun convertResponseToRawOutputContents(request: V2Dataplane.ModelInferResponse):
                         .array().toList()
                 }.toByteArray()
             }
-            DataType.FP16 -> {  // as data is stored as FP32 we treat the same. Its unclear if Triton would handle this correctly though
-                throw UnsupportedOperationException("FP16 is not presently supported in Pipeline joins")
-            }
+            DataType.FP16, // may need to handle this separately in future
             DataType.FP32 -> {
                 output.contents.fp32ContentsList.flatMap {
                     ByteBuffer

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/protocol.kt
@@ -1,0 +1,157 @@
+package io.seldon.dataflow.kafka
+
+import com.google.protobuf.kotlin.toByteString
+import io.seldon.mlops.inference.v2.V2Dataplane
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+enum class DataType {
+    BOOL, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64, FP16, FP32, FP64, BYTES
+}
+
+fun convertRequestToRawInputContents(request: V2Dataplane.ModelInferRequest): V2Dataplane.ModelInferRequest {
+    val builder = request.toBuilder()
+    request.inputsList.forEachIndexed { idx, input ->
+        when (DataType.valueOf(input.datatype)) {
+            DataType.UINT8 -> {
+                val v = input.contents.uintContentsList.flatMap { ByteBuffer.allocate(1)
+                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.UINT16 -> {
+                val v = input.contents.uintContentsList.flatMap { ByteBuffer.allocate(UShort.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.UINT32 -> {
+                val v = input.contents.uintContentsList.flatMap { ByteBuffer.allocate(UInt.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.UINT64 -> {
+                val v = input.contents.uint64ContentsList.flatMap { ByteBuffer.allocate(ULong.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.INT8 -> {
+                val v = input.contents.intContentsList.flatMap { ByteBuffer.allocate(1)
+                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.INT16 -> {
+                val v = input.contents.intContentsList.flatMap { ByteBuffer.allocate(Short.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.INT32 -> {
+                val v = input.contents.intContentsList.flatMap { ByteBuffer.allocate(Int.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.INT64 -> {
+                val v = input.contents.int64ContentsList.flatMap { ByteBuffer.allocate(Long.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.BOOL -> {
+                val v = input.contents.boolContentsList.flatMap { ByteBuffer.allocate(1)
+                    .order(ByteOrder.LITTLE_ENDIAN).put(if (it) {1} else {0}) .array().toList() }.toByteArray()
+            }
+            DataType.FP16, // Unclear if this is correct as will be stored as 4 byte floats
+            DataType.FP32 -> {
+                val v = input.contents.fp32ContentsList.flatMap { ByteBuffer.allocate(Float.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putFloat(it).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.FP64 -> {
+                val v = input.contents.fp64ContentsList.flatMap { ByteBuffer.allocate(Double.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putDouble(it).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+            DataType.BYTES -> {
+                val v = input.contents.bytesContentsList.flatMap { ByteBuffer.allocate(it.size() + 4)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .putInt(it.size())
+                    .put(it.toByteArray()).array().toList() }.toByteArray()
+                builder.addRawInputContents(v.toByteString())
+            }
+        }
+        // Clear the contents now we have added the raw inputs
+        builder.setInputs(idx, input.toBuilder().clearContents())
+    }
+    return builder.build()
+}
+
+fun convertResponseToRawOutputContents(request: V2Dataplane.ModelInferResponse): V2Dataplane.ModelInferResponse {
+    val builder = request.toBuilder()
+    request.outputsList.forEachIndexed { idx, output ->
+        when (DataType.valueOf(output.datatype)) {
+            DataType.UINT8 -> {
+                val v = output.contents.uintContentsList.flatMap { ByteBuffer.allocate(1)
+                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.UINT16 -> {
+                val v = output.contents.uintContentsList.flatMap { ByteBuffer.allocate(UShort.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.UINT32 -> {
+                val v = output.contents.uintContentsList.flatMap { ByteBuffer.allocate(UInt.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.UINT64 -> {
+                val v = output.contents.uint64ContentsList.flatMap { ByteBuffer.allocate(ULong.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.INT8 -> {
+                val v = output.contents.intContentsList.flatMap { ByteBuffer.allocate(1)
+                    .order(ByteOrder.LITTLE_ENDIAN).put(it.toByte()).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.INT16 -> {
+                val v = output.contents.intContentsList.flatMap { ByteBuffer.allocate(Short.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putShort(it.toShort()).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.INT32 -> {
+                val v = output.contents.intContentsList.flatMap { ByteBuffer.allocate(Int.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putInt(it).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.INT64 -> {
+                val v = output.contents.int64ContentsList.flatMap { ByteBuffer.allocate(Long.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putLong(it).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.BOOL -> {
+                val v = output.contents.boolContentsList.flatMap { ByteBuffer.allocate(1)
+                    .order(ByteOrder.LITTLE_ENDIAN).put(if (it) {1} else {0}) .array().toList() }.toByteArray()
+            }
+            DataType.FP16, // Unclear if this is correct as will be stored as 4 byte floats
+            DataType.FP32 -> {
+                val v = output.contents.fp32ContentsList.flatMap { ByteBuffer.allocate(Float.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putFloat(it).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.FP64 -> {
+                val v = output.contents.fp64ContentsList.flatMap { ByteBuffer.allocate(Double.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN).putDouble(it).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+            DataType.BYTES -> {
+                val v = output.contents.bytesContentsList.flatMap { ByteBuffer.allocate(it.size() + 4)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .putInt(it.size())
+                    .put(it.toByteArray()).array().toList() }.toByteArray()
+                builder.addRawOutputContents(v.toByteString())
+            }
+        }
+        // Clear the contents now we have added the raw inputs
+        builder.setOutputs(idx, output.toBuilder().clearContents())
+    }
+    return builder.build()
+}
+


### PR DESCRIPTION
Triton will fail if some inputs have raw contents and some do not.
This PR ensures we always just have raw contents if one input does and another does not when joining streams of data.

Fixes: #4776