### PR TITLE
Fix reconcile diffs found on hpa/keda updates

### DIFF
--- a/operator/apis/machinelearning.seldon.io/v1/prepack.go
+++ b/operator/apis/machinelearning.seldon.io/v1/prepack.go
@@ -154,8 +154,6 @@ func getPredictorServerConfigs() (map[string]PredictorServerConfig, error) {
 	err := C.Get(context.TODO(), k8types.NamespacedName{Name: ControllerConfigMapName, Namespace: ControllerNamespace}, configMap)
 
 	if err != nil {
-		fmt.Println("Failed to find config map " + ControllerConfigMapName)
-		fmt.Println(err)
 		return map[string]PredictorServerConfig{}, err
 	}
 	return getPredictorServerConfigsFromMap(configMap)

--- a/operator/controllers/utils/patch_utils.go
+++ b/operator/controllers/utils/patch_utils.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"emperror.dev/errors"
+	"github.com/banzaicloud/k8s-objectmatcher/patch"
+	json "github.com/json-iterator/go"
+)
+
+func IgnoreReplicas() patch.CalculateOption {
+	return func(current, modified []byte) ([]byte, []byte, error) {
+		current, err := deleteReplicas(current)
+		if err != nil {
+			return []byte{}, []byte{}, errors.Wrap(err, "could not delete replicas field from current byte sequence")
+		}
+
+		modified, err = deleteReplicas(modified)
+		if err != nil {
+			return []byte{}, []byte{}, errors.Wrap(err, "could not delete replicas field from modified byte sequence")
+		}
+
+		return current, modified, nil
+	}
+}
+
+func deleteReplicas(obj []byte) ([]byte, error) {
+	resource := map[string]interface{}{}
+	err := json.Unmarshal(obj, &resource)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "could not unmarshal byte sequence")
+	}
+
+	if spec, ok := resource["spec"]; ok {
+		if spec, ok := spec.(map[string]interface{}); ok {
+			if _, ok := spec["replicas"]; ok {
+				spec["replicas"] = nil
+			}
+		}
+	}
+
+	obj, err = json.ConfigCompatibleWithStandardLibrary.Marshal(resource)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "could not marshal byte sequence")
+	}
+
+	return obj, nil
+}

--- a/operator/controllers/utils/patch_utils_test.go
+++ b/operator/controllers/utils/patch_utils_test.go
@@ -1,0 +1,94 @@
+package utils
+
+import (
+	"encoding/json"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func getTestDeployment(replicas *int32) *v1.Deployment {
+	d := &v1.Deployment{
+		Spec: v1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "mycontainer",
+						},
+					},
+				},
+			},
+		},
+	}
+	if replicas != nil {
+		d.Spec.Replicas = replicas
+	}
+	return d
+}
+
+func TestReplica(t *testing.T) {
+	g := NewGomegaWithT(t)
+	type test struct {
+		name         string
+		dep1         *v1.Deployment
+		dep2         *v1.Deployment
+		expectedDep1 *v1.Deployment
+		expectedDep2 *v1.Deployment
+	}
+	getInt32Ptr := func(v int32) *int32 { return &v }
+	tests := []test{
+		{
+			name:         "no replicas",
+			dep1:         getTestDeployment(nil),
+			dep2:         getTestDeployment(nil),
+			expectedDep1: getTestDeployment(nil),
+			expectedDep2: getTestDeployment(nil),
+		},
+		{
+			name:         "first dep with replicas",
+			dep1:         getTestDeployment(getInt32Ptr(1)),
+			dep2:         getTestDeployment(nil),
+			expectedDep1: getTestDeployment(nil),
+			expectedDep2: getTestDeployment(nil),
+		},
+		{
+			name:         "second dep with replicas",
+			dep1:         getTestDeployment(nil),
+			dep2:         getTestDeployment(getInt32Ptr(1)),
+			expectedDep1: getTestDeployment(nil),
+			expectedDep2: getTestDeployment(nil),
+		},
+		{
+			name:         "both deps with replicas",
+			dep1:         getTestDeployment(getInt32Ptr(2)),
+			dep2:         getTestDeployment(getInt32Ptr(4)),
+			expectedDep1: getTestDeployment(nil),
+			expectedDep2: getTestDeployment(nil),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := IgnoreReplicas()
+			b1, err := json.Marshal(test.dep1)
+			g.Expect(err).To(BeNil())
+			b2, err := json.Marshal(test.dep2)
+			g.Expect(err).To(BeNil())
+
+			b3, b4, err := f(b1, b2)
+			g.Expect(err).To(BeNil())
+
+			d1 := &v1.Deployment{}
+			err = json.Unmarshal(b3, d1)
+			g.Expect(err).To(BeNil())
+
+			d2 := &v1.Deployment{}
+			err = json.Unmarshal(b4, d2)
+			g.Expect(err).To(BeNil())
+
+			g.Expect(d1).To(Equal(test.expectedDep1))
+			g.Expect(d2).To(Equal(test.expectedDep2))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When an HPA/KEDA spec in an sdep is updated a failed reconcile loop is created due to Deployments having replicas that don't match the sdep spec due to the fact that the replicas field is handled/updated by the HPA/KEDA directly.

The solution is to add an ignore replica check for the patcher we use when the deployment being checked is controlled by an HPA or KEDA spec.

We add a `func IgnoreReplicas() patch.CalculateOption {` which is used in the createDeployement method,
The `ignoreReplicas` deletes the `spec.replicas` field in both arguments to ensure it can never cause a difference.


```golang
opts := []patch.CalculateOption{
		patch.IgnoreStatusFields(),
		patch.IgnoreField("kind"),
		patch.IgnoreField("apiVersion"),
		patch.IgnoreField("metadata"),
	}
// Ignore replica count disparities as that is controlled by HPA/KEDA
if components.deploymentHasHpa(deploy.Name) || components.deploymentHasKeda(deploy.Name) {
	opts = append(opts, utils2.IgnoreReplicas())
}
```

Also print statements for diffs are removed and added to debug level logs.
Fixes #4922 
Fixes #4917 

**Special notes for your reviewer**:
