### PR TITLE
Remove missing link to blog article

### DIFF
--- a/doc/source/tutorials/blogs.rst
+++ b/doc/source/tutorials/blogs.rst
@@ -9,7 +9,6 @@ Blog articles featuring different use cases of Seldon:
 
    Stream-Based Model Serving with Cloudflow and Seldon <https://www.lightbend.com/blog/stream-based-model-serving-with-cloudflow-and-seldon>
    Seldon Inference Graph: Serving your Models in a Pipeline <https://medium.com/@shirish.ph/seldon-inference-graph-pipelined-model-serving-211c6b095f62>
-   Open Source Model Management Roundup <https://www.anaconda.com/blog/developer-blog/open-source-model-management-roundup-polyaxon-argo-and-seldon/>
    Polyaxon, Argo and Seldon for model training <https://danielfrg.com/blog/2018/10/model-management-polyaxon-argo-seldon/>
    Manage ML Deployments Like A Boss <https://medium.com/analytics-vidhya/manage-ml-deployments-like-a-boss-deploy-your-first-ab-test-with-sklearn-kubernetes-and-b10ae0819dfe>
    Using PyTorch 1.0 and ONNX with Fabric for Deep Learning <https://developer.ibm.com/blogs/2018/10/01/announcing-pytorch-1-support-in-fabric-for-deep-learning/>


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Remove missing link to blog article which is now returning a 404 (https://www.anaconda.com/blog/developer-blog/open-source-model-management-roundup-polyaxon-argo-and-seldon/).

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
