### PR TITLE
retry failed models on server disconnects

### DIFF
--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -465,6 +465,14 @@ func (s *Server) removeServerReplicaImpl(serverName string, serverReplicaIdx int
 			s.logger.Debugf("Failed to reschedule model %s when server %s replica %d disconnected", modelName, serverName, serverReplicaIdx)
 		}
 	}
+	// retry failed models
+	// this is perhaps counterintuitive, but we want to retry failed models on other servers
+	// specifically in the case of model state `LoadFailed` and the server replica disconnects, we want to reconcile 
+	// the model state with th new set of active servers
+	// note that this will also retry `ScheduleFailed`, which is a side effect of calling `ScheduleFailedModels`
+	if _, err := s.scheduler.ScheduleFailedModels(); err != nil {
+		s.logger.WithError(err).Errorf("Failed to reschedule failed models when server %s replica %d disconnected", serverName, serverReplicaIdx)
+	}
 }
 
 func (s *Server) drainServerReplicaImpl(serverName string, serverReplicaIdx int) {

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -134,7 +134,7 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 		logger.Debugf("Model %s is deleted ensuring removed", modelName)
 		err = s.store.UpdateLoadedModels(modelName, latestModel.GetVersion(), server, []*store.ServerReplica{})
 		if err != nil {
-			logger.Warnf("Failed to unschedule model replicas for model %s on server %s", modelName, server)
+			logger.WithError(err).Warnf("Failed to unschedule model replicas for model %s on server %s", modelName, server)
 		}
 
 	} else {

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -511,7 +511,7 @@ func (m *MemoryStore) updateModelStateImpl(
 			modelKey, version, serverKey, replicaIdx, desiredState.String(),
 		)
 
-		// Update models loaded onto replica if loaded or unloaded is state
+		// Update models loaded onto replica for relevant state
 		if desiredState == Loaded || desiredState == Loading || desiredState == Unloaded || desiredState == LoadFailed {
 			server, ok := m.store.servers[serverKey]
 			if ok {

--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -118,7 +118,8 @@ func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string
 		AvailableReplicas:   modelVersion.state.AvailableReplicas,
 		UnavailableReplicas: modelVersion.GetModel().GetDeploymentSpec().GetReplicas() - modelVersion.state.AvailableReplicas,
 	}
-
+	// make sure we reset server
+	modelVersion.server = ""
 	m.eventHub.PublishModelEvent(
 		modelFailureEventSource,
 		coordinator.ModelEventMsg{


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR fixes issues related to the user wanting to delete a model (using `kubectl`) in the following cases:

- Delete `ModelFailed` models in the cases where the server replica disconnected. In this case we are going to force a reschedule to reconcile the model state.
- Delete `SechduleFailed` models that transitioned from  some other state (e.g. the model was loaded on a server then the server got disconnected and we could not now schedule the model). In this case the issue was that the model state had a server associated with it that caused issues. This PR clears this state.

These issues were all related to the finalizer.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:
