### PR TITLE
Add a macOS m1 specific build target for seldon client

### DIFF
--- a/docs/source/contents/cli/index.md
+++ b/docs/source/contents/cli/index.md
@@ -5,7 +5,8 @@ Seldon provides a CLI to allow easy management and testing of Model, Experiment,
 At present this needs to be built by hand from the operator folder.
 
 ```
-make build-seldon
+make build-seldon     # for linux/macOS amd64
+make build-seldon-arm # for macOS ARM
 ```
 
 Then place the `bin/seldon` executable in your path.
@@ -109,15 +110,15 @@ $ seldon config deactivate kind-sasl
 $ seldon config list
 config		path						active
 ------		----						------
-kind-sasl	/home/work/seldon/cli/config-sasl.json	
+kind-sasl	/home/work/seldon/cli/config-sasl.json
 
 $ seldon config add gcp-scv2 ~/seldon/cli/gcp.json
 
 $ seldon config list
 config		path						active
 ------		----						------
-gcp-scv2	/home/work/seldon/cli/gcp.json		
-kind-sasl	/home/work/seldon/cli/config-sasl.json	
+gcp-scv2	/home/work/seldon/cli/gcp.json
+kind-sasl	/home/work/seldon/cli/config-sasl.json
 
 $ seldon config activate gcp-scv2
 

--- a/docs/source/contents/getting-started/cli.md
+++ b/docs/source/contents/getting-started/cli.md
@@ -25,6 +25,21 @@ make build-seldon
 
 Add `<project-root>/operator/bin` to your PATH.
 
+## Local macOS ARM build (requires Go and librdkafka)
+
+```bash
+# install dependencies
+brew install go librdkafka
+```
+
+```bash
+git clone https://github.com/SeldonIO/seldon-core --branch=v2
+cd seldon-core/operator
+make build-seldon-arm
+```
+
+Add `<project-root>/operator/bin` to your PATH.
+
 
 
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -65,7 +65,7 @@ vet: ## Run go vet against code.
 .GOLANGCILINT_VERSION := v1.51.2
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
-${.GOLANGCILINT_PATH}/golangci-lint: 
+${.GOLANGCILINT_PATH}/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sh -s -- -b ${.GOLANGCILINT_PATH} ${.GOLANGCILINT_VERSION}
 
@@ -92,6 +92,9 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 build-seldon: generate fmt vet
 	go build -o bin/seldon -v ./cmd/seldon
+
+build-seldon-arm: generate fmt vet
+	GOOS=darwin GOARCH=arm64 go build -tags dynamic -o bin/seldon -v ./cmd/seldon
 
 build-seldon-docgen:
 	go build -o bin/seldon-gendocs -v ./cmd/seldon/docs


### PR DESCRIPTION
**What this PR does / why we need it**:

Ship an ARM Seldon CLI binary that can be used for macOS. The build tags are documented [here](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/README.md#build-tags). Adding the `-tags dynamic` builds the binary on a macOS M1 and works assuming `librdkafka` has been installed. `brew` can install it.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

Unsure how the release for the binary happens and where to add any documentation for it.