### PR TITLE
add: Helm-charts seldon-core-operator affinity, nodeselector, and tolerations.

### DIFF
--- a/helm-charts/seldon-core-operator/README.md
+++ b/helm-charts/seldon-core-operator/README.md
@@ -72,6 +72,7 @@ helm install seldon-core-operator seldonio/seldon-core-operator --namespace seld
 | istio.tlsMode | string | `""` |  |
 | keda.enabled | bool | `false` |  |
 | kubeflow | bool | `false` |  |
+| manager.affinity | object | `{}` | Affinity rules for scheduling the manager pod. |
 | manager.annotations | object | `{}` |  |
 | manager.containerSecurityContext | object | `{}` |  |
 | manager.cpuLimit | string | `"500m"` |  |
@@ -85,7 +86,9 @@ helm install seldon-core-operator seldonio/seldon-core-operator --namespace seld
 | manager.logLevel | string | `"INFO"` |  |
 | manager.memoryLimit | string | `"300Mi"` |  |
 | manager.memoryRequest | string | `"200Mi"` |  |
+| manager.nodeSelector | object | `{}` | Node selectors to schedule the manager pod to nodes with labels. |
 | manager.priorityClassName | string | `nil` |  |
+| manager.tolerations | list | `[]` | Tolerations to allow the pod to be scheduled to nodes with taints. |
 | managerCreateResources | bool | `false` |  |
 | managerUserID | int | `8888` |  |
 | metrics.port | int | `8080` |  |

--- a/helm-charts/seldon-core-operator/README.md
+++ b/helm-charts/seldon-core-operator/README.md
@@ -130,4 +130,8 @@ helm install seldon-core-operator seldonio/seldon-core-operator --namespace seld
 | storageInitializer.memoryLimit | string | `"1Gi"` |  |
 | storageInitializer.memoryRequest | string | `"100Mi"` |  |
 | usageMetrics.enabled | bool | `false` |  |
+| usageMetrics.spartakus.affinity | object | `{}` | Affinity rules for scheduling the spartakus pod, if usageMetrics is enabled. |
+| usageMetrics.spartakus.nodeSelector | object | `{}` | Node selectors to schedule the spartakus pod, if usageMetrics is enabled. |
+| usageMetrics.spartakus.resources | object | `{}` | Resources for the spartakus pod, if usageMetrics is enabled. |
+| usageMetrics.spartakus.tolerations | list | `[]` | Tolerations to allow the spartakus pod to be scheduled to nodes with taints, if usageMetrics is enabled. |
 | webhook.port | int | `4443` |  |

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -34,6 +34,10 @@ spec:
         app.kubernetes.io/version: v0.5
         control-plane: seldon-controller-manager
     spec:
+      {{- with .Values.manager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - --enable-leader-election
@@ -183,11 +187,19 @@ spec:
           readOnly: true
 {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
+      {{- with .Values.manager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}   
+      {{- end }}
       priorityClassName: '{{ .Values.manager.priorityClassName }}'
       securityContext:
         runAsUser: {{ .Values.managerUserID }}
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
       terminationGracePeriodSeconds: 10
+      {{- with .Values.manager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- if not .Values.managerCreateResources }}
       volumes:
       - name: cert

--- a/helm-charts/seldon-core-operator/templates/deployment_seldon-spartakus-volunteer.yaml
+++ b/helm-charts/seldon-core-operator/templates/deployment_seldon-spartakus-volunteer.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: seldon-spartakus-volunteer
     spec:
+      {{- with .Values.usageMetrics.spartakus.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - -c
@@ -22,10 +26,22 @@ spec:
         - /bin/sh
         image: gcr.io/google_containers/spartakus-amd64:v1.1.0
         name: seldon-spartakus-volunteer
+        {{- with .Values.usageMetrics.spartakus.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /etc/config
           name: seldon-spartakus-config-volume
+      {{- with .Values.usageMetrics.spartakus.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}   
+      {{- end }}
       serviceAccountName: seldon-spartakus-volunteer
+      {{- with .Values.usageMetrics.spartakus.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - configMap:
           name: seldon-spartakus-config

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -117,6 +117,15 @@ storageInitializer:
   memoryRequest: 100Mi
 usageMetrics:
   enabled: false
+  spartakus:
+    # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    affinity: {}
+    # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
+    nodeSelector: {}
+    resources: {}
+    # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
 # In scenarios like EKS with non-standard CNI plugin like calico, the control plane cannot reach the webhook
 # hence it is needed to set hostNetwork: true
 hostNetwork: false

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -63,8 +63,8 @@ executor:
   serviceAccount:
     name: default
   user: 8888
-# If you want to make available your own request logger for ELK integration you can set this
-# For more information see the Production Integration for Payload Request Logging with ELK in the docs
+  # If you want to make available your own request logger for ELK integration you can set this
+  # For more information see the Production Integration for Payload Request Logging with ELK in the docs
   requestLogger:
     defaultEndpoint: 'http://default-broker'
     workQueueSize: 10000
@@ -94,6 +94,13 @@ manager:
   containerSecurityContext: {}
   deploymentNameAsPrefix: false
   priorityClassName:
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+  # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 rbac:
   configmap:
     create: true
@@ -151,7 +158,7 @@ predictor_servers:
         image: seldonio/tfserving-proxy
       tensorflow:
         defaultImageVersion: 2.1.0
-        image:  tensorflow/serving
+        image: tensorflow/serving
   XGBOOST_SERVER:
     protocols:
       seldon:

--- a/helm-charts/seldon-core-operator/values.yaml
+++ b/helm-charts/seldon-core-operator/values.yaml
@@ -97,7 +97,6 @@ manager:
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
   # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
@@ -121,7 +120,6 @@ usageMetrics:
     # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     affinity: {}
     # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
     nodeSelector: {}
     resources: {}
     # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
As a deployer of seldon-core-operator via helm into mixed-node kubernetes clusters; I want to be able to specify affinities, nodeSelectors, and tolerations for the manager and spartakus pods so that I can better control which nodes they get scheduled on.

This PR adds helm values to set the aforementioned in the deployment spec for the manager and spartakus volunteer.

Additionally it adds missing resources values for the spartakus volunteer pod spec to allow the user better control over resource to it.
