### PR TITLE
Add note in v2 docs about vCPU compatibility

### DIFF
--- a/docs/source/contents/getting-started/index.md
+++ b/docs/source/contents/getting-started/index.md
@@ -1,5 +1,10 @@
 # Getting Started
 
+```{note}
+Some dependencies may require that the (virtual) machines on which you deploy, support the SSE4.2 instruction set or x86-64-v2 microarchitecture. If `lscpu | grep sse4_2` does not return anything on your machine, your CPU is not compatible, and you may need to update the (virtual) host's CPU. 
+```
+
+Seldon Core can be installed either with Docker Compose or with Kubernetes:
 
  * [Install locally with Docker Compose](./docker-installation/index.md)
  * [Install onto a Kubernetes cluster](./kubernetes-installation/index.md)


### PR DESCRIPTION
```release-note
Added note to the local install docs about vCPU compatibility
```

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**: Incompatible vCPUs lead to containers in Docker crashing with "glibc x86-64-v2" errors. Users deploying on their own cluster should be aware they need to create VMs with compatible vCPUs.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
