### PR TITLE
Ensure metrics.port value is used in operator's Deployment

### DIFF
--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -38,6 +38,7 @@ spec:
       - args:
         - --enable-leader-election
         - --webhook-port={{ .Values.webhook.port }}
+        - --metrics-addr={{ .Values.metrics.port }}
         - --create-resources=$(MANAGER_CREATE_RESOURCES)
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -38,7 +38,7 @@ spec:
       - args:
         - --enable-leader-election
         - --webhook-port={{ .Values.webhook.port }}
-        - --metrics-addr={{ .Values.metrics.port }}
+        - --metrics-addr=:{{ .Values.metrics.port }}
         - --create-resources=$(MANAGER_CREATE_RESOURCES)
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
         args:
         - --enable-leader-election
         - --webhook-port=4443
+        - --metrics-addr=8080
         - --create-resources=$(MANAGER_CREATE_RESOURCES)
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         args:
         - --enable-leader-election
         - --webhook-port=4443
-        - --metrics-addr=8080
+        - --metrics-addr=:8080
         - --create-resources=$(MANAGER_CREATE_RESOURCES)
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -221,12 +221,24 @@ if __name__ == "__main__":
                 )
 
                 # Update metrics port
-                res["spec"]["template"]["metadata"]["annotations"]["prometheus.io/port"] = helm_value('metrics.port')
+                res["spec"]["template"]["metadata"]["annotations"]["prometheus.io/port"] = helm_value("metrics.port")
                 for portSpec in res["spec"]["template"]["spec"]["containers"][0][
                     "ports"
                 ]:
                     if portSpec["name"] == "metrics":
                         portSpec["containerPort"] = helm_value("metrics.port")
+
+                for argIdx in range(
+                    0, len(res["spec"]["template"]["spec"]
+                           ["containers"][0]["args"])
+                ):
+                    if (
+                        res["spec"]["template"]["spec"]["containers"][0]["args"][argIdx]
+                        == "--metrics-addr=8080"
+                    ):
+                        res["spec"]["template"]["spec"]["containers"][0]["args"][
+                            argIdx
+                        ] = "--metrics-addr=" + helm_value("metrics.port")
 
                 # Networking
                 res["spec"]["template"]["spec"]["hostNetwork"] = helm_value("hostNetwork")

--- a/operator/helm/split_resources.py
+++ b/operator/helm/split_resources.py
@@ -234,11 +234,11 @@ if __name__ == "__main__":
                 ):
                     if (
                         res["spec"]["template"]["spec"]["containers"][0]["args"][argIdx]
-                        == "--metrics-addr=8080"
+                        == "--metrics-addr=:8080"
                     ):
                         res["spec"]["template"]["spec"]["containers"][0]["args"][
                             argIdx
-                        ] = "--metrics-addr=" + helm_value("metrics.port")
+                        ] = "--metrics-addr=:" + helm_value("metrics.port")
 
                 # Networking
                 res["spec"]["template"]["spec"]["hostNetwork"] = helm_value("hostNetwork")


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Forward the `metrics.port` value from the Helm chart to the `--metrics-addr` flag of the operator `Deployment`. Otherwise, the operator will keep using the default value for its metric port (i.e. `8080`). 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4705 

**Special notes for your reviewer**:
