### PR TITLE
Use Istio gateway in server_examples notebook

### DIFF
--- a/notebooks/server_examples.ipynb
+++ b/notebooks/server_examples.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -179,7 +179,7 @@
    ],
    "source": [
     "X=!curl -s -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0, 6.0]]}}' \\\n",
-    "   -X POST http://localhost:8003/seldon/seldon/sklearn/api/v1.0/predictions \\\n",
+    "   -X POST http://localhost:8004/seldon/seldon/sklearn/api/v1.0/predictions \\\n",
     "   -H \"Content-Type: application/json\"\n",
     "d=json.loads(X[0])\n",
     "print(d)"
@@ -187,15 +187,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-26 11:57:42.874047: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory\n",
-      "2023-01-26 11:57:42.874067: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.\n"
+      "2023-04-05 12:10:59.788552: W tensorflow/stream_executor/platform/default/dso_loader.cc:60] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory\n",
+      "2023-04-05 12:10:59.788591: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.\n"
      ]
     }
    ],
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -222,15 +222,15 @@
       "  tensor {\n",
       "    shape: 1\n",
       "    shape: 4\n",
-      "    values: 0.46208907206436756\n",
-      "    values: 0.6517307843094118\n",
-      "    values: 0.4661467851242891\n",
-      "    values: 0.8231175614862333\n",
+      "    values: 0.18074408087534688\n",
+      "    values: 0.6721908290904416\n",
+      "    values: 0.8940875599384824\n",
+      "    values: 0.8441462843675384\n",
       "  }\n",
       "}\n",
       "\n",
       "Response:\n",
-      "{'data': {'names': ['t:0', 't:1', 't:2'], 'tensor': {'shape': [1, 3], 'values': [0.29597045965026947, 0.26685596602741024, 0.43717357432232035]}}, 'meta': {'requestPath': {'classifier': 'seldonio/sklearnserver:1.16.0-dev'}}}\n"
+      "{'data': {'names': ['t:0', 't:1', 't:2'], 'tensor': {'shape': [1, 3], 'values': [0.12482764026160484, 0.2572575936558566, 0.6179147660825386]}}, 'meta': {'requestPath': {'classifier': 'seldonio/sklearnserver:1.16.0-dev'}}}\n"
      ]
     }
    ],
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -258,9 +258,9 @@
      "text": [
       "Success:True message:\n",
       "Request:\n",
-      "{'meta': {}, 'data': {'tensor': {'shape': [1, 4], 'values': [0.8211074864621337, 0.4514442699558937, 0.04629442881848189, 0.005292625836879394]}}}\n",
+      "{'meta': {}, 'data': {'tensor': {'shape': [1, 4], 'values': [0.6485788008891878, 0.3631270875403313, 0.9168056221175495, 0.08968731516170181]}}}\n",
       "Response:\n",
-      "{'meta': {'requestPath': {'classifier': 'seldonio/sklearnserver:1.16.0-dev'}}, 'data': {'names': ['t:0', 't:1', 't:2'], 'tensor': {'shape': [1, 3], 'values': [0.5148389742974484, 0.45814904555115293, 0.02701198015139876]}}}\n"
+      "{'meta': {'requestPath': {'classifier': 'seldonio/sklearnserver:1.16.0-dev'}}, 'data': {'names': ['t:0', 't:1', 't:2'], 'tensor': {'shape': [1, 3], 'values': [0.17556748426888816, 0.5393767019782432, 0.28505581375286865]}}}\n"
      ]
     }
    ],
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 28,
    "metadata": {
     "scrolled": true
    },
@@ -289,7 +289,7 @@
     "X=!cd ../executor/proto && grpcurl -d '{\"data\":{\"ndarray\":[[1.0,2.0,5.0,6.0]]}}' \\\n",
     "         -rpc-header seldon:sklearn -rpc-header namespace:seldon \\\n",
     "         -plaintext \\\n",
-    "         -proto ./prediction.proto  0.0.0.0:8003 seldon.protos.Seldon/Predict\n",
+    "         -proto ./prediction.proto  0.0.0.0:8004 seldon.protos.Seldon/Predict\n",
     "d=json.loads(\"\".join(X))\n",
     "print(d)"
    ]
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -385,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -421,16 +421,16 @@
       "{\n",
       "  \"model_name\": \"classifier\",\n",
       "  \"model_version\": \"v1\",\n",
