### PR TITLE
fix(helm): fix dataflow using non-existing Helm value (brokerCa instead of brokerCaPath)

### DIFF
--- a/ansible/playbooks/templates/values-seldon-core-v2-components.yaml.j2
+++ b/ansible/playbooks/templates/values-seldon-core-v2-components.yaml.j2
@@ -40,4 +40,4 @@ security:
         keyPath: /tmp/certs/kafka/client/user.key
         crtPath: /tmp/certs/kafka/client/user.crt
         caPath: /tmp/certs/kafka/client/ca.crt
-        brokerCa: /tmp/certs/kafka/broker/ca.crt
+        brokerCaPath: /tmp/certs/kafka/broker/ca.crt

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -655,7 +655,7 @@ spec:
         - name: SELDON_TLS_BROKER_SECRET
           value: '{{ .Values.security.kafka.ssl.client.brokerValidationSecret }}'
         - name: SELDON_TLS_BROKER_CA_PATH
-          value: '{{ .Values.security.kafka.ssl.client.brokerCa }}'
+          value: '{{ .Values.security.kafka.ssl.client.brokerCaPath }}'
         - name: SELDON_TLS_ENDPOINT_IDENTIFICATION_ALGORITHM
           value: '{{ .Values.security.kafka.ssl.client.endpointIdentificationAlgorithm
             }}'

--- a/k8s/kustomize/helm-components/patch_dataflow.yaml
+++ b/k8s/kustomize/helm-components/patch_dataflow.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,13 +14,13 @@ spec:
         - name: SELDON_KAFKA_BOOTSTRAP_SERVERS
           value: '{{ .Values.kafka.bootstrap }}'
         - name: SELDON_KAFKA_REPLICATION_FACTOR
-          value: '{{ .Values.kafka.topics.replicationFactor }}'        
+          value: '{{ .Values.kafka.topics.replicationFactor }}'
         - name: SELDON_KAFKA_PARTITIONS_DEFAULT
-          value: '{{ .Values.kafka.topics.numPartitions }}'        
+          value: '{{ .Values.kafka.topics.numPartitions }}'
         - name: SELDON_CORES_COUNT
           value: '{{ .Values.dataflow.cores }}'
         - name: SELDON_KAFKA_SECURITY_PROTOCOL
-          value: '{{ .Values.security.kafka.protocol }}'            
+          value: '{{ .Values.security.kafka.protocol }}'
         - name: SELDON_TLS_CLIENT_SECRET
           value: '{{ .Values.security.kafka.ssl.client.secret }}'
         - name: SELDON_TLS_CLIENT_KEY_PATH
@@ -37,7 +38,7 @@ spec:
         - name: SELDON_TLS_BROKER_SECRET
           value: '{{ .Values.security.kafka.ssl.client.brokerValidationSecret }}'
         - name: SELDON_TLS_BROKER_CA_PATH
-          value: '{{ .Values.security.kafka.ssl.client.brokerCa }}'
+          value: '{{ .Values.security.kafka.ssl.client.brokerCaPath }}'
         - name: SELDON_TLS_ENDPOINT_IDENTIFICATION_ALGORITHM
           value: '{{ .Values.security.kafka.ssl.client.endpointIdentificationAlgorithm }}'
         resources:

--- a/k8s/samples/strimzi-example-tls-user.yaml
+++ b/k8s/samples/strimzi-example-tls-user.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser
 metadata:

--- a/k8s/samples/values-strimzi-kafka-mtls.yaml
+++ b/k8s/samples/values-strimzi-kafka-mtls.yaml
@@ -1,3 +1,4 @@
+---
 kafka:
   bootstrap: seldon-kafka-bootstrap.seldon-mesh.svc.cluster.local:9093
 
@@ -7,8 +8,8 @@ security:
     ssl:
       client:
         secret: seldon
-        brokerValidationSecret: seldon-cluster-ca-cert        
+        brokerValidationSecret: seldon-cluster-ca-cert
         keyPath: /tmp/certs/kafka/client/user.key
         crtPath: /tmp/certs/kafka/client/user.crt
         caPath: /tmp/certs/kafka/client/ca.crt
-        brokerCa: /tmp/certs/kafka/broker/ca.crt
+        brokerCaPath: /tmp/certs/kafka/broker/ca.crt

--- a/k8s/samples/values-strimzi-kafka-sasl-scram.yaml
+++ b/k8s/samples/values-strimzi-kafka-sasl-scram.yaml
@@ -1,3 +1,4 @@
+---
 kafka:
   bootstrap: seldon-kafka-bootstrap.seldon-mesh.svc.cluster.local:9093
 
@@ -11,5 +12,5 @@ security:
         passwordPath: /tmp/sasl/kafka/client/password
     ssl:
       client:
-        brokerValidationSecret: seldon-cluster-ca-cert        
-        brokerCa: /tmp/certs/kafka/broker/ca.crt
+        brokerValidationSecret: seldon-cluster-ca-cert
+        brokerCaPath: /tmp/certs/kafka/broker/ca.crt


### PR DESCRIPTION

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Our Helm charts defines [here](https://github.com/SeldonIO/seldon-core/blob/17c37214877706f9fd485a7093c54c33cad4095b/k8s/helm-charts/seldon-core-v2-setup/values.yaml#L34)
```
security.kafka.ssl.client.brokerCaPath: /tmp/certs/kafka/broker/ca.crt
```
however Dataflow Engine seems to be using [brokerCa](https://github.com/SeldonIO/seldon-core/blob/17c37214877706f9fd485a7093c54c33cad4095b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml#L657-L658) instead. 


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
