### PR TITLE
Use release namespace for configmaps in setup helm chart

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/agent.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/agent.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: seldon-agent
+  namespace: '{{ .Release.Namespace }}'
 data:
   agent.yaml: |-
-    rclone: 
+    rclone:
       config_secrets: ["seldon-rclone-gs-public"]

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/kafka.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/kafka.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: seldon-kafka
+  namespace: '{{ .Release.Namespace }}'
 data:
   kafka.json: |-
    {

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/rclone-gs-public.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/rclone-gs-public.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: seldon-rclone-gs-public
+  namespace: '{{ .Release.Namespace }}'
 type: Opaque
 stringData:
   gs: |

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/tracing.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/tracing.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: seldon-tracing
+  namespace: '{{ .Release.Namespace }}'
 data:
   tracing.json: |-
    {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the release namespace for the agent, kafka, and tracing configmaps and for rclone secret.

**Which issue(s) this PR fixes**:
None

```release-note
Set the namespace for Agent, Kafka and Tracing `ConfigMap` and for the `rclone` `Secret`.
```

**Special notes for your reviewer**:
None