### PR TITLE
Remove librpmio from Dockerfile.dataflow

### DIFF
--- a/scheduler/Dockerfile.dataflow
+++ b/scheduler/Dockerfile.dataflow
@@ -20,7 +20,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2.1681917142
 USER root
 RUN microdnf update -y
 # Remove some unneeded packages that might contain CVEs
-RUN microdnf remove -y microdnf libdnf rpm-libs rpm  libsolv librpmio libmodulemd curl-minimal
+RUN microdnf remove -y microdnf libdnf rpm-libs rpm  libsolv libmodulemd curl-minimal
 USER default
 
 WORKDIR /app


### PR DESCRIPTION
remove librpmio as it is not installed anymore!

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
It looks like `librpmio` is not available anymore in the base image and therefore we currently fail in during `microdnf remove`. Fix is to remove it.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
