### PR TITLE
Fix Alibi Explainer tests

### DIFF
--- a/.github/workflows/alibiexplainer_tests.yml
+++ b/.github/workflows/alibiexplainer_tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: snok/install-poetry@v1
         with:
           version: 1.1.15
-          virtualenvs-create: false
+          virtualenvs-create: true
       - name: test-python
         run: |
           pip install --upgrade pip setuptools

--- a/.github/workflows/alibiexplainer_tests.yml
+++ b/.github/workflows/alibiexplainer_tests.yml
@@ -23,19 +23,14 @@ jobs:
 
   python-tests:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: seldonio/python-builder:0.6
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.1.15
-          virtualenvs-create: false
-      - name: test-python
+      - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools
-          make -C components/alibi-explain-server dev_install build_apis test
+          make -C components/alibi-explain-server dev_install
+      - name: test-python
+        run: |
+          make -C components/alibi-explain-server build_apis test

--- a/.github/workflows/alibiexplainer_tests.yml
+++ b/.github/workflows/alibiexplainer_tests.yml
@@ -23,7 +23,7 @@ jobs:
 
   python-tests:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -34,7 +34,7 @@ jobs:
         uses: snok/install-poetry@v1
         with:
           version: 1.1.15
-          virtualenvs-create: true
+          virtualenvs-create: false
       - name: test-python
         run: |
           pip install --upgrade pip setuptools


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Following the release of `urllib3` 2.0, the Alibi Explain Server tests have suddenly started to fail with the error below:

```
  AttributeError

  'HTTPResponse' object has no attribute 'strict'

  at ~/.local/venv/lib/python3.7/site-packages/cachecontrol/serialize.py:54 in dumps
       50│                 ),
       51│                 u"status": response.status,
       52│                 u"version": response.version,
       53│                 u"reason": text_type(response.reason),
    →  54│                 u"strict": response.strict,
       55│                 u"decode_content": response.decode_content,
       56│             }
       57│         }
       58│ 
```

This PR makes sure that the tests run with the `python-builder` image.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
