### PR TITLE
fix: server can be return as nil when not found causing panics

### DIFF
--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -569,6 +569,9 @@ func (p *IncrementalProcessor) modelUpdate(modelName string) error {
 		return p.updateEnvoy() // in practice we should not be here
 	}
 
+	// Add a modelRemoved boolean so we can continue to batch update but skip steps if we have
+	// decided this model can't be added for some reason. This allows batch deletion of routes
+	// to take place for errors as well as the successful path through the methods
 	modelRemoved := false
 	if !model.CanReceiveTraffic() {
 		logger.Debugf("sync: Model can't receive traffic - removing for %s", modelName)

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -308,6 +308,9 @@ func (p *IncrementalProcessor) addModelTraffic(routeName string, model *store.Mo
 	modelName := model.Name
 	latestModel := model.GetLatest()
 	if latestModel == nil || !model.CanReceiveTraffic() {
+		if latestModel == nil {
+			logger.Infof("latest model is nil for model %s route %s", model.Name, routeName)
+		}
 		return fmt.Errorf("No live replica for model %s for model route %s", model.Name, routeName)
 	}
 
@@ -566,37 +569,44 @@ func (p *IncrementalProcessor) modelUpdate(modelName string) error {
 		return p.updateEnvoy() // in practice we should not be here
 	}
 
+	modelRemoved := false
 	if !model.CanReceiveTraffic() {
 		logger.Debugf("sync: Model can't receive traffic - removing for %s", modelName)
 		if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
 			logger.WithError(err).Errorf("Failed to remove model route from envoy %s", modelName)
 			return err
 		}
+		modelRemoved = true
 	}
 
-	_, err = p.modelStore.GetServer(latestModel.Server(), false, false)
-	if err != nil {
-		logger.Debugf("sync: No server - removing for %s", modelName)
-		if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
-			logger.WithError(err).Errorf("Failed to remove model route from envoy %s", modelName)
-			return err
+	if !modelRemoved {
+		_, err = p.modelStore.GetServer(latestModel.Server(), false, false)
+		if err != nil {
+			logger.Debugf("sync: No server - removing for %s", modelName)
+			if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
+				logger.WithError(err).Errorf("Failed to remove model route from envoy %s", modelName)
+				return err
+			}
+			modelRemoved = true
 		}
 	}
 
-	// Remove routes before we recreate
-	if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
-		logger.Debugf("Failed to remove route before starting update for %s", modelName)
-		return err
-	}
-
-	err = p.addModel(model)
-	if err != nil {
-		// note that on error for `addModel` we specifically do not return so that we can do batched
-		// delete of envoy routes
-		logger.WithError(err).Errorf("Failed to add traffic for model %s", modelName)
+	if !modelRemoved {
+		// Remove routes before we recreate
 		if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
-			logger.WithError(err).Errorf("Failed to remove model route from envoy %s", modelName)
+			logger.Debugf("Failed to remove route before starting update for %s", modelName)
 			return err
+		}
+
+		err = p.addModel(model)
+		if err != nil {
+			// note that on error for `addModel` we specifically do not return so that we can do batched
+			// delete of envoy routes
+			logger.WithError(err).Errorf("Failed to add traffic for model %s", modelName)
+			if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
+				logger.WithError(err).Errorf("Failed to remove model route from envoy %s", modelName)
+				return err
+			}
 		}
 	}
 

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -574,8 +574,8 @@ func (p *IncrementalProcessor) modelUpdate(modelName string) error {
 		}
 	}
 
-	server, err := p.modelStore.GetServer(latestModel.Server(), false, false)
-	if err != nil || server == nil {
+	_, err = p.modelStore.GetServer(latestModel.Server(), false, false)
+	if err != nil {
 		logger.Debugf("sync: No server - removing for %s", modelName)
 		if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
 			logger.WithError(err).Errorf("Failed to remove model route from envoy %s", modelName)
@@ -658,7 +658,7 @@ func (p *IncrementalProcessor) modelSync() {
 		}
 
 		s, err := p.modelStore.GetServer(v.Server(), false, false)
-		if err != nil || s == nil {
+		if err != nil {
 			logger.Debugf("Failed to get server for model %s server %s", mv.name, v.Server())
 			p.modelStore.UnlockModel(mv.name)
 			continue

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -425,9 +425,6 @@ func (s *SchedulerServer) ServerStatus(
 		if err != nil {
 			return status.Errorf(codes.FailedPrecondition, err.Error())
 		}
-		if server == nil {
-			return status.Errorf(codes.FailedPrecondition, fmt.Sprintf("Failed to find server %s", req.GetName()))
-		}
 		resp := createServerStatusResponse(server)
 		err = stream.Send(resp)
 		if err != nil {

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -221,10 +221,6 @@ func (s *SchedulerServer) sendServerStatus() {
 			logger.Errorf("Failed to get server %s", serverName)
 			continue
 		}
-		if server == nil {
-			logger.Warnf("Server %s does not exist", serverName)
-			continue
-		}
 		ssr := createServerStatusResponse(server)
 
 		for stream, subscription := range s.serverEventStream.streams {

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -231,7 +231,7 @@ func (m *MemoryStore) GetServer(serverKey string, shallow bool, modelDetails boo
 	defer m.mu.RUnlock()
 	server := m.store.servers[serverKey]
 	if server == nil {
-		return nil, nil
+		return nil, fmt.Errorf("Server not found")
 	} else {
 		return server.CreateSnapshot(shallow, modelDetails), nil
 	}

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -231,7 +231,7 @@ func (m *MemoryStore) GetServer(serverKey string, shallow bool, modelDetails boo
 	defer m.mu.RUnlock()
 	server := m.store.servers[serverKey]
 	if server == nil {
-		return nil, fmt.Errorf("Server not found")
+		return nil, fmt.Errorf("Server [%s] not found", serverKey)
 	} else {
 		return server.CreateSnapshot(shallow, modelDetails), nil
 	}

--- a/scheduler/pkg/store/memory_test.go
+++ b/scheduler/pkg/store/memory_test.go
@@ -1530,10 +1530,11 @@ func TestRemoveServerReplica(t *testing.T) {
 			g.Expect(err).To(BeNil())
 			g.Expect(test.modelsReturned).To(Equal(len(models)))
 			server, err := ms.GetServer(test.serverName, false, true)
-			g.Expect(err).To(BeNil())
 			if test.serverExists {
+				g.Expect(err).To(BeNil())
 				g.Expect(server).ToNot(BeNil())
 			} else {
+				g.Expect(err).ToNot(BeNil())
 				g.Expect(server).To(BeNil())
 			}
 		})


### PR DESCRIPTION
FIXES: #4931 where a panic was causes when mlserver was deleted while it had a model. The envoy logic was getting the server for this model but there was none.

We were return no error when a server was not found but just a nil server. Having checked all the uses I think returning an error is best and no functionality will change. 

In future we could return a typed error for no server found if we think clients need to check for this type of error but this does not seem to be needed right now.

Have tested the use case in #4931 and the model is reloaded ok after the mlserver pod comes back.

The PR also cleans up the Envoy update to not do unnecessary calls when an error state has been hit. The control flow still needs to reach the end of the `modelUpdate` call to do batch updates.