-      "  \"id\": \"40ec7f1b-437f-443c-a9eb-f07433c41027\",\n",
-      "  \"parameters\": null,\n",
+      "  \"id\": \"360a5fed-06fc-4d5e-8f83-b16ab3a76e20\",\n",
+      "  \"parameters\": {},\n",
       "  \"outputs\": [\n",
       "    {\n",
       "      \"name\": \"predict\",\n",
       "      \"shape\": [\n",
+      "        1,\n",
       "        1\n",
       "      ],\n",
       "      \"datatype\": \"INT64\",\n",
-      "      \"parameters\": null,\n",
       "      \"data\": [\n",
       "        2\n",
       "      ]\n",
@@ -451,7 +451,7 @@
     "    ]\n",
     "}\n",
     "\n",
-    "endpoint = \"http://localhost:8003/seldon/seldon/sklearn/v2/models/infer\"\n",
+    "endpoint = \"http://localhost:8004/seldon/seldon/sklearn/v2/models/infer\"\n",
     "response = requests.post(endpoint, json=inference_request)\n",
     "\n",
     "print(json.dumps(response.json(), indent=2))\n",
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -544,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -561,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -586,20 +586,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'data': {'names': [], 'ndarray': [2.0]}, 'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.15.0-dev'}}}\n"
+      "{'data': {'names': [], 'ndarray': [2.0]}, 'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.16.0-dev'}}}\n"
      ]
     }
    ],
    "source": [
     "X=!curl -s -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0, 6.0]]}}' \\\n",
-    "   -X POST http://localhost:8003/seldon/seldon/xgboost/api/v1.0/predictions \\\n",
+    "   -X POST http://localhost:8004/seldon/seldon/xgboost/api/v1.0/predictions \\\n",
     "   -H \"Content-Type: application/json\"\n",
     "d=json.loads(X[0])\n",
     "print(d)"
@@ -607,7 +607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -633,15 +633,15 @@
       "  tensor {\n",
       "    shape: 1\n",
       "    shape: 4\n",
-      "    values: 0.11505797695897957\n",
-      "    values: 0.6653444811321626\n",
-      "    values: 0.9965715379444539\n",
-      "    values: 0.8384169363970597\n",
+      "    values: 0.11128363059912161\n",
+      "    values: 0.22913600309699855\n",
+      "    values: 0.608313625499634\n",
+      "    values: 0.29349742276196966\n",
       "  }\n",
       "}\n",
       "\n",
       "Response:\n",
-      "{'data': {'names': [], 'tensor': {'shape': [1], 'values': [0.0]}}, 'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.15.0-dev'}}}\n"
+      "{'data': {'names': [], 'tensor': {'shape': [1], 'values': [0.0]}}, 'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.16.0-dev'}}}\n"
      ]
     }
    ],
@@ -660,7 +660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -669,9 +669,9 @@
      "text": [
       "Success:True message:\n",
       "Request:\n",
-      "{'meta': {}, 'data': {'tensor': {'shape': [1, 4], 'values': [0.327861849576622, 0.35057181020933914, 0.28573556648775744, 0.06259376197077815]}}}\n",
+      "{'meta': {}, 'data': {'tensor': {'shape': [1, 4], 'values': [0.8118828232994345, 0.4741520322548194, 0.08129225429711506, 0.00842530400484165]}}}\n",
       "Response:\n",
-      "{'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.15.0-dev'}}, 'data': {'tensor': {'shape': [1], 'values': [0.0]}}}\n"
+      "{'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.16.0-dev'}}, 'data': {'tensor': {'shape': [1], 'values': [0.0]}}}\n"
      ]
     }
    ],
@@ -683,7 +683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 43,
    "metadata": {
     "scrolled": true
    },
@@ -692,7 +692,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.15.0-dev'}}, 'data': {'ndarray': [2]}}\n"
+      "{'meta': {'requestPath': {'classifier': 'seldonio/xgboostserver:1.16.0-dev'}}, 'data': {'ndarray': [2]}}\n"
      ]
     }
    ],
