### PR TITLE
ci: Add CI workflow ensuring PR titles conform to Conventional Commit format

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,23 @@
+name: lint-pr-title
+
+on:
+  pull_request:
+    branches:
+      - v2
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  conventional-commit:
+    if: github.repository == 'SeldonIO/seldon-core' # Do not run this on forks.
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title matches Conventional Commit format
+        uses: matthiashermsen/lint-pull-request-title@v1.0.0
+        with:
+          allowed-pull-request-types: build,ci,docs,feat,fix,refactor,revert,test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,12 @@ license the work to the project under the project's open source license. Whether
 state this explicitly, by submitting any copyrighted material via pull request, email, or
 other means you agree to license the material under the project's open source license and
 warrant that you have the legal authority to do so.
+
+## PRs
+
+Automated checks are run against PRs to ensure a certain level of quality.
+
+One of these is a check that PR _titles_ conform to the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
+This format ensures certain small but useful pieces of context are available.
+Specifically, these are the _type_ of change being introduced, whether or not it is a breaking change, and an optional _scope_ of impact.
+The permitted _types_ can be found in the [CI workflow](./.github/workflows/pr-title.yaml).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a check for PR titles to ensure that they are compatible with the [Conventional Commit format](https://www.conventionalcommits.org/en/v1.0.0/).  This imposes minimal burden to contributors: they need to specify the **type** of change, whether or not it is a breaking change, and optionally its scope.

This has a couple of benefits, both for human users and automation.  For maintainers, it is easier to quickly grok the scope and impact of changes due to the additional context.  Using tools like grep, it is also easy to filter for particular types of changes.  We could consider using the CC format in release notes in the future, such that changes are automatically grouped into sections, e.g. new features, bug fixes, and breaking changes.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
The PR check can be seen working on this PR.  Initially it will fail as I have deliberately not met the CC format for the title.  After changing this, the check should pass.