### PR TITLE
docs(examples/transformers): Add a note on profobuf version and fix links

### DIFF
--- a/examples/transformers/v2-protocol/README.ipynb
+++ b/examples/transformers/v2-protocol/README.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "cdb42efd-86dd-4d4e-904f-5956aa4727ad",
       "metadata": {},
@@ -20,6 +21,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "cd60a985-54e3-4973-a640-40ed52d30203",
       "metadata": {},
@@ -97,6 +99,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "f8b4ca8d-5948-4ad1-a401-15457c29a5e8",
       "metadata": {},
@@ -107,6 +110,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "6d46ea7b-455b-4df0-aebb-9ef5296cd2b9",
       "metadata": {},
@@ -139,6 +143,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "8422729e-1b9c-4e94-8ce0-12466f467003",
       "metadata": {},
@@ -170,6 +175,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "4ffdfa09-61b8-46d6-82d1-097e938f3bea",
       "metadata": {},
@@ -185,12 +191,15 @@
         "\n",
         "\n",
         "Since we're leveraging MLServer to write our custom pre-processor, it should be **easy to test it locally**.\n",
-        "For this, we will start MLServer using the [`mlserver start` subcommand](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-start).\n",
-        "Note that this command has to be carried out on a separate terminal:\n",
+        "For this, we will start MLServer using the [mlserver start subcommand](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-start).\n",
+        "This command has to be carried out on a separate terminal.\n",
+        "\n",
+        "> **NOTE**: If you are using the `protobuf` Python package 3.20.1 or newer, you will need to set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` in your environment variable.\n",
         "\n",
         "```bash\n",
         "mlserver start ./tokeniser\n",
         "```\n",
+        "\n",
         "\n",
         "We can then send a test request using `curl` as follows:"
       ]
@@ -210,6 +219,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "846d4500-00eb-46eb-a800-6b71486e1457",
       "metadata": {},
@@ -218,13 +228,14 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "3953dfee-7c21-4586-a1b5-a3e33a2e9231",
       "metadata": {},
       "source": [
         "### Building the image\n",
         "\n",
-        "Once we have our custom code tested and ready, we should be able to build our custom image by using the [`mlserver build` subcommand](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-build).\n",
+        "Once we have our custom code tested and ready, we should be able to build our custom image by using the [mlserver build subcommand](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-build).\n",
         "This image will be created under the `gpt2-tokeniser:0.1.0` tag."
       ]
     },
@@ -242,6 +253,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "308134b7-a0fb-4714-bc52-0942e9f9686d",
       "metadata": {},
@@ -254,7 +266,7 @@
         "\n",
         "As outlined above, this manifest will re-use the image and resources built in the [GPT-2 Model example](https://docs.seldon.io/projects/seldon-core/en/latest/examples/triton_gpt2_example.html), which is accessible from GCS.\n",
         "\n",
-        "> **NOTE:** This manifest expects that the `gpt2-tokeniser:0.1.0` image built in the previous section **is accessible** from within the cluster where Seldon Core has been installed. If you are [using `kind`](https://docs.seldon.io/projects/seldon-core/en/latest/install/kind.html), you should be able to load the image into your local cluster with the following command:\n",
+        "> **NOTE:** This manifest expects that the `gpt2-tokeniser:0.1.0` image built in the previous section **is accessible** from within the cluster where Seldon Core has been installed. If you are [using kind](https://docs.seldon.io/projects/seldon-core/en/latest/install/kind.html), you should be able to load the image into your local cluster with the following command:\n",
         "```bash\n",
         "kind load docker-image gpt2-tokeniser:0.1.0\n",
         "```"
@@ -316,6 +328,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "a103cd18-6fb0-4db5-aaa0-c887b860f613",
       "metadata": {},
@@ -343,6 +356,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "5ca23aec-f3e3-4174-8ce6-2df1d7d6cea7",
       "metadata": {},
@@ -374,16 +388,16 @@
           "text": [
             "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
             "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-            "\r",
-            "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r",
-            "100   115    0     0  100   115      0     95  0:00:01  0:00:01 --:--:--    95\r",
-            "100   115    0     0  100   115      0     52  0:00:02  0:00:02 --:--:--    52\r",
-            "100   115    0     0  100   115      0     35  0:00:03  0:00:03 --:--:--    35\r",
-            "100   115    0     0  100   115      0     27  0:00:04  0:00:04 --:--:--    27\r",
-            "100   115    0     0  100   115      0     22  0:00:05  0:00:05 --:--:--    22\r",
-            "100   115    0     0  100   115      0     18  0:00:06  0:00:06 --:--:--     0\r",
-            "100   115    0     0  100   115      0     15  0:00:07  0:00:07 --:--:--     0\r",
-            "100   334  100   219  100   115     27     14  0:00:08  0:00:08 --:--:--    45\r",
+            "\r\n",
+            "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r\n",
+            "100   115    0     0  100   115      0     95  0:00:01  0:00:01 --:--:--    95\r\n",
+            "100   115    0     0  100   115      0     52  0:00:02  0:00:02 --:--:--    52\r\n",
+            "100   115    0     0  100   115      0     35  0:00:03  0:00:03 --:--:--    35\r\n",
+            "100   115    0     0  100   115      0     27  0:00:04  0:00:04 --:--:--    27\r\n",
+            "100   115    0     0  100   115      0     22  0:00:05  0:00:05 --:--:--    22\r\n",
+            "100   115    0     0  100   115      0     18  0:00:06  0:00:06 --:--:--     0\r\n",
+            "100   115    0     0  100   115      0     15  0:00:07  0:00:07 --:--:--     0\r\n",
+            "100   334  100   219  100   115     27     14  0:00:08  0:00:08 --:--:--    45\r\n",
             "100   334  100   219  100   115     27     14  0:00:08  0:00:08 --:--:--    57\n"
           ]
         }
@@ -396,6 +410,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "id": "7322029d-70f0-4c20-9f81-62c84b2b846a",
       "metadata": {},

--- a/examples/transformers/v2-protocol/README.md
+++ b/examples/transformers/v2-protocol/README.md
@@ -121,8 +121,10 @@ In our case, we will use this file to tell MLServer that it should always use ou
 
 
 Since we're leveraging MLServer to write our custom pre-processor, it should be **easy to test it locally**.
-For this, we will start MLServer using the [`mlserver start` subcommand](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-start).
-Note that this command has to be carried out on a separate terminal:
+For this, we will start MLServer using the [mlserver start subcommand](https://mlserver.readthedocs.io/en/latest/reference/cli.html#mlserver-start).
+Note that this command has to be carried out on a separate terminal.
+
+> **NOTE**: If you are using the `protobuf` Python package 3.20.1 or newer, you will need to set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` in your environment variable.
 
 ```bash
 mlserver start ./tokeniser


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
- Currently `mlserver start ./tokeniser/` fails due to outdated generated pb2 files not compatible with protobuf 3.20.1 or newer, and this note adds a workaround via an environment variable.
  - Related: https://github.com/protocolbuffers/protobuf/issues/10051 
- Links were not properly rendered previously. Removed backticks inside brackets to fix those. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
