### PR TITLE
v2: remove deprecated ansible parameter

### DIFF
--- a/ansible/roles/kind/tasks/download_kind.yaml
+++ b/ansible/roles/kind/tasks/download_kind.yaml
@@ -14,7 +14,6 @@
   shell: "curl -Lo kind-{{ kind_version }} {{ kind_url }}"
   args:
     chdir: "{{ seldon_cache_directory }}"
-    warn: false
   when: kind_binary.stat.exists == false
 
 - name: Make Kind {{ kind_version }} binary executable


### PR DESCRIPTION
As in title, otherwise we may hit
```
TASK [kind : Download Kind v0.17.0 binary] ************************************************************************
fatal: [localhost]: FAILED! => changed=false 
  msg: 'Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, removes, stdin, stdin_add_newline, strip_empty_ends.'
```
if `kind` is not yet downloaded
