### PR TITLE
Add utilities to re-build artefacts

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -1,8 +1,39 @@
+VERSION := $(shell grep seldonio/mlserver ../scheduler/Makefile | cut -d':' -f2)
+MLSERVER_VERSION ?= ${VERSION}
+MLSERVER_FOLDER = mlserver_${MLSERVER_VERSION}
+TRITON_VERSION=23-03
+TRITON_FOLDER=triton_${TRITON_VERSION}
 EXAMPLES := $(wildcard *.ipynb) $(wildcard examples/*/*.ipynb)
 EXAMPLES_MD := $(EXAMPLES:.ipynb=.md)
 
 .PHONY: all
 all: $(EXAMPLES_MD)
+
+.PHONY: train-all
+train-all:
+	make -C ./scripts/models train-all
+	make -C ./scripts/explainers train-all
+	make -C ./examples/image_classifier train
+	make -C ./examples/income_classifier train
+
+.PHONY: upload-all
+upload-all:
+	# Upload all artefacts to GCS
+	make -C ./scripts/models upload-all
+	make -C ./scripts/explainers upload-all
+	make -C ./examples/image_classifier upload_artifacts
+	make -C ./examples/income_classifier upload_artifacts
+	# Rename all references in notebooks, YAMLs and MD files
+	find . \
+		-type f \( -name '*.ipynb' -o -name '*.md' -o -name '*.yaml' \) \
+		-exec \
+			sed -i "s/gs:\/\/\(.*\)\/mlserver_.*\/\(.*\)/gs:\/\/\1\/$(MLSERVER_FOLDER)\/\2/g" \
+			{} \;
+	find . \
+		-type f \( -name '*.ipynb' -o -name '*.md' -o -name '*.yaml' \) \
+		-exec \
+			sed -i "s/gs:\/\/\(.*\)\/triton_.*\/\(.*\)/gs:\/\/\1\/$(TRITON_FOLDER)\/\2/g" \
+			{} \;
 
 %.md: %.ipynb
 	jupyter nbconvert \

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -1,7 +1,7 @@
 VERSION := $(shell grep seldonio/mlserver ../scheduler/Makefile | cut -d':' -f2)
 MLSERVER_VERSION ?= ${VERSION}
 MLSERVER_FOLDER = mlserver_${MLSERVER_VERSION}
-TRITON_VERSION=23-03
+TRITON_VERSION=$(shell grep 'nvidia/tritonserver' ../scheduler/Makefile | cut -d':' -f2 | cut -d'-' -f1 | tr '.' '-')
 TRITON_FOLDER=triton_${TRITON_VERSION}
 EXAMPLES := $(wildcard *.ipynb) $(wildcard examples/*/*.ipynb)
 EXAMPLES_MD := $(EXAMPLES:.ipynb=.md)

--- a/samples/README.md
+++ b/samples/README.md
@@ -7,4 +7,20 @@ Various example notebooks.
  * a seldon cli
  * jupyter notebook
  * jq
+
+## Artefacts
+
+All (Python) artefacts are versioned by their respective version of Triton and
+MLServer used at the time of training (e.g.
+`gs://seldon-models/scv2/samples/mlserver_1.3.0/iris-sklearn`).
+To re-generate them, you can call the following Makefile targets:
+
+```
+$ make train-all upload-all
+```
+
+The new version of the artefacts will get uploaded to GCS, using the version of
+Triton and MLServer specified on [scheduler/Makefile](../scheduler/Makefile).
+The `upload-all` target will also replace all previous references to versioned
+artefacts in the notebooks.
  

--- a/samples/scripts/explainers/Makefile
+++ b/samples/scripts/explainers/Makefile
@@ -10,6 +10,12 @@ define generate_file
 	REPLACE_ME=${1} envsubst < model-settings.json.template > ${OUTPUT_DIR}/${1}/model-settings.json
 endef
 
+.PHONY: train-all
+train-all: kernel_shap anchor_text_moviesentiment
+
+.PHONY: upload-all
+upload-all: upload_kernel_shap upload_anchor_text_moviesentiment
+
 .PHONY: env
 env:
 	python3 -m venv .env

--- a/samples/scripts/models/Makefile
+++ b/samples/scripts/models/Makefile
@@ -7,7 +7,7 @@ TRITON_FOLDER=triton_${TRITON_VERSION}
 .PHONY: train-all
 train-all: iris moviesentiment income income-xgb income-lgb download-mnist-onnx download-cifar10-tensorflow wine-mlflow mnist-pytorch
 
-.PHONY: all
+.PHONY: upload-all
 upload-all: upload-iris upload-moviesentiment upload-income upload-income-xgb upload-income-lgb upload-mnist-onnx upload-cifar10-tensorflow upload-wine-mlflow upload-mnist-pytorch
 
 .PHONY: env

--- a/samples/scripts/models/Makefile
+++ b/samples/scripts/models/Makefile
@@ -4,6 +4,12 @@ MLSERVER_FOLDER = mlserver_${MLSERVER_VERSION}
 TRITON_VERSION=23-03
 TRITON_FOLDER=triton_${TRITON_VERSION}
 
+.PHONY: train-all
+train-all: iris moviesentiment income income-xgb income-lgb download-mnist-onnx download-cifar10-tensorflow wine-mlflow mnist-pytorch
+
+.PHONY: all
+upload-all: upload-iris upload-moviesentiment upload-income upload-income-xgb upload-income-lgb upload-mnist-onnx upload-cifar10-tensorflow upload-wine-mlflow upload-mnist-pytorch
+
 .PHONY: env
 env:
 	python3 -m venv .env

--- a/samples/scripts/models/Makefile
+++ b/samples/scripts/models/Makefile
@@ -1,7 +1,7 @@
 VERSION := $(shell grep seldonio/mlserver ../../../scheduler/Makefile | cut -d':' -f2)
 MLSERVER_VERSION ?= ${VERSION}
 MLSERVER_FOLDER = mlserver_${MLSERVER_VERSION}
-TRITON_VERSION=23-03
+TRITON_VERSION=$(shell grep 'nvidia/tritonserver' ../../../scheduler/Makefile | cut -d':' -f2 | cut -d'-' -f1 | tr '.' '-')
 TRITON_FOLDER=triton_${TRITON_VERSION}
 
 .PHONY: train-all


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR adds a `make -C samples train-all upload-all` target which will:

- Call the underlying `make` targets to train and upload artefacts in `./samples/scripts/models`, `./samples/scripts/explainers`, `./samples/examples/image_classifier` and `./samples/examples/income_classifiers`.
- Rename all `gs://.../mlserver_<version>` and `gs://.../triton_<version>` references in the notebooks.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
