### PR TITLE
refactor(agent): Format agent code

### DIFF
--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -584,7 +584,11 @@ func (c *Client) LoadModel(request *agent.ModelOperationMessage) error {
 
 	// Copy model artifact
 	chosenVersionPath, err := c.ModelRepository.DownloadModelVersion(
-		modelWithVersion, pinnedModelVersion, request.GetModelVersion().GetModel().GetModelSpec(), config)
+		modelWithVersion,
+		pinnedModelVersion,
+		request.GetModelVersion().GetModel().GetModelSpec(),
+		config,
+	)
 	if err != nil {
 		c.sendModelEventError(modelName, modelVersion, agent.ModelEventMessage_LOAD_FAILED, err)
 		return err
@@ -592,7 +596,11 @@ func (c *Client) LoadModel(request *agent.ModelOperationMessage) error {
 	logger.Infof("Chose path %s for model %s:%d", *chosenVersionPath, modelName, modelVersion)
 
 	// TODO: consider whether we need the actual protos being sent to `LoadModelVersion`?
-	modifiedModelVersionRequest := getModifiedModelVersion(modelWithVersion, pinnedModelVersion, request.GetModelVersion())
+	modifiedModelVersionRequest := getModifiedModelVersion(
+		modelWithVersion,
+		pinnedModelVersion,
+		request.GetModelVersion(),
+	)
 	loaderFn := func() error {
 		return c.stateManager.LoadModelVersion(modifiedModelVersionRequest)
 	}

--- a/scheduler/pkg/agent/config/config.go
+++ b/scheduler/pkg/agent/config/config.go
@@ -159,16 +159,20 @@ func (a *AgentConfigHandler) getConfiguration() *AgentConfiguration {
 func (a *AgentConfigHandler) updateConfig(configData []byte) error {
 	logger := a.logger.WithField("func", "updateConfig")
 	logger.Infof("Updating config %s", configData)
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
+
 	config := AgentConfiguration{}
 	err := yaml.Unmarshal(configData, &config)
 	if err != nil {
 		return err
 	}
+
 	if config.Rclone != nil {
 		logger.Infof("Rclone Config loaded %v", config.Rclone)
 	}
+
 	a.config = &config
 	return nil
 }

--- a/scheduler/pkg/agent/k8s/secrets.go
+++ b/scheduler/pkg/agent/k8s/secrets.go
@@ -41,16 +41,19 @@ func (s *SecretHandler) GetSecretConfig(secretName string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if len(secret.Data) == 1 {
 		for _, val := range secret.Data {
 			return val, nil
 		}
 	}
+
 	if len(secret.StringData) == 1 {
 		for _, val := range secret.StringData {
 			return []byte(val), nil
 		}
 	}
+
 	//TODO allow more than 1 key in secret
 	return nil, fmt.Errorf("Secret does not have 1 key %s", secretName)
 }

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -305,21 +305,26 @@ func (r *RCloneClient) Copy(modelName string, srcUri string, config []byte) (str
 	if err != nil {
 		return "", err
 	}
+
 	dst := fmt.Sprintf("%s/%d", r.localPath, hash)
 	copy := RcloneCopy{
 		SrcFs:              srcUpdated,
 		DstFs:              dst,
 		CreateEmptySrcDirs: true,
 	}
+
 	r.logger.Infof("Copy from %s (original %s) to %s", srcUpdated, srcUri, dst)
+
 	b, err := json.Marshal(copy)
 	if err != nil {
 		return "", err
 	}
+
 	_, err = r.call(b, RcloneSyncCopyPath)
 	if err != nil {
 		return "", fmt.Errorf("Failed to sync/copy %s to %s %w", srcUpdated, dst, err)
 	}
+
 	// Even if we had success from rclone the src may be empty so need to check
 	pathExists, err := pathExists(dst)
 	if err != nil {
@@ -328,6 +333,7 @@ func (r *RCloneClient) Copy(modelName string, srcUri string, config []byte) (str
 	if !pathExists {
 		return "", fmt.Errorf("Failed to download from %s any files", srcUri)
 	}
+
 	return dst, nil
 }
 

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -110,7 +110,13 @@ func createConfigUpdateFromCreate(create *RcloneConfigCreate) *RcloneConfigUpdat
 	return &update
 }
 
-func NewRCloneClient(host string, port int, localPath string, logger log.FieldLogger, namespace string) *RCloneClient {
+func NewRCloneClient(
+	host string,
+	port int,
+	localPath string,
+	logger log.FieldLogger,
+	namespace string,
+) *RCloneClient {
 	logger.Infof("Rclone server %s:%d with model-cache:%s", host, port, localPath)
 	return &RCloneClient{
 		host:       host,

--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -228,10 +228,12 @@ func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, e
 	if err != nil {
 		return "", err
 	}
+
 	parsed, err := r.parseRcloneConfig(config)
 	if err != nil {
 		return "", err
 	}
+
 	var sb strings.Builder
 	sb.WriteString(":")
 	sb.WriteString(remote)
@@ -239,15 +241,18 @@ func (r *RCloneClient) createUriWithConfig(uri string, config []byte) (string, e
 		sb.WriteString(",")
 		sb.WriteString(k)
 		sb.WriteString("=")
+
 		if strings.ContainsAny(v, ":,") {
 			sb.WriteString(`"`)
 			v = strings.Replace(v, `"`, `""`, -1)
 		}
+
 		sb.WriteString(v)
 		if strings.ContainsAny(v, ":,") {
 			sb.WriteString(`"`)
 		}
 	}
+
 	return strings.Replace(uri, remote, sb.String(), 1), nil
 }
 

--- a/scheduler/pkg/agent/rclone/rclone_config.go
+++ b/scheduler/pkg/agent/rclone/rclone_config.go
@@ -29,25 +29,25 @@ func (r *RCloneClient) loadRcloneConfiguration(config *config.AgentConfiguration
 		return nil
 	}
 
-	var rcloneNamesAdded []string
+	var addedFromSecrets []string
 	var err error
 
 	// Load any secrets that have Rclone config
-	rcloneNamesAdded, err = r.loadRcloneSecretsConfiguration(config)
+	addedFromSecrets, err = r.loadRcloneSecretsConfiguration(config)
 	if err != nil {
 		return err
 	}
 
 	// Load any raw Rclone configs
-	rcloneNamesAddedSecrets, err := r.loadRcloneRawConfiguration(config)
+	addedFromRawConfig, err := r.loadRcloneRawConfiguration(config)
 	if err != nil {
 		return err
 	}
 
-	rcloneNamesAdded = append(rcloneNamesAdded, rcloneNamesAddedSecrets...)
+	addedFromSecrets = append(addedFromSecrets, addedFromRawConfig...)
 
 	// Delete any existing remotes not in defaults
-	err = r.deleteUnusedRcloneConfiguration(config, rcloneNamesAdded)
+	err = r.deleteUnusedRcloneConfiguration(config, addedFromSecrets)
 	if err != nil {
 		logger.WithError(err).Errorf("Failed to delete unused Rclone configuration")
 	}

--- a/scheduler/pkg/agent/rclone/rclone_config.go
+++ b/scheduler/pkg/agent/rclone/rclone_config.go
@@ -24,38 +24,40 @@ import (
 func (r *RCloneClient) loadRcloneConfiguration(config *config.AgentConfiguration) error {
 	logger := r.logger.WithField("func", "loadRcloneConfiguration")
 
+	if config == nil {
+		logger.Warn("nil config passed")
+		return nil
+	}
+
 	var rcloneNamesAdded []string
 	var err error
-	if config != nil {
-		// Load any secrets that have Rclone config
-		rcloneNamesAdded, err = r.loadRcloneSecretsConfiguration(config)
-		if err != nil {
-			return err
-		}
 
-		// Load any raw Rclone configs
-		rcloneNamesAddedSecrets, err := r.loadRcloneRawConfiguration(config)
-		if err != nil {
-			return err
-		}
-
-		rcloneNamesAdded = append(rcloneNamesAdded, rcloneNamesAddedSecrets...)
-
-		// Delete any existing remotes not in defaults
-		err = r.deleteUnusedRcloneConfiguration(config, rcloneNamesAdded)
-		if err != nil {
-			logger.WithError(err).Errorf("Failed to delete unused Rclone configuration")
-		}
-
-		existingRemotes, err := r.ListRemotes()
-		if err != nil {
-			return err
-		}
-
-		logger.Infof("After update current set of remotes is %v", existingRemotes)
-	} else {
-		logger.Warn("nil config passed")
+	// Load any secrets that have Rclone config
+	rcloneNamesAdded, err = r.loadRcloneSecretsConfiguration(config)
+	if err != nil {
+		return err
 	}
+
+	// Load any raw Rclone configs
+	rcloneNamesAddedSecrets, err := r.loadRcloneRawConfiguration(config)
+	if err != nil {
+		return err
+	}
+
+	rcloneNamesAdded = append(rcloneNamesAdded, rcloneNamesAddedSecrets...)
+
+	// Delete any existing remotes not in defaults
+	err = r.deleteUnusedRcloneConfiguration(config, rcloneNamesAdded)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to delete unused Rclone configuration")
+	}
+
+	existingRemotes, err := r.ListRemotes()
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("After update current set of remotes is %v", existingRemotes)
 
 	return nil
 }

--- a/scheduler/pkg/agent/rclone/rclone_config.go
+++ b/scheduler/pkg/agent/rclone/rclone_config.go
@@ -29,11 +29,8 @@ func (r *RCloneClient) loadRcloneConfiguration(config *config.AgentConfiguration
 		return nil
 	}
 
-	var addedFromSecrets []string
-	var err error
-
 	// Load any secrets that have Rclone config
-	addedFromSecrets, err = r.loadRcloneSecretsConfiguration(config)
+	addedFromSecrets, err := r.loadRcloneSecretsConfiguration(config)
 	if err != nil {
 		return err
 	}

--- a/scheduler/pkg/agent/rclone/rclone_config.go
+++ b/scheduler/pkg/agent/rclone/rclone_config.go
@@ -23,6 +23,7 @@ import (
 
 func (r *RCloneClient) loadRcloneConfiguration(config *config.AgentConfiguration) error {
 	logger := r.logger.WithField("func", "loadRcloneConfiguration")
+
 	var rcloneNamesAdded []string
 	var err error
 	if config != nil {
@@ -31,11 +32,13 @@ func (r *RCloneClient) loadRcloneConfiguration(config *config.AgentConfiguration
 		if err != nil {
 			return err
 		}
+
 		// Load any raw Rclone configs
 		rcloneNamesAddedSecrets, err := r.loadRcloneRawConfiguration(config)
 		if err != nil {
 			return err
 		}
+
 		rcloneNamesAdded = append(rcloneNamesAdded, rcloneNamesAddedSecrets...)
 
 		// Delete any existing remotes not in defaults
@@ -43,39 +46,48 @@ func (r *RCloneClient) loadRcloneConfiguration(config *config.AgentConfiguration
 		if err != nil {
 			logger.WithError(err).Errorf("Failed to delete unused Rclone configuration")
 		}
+
 		existingRemotes, err := r.ListRemotes()
 		if err != nil {
 			return err
 		}
+
 		logger.Infof("After update current set of remotes is %v", existingRemotes)
 	} else {
 		logger.Warn("nil config passed")
 	}
+
 	return nil
 }
 
 func (r *RCloneClient) loadRcloneRawConfiguration(config *config.AgentConfiguration) ([]string, error) {
 	logger := r.logger.WithField("func", "loadRcloneRawConfiguration")
+
 	var rcloneNamesAdded []string
 	if len(config.Rclone.Config) > 0 {
 		for _, config := range config.Rclone.Config {
 			logger.Infof("Loading rclone config %s", config)
+
 			name, err := r.Config([]byte(config))
 			if err != nil {
 				return nil, err
 			}
+
 			rcloneNamesAdded = append(rcloneNamesAdded, name)
 		}
 	}
+
 	return rcloneNamesAdded, nil
 }
 
 func (r *RCloneClient) deleteUnusedRcloneConfiguration(config *config.AgentConfiguration, rcloneNamesAdded []string) error {
 	logger := r.logger.WithField("func", "deleteUnusedRcloneConfiguration")
+
 	existingRemotes, err := r.ListRemotes()
 	if err != nil {
 		return err
 	}
+
 	for _, existingName := range existingRemotes {
 		found := false
 		for _, addedName := range rcloneNamesAdded {
@@ -84,19 +96,23 @@ func (r *RCloneClient) deleteUnusedRcloneConfiguration(config *config.AgentConfi
 				break
 			}
 		}
+
 		if !found {
 			logger.Infof("Delete remote %s as not in new list of defaults", existingName)
+
 			err := r.DeleteRemote(existingName)
 			if err != nil {
 				return err
 			}
 		}
 	}
+
 	return nil
 }
 
 func (r *RCloneClient) loadRcloneSecretsConfiguration(config *config.AgentConfiguration) ([]string, error) {
 	logger := r.logger.WithField("func", "loadRcloneSecretsConfiguration")
+
 	var rcloneNamesAdded []string
 	// Load any secrets that have Rclone config
 	if len(config.Rclone.ConfigSecrets) > 0 {
@@ -104,19 +120,24 @@ func (r *RCloneClient) loadRcloneSecretsConfiguration(config *config.AgentConfig
 		if err != nil {
 			return nil, err
 		}
+
 		secretsHandler := k8s.NewSecretsHandler(secretClientSet, r.namespace)
 		for _, secret := range config.Rclone.ConfigSecrets {
 			logger.Infof("Loading rclone secret %s", secret)
+
 			config, err := secretsHandler.GetSecretConfig(secret)
 			if err != nil {
 				return nil, err
 			}
+
 			name, err := r.Config(config)
 			if err != nil {
 				return nil, err
 			}
+
 			rcloneNamesAdded = append(rcloneNamesAdded, name)
 		}
 	}
+
 	return rcloneNamesAdded, nil
 }

--- a/scheduler/pkg/agent/repository/model_repository.go
+++ b/scheduler/pkg/agent/repository/model_repository.go
@@ -68,7 +68,8 @@ func NewModelRepository(logger log.FieldLogger,
 	}
 }
 
-func (r *V2ModelRepository) DownloadModelVersion(modelName string,
+func (r *V2ModelRepository) DownloadModelVersion(
+	modelName string,
 	version uint32,
 	modelSpec *scheduler.ModelSpec,
 	config []byte,
@@ -80,6 +81,7 @@ func (r *V2ModelRepository) DownloadModelVersion(modelName string,
 	srcUri := modelSpec.Uri
 	explainerSpec := modelSpec.GetExplainer()
 	parameters := modelSpec.GetParameters()
+
 	logger.Debugf("running with model %s:%d srcUri %s", modelName, version, srcUri)
 
 	// Run rclone copy sync
@@ -89,11 +91,23 @@ func (r *V2ModelRepository) DownloadModelVersion(modelName string,
 	}
 
 	// Find the version folder we want
-	modelVersionFolder, foundVersionFolder, err := r.modelrepositoryHandler.FindModelVersionFolder(modelName, artifactVersion, rclonePath)
+	modelVersionFolder, foundVersionFolder, err := r.modelrepositoryHandler.FindModelVersionFolder(
+		modelName,
+		artifactVersion,
+		rclonePath,
+	)
 	if err != nil {
 		return nil, err
 	}
-	logger.Debugf("Found model %s:%d artifactVersion %d for %s at %s ", modelName, version, artifactVersion, srcUri, modelVersionFolder)
+
+	logger.Debugf(
+		"Found model %s:%d artifactVersion %d for %s at %s ",
+		modelName,
+		version,
+		artifactVersion,
+		srcUri,
+		modelVersionFolder,
+	)
 
 	// Create model directory if needed in model repo
 	modelPathInRepo := filepath.Join(r.repoPath, modelName)
@@ -117,14 +131,24 @@ func (r *V2ModelRepository) DownloadModelVersion(modelName string,
 	}
 
 	// Update model version in repo
-	err = r.modelrepositoryHandler.UpdateModelVersion(modelName, version, modelVersionPathInRepo, modelSpec)
+	err = r.modelrepositoryHandler.UpdateModelVersion(
+		modelName,
+		version,
+		modelVersionPathInRepo,
+		modelSpec,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	// Update details for blackbox explainer
 	if explainerSpec != nil {
-		err = r.modelrepositoryHandler.SetExplainer(modelVersionPathInRepo, explainerSpec, r.envoyHost, r.envoyPort)
+		err = r.modelrepositoryHandler.SetExplainer(
+			modelVersionPathInRepo,
+			explainerSpec,
+			r.envoyHost,
+			r.envoyPort,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -137,7 +161,12 @@ func (r *V2ModelRepository) DownloadModelVersion(modelName string,
 	}
 
 	// Update global model configuration
-	err = r.modelrepositoryHandler.UpdateModelRepository(modelName, modelVersionFolder, foundVersionFolder, modelPathInRepo)
+	err = r.modelrepositoryHandler.UpdateModelRepository(
+		modelName,
+		modelVersionFolder,
+		foundVersionFolder,
+		modelPathInRepo,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the formatting of various parts of the Core v2 agent's codebase.  Improvements includ:
* Adding blank for logical grouping (and easier navigation in some editors/modes).
* Splitting long lines, e.g. for method signatures, over multiple lines.  This aids legibility, as humans are generally not good at reading across wide texts.  Part of this is about too many things on one line, which makes separating them difficult, and another part of it is about how much eye movement is required to scan code.
* Using more consistent splitting of lines.  Maintaining consistency sets expectations for how to read the code and minimises the risk of important information being (literally) overlooked.

This PR should be a pure refactor; no functional changes are expected to have been introduced.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A