### PR TITLE
feat(models): Add model status message for k8s resource status

### DIFF
--- a/operator/apis/mlops/v1alpha1/model_conditions.go
+++ b/operator/apis/mlops/v1alpha1/model_conditions.go
@@ -61,7 +61,12 @@ func (ms *ModelStatus) SetCondition(conditionType apis.ConditionType, condition 
 	}
 }
 
-func (ms *ModelStatus) CreateAndSetCondition(conditionType apis.ConditionType, isTrue bool, reason string) {
+func (ms *ModelStatus) CreateAndSetCondition(
+	conditionType apis.ConditionType,
+	isTrue bool,
+	message string,
+	reason string,
+) {
 	condition := apis.Condition{}
 	if isTrue {
 		condition.Status = v1.ConditionTrue
@@ -69,6 +74,7 @@ func (ms *ModelStatus) CreateAndSetCondition(conditionType apis.ConditionType, i
 		condition.Status = v1.ConditionFalse
 	}
 	condition.Type = conditionType
+	condition.Message = message
 	condition.Reason = reason
 	condition.LastTransitionTime = apis.VolatileTime{
 		Inner: metav1.Now(),

--- a/operator/apis/mlops/v1alpha1/pipeline_types.go
+++ b/operator/apis/mlops/v1alpha1/pipeline_types.go
@@ -276,8 +276,8 @@ func (ps *PipelineStatus) SetCondition(conditionType apis.ConditionType, conditi
 func (ps *PipelineStatus) CreateAndSetCondition(
 	conditionType apis.ConditionType,
 	isTrue bool,
+	message string,
 	reason string,
-	description string,
 ) {
 	condition := apis.Condition{}
 	if isTrue {
@@ -286,8 +286,8 @@ func (ps *PipelineStatus) CreateAndSetCondition(
 		condition.Status = v1.ConditionFalse
 	}
 	condition.Type = conditionType
+	condition.Message = message
 	condition.Reason = reason
-	condition.Message = description
 	condition.LastTransitionTime = apis.VolatileTime{
 		Inner: metav1.Now(),
 	}

--- a/operator/controllers/mlops/model_controller.go
+++ b/operator/controllers/mlops/model_controller.go
@@ -126,9 +126,9 @@ func (r *ModelReconciler) updateStatusFromError(
 	canRetry bool,
 	err error,
 ) {
-	modelStatus := schedulerAPI.ModelStatus_ModelFailed
+	modelStatus := schedulerAPI.ModelStatus_ModelFailed.String()
 	if canRetry {
-		modelStatus = schedulerAPI.ModelStatus_ModelProgressing
+		modelStatus = schedulerAPI.ModelStatus_ModelProgressing.String()
 	}
 
 	model.Status.CreateAndSetCondition(mlopsv1alpha1.ModelReady, false, modelStatus, err.Error())

--- a/operator/controllers/mlops/pipeline_controller.go
+++ b/operator/controllers/mlops/pipeline_controller.go
@@ -44,8 +44,11 @@ type PipelineReconciler struct {
 	Recorder  record.EventRecorder
 }
 
-func (r *PipelineReconciler) handleFinalizer(ctx context.Context, logger logr.Logger, pipeline *mlopsv1alpha1.Pipeline) (bool, error) {
-
+func (r *PipelineReconciler) handleFinalizer(
+	ctx context.Context,
+	logger logr.Logger,
+	pipeline *mlopsv1alpha1.Pipeline,
+) (bool, error) {
 	// Check if we are being deleted or not
 	if pipeline.ObjectMeta.DeletionTimestamp.IsZero() { // Not being deleted
 
@@ -64,7 +67,10 @@ func (r *PipelineReconciler) handleFinalizer(ctx context.Context, logger logr.Lo
 					return true, err
 				} else {
 					// Remove pipeline anyway on error as we assume errors from scheduler are fatal here
-					pipeline.ObjectMeta.Finalizers = utils.RemoveStr(pipeline.ObjectMeta.Finalizers, constants.PipelineFinalizerName)
+					pipeline.ObjectMeta.Finalizers = utils.RemoveStr(
+						pipeline.ObjectMeta.Finalizers,
+						constants.PipelineFinalizerName,
+					)
 					if errUpdate := r.Update(ctx, pipeline); errUpdate != nil {
 						logger.Error(err, "Failed to remove finalizer", "pipeline", pipeline.Name)
 						return true, err
@@ -124,10 +130,25 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, nil
 }
 
-func (r *PipelineReconciler) updateStatusFromError(ctx context.Context, logger logr.Logger, pipeline *mlopsv1alpha1.Pipeline, err error) {
-	pipeline.Status.CreateAndSetCondition(mlopsv1alpha1.PipelineReady, false, schedulerAPI.PipelineVersionState_PipelineFailed.String(), err.Error())
+func (r *PipelineReconciler) updateStatusFromError(
+	ctx context.Context,
+	logger logr.Logger,
+	pipeline *mlopsv1alpha1.Pipeline,
+	err error,
+) {
+	pipeline.Status.CreateAndSetCondition(
+		mlopsv1alpha1.PipelineReady,
+		false,
+		schedulerAPI.PipelineVersionState_PipelineFailed.String(),
+		err.Error(),
+	)
 	if errSet := r.Status().Update(ctx, pipeline); errSet != nil {
-		logger.Error(errSet, "Failed to set status on pipeline on error", "pipeline", pipeline.Name, "error", err.Error())
+		logger.Error(
+			errSet,
+			"Failed to set status on pipeline on error",
+			"pipeline", pipeline.Name,
+			"error", err.Error(),
+		)
 	}
 }
 

--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -99,18 +99,39 @@ func (s *SchedulerClient) ConnectToScheduler(host string, plainTxtPort int, tlsP
 func (s *SchedulerClient) checkErrorRetryable(resource string, resourceName string, err error) bool {
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
-			s.logger.Info("Got grpc status code", "err", err.Error(), "code", st.Code(), "resource", resource, "resourceName", resourceName)
+			s.logger.Info(
+				"Got grpc status code",
+				"err", err.Error(),
+				"code", st.Code(),
+				"resource", resource,
+				"resourceName", resourceName,
+			)
 			switch st.Code() {
 			case codes.FailedPrecondition,
 				codes.Unimplemented:
-				s.logger.Info("Non retryable error", "code", st.Code(), "resource", resource, "resourceName", resourceName)
+				s.logger.Info(
+					"Non retryable error",
+					"code", st.Code(),
+					"resource", resource,
+					"resourceName", resourceName,
+				)
 				return false
 			default:
-				s.logger.Info("retryable error", "code", st.Code(), "resource", resource, "resourceName", resourceName)
+				s.logger.Info(
+					"retryable error",
+					"code", st.Code(),
+					"resource", resource,
+					"resourceName", resourceName,
+				)
 				return true
 			}
 		} else {
-			s.logger.Info("Got non grpc error", "error", err.Error(), "resource", resource, "resourceName", resourceName)
+			s.logger.Info(
+				"Got non grpc error",
+				"error", err.Error(),
+				"resource", resource,
+				"resourceName", resourceName,
+			)
 			return true
 		}
 	} else {

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -196,14 +196,24 @@ func (s *SchedulerClient) SubscribeModelEvents(ctx context.Context) error {
 					"name", event.ModelName,
 					"state", latestVersionStatus.State.State.String(),
 				)
-				latestModel.Status.CreateAndSetCondition(v1alpha1.ModelReady, true, latestVersionStatus.State.Reason)
+				latestModel.Status.CreateAndSetCondition(
+					v1alpha1.ModelReady,
+					true,
+					latestVersionStatus.GetState().GetState().String(),
+					latestVersionStatus.State.Reason,
+				)
 			default:
 				logger.Info(
 					"Setting model to not ready",
 					"name", event.ModelName,
 					"state", latestVersionStatus.State.State.String(),
 				)
-				latestModel.Status.CreateAndSetCondition(v1alpha1.ModelReady, false, latestVersionStatus.State.Reason)
+				latestModel.Status.CreateAndSetCondition(
+					v1alpha1.ModelReady,
+					false,
+					latestVersionStatus.GetState().GetState().String(),
+					latestVersionStatus.State.Reason,
+				)
 			}
 
 			// Set the total number of replicas targeted by this model

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -145,7 +145,10 @@ func (s *SchedulerClient) SubscribeModelEvents(ctx context.Context) error {
 
 				if !latestModel.ObjectMeta.DeletionTimestamp.IsZero() { // Model is being deleted
 					// remove finalizer now we have completed successfully
-					latestModel.ObjectMeta.Finalizers = utils.RemoveStr(latestModel.ObjectMeta.Finalizers, constants.ModelFinalizerName)
+					latestModel.ObjectMeta.Finalizers = utils.RemoveStr(
+						latestModel.ObjectMeta.Finalizers,
+						constants.ModelFinalizerName,
+					)
 					if err := s.Update(ctx, latestModel); err != nil {
 						logger.Error(err, "Failed to remove finalizer", "model", latestModel.GetName())
 						return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `message` field for model statuses to indicate, at a high level, why a model is (not) ready.  At present, models can only be ready or not ready, and may have a `reason` describing the underlying cause of that status.  That reason is fine for humans, but is verbose and is not suitable for automated systems to parse easily.

This PR also updates the pipeline status fields to share the same semantics are for models:
* Message = short-form description of the status, generally as a term from the Protobuf contracts.
* Reason = free-form text describing the underlying cause of the status.

There are also a number of formatting changes to break long lines (>120 characters) and introduce some whitespace for logical grouping/separation.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
