### PR TITLE
Upgrade to go 1.19.8 due to CVE-2023-24537

### DIFF
--- a/hodometer/Dockerfile.hodometer
+++ b/hodometer/Dockerfile.hodometer
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-buster as builder
+FROM golang:1.19.8-buster as builder
 
 WORKDIR /build
 # Copy the Go Modules manifests

--- a/hodometer/Dockerfile.receiver
+++ b/hodometer/Dockerfile.receiver
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS builder
+FROM golang:1.19.8-alpine AS builder
 
 RUN apk add --upgrade make
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.7 as builder
+FROM golang:1.19.8 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/scheduler/Dockerfile.agent
+++ b/scheduler/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-alpine as builder
+FROM golang:1.19.8-alpine as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.modelgateway
+++ b/scheduler/Dockerfile.modelgateway
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-buster as builder
+FROM golang:1.19.8-buster as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.pipelinegateway
+++ b/scheduler/Dockerfile.pipelinegateway
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-buster as builder
+FROM golang:1.19.8-buster as builder
 
 WORKDIR /build
 COPY . .

--- a/scheduler/Dockerfile.scheduler
+++ b/scheduler/Dockerfile.scheduler
@@ -1,4 +1,4 @@
-FROM golang:1.19.7-buster as builder
+FROM golang:1.19.8-buster as builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
Upgrade Go to fix [CVE-2023-24537](https://nvd.nist.gov/vuln/detail/CVE-2023-24537)