@@ -700,7 +700,7 @@
     "X=!cd ../executor/proto && grpcurl -d '{\"data\":{\"ndarray\":[[1.0,2.0,5.0,6.0]]}}' \\\n",
     "         -rpc-header seldon:xgboost -rpc-header namespace:seldon \\\n",
     "         -plaintext \\\n",
-    "         -proto ./prediction.proto  0.0.0.0:8003 seldon.protos.Seldon/Predict\n",
+    "         -proto ./prediction.proto  0.0.0.0:8004 seldon.protos.Seldon/Predict\n",
     "d=json.loads(\"\".join(X))\n",
     "print(d)"
    ]
@@ -714,7 +714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -741,7 +741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -780,14 +780,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "seldondeployment.machinelearning.seldon.io/xgboost configured\n"
+      "seldondeployment.machinelearning.seldon.io/xgboost created\n"
      ]
     }
    ],
@@ -797,15 +797,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Waiting for deployment \"xgboost-default-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
-      "deployment \"xgboost-default-0-classifier\" successfully rolled out\n"
+      "Waiting for deployment \"xgboost-default-0-iris\" rollout to finish: 0 of 1 updated replicas are available...\n",
+      "deployment \"xgboost-default-0-iris\" successfully rolled out\n"
      ]
     }
    ],
@@ -823,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -833,11 +833,8 @@
       "{\n",
       "  \"model_name\": \"iris\",\n",
       "  \"model_version\": \"v0.1.0\",\n",
-      "  \"id\": \"ef17770b-750d-4b13-9d32-770349ae3fa9\",\n",
-      "  \"parameters\": {\n",
-      "    \"content_type\": null,\n",
-      "    \"headers\": null\n",
-      "  },\n",
+      "  \"id\": \"4d9704ae-aa6c-4378-b70b-b4a96b4db191\",\n",
+      "  \"parameters\": {},\n",
       "  \"outputs\": [\n",
       "    {\n",
       "      \"name\": \"predict\",\n",
@@ -846,7 +843,6 @@
       "        1\n",
       "      ],\n",
       "      \"datatype\": \"FP32\",\n",
-      "      \"parameters\": null,\n",
       "      \"data\": [\n",
       "        2.0\n",
       "      ]\n",
@@ -867,7 +863,7 @@
     "    ]\n",
     "}\n",
     "\n",
-    "endpoint = \"http://localhost:8003/seldon/seldon/xgboost/v2/models/infer\"\n",
+    "endpoint = \"http://localhost:8004/seldon/seldon/xgboost/v2/models/infer\"\n",
     "response = requests.post(endpoint, json=inference_request)\n",
     "\n",
     "print(json.dumps(response.json(), indent=2))\n",
@@ -883,7 +879,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -1986,7 +1982,7 @@
    "source": [
     "import json\n",
     "X=!curl -s -d '{\"instances\": [1.0, 2.0, 5.0]}' \\\n",
-    "   -X POST http://localhost:8003/seldon/seldon/hpt/v1/models/halfplustwo/:predict \\\n",
+    "   -X POST http://localhost:8004/seldon/seldon/hpt/v1/models/halfplustwo/:predict \\\n",
     "   -H \"Content-Type: application/json\"\n",
     "d=json.loads(\"\".join(X))\n",
     "print(d)\n",
@@ -2011,7 +2007,7 @@
     "   -d '{\"model_spec\":{\"name\":\"halfplustwo\"},\"inputs\":{\"x\":{\"dtype\": 1, \"tensor_shape\": {\"dim\":[{\"size\": 3}]}, \"floatVal\" : [1.0, 2.0, 3.0]}}}' \\\n",
     "   -rpc-header seldon:hpt -rpc-header namespace:seldon \\\n",
     "   -plaintext -proto ./prediction_service.proto \\\n",
-    "   0.0.0.0:8003 tensorflow.serving.PredictionService/Predict\n",
+    "   0.0.0.0:8004 tensorflow.serving.PredictionService/Predict\n",
     "d=json.loads(\"\".join(X))\n",
     "print(d)\n",
     "assert(d[\"outputs\"][\"x\"][\"floatVal\"][0] == 2.5)"
@@ -2039,8 +2035,21 @@
    "metadata": {},
    "source": [
     "## Serve MLFlow Elasticnet Wines Model\n",
-    "We can deploy an MLFlow model uploaded to an object store by using the MLFlow\n",
-    "model server implementation as the config below:"
+    "\n",
+    "In order to deploy MLflow models, we can leverage the [pre-packaged MLflow inference server](https://docs.seldon.io/projects/seldon-core/en/latest/servers/mlflow.html).\n",
+    "The exposed API can follow either:\n",
+    "\n",
+    "- The default Seldon protocol. \n",
+    "- The V2 protocol."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Default Seldon protocol\n",
+    "\n",
+    "We can deploy an MLFlow model uploaded to an object store by using the MLFlow model server implementation as the config below:"
    ]
   },
   {
@@ -2052,7 +2061,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing ./resources/elasticnet_wine.yaml\n"
+      "Overwriting ./resources/elasticnet_wine.yaml\n"
      ]
     }
    ],
