### PR TITLE
allow custom metrics export via `metrics` method for `predict_raw`-based nodes

### DIFF
--- a/python/seldon_core/seldon_methods.py
+++ b/python/seldon_core/seldon_methods.py
@@ -102,6 +102,7 @@ def predict(
         if hasattr(user_model, "predict_raw"):
             try:
                 response = user_model.predict_raw(request)
+                client_custom_metrics(user_model, seldon_metrics, PREDICT_METRIC_METHOD_TAG, [])
                 handle_raw_custom_metrics(
                     response, seldon_metrics, is_proto, PREDICT_METRIC_METHOD_TAG
                 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for using custom metrics export via  the`def metrics` method for `predict_raw`-based inference nodes and not add `['meta']['metrics']` key in response.

My current project requires exact response schema and extra fields like `meta` are forbidden. Unfortunately the only way to use custom metrics in current seldon-core code is via `['meta']['metrics']` field in response. `INCLUDE_METRICS_IN_CLIENT_RESPONSE=false` environment variable does not help because it only deletes `meta.metrics` key, but keeps `meta`. 

One more possible solution: run one more metrics webserver using [custom_service](https://github.com/SeldonIO/seldon-core/blob/970d254c3ff0bc81f7fb2d5cb479b224b0a24625/python/seldon_core/microservice.py#L545). But custom_service usage is undocumented and will require to add 2 metrics endpoints to prometheus scraper instead of 1. (Because variable [`seldon_metrics`](https://github.com/SeldonIO/seldon-core/blob/62ce43c4e62640c279bcf51855d6701bd1b48db7/python/seldon_core/microservice.py#L623) is not accessible globally (from other thread)) and you can't write/merge metrics to same `SeldonMetrics` container.

So this PR fixes this. Basically I just added parsing metrics from `metrics` to `predict_raw` `if` branch.