### PR TITLE
feat: Set access log to /dev/stdout and add GRPC response codes

### DIFF
--- a/scheduler/pkg/envoy/resources/resource.go
+++ b/scheduler/pkg/envoy/resources/resource.go
@@ -777,13 +777,13 @@ func createTapConfig() *anypb.Any {
 
 func createAccessLogConfig() *anypb.Any {
 	accessFilter := accesslog_file.FileAccessLog{
-		Path: "/tmp/envoy-accesslog.txt",
+		Path: "/dev/stdout",
 		AccessLogFormat: &accesslog_file.FileAccessLog_LogFormat{
 			LogFormat: &core.SubstitutionFormatString{
 				Format: &core.SubstitutionFormatString_TextFormatSource{
 					TextFormatSource: &core.DataSource{
 						Specifier: &core.DataSource_InlineString{
-							InlineString: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n",
+							InlineString: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %GRPC_STATUS% %GRPC_STATUS_NUMBER% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n",
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Sends the Envoy access log to `/dev/stdout` so it can be analysed and add GRPC headers to the default log format.
