### PR TITLE
Filter steps by pipeline header for CLI pipeline inspect

### DIFF
--- a/operator/pkg/cli/kafka.go
+++ b/operator/pkg/cli/kafka.go
@@ -258,7 +258,7 @@ func (kc *KafkaClient) getPipelineStatus(pipelineSpec string) (*scheduler.Pipeli
 
 func getPipelineNameFromHeaders(headers []kafka.Header) (string, error) {
 	for _, header := range headers {
-		if header.Key == "pipeline" {
+		if header.Key == PipelineSpecifier {
 			return string(header.Value), nil
 		}
 	}

--- a/operator/pkg/cli/kafka.go
+++ b/operator/pkg/cli/kafka.go
@@ -345,7 +345,6 @@ func (kc *KafkaClient) createInspectTopic(topic string, pipeline string, tensor 
 				if err != nil {
 					return nil, err
 				}
-				fmt.Printf("Pipeline name is: %s", pipelineName)
 				if pipelineName == pipeline && ((string(e.Key) == key) || key == "") {
 					kitm, err := createKafkaMsg(e, topic, tensor, verbose, truncateData)
 					if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently calling `seldon pipeline inspect MYPIPELINE` will show the last requests and responses for every step in the pipeline, even if some steps have been called as part of a different pipeline which makes it confusing. Instead, after we get the topic names for the pipeline in question, we can filter on the pipeline name to only pick up the steps relevant for the pipeline under inspection.

**Which issue(s) this PR fixes**:
Consider the following example, with 2 pipelines `pipeline-mul10-monitor-inputs` and `pipeline-mul10-monitor-outputs` sharing the same underlying model `average`. Current behaviour (note that the command is picking up requests to `average` that have been processed by the `*-output` pipeline instead of the `*-inputs` pipeline:
```bash
seldon pipeline inspect pipeline-mul10-monitor-inputs -- verbose

seldon.default.model.average.inputs	chsa5158gs9c73b1o3tg	{"inputs":[{"name":"INPUT", "datatype":"FP32", "shape":["4"], "contents":{"fp32Contents":[10, 20, 30, 40]}}], "rawInputContents":["AAAgQQAAoEEAAPBBAAAgQg=="]}		traceparent=[00-9ff6ea2726f41f5c61c416f29601cdd3-75085f29611339f7-01]	x-forwarded-proto=[http]	x-envoy-expected-rq-timeout-ms=[60000]	x-request-id=[chsa5158gs9c73b1o3tg]	x-envoy-upstream-service-time=[2]	x-seldon-route=[:mul10_1:]	pipeline=[pipeline-mul10-monitor-outputs]
seldon.default.model.average.outputs	chsa5158gs9c73b1o3tg	{"modelName":"average_1", "modelVersion":"1", "outputs":[{"name":"OUTPUT", "datatype":"FP32", "contents":{"fp32Contents":[25]}}]}		x-forwarded-proto=[http]	x-envoy-expected-rq-timeout-ms=[60000]	x-request-id=[chsa5158gs9c73b1o3tg]	x-envoy-upstream-service-time=[2]	x-seldon-route=[:mul10_1: :average_1:]	pipeline=[pipeline-mul10-monitor-outputs]	traceparent=[00-9ff6ea2726f41f5c61c416f29601cdd3-ce3e1e404eb0868f-01]
seldon.default.pipeline.pipeline-mul10-monitor-inputs.inputs	chsa5158gs9c73b1o3tg	{"inputs":[{"name":"INPUT", "datatype":"FP32", "shape":["4"], "contents":{"fp32Contents":[1, 2, 3, 4]}}]}		x-forwarded-proto=[http]	x-envoy-expected-rq-timeout-ms=[60000]	x-request-id=[chsa5158gs9c73b1o3tg]	pipeline=[pipeline-mul10-monitor-inputs]	traceparent=[00-9ff6ea2726f41f5c61c416f29601cdd3-5412bd16a3c8e3b0-01]
seldon.default.pipeline.pipeline-mul10-monitor-inputs.outputs	chsa5158gs9c73b1o3tg	{"outputs":[{"name":"OUTPUT", "datatype":"FP32", "contents":{"fp32Contents":[2.5]}}]}		pipeline=[pipeline-mul10-monitor-inputs]	traceparent=[00-9ff6ea2726f41f5c61c416f29601cdd3-5868d64a9b7da674-01]	x-forwarded-proto=[http]	x-envoy-expected-rq-timeout-ms=[60000]	x-request-id=[chsa5158gs9c73b1o3tg]	x-envoy-upstream-service-time=[1]	x-seldon-route=[:average_1:]
```

With this PR:
```bash
seldon.default.pipeline.pipeline-mul10-monitor-inputs.inputs	chsa5158gs9c73b1o3tg	{"inputs":[{"name":"INPUT","datatype":"FP32","shape":["4"],"contents":{"fp32Contents":[1,2,3,4]}}]}		x-forwarded-proto=[http]	x-envoy-expected-rq-timeout-ms=[60000]	x-request-id=[chsa5158gs9c73b1o3tg]	pipeline=[pipeline-mul10-monitor-inputs]	traceparent=[00-9ff6ea2726f41f5c61c416f29601cdd3-5412bd16a3c8e3b0-01]
seldon.default.pipeline.pipeline-mul10-monitor-inputs.outputs	chsa5158gs9c73b1o3tg	{"outputs":[{"name":"OUTPUT","datatype":"FP32","contents":{"fp32Contents":[2.5]}}]}		pipeline=[pipeline-mul10-monitor-inputs]	traceparent=[00-9ff6ea2726f41f5c61c416f29601cdd3-5868d64a9b7da674-01]	x-forwarded-proto=[http]	x-envoy-expected-rq-timeout-ms=[60000]	x-request-id=[chsa5158gs9c73b1o3tg]	x-envoy-upstream-service-time=[1]	x-seldon-route=[:average_1:]
```

**Special notes for your reviewer**:
I don't think this is a full solution because even though we filter out the irrelevant steps, the steps will have been taken by the pipeline under inspection at some earlier time and this information is missing. I'm not sure if it's possible to get this information as any model inside a pipeline may have been called by arbitrarily many other callers/pipelines after our pipeline of interest has called it.