### PR TITLE
Use a more recent jdk base image

### DIFF
--- a/scheduler/Dockerfile.dataflow
+++ b/scheduler/Dockerfile.dataflow
@@ -14,7 +14,7 @@ RUN gradle build --no-daemon --info
 ################################################################################
 
 # Some dependencies require glibc, which Alpine does not provide
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
 
 # Run update to pickup any necessary security updates
 USER root


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Update `dataflow-engine` base jdk image to use a more recent one to sort out CVEs. 

At the time of writing:
![image](https://user-images.githubusercontent.com/5911512/233982884-b34f926b-b331-4407-b7ed-d2a715734f74.png)


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
