### PR TITLE
fix: Allow config CRD changes to cause a reconcilliation loop for dependent (but not owned) resources

### DIFF
--- a/operator/controllers/mlops/seldonruntime_controller.go
+++ b/operator/controllers/mlops/seldonruntime_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/operator/controllers/mlops/seldonruntime_controller.go
+++ b/operator/controllers/mlops/seldonruntime_controller.go
@@ -19,8 +19,7 @@ package mlops
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/source"
+
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,8 +34,10 @@ import (
 	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	mlopsv1alpha1 "github.com/seldonio/seldon-core/operator/v2/apis/mlops/v1alpha1"
 	"github.com/seldonio/seldon-core/operator/v2/controllers/reconcilers/common"
@@ -219,6 +220,7 @@ func (r *SeldonRuntimeReconciler) updateStatus(seldonRuntime *mlopsv1alpha1.Seld
 	return nil
 }
 
+// Find SeldonRuntimes that reference the changes SeldonConfig
 func (r *SeldonRuntimeReconciler) mapSeldonRuntimesFromSeldonConfig(obj client.Object) []reconcile.Request {
 	logger := log.FromContext(context.Background()).WithName("mapSeldonRuntimesFromSeldonConfig")
 	var seldonRuntimes mlopsv1alpha1.SeldonRuntimeList

--- a/operator/controllers/mlops/server_controller.go
+++ b/operator/controllers/mlops/server_controller.go
@@ -19,8 +19,7 @@ package mlops
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/source"
+
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,8 +33,10 @@ import (
 	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	mlopsv1alpha1 "github.com/seldonio/seldon-core/operator/v2/apis/mlops/v1alpha1"
 	"github.com/seldonio/seldon-core/operator/v2/controllers/reconcilers/common"

--- a/operator/controllers/mlops/server_controller.go
+++ b/operator/controllers/mlops/server_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/samples/k8s-clusterwide-kafka-mtls-demo.ipynb
+++ b/samples/k8s-clusterwide-kafka-mtls-demo.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 172,
    "id": "b4d93216",
    "metadata": {},
    "outputs": [
@@ -48,13 +48,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Release \"seldon-core-v2-crds\" does not exist. Installing it now.\n",
-      "NAME: seldon-core-v2-crds\n",
-      "LAST DEPLOYED: Wed Jun 14 17:26:57 2023\n",
-      "NAMESPACE: seldon-mesh\n",
-      "STATUS: deployed\n",
-      "REVISION: 1\n",
-      "TEST SUITE: None\n"
+      "Release \"seldon-core-v2-crds\" has been upgraded. Happy Helming!\r\n",
+      "NAME: seldon-core-v2-crds\r\n",
+      "LAST DEPLOYED: Thu Jun 22 15:22:04 2023\r\n",
+      "NAMESPACE: seldon-mesh\r\n",
+      "STATUS: deployed\r\n",
+      "REVISION: 5\r\n",
+      "TEST SUITE: None\r\n"
      ]
     }
    ],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 173,
    "id": "bcf13333",
    "metadata": {},
    "outputs": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 174,
    "id": "edba01cd",
    "metadata": {},
    "outputs": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 175,
    "id": "6a9cdb85",
    "metadata": {},
    "outputs": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 176,
    "id": "71bf922e",
    "metadata": {},
    "outputs": [
@@ -141,7 +141,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2\r\n",
-      "LAST DEPLOYED: Wed Jun 14 17:27:04 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 15:22:11 2023\r\n",
       "NAMESPACE: seldon-mesh\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 177,
    "id": "fd76efe2",
    "metadata": {},
    "outputs": [
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 178,
    "id": "b3e2dbee",
    "metadata": {},
    "outputs": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 179,
    "id": "96872dd2",
    "metadata": {},
    "outputs": [
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 180,
    "id": "24ce240c",
    "metadata": {},
    "outputs": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 181,
    "id": "e28147b1",
    "metadata": {},
    "outputs": [
@@ -254,7 +254,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-runtime\r\n",
-      "LAST DEPLOYED: Wed Jun 14 15:39:32 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 15:22:19 2023\r\n",
       "NAMESPACE: ns1\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -263,12 +263,12 @@
     }
    ],
    "source": [
-    "!helm install seldon-v2-runtime ../k8s/helm-charts/seldon-core-v2-runtime  -n ns1"
+    "!helm install seldon-v2-runtime ../k8s/helm-charts/seldon-core-v2-runtime  -n ns1 --wait"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 182,
    "id": "4423b5f5",
    "metadata": {},
    "outputs": [
@@ -277,7 +277,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-runtime\r\n",
-      "LAST DEPLOYED: Wed Jun 14 15:39:47 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 15:22:20 2023\r\n",
       "NAMESPACE: ns2\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -286,7 +286,91 @@
     }
    ],
    "source": [
-    "!helm install seldon-v2-runtime ../k8s/helm-charts/seldon-core-v2-runtime  -n ns2"
+    "!helm install seldon-v2-runtime ../k8s/helm-charts/seldon-core-v2-runtime  -n ns2 --wait"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 183,
+   "id": "21e2dd25",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NAME: seldon-v2-servers\r\n",
+      "LAST DEPLOYED: Thu Jun 22 15:22:23 2023\r\n",
+      "NAMESPACE: ns1\r\n",
+      "STATUS: deployed\r\n",
+      "REVISION: 1\r\n",
+      "TEST SUITE: None\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!helm install seldon-v2-servers ../k8s/helm-charts/seldon-core-v2-servers  -n ns1 --wait"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "id": "56a28fc8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NAME: seldon-v2-servers\r\n",
+      "LAST DEPLOYED: Thu Jun 22 15:22:24 2023\r\n",
+      "NAMESPACE: ns2\r\n",
+      "STATUS: deployed\r\n",
+      "REVISION: 1\r\n",
+      "TEST SUITE: None\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!helm install seldon-v2-servers ../k8s/helm-charts/seldon-core-v2-servers  -n ns2 --wait"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "id": "1dd6a5dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "server.mlops.seldon.io/mlserver condition met\n",
+      "server.mlops.seldon.io/triton condition met\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl wait --for condition=ready --timeout=300s server --all -n ns1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 186,
+   "id": "e2464284",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "server.mlops.seldon.io/mlserver condition met\n",
+      "server.mlops.seldon.io/triton condition met\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl wait --for condition=ready --timeout=300s server --all -n ns2"
    ]
   },
   {
@@ -299,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 187,
    "id": "3835b3dc",
    "metadata": {},
    "outputs": [
@@ -309,7 +393,7 @@
        "'172.21.255.2'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 187,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 188,
    "id": "33f7a263",
    "metadata": {},
    "outputs": [
@@ -334,7 +418,7 @@
        "'172.21.255.4'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 188,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -357,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 189,
    "id": "fc5fdee5",
    "metadata": {},
    "outputs": [
@@ -377,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 190,
    "id": "5c1328c8",
    "metadata": {},
    "outputs": [
@@ -396,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 191,
    "id": "d8d6a6dd",
    "metadata": {},
    "outputs": [
@@ -414,7 +498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 192,
    "id": "f0861650",
    "metadata": {},
    "outputs": [
@@ -432,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 193,
    "id": "4e5f2e9c",
    "metadata": {},
    "outputs": [
@@ -518,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 194,
    "id": "88954ff6",
    "metadata": {},
    "outputs": [
@@ -538,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 195,
    "id": "447ed372",
    "metadata": {},
    "outputs": [
@@ -557,7 +641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 196,
    "id": "95d62d6a",
    "metadata": {},
    "outputs": [
@@ -575,7 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 197,
    "id": "8e8ebee6",
    "metadata": {},
    "outputs": [
@@ -593,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 199,
    "id": "1ce5d740",
    "metadata": {},
    "outputs": [
@@ -679,7 +763,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 200,
    "id": "11d99aac",
    "metadata": {},
    "outputs": [
@@ -707,7 +791,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 201,
+   "id": "7ab5b2e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "release \"seldon-v2-servers\" uninstalled\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!helm delete seldon-v2-servers -n ns1 --wait"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 202,
    "id": "3a84da13",
    "metadata": {},
    "outputs": [
@@ -720,12 +822,30 @@
     }
    ],
    "source": [
-    "!helm delete seldon-v2-runtime -n ns1"
+    "!helm delete seldon-v2-runtime -n ns1 --wait"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 203,
+   "id": "d77a5ae9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "release \"seldon-v2-servers\" uninstalled\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!helm delete seldon-v2-servers -n ns2 --wait"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 204,
    "id": "a5e6e07c",
    "metadata": {},
    "outputs": [
@@ -738,12 +858,12 @@
     }
    ],
    "source": [
-    "!helm delete seldon-v2-runtime -n ns2"
+    "!helm delete seldon-v2-runtime -n ns2 --wait"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 205,
    "id": "4b13fb4a",
    "metadata": {},
    "outputs": [
@@ -761,8 +881,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 206,
    "id": "f06f0dac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "namespace \"ns1\" deleted\n",
+      "namespace \"ns2\" deleted\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl delete namespace ns1\n",
+    "!kubectl delete namespace ns2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "555788e7",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/samples/k8s-clusterwide-ssl-demo.ipynb
+++ b/samples/k8s-clusterwide-ssl-demo.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 1,
    "id": "b4d93216",
    "metadata": {},
    "outputs": [
@@ -48,13 +48,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Release \"seldon-core-v2-crds\" does not exist. Installing it now.\n",
-      "NAME: seldon-core-v2-crds\n",
-      "LAST DEPLOYED: Wed Jun 21 11:03:14 2023\n",
-      "NAMESPACE: seldon-mesh\n",
-      "STATUS: deployed\n",
-      "REVISION: 1\n",
-      "TEST SUITE: None\n"
+      "Release \"seldon-core-v2-crds\" has been upgraded. Happy Helming!\r\n",
+      "NAME: seldon-core-v2-crds\r\n",
+      "LAST DEPLOYED: Thu Jun 22 09:11:26 2023\r\n",
+      "NAMESPACE: seldon-mesh\r\n",
+      "STATUS: deployed\r\n",
+      "REVISION: 2\r\n",
+      "TEST SUITE: None\r\n"
      ]
     }
    ],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 2,
    "id": "bcf13333",
    "metadata": {},
    "outputs": [
@@ -72,7 +72,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error from server (AlreadyExists): object is being deleted: namespaces \"ns1\" already exists\r\n"
+      "namespace/ns1 created\r\n"
      ]
     }
    ],
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "edba01cd",
    "metadata": {},
    "outputs": [
@@ -90,7 +90,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error from server (AlreadyExists): namespaces \"ns2\" already exists\r\n"
+      "namespace/ns2 created\r\n"
      ]
     }
    ],
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 48,
    "id": "422fce1b",
    "metadata": {},
    "outputs": [
@@ -109,7 +109,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-certs\r\n",
-      "LAST DEPLOYED: Wed Jun 21 10:29:32 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 10:00:32 2023\r\n",
       "NAMESPACE: ns1\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "df456290",
    "metadata": {},
    "outputs": [
@@ -132,7 +132,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-certs\r\n",
-      "LAST DEPLOYED: Wed Jun 21 10:29:34 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 09:11:36 2023\r\n",
       "NAMESPACE: ns2\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "6a9cdb85",
    "metadata": {},
    "outputs": [
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "71bf922e",
    "metadata": {},
    "outputs": [
@@ -197,7 +197,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2\r\n",
-      "LAST DEPLOYED: Wed Jun 21 10:29:40 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 09:11:40 2023\r\n",
       "NAMESPACE: seldon-mesh\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 49,
    "id": "e28147b1",
    "metadata": {},
    "outputs": [
@@ -220,7 +220,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-runtime\r\n",
-      "LAST DEPLOYED: Wed Jun 21 10:30:26 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 10:00:36 2023\r\n",
       "NAMESPACE: ns1\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 50,
    "id": "2864216b",
    "metadata": {},
    "outputs": [
@@ -243,7 +243,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-servers\r\n",
-      "LAST DEPLOYED: Wed Jun 21 10:30:41 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 10:00:36 2023\r\n",
       "NAMESPACE: ns1\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -257,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "4423b5f5",
    "metadata": {},
    "outputs": [
@@ -266,7 +266,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-runtime\r\n",
-      "LAST DEPLOYED: Wed Jun 21 10:30:44 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 09:11:49 2023\r\n",
       "NAMESPACE: ns2\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "477c43a4",
    "metadata": {},
    "outputs": [
@@ -289,7 +289,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-servers\r\n",
-      "LAST DEPLOYED: Wed Jun 21 10:31:00 2023\r\n",
+      "LAST DEPLOYED: Thu Jun 22 09:12:16 2023\r\n",
       "NAMESPACE: ns2\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "5f781131",
    "metadata": {},
    "outputs": [
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "af734add",
    "metadata": {},
    "outputs": [
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "3835b3dc",
    "metadata": {},
    "outputs": [
@@ -359,7 +359,7 @@
        "'172.21.255.2'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 31,
    "id": "33f7a263",
    "metadata": {},
    "outputs": [
@@ -384,7 +384,7 @@
        "'172.21.255.4'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "181faf47",
    "metadata": {},
    "outputs": [],
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "5db513b9",
    "metadata": {},
    "outputs": [],
@@ -427,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 18,
    "id": "fc5fdee5",
    "metadata": {},
    "outputs": [
@@ -445,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 19,
    "id": "5c1328c8",
    "metadata": {},
    "outputs": [
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "id": "d048aa51",
    "metadata": {},
    "outputs": [
@@ -474,7 +474,7 @@
       "{\r\n",
       "\t\"model_name\": \"iris_1\",\r\n",
       "\t\"model_version\": \"1\",\r\n",
-      "\t\"id\": \"d7ba2bcb-b901-4c39-a91e-0e19b67a9d19\",\r\n",
+      "\t\"id\": \"77f21360-b6cf-4c50-a000-1f219f5e9e29\",\r\n",
       "\t\"parameters\": {},\r\n",
       "\t\"outputs\": [\r\n",
       "\t\t{\r\n",
@@ -511,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 21,
    "id": "5e2e72aa",
    "metadata": {},
    "outputs": [
@@ -529,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 22,
    "id": "6cb7f562",
    "metadata": {},
    "outputs": [
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 37,
    "id": "4f116773",
    "metadata": {},
    "outputs": [
@@ -558,7 +558,7 @@
       "{\r\n",
       "\t\"model_name\": \"iris_1\",\r\n",
       "\t\"model_version\": \"1\",\r\n",
-      "\t\"id\": \"cd07f18a-a408-4365-8924-75e4db3bfaf9\",\r\n",
+      "\t\"id\": \"902b8483-0ede-4136-97be-dbf266f05a0c\",\r\n",
       "\t\"parameters\": {},\r\n",
       "\t\"outputs\": [\r\n",
       "\t\t{\r\n",
@@ -595,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 38,
    "id": "11d99aac",
    "metadata": {},
    "outputs": [
@@ -613,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 39,
    "id": "d91cd84a",
    "metadata": {},
    "outputs": [
@@ -631,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 51,
    "id": "3a84da13",
    "metadata": {},
    "outputs": [
@@ -653,7 +653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 52,
    "id": "a5e6e07c",
    "metadata": {},
    "outputs": [
@@ -675,7 +675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 53,
    "id": "4b13fb4a",
    "metadata": {},
    "outputs": [
@@ -693,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 54,
    "id": "89b13117",
    "metadata": {},
    "outputs": [
@@ -711,7 +711,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "id": "f06f0dac",
    "metadata": {},
    "outputs": [
@@ -719,7 +719,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "namespace \"ns1\" deleted\r\n"
+      "namespace \"ns1\" deleted\n",
+      "namespace \"ns2\" deleted\n"
      ]
     }
    ],

--- a/samples/k8s-clusterwide-ssl-demo.ipynb
+++ b/samples/k8s-clusterwide-ssl-demo.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 48,
    "id": "b4d93216",
    "metadata": {},
    "outputs": [
@@ -50,7 +50,7 @@
      "text": [
       "Release \"seldon-core-v2-crds\" does not exist. Installing it now.\n",
       "NAME: seldon-core-v2-crds\n",
-      "LAST DEPLOYED: Wed May 31 19:07:47 2023\n",
+      "LAST DEPLOYED: Wed Jun 21 11:03:14 2023\n",
       "NAMESPACE: seldon-mesh\n",
       "STATUS: deployed\n",
       "REVISION: 1\n",
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 49,
    "id": "bcf13333",
    "metadata": {},
    "outputs": [
@@ -72,7 +72,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "namespace/ns1 created\r\n"
+      "Error from server (AlreadyExists): object is being deleted: namespaces \"ns1\" already exists\r\n"
      ]
     }
    ],
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "edba01cd",
    "metadata": {},
    "outputs": [
@@ -90,7 +90,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "namespace/ns2 created\r\n"
+      "Error from server (AlreadyExists): namespaces \"ns2\" already exists\r\n"
      ]
     }
    ],
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "422fce1b",
    "metadata": {},
    "outputs": [
@@ -109,7 +109,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-certs\r\n",
-      "LAST DEPLOYED: Wed May 31 19:07:52 2023\r\n",
+      "LAST DEPLOYED: Wed Jun 21 10:29:32 2023\r\n",
       "NAMESPACE: ns1\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "df456290",
    "metadata": {},
    "outputs": [
@@ -132,7 +132,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-certs\r\n",
-      "LAST DEPLOYED: Wed May 31 19:07:54 2023\r\n",
+      "LAST DEPLOYED: Wed Jun 21 10:29:34 2023\r\n",
       "NAMESPACE: ns2\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "6a9cdb85",
    "metadata": {},
    "outputs": [
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "71bf922e",
    "metadata": {},
    "outputs": [
@@ -197,7 +197,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2\r\n",
-      "LAST DEPLOYED: Wed May 31 19:08:00 2023\r\n",
+      "LAST DEPLOYED: Wed Jun 21 10:29:40 2023\r\n",
       "NAMESPACE: seldon-mesh\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "e28147b1",
    "metadata": {},
    "outputs": [
@@ -220,7 +220,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-runtime\r\n",
-      "LAST DEPLOYED: Wed May 31 19:08:23 2023\r\n",
+      "LAST DEPLOYED: Wed Jun 21 10:30:26 2023\r\n",
       "NAMESPACE: ns1\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -234,7 +234,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
+   "id": "2864216b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NAME: seldon-v2-servers\r\n",
+      "LAST DEPLOYED: Wed Jun 21 10:30:41 2023\r\n",
+      "NAMESPACE: ns1\r\n",
+      "STATUS: deployed\r\n",
+      "REVISION: 1\r\n",
+      "TEST SUITE: None\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!helm install seldon-v2-servers ../k8s/helm-charts/seldon-core-v2-servers  -n ns1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "4423b5f5",
    "metadata": {},
    "outputs": [
@@ -243,7 +266,7 @@
      "output_type": "stream",
      "text": [
       "NAME: seldon-v2-runtime\r\n",
-      "LAST DEPLOYED: Wed May 31 19:09:54 2023\r\n",
+      "LAST DEPLOYED: Wed Jun 21 10:30:44 2023\r\n",
       "NAMESPACE: ns2\r\n",
       "STATUS: deployed\r\n",
       "REVISION: 1\r\n",
@@ -257,7 +280,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
+   "id": "477c43a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NAME: seldon-v2-servers\r\n",
+      "LAST DEPLOYED: Wed Jun 21 10:31:00 2023\r\n",
+      "NAMESPACE: ns2\r\n",
+      "STATUS: deployed\r\n",
+      "REVISION: 1\r\n",
+      "TEST SUITE: None\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!helm install seldon-v2-servers ../k8s/helm-charts/seldon-core-v2-servers  -n ns2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "id": "5f781131",
    "metadata": {},
    "outputs": [
@@ -276,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "af734add",
    "metadata": {},
    "outputs": [
@@ -303,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "id": "3835b3dc",
    "metadata": {},
    "outputs": [
@@ -313,7 +359,7 @@
        "'172.21.255.2'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -328,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "id": "33f7a263",
    "metadata": {},
    "outputs": [
@@ -338,7 +384,7 @@
        "'172.21.255.4'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -353,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "id": "181faf47",
    "metadata": {},
    "outputs": [],
@@ -363,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "id": "5db513b9",
    "metadata": {},
    "outputs": [],
@@ -381,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 35,
    "id": "fc5fdee5",
    "metadata": {},
    "outputs": [
@@ -399,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 36,
    "id": "5c1328c8",
    "metadata": {},
    "outputs": [
@@ -417,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 37,
    "id": "d048aa51",
    "metadata": {},
    "outputs": [
@@ -428,7 +474,7 @@
       "{\r\n",
       "\t\"model_name\": \"iris_1\",\r\n",
       "\t\"model_version\": \"1\",\r\n",
-      "\t\"id\": \"1591cb0c-ec67-4f43-8fb7-1e910f94ee66\",\r\n",
+      "\t\"id\": \"d7ba2bcb-b901-4c39-a91e-0e19b67a9d19\",\r\n",
       "\t\"parameters\": {},\r\n",
       "\t\"outputs\": [\r\n",
       "\t\t{\r\n",
@@ -438,6 +484,9 @@
       "\t\t\t\t1\r\n",
       "\t\t\t],\r\n",
       "\t\t\t\"datatype\": \"INT64\",\r\n",
+      "\t\t\t\"parameters\": {\r\n",
+      "\t\t\t\t\"content_type\": \"np\"\r\n",
+      "\t\t\t},\r\n",
       "\t\t\t\"data\": [\r\n",
       "\t\t\t\t2\r\n",
       "\t\t\t]\r\n",
@@ -462,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 38,
    "id": "5e2e72aa",
    "metadata": {},
    "outputs": [
@@ -480,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 39,
    "id": "6cb7f562",
    "metadata": {},
    "outputs": [
@@ -498,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 40,
    "id": "4f116773",
    "metadata": {},
    "outputs": [
@@ -509,7 +558,7 @@
       "{\r\n",
       "\t\"model_name\": \"iris_1\",\r\n",
       "\t\"model_version\": \"1\",\r\n",
-      "\t\"id\": \"572a191c-4f0d-4841-853e-0cfcf5ba8464\",\r\n",
+      "\t\"id\": \"cd07f18a-a408-4365-8924-75e4db3bfaf9\",\r\n",
       "\t\"parameters\": {},\r\n",
       "\t\"outputs\": [\r\n",
       "\t\t{\r\n",
@@ -519,6 +568,9 @@
       "\t\t\t\t1\r\n",
       "\t\t\t],\r\n",
       "\t\t\t\"datatype\": \"INT64\",\r\n",
+      "\t\t\t\"parameters\": {\r\n",
+      "\t\t\t\t\"content_type\": \"np\"\r\n",
+      "\t\t\t},\r\n",
       "\t\t\t\"data\": [\r\n",
       "\t\t\t\t2\r\n",
       "\t\t\t]\r\n",
@@ -543,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 41,
    "id": "11d99aac",
    "metadata": {},
    "outputs": [
@@ -561,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 42,
    "id": "d91cd84a",
    "metadata": {},
    "outputs": [
@@ -579,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 43,
    "id": "3a84da13",
    "metadata": {},
    "outputs": [
@@ -587,19 +639,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "release \"seldon-v2-servers\" uninstalled\n",
       "release \"seldon-v2-runtime\" uninstalled\n",
       "release \"seldon-v2-certs\" uninstalled\n"
      ]
     }
    ],
    "source": [
+    "!helm delete seldon-v2-servers -n ns1\n",
     "!helm delete seldon-v2-runtime -n ns1\n",
     "!helm delete seldon-v2-certs -n ns1"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 44,
    "id": "a5e6e07c",
    "metadata": {},
    "outputs": [
@@ -608,18 +662,20 @@
      "output_type": "stream",
      "text": [
       "release \"seldon-v2-runtime\" uninstalled\n",
+      "Error: uninstall: Release not loaded: seldon-v2-runtime: release: not found\n",
       "release \"seldon-v2-certs\" uninstalled\n"
      ]
     }
    ],
    "source": [
     "!helm delete seldon-v2-runtime -n ns2\n",
+    "!helm delete seldon-v2-runtime -n ns2\n",
     "!helm delete seldon-v2-certs -n ns2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 45,
    "id": "4b13fb4a",
    "metadata": {},
    "outputs": [
@@ -637,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 46,
    "id": "89b13117",
    "metadata": {},
    "outputs": [
@@ -655,7 +711,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "f06f0dac",
    "metadata": {},
    "outputs": [
@@ -663,8 +719,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "namespace \"ns1\" deleted\n",
-      "namespace \"ns2\" deleted\n"
+      "namespace \"ns1\" deleted\r\n"
      ]
     }
    ],


### PR DESCRIPTION
At present changes to SeldonConfig do not cause a reconcile of associated SeldonRuntimes and ServerConfig changes do not cause a reconcile for Servers. This would hamper rollout of changes.

There is not a direct ownership from SeldonConfigs to SeldonRuntimes or ServerConfigs to Servers as SeldonRuntimes and Servers are created later and have a `spec` link to an associated config.

The solution is to add to the controllers watches with custom reconcile e.g.

```
Watches(
			&source.Kind{Type: &mlopsv1alpha1.SeldonConfig{}},
			handler.EnqueueRequestsFromMapFunc(r.mapSeldonRuntimesFromSeldonConfig),
		).
```

where we add 
```
// Find SeldonRuntimes that reference the changes SeldonConfig
func (r *SeldonRuntimeReconciler) mapSeldonRuntimesFromSeldonConfig(obj client.Object) []reconcile.Request {
	logger := log.FromContext(context.Background()).WithName("mapSeldonRuntimesFromSeldonConfig")
	var seldonRuntimes mlopsv1alpha1.SeldonRuntimeList
	if err := r.Client.List(context.Background(), &seldonRuntimes); err != nil {
		logger.Error(err, "error listing seldonRuntimes")
		return nil
	}

	seldonConfig := obj.(*mlopsv1alpha1.SeldonConfig)
	var req []reconcile.Request
	for _, seldonRuntime := range seldonRuntimes.Items {
		if seldonRuntime.Spec.SeldonConfig == seldonConfig.Name {
			req = append(req, reconcile.Request{
				NamespacedName: types.NamespacedName{
					Namespace: seldonRuntime.Namespace,
					Name:      seldonRuntime.Name,
				},
			})
		}
	}
	return req
}
``` 