@@ -2107,7 +2116,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "seldondeployment.machinelearning.seldon.io/mlflow created\n"
+      "seldondeployment.machinelearning.seldon.io/mlflow configured\n"
      ]
     }
    ],
@@ -2124,7 +2133,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Waiting for deployment \"mlflow-default-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
+      "Waiting for deployment \"mlflow-default-0-classifier\" rollout to finish: 1 old replicas are pending termination...\n",
+      "Waiting for deployment \"mlflow-default-0-classifier\" rollout to finish: 1 old replicas are pending termination...\n",
       "deployment \"mlflow-default-0-classifier\" successfully rolled out\n"
      ]
     }
@@ -2137,7 +2147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### REST requests"
+    "#### REST requests"
    ]
   },
   {
@@ -2149,13 +2159,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'data': {'names': [], 'ndarray': [5.275558760255375]}, 'meta': {'requestPath': {'classifier': 'seldonio/mlflowserver:1.15.0-dev'}}}\n"
+      "{'data': {'names': [], 'ndarray': [5.275558760255375]}, 'meta': {'requestPath': {'classifier': 'seldonio/mlflowserver:1.16.0-dev'}}}\n"
      ]
     }
    ],
    "source": [
     "X=!curl -s -d '{\"data\": {\"ndarray\":[[0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1]]}}' \\\n",
-    "   -X POST http://localhost:8003/seldon/seldon/mlflow/api/v1.0/predictions \\\n",
+    "   -X POST http://localhost:8004/seldon/seldon/mlflow/api/v1.0/predictions \\\n",
     "   -H \"Content-Type: application/json\"\n",
     "d=json.loads(X[0])\n",
     "print(d)"
@@ -2189,22 +2199,22 @@
       "  tensor {\n",
       "    shape: 1\n",
       "    shape: 11\n",
-      "    values: 0.08557947016760259\n",
-      "    values: 0.3904340887602685\n",
-      "    values: 0.013650233499940545\n",
-      "    values: 0.667873429847926\n",
-      "    values: 0.8854441380301948\n",
-      "    values: 0.2158356850044546\n",
-      "    values: 0.39582510842260477\n",
-      "    values: 0.6090407713228351\n",
-      "    values: 0.7908824041187265\n",
-      "    values: 0.6806393014966566\n",
-      "    values: 0.5804883985108746\n",
+      "    values: 0.5131731192837686\n",
+      "    values: 0.5630351572109149\n",
+      "    values: 0.5589290658474012\n",
+      "    values: 0.40177166033018785\n",
+      "    values: 0.17613466317023851\n",
+      "    values: 0.6274180872690845\n",
+      "    values: 0.23926864659056346\n",
+      "    values: 0.7201875999123106\n",
+      "    values: 0.1552566403993214\n",
+      "    values: 0.9674953121408173\n",
+      "    values: 0.6357052126091363\n",
       "  }\n",
       "}\n",
       "\n",
       "Response:\n",
-      "{'data': {'names': [], 'tensor': {'shape': [1], 'values': [5.2237671948422015]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mlflowserver:1.15.0-dev'}}}\n"
+      "{'data': {'names': [], 'tensor': {'shape': [1], 'values': [5.233130968745312]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mlflowserver:1.16.0-dev'}}}\n"
      ]
     }
    ],
@@ -2218,27 +2228,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### gRPC Requests"
+    "#### gRPC Requests"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 57,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'meta': {'requestPath': {'classifier': 'seldonio/mlflowserver:1.15.0-dev'}}, 'data': {'ndarray': [5.275558760255375]}}\n"
-     ]
-    }
-   ],
    "source": [
     "X=!cd ../executor/proto && grpcurl -d '{\"data\":{\"ndarray\":[[0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1]]}}' \\\n",
     "         -rpc-header seldon:mlflow -rpc-header namespace:seldon \\\n",
     "         -plaintext \\\n",
-    "         -proto ./prediction.proto  0.0.0.0:8003 seldon.protos.Seldon/Predict\n",
+    "         -proto ./prediction.proto  0.0.0.0:8004 seldon.protos.Seldon/Predict\n",
     "d=json.loads(\"\".join(X))\n",
     "print(d)"
    ]
@@ -2254,9 +2254,9 @@
      "text": [
       "Success:True message:\n",
       "Request:\n",
-      "{'meta': {}, 'data': {'tensor': {'shape': [1, 11], 'values': [0.1504501387663657, 0.09916272705865703, 0.48360619526082804, 0.10653978599045866, 0.28875817583971986, 0.2490316271245857, 0.7923655335917282, 0.2630601591638151, 0.33789481427553547, 0.30831566652953724, 0.6134317115838707]}}}\n",
+      "{'meta': {}, 'data': {'tensor': {'shape': [1, 11], 'values': [0.2741715234017964, 0.2975028644869532, 0.5500372035725075, 0.8971403317945944, 0.6731839913065211, 0.008691314441036435, 0.02327779746327674, 0.40891038804558943, 0.10278575532695344, 0.6039801966407603, 0.8264391590039933]}}}\n",
       "Response:\n",
-      "{'meta': {'requestPath': {'classifier': 'seldonio/mlflowserver:1.15.0-dev'}}, 'data': {'tensor': {'shape': [1], 'values': [5.225506841935588]}}}\n"
+      "{'meta': {'requestPath': {'classifier': 'seldonio/mlflowserver:1.16.0-dev'}}, 'data': {'tensor': {'shape': [1], 'values': [5.247301541159445]}}}\n"
      ]
     }
    ],
@@ -2287,7 +2287,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## MLFlow V2 protocol"
+    "### V2 protocol\n",
+    "\n",
+    "We can deploy a MLflow model, exposing an API compatible with v2 protocol by specifying the `protocol` of our `SeldonDeployment` as `v2`.\n",
+    "For example, we can consider the config below:"
    ]
   },
   {
@@ -2361,7 +2364,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## REST requests"
+    "Once it's deployed, we can send inference requests to our model.\n",
+    "Note that, since it's using the V2 Protocol, these requests will be different to the ones using the default Seldon Protocol."
    ]
   },
   {
@@ -2376,7 +2380,7 @@
       "{\n",
       "  \"model_name\": \"classifier\",\n",
       "  \"model_version\": \"v1\",\n",
-      "  \"id\": \"a43e833e-0e20-46b9-b0b2-c8b6917febd7\",\n",
+      "  \"id\": \"fa6c916b-2ab6-4ae9-82d8-a204e75694c1\",\n",
       "  \"parameters\": null,\n",
       "  \"outputs\": [\n",
       "    {\n",
@@ -2483,7 +2487,7 @@
     "    ],\n",
     "}\n",
     "\n",
-    "endpoint = \"http://localhost:8003/seldon/seldon/mlflow/v2/models/infer\"\n",
+    "endpoint = \"http://localhost:8004/seldon/seldon/mlflow/v2/models/infer\"\n",
     "response = requests.post(endpoint, json=inference_request)\n",
     "\n",
     "print(json.dumps(response.json(), indent=2))\n",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

It seems like Ambassador has a small delay between the pod coming up and actually start routing traffic there. Which means that sending an inference request immediately after the pod becomes ready can sometimes lead to a `404` - thus causing flakiness on some of the integration tests.

This PR changes one of the notebooks used in the tests to use the Istio gateway instead (which seems slightly more stable?). 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
