### PR TITLE
fix: Only create kafka config once in model gateway

### DIFF
--- a/scheduler/cmd/modelgateway/main.go
+++ b/scheduler/cmd/modelgateway/main.go
@@ -142,8 +142,8 @@ func main() {
 		HttpPort: envoyPort,
 		GrpcPort: envoyPort,
 	}
-	consumerConfig := gateway.ConsumerConfig{
-		KafkaConfig:           kafkaConfigMap,
+	consumerConfig := gateway.ManagerConfig{
+		SeldonKafkaConfig:     kafkaConfigMap,
 		Namespace:             namespace,
 		InferenceServerConfig: inferServerConfig,
 		TraceProvider:         tracer,

--- a/scheduler/cmd/modelgateway/main.go
+++ b/scheduler/cmd/modelgateway/main.go
@@ -149,8 +149,11 @@ func main() {
 		TraceProvider:         tracer,
 		NumWorkers:            getEnVar(logger, gateway.EnvVarNumWorkers, gateway.DefaultNumWorkers),
 	}
-	kafkaConsumer := gateway.NewConsumerManager(logger, &consumerConfig,
+	kafkaConsumer, err := gateway.NewConsumerManager(logger, &consumerConfig,
 		getEnVar(logger, gateway.EnvMaxNumConsumers, gateway.DefaultMaxNumConsumers))
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to create consumer manager")
+	}
 	defer kafkaConsumer.Stop()
 
 	kafkaSchedulerClient := gateway.NewKafkaSchedulerClient(logger, kafkaConsumer)

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -55,7 +55,7 @@ type InferKafkaHandler struct {
 	done              chan bool
 	tracer            trace.Tracer
 	topicNamer        *kafka2.TopicNamer
-	consumerConfig    *ConsumerConfig
+	consumerConfig    *ManagerConfig
 	adminClient       *kafka.AdminClient
 	consumerName      string
 	replicationFactor int
@@ -66,7 +66,7 @@ type InferKafkaHandler struct {
 }
 
 func NewInferKafkaHandler(logger log.FieldLogger,
-	consumerConfig *ConsumerConfig,
+	consumerConfig *ManagerConfig,
 	consumerConfigMap kafka.ConfigMap,
 	producerConfigMap kafka.ConfigMap,
 	consumerName string) (*InferKafkaHandler, error) {
@@ -82,7 +82,7 @@ func NewInferKafkaHandler(logger log.FieldLogger,
 	if err != nil {
 		return nil, err
 	}
-	topicNamer, err := kafka2.NewTopicNamer(consumerConfig.Namespace, consumerConfig.KafkaConfig.TopicPrefix)
+	topicNamer, err := kafka2.NewTopicNamer(consumerConfig.Namespace, consumerConfig.SeldonKafkaConfig.TopicPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (kc *InferKafkaHandler) setup(consumerConfig kafka.ConfigMap, producerConfi
 	}
 	logger.Infof("Created consumer %s", kc.consumer.String())
 
-	if kc.consumerConfig.KafkaConfig.HasKafkaBootstrapServer() {
+	if kc.consumerConfig.SeldonKafkaConfig.HasKafkaBootstrapServer() {
 		kc.adminClient, err = kafka.NewAdminClient(&consumerConfig)
 		if err != nil {
 			return err

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -18,7 +18,6 @@ package gateway
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -32,7 +31,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	kafka2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka"
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/config"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
@@ -67,7 +65,11 @@ type InferKafkaHandler struct {
 	producerActive    atomic.Bool
 }
 
-func NewInferKafkaHandler(logger log.FieldLogger, consumerConfig *ConsumerConfig, consumerName string) (*InferKafkaHandler, error) {
+func NewInferKafkaHandler(logger log.FieldLogger,
+	consumerConfig *ConsumerConfig,
+	consumerConfigMap kafka.ConfigMap,
+	producerConfigMap kafka.ConfigMap,
+	consumerName string) (*InferKafkaHandler, error) {
 	replicationFactor, err := util.GetIntEnvar(envDefaultReplicationFactor, defaultReplicationFactor)
 	if err != nil {
 		return nil, err
@@ -97,26 +99,13 @@ func NewInferKafkaHandler(logger log.FieldLogger, consumerConfig *ConsumerConfig
 		numPartitions:     numPartitions,
 		tlsClientOptions:  tlsClientOptions,
 	}
-	return ic, ic.setup()
+	return ic, ic.setup(consumerConfigMap, producerConfigMap)
 }
 
-func (kc *InferKafkaHandler) setup() error {
+func (kc *InferKafkaHandler) setup(consumerConfig kafka.ConfigMap, producerConfig kafka.ConfigMap) error {
 	logger := kc.logger.WithField("func", "setup")
 	var err error
 
-	producerConfig := config.CloneKafkaConfigMap(kc.consumerConfig.KafkaConfig.Producer)
-	producerConfig["go.delivery.reports"] = true
-	err = config.AddKafkaSSLOptions(producerConfig)
-	if err != nil {
-		return err
-	}
-
-	producerConfigAsJSON, err := json.Marshal(&producerConfig)
-	if err != nil {
-		logger.WithField("config", &producerConfig).Info("Creating producer")
-	} else {
-		logger.WithField("config", string(producerConfigAsJSON)).Info("Creating producer")
-	}
 	kc.logger.Infof("Creating producer with config %v", producerConfig)
 	kc.producer, err = kafka.NewProducer(&producerConfig)
 	if err != nil {
@@ -125,23 +114,11 @@ func (kc *InferKafkaHandler) setup() error {
 	kc.producerActive.Store(true)
 	logger.Infof("Created producer %s", kc.producer.String())
 
-	consumerConfig := config.CloneKafkaConfigMap(kc.consumerConfig.KafkaConfig.Consumer)
 	// we map topics consistently to consumers and we choose the consumer group.id based on this mapping
 	// for eg. hash(topic1) -> modelgateway-0
 	// this is done by the caller i.e. ConsumerManager (store.go)
 	consumerConfig["group.id"] = kc.consumerName
-	err = config.AddKafkaSSLOptions(consumerConfig)
-	if err != nil {
-		return err
-	}
-
-	consumerConfigAsJson, err := json.Marshal(&consumerConfig)
-	if err != nil {
-		logger.WithField("config", &consumerConfig).Info("Creating consumer")
-	} else {
-		logger.WithField("config", string(consumerConfigAsJson)).Info("Creating consumer")
-	}
-
+	kc.logger.Infof("Creating consumer with config %v", consumerConfig)
 	kc.consumer, err = kafka.NewConsumer(&consumerConfig)
 	if err != nil {
 		return err

--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -17,8 +17,10 @@ limitations under the License.
 package gateway
 
 import (
+	"encoding/json"
 	"sync"
 
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/config"
@@ -36,9 +38,11 @@ type ConsumerManager struct {
 	logger log.FieldLogger
 	mu     sync.Mutex
 	// all consumers we have
-	consumers       map[string]*InferKafkaHandler
-	consumerConfig  *ConsumerConfig
-	maxNumConsumers int
+	consumers         map[string]*InferKafkaHandler
+	managerConfig     *ConsumerConfig
+	maxNumConsumers   int
+	consumerConfigMap kafka.ConfigMap
+	producerConfigMap kafka.ConfigMap
 }
 
 type ConsumerConfig struct {
@@ -49,13 +53,62 @@ type ConsumerConfig struct {
 	NumWorkers            int // infer workers
 }
 
-func NewConsumerManager(logger log.FieldLogger, consumerConfig *ConsumerConfig, maxNumConsumers int) *ConsumerManager {
-	return &ConsumerManager{
+func cloneKafkaConfigMap(m kafka.ConfigMap) kafka.ConfigMap {
+	m2 := make(kafka.ConfigMap)
+	for k, v := range m {
+		m2[k] = v
+	}
+	return m2
+}
+
+func NewConsumerManager(logger log.FieldLogger, managerConfig *ConsumerConfig, maxNumConsumers int) (*ConsumerManager, error) {
+	cm := &ConsumerManager{
 		logger:          logger.WithField("source", "ConsumerManager"),
-		consumerConfig:  consumerConfig,
+		managerConfig:   managerConfig,
 		consumers:       make(map[string]*InferKafkaHandler),
 		maxNumConsumers: maxNumConsumers,
 	}
+	err := cm.createKafkaConfigs(managerConfig)
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+func (cm *ConsumerManager) createKafkaConfigs(kafkaConfig *ConsumerConfig) error {
+	logger := cm.logger.WithField("func", "createKafkaConfigs")
+	var err error
+
+	producerConfigMap := config.CloneKafkaConfigMap(kafkaConfig.KafkaConfig.Producer)
+	producerConfigMap["go.delivery.reports"] = true
+	err = config.AddKafkaSSLOptions(producerConfigMap)
+	if err != nil {
+		return err
+	}
+
+	producerConfigAsJSON, err := json.Marshal(&producerConfigMap)
+	if err != nil {
+		logger.WithField("config", &producerConfigMap).Info("Creating producer config for use later")
+	} else {
+		logger.WithField("config", string(producerConfigAsJSON)).Info("Creating producer config for use later")
+	}
+
+	consumerConfigMap := config.CloneKafkaConfigMap(kafkaConfig.KafkaConfig.Consumer)
+	err = config.AddKafkaSSLOptions(consumerConfigMap)
+	if err != nil {
+		return err
+	}
+
+	consumerConfigAsJson, err := json.Marshal(&consumerConfigMap)
+	if err != nil {
+		logger.WithField("config", &consumerConfigMap).Info("Creating consumer config for use later")
+	} else {
+		logger.WithField("config", string(consumerConfigAsJson)).Info("Creating consumer config for use later")
+	}
+
+	cm.consumerConfigMap = consumerConfigMap
+	cm.producerConfigMap = producerConfigMap
+	return nil
 }
 
 func (cm *ConsumerManager) getInferKafkaConsumer(modelName string, create bool) (*InferKafkaHandler, error) {
@@ -69,7 +122,11 @@ func (cm *ConsumerManager) getInferKafkaConsumer(modelName string, create bool) 
 
 	if !ok {
 		var err error
-		ic, err = NewInferKafkaHandler(cm.logger, cm.consumerConfig, consumerBucketId)
+		ic, err = NewInferKafkaHandler(cm.logger,
+			cm.managerConfig,
+			cloneKafkaConfigMap(cm.consumerConfigMap),
+			cloneKafkaConfigMap(cm.producerConfigMap),
+			consumerBucketId)
 		if err != nil {
 			return nil, err
 		}

--- a/scheduler/pkg/kafka/gateway/manager_test.go
+++ b/scheduler/pkg/kafka/gateway/manager_test.go
@@ -73,7 +73,7 @@ func TestAddRemoveModel(t *testing.T) {
 			}
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
-			c := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
+			c := &ManagerConfig{SeldonKafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
 			cm, err := NewConsumerManager(logger, c, test.numConsumers)
 			g.Expect(err).To(BeNil())
 			for _, model := range test.models {
@@ -117,7 +117,7 @@ func TestConsistentModelToConsumer(t *testing.T) {
 			}
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
-			c := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
+			c := &ManagerConfig{SeldonKafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
 			cm, err := NewConsumerManager(logger, c, 10)
 			g.Expect(err).To(BeNil())
 			ic, _ := cm.getInferKafkaConsumer(test.model, true)

--- a/scheduler/pkg/kafka/gateway/manager_test.go
+++ b/scheduler/pkg/kafka/gateway/manager_test.go
@@ -74,7 +74,8 @@ func TestAddRemoveModel(t *testing.T) {
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
 			c := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
-			cm := NewConsumerManager(logger, c, test.numConsumers)
+			cm, err := NewConsumerManager(logger, c, test.numConsumers)
+			g.Expect(err).To(BeNil())
 			for _, model := range test.models {
 				err := cm.AddModel(model)
 				g.Expect(err).To(BeNil())
@@ -117,7 +118,8 @@ func TestConsistentModelToConsumer(t *testing.T) {
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
 			c := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
-			cm := NewConsumerManager(logger, c, 10)
+			cm, err := NewConsumerManager(logger, c, 10)
+			g.Expect(err).To(BeNil())
 			ic, _ := cm.getInferKafkaConsumer(test.model, true)
 			ic2, _ := cm.getInferKafkaConsumer(test.model, false)
 			g.Expect(ic).To(Equal(ic2))

--- a/scheduler/pkg/kafka/gateway/worker_test.go
+++ b/scheduler/pkg/kafka/gateway/worker_test.go
@@ -89,7 +89,7 @@ func TestRestRequest(t *testing.T) {
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
 			config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
-			ic, err := NewInferKafkaHandler(logger, config, "dummy")
+			ic, err := NewInferKafkaHandler(logger, config, kafka.ConfigMap{}, kafka.ConfigMap{}, "dummy")
 			g.Expect(err).To(BeNil())
 			tn, err := kafka2.NewTopicNamer("default", "seldon")
 			g.Expect(err).To(BeNil())
@@ -136,7 +136,7 @@ func TestProcessRequestRest(t *testing.T) {
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
 			config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
-			ic, err := NewInferKafkaHandler(logger, config, "dummy")
+			ic, err := NewInferKafkaHandler(logger, config, kafka.ConfigMap{}, kafka.ConfigMap{}, "dummy")
 			g.Expect(err).To(BeNil())
 			tn, err := kafka2.NewTopicNamer("default", "seldon")
 			g.Expect(err).To(BeNil())
@@ -210,7 +210,7 @@ func createInferWorkerWithMockConn(
 	tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 	g.Expect(err).To(BeNil())
 	config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: serverConfig, TraceProvider: tp, NumWorkers: 0}
-	ic, err := NewInferKafkaHandler(logger, config, "dummy")
+	ic, err := NewInferKafkaHandler(logger, config, kafka.ConfigMap{}, kafka.ConfigMap{}, "dummy")
 	g.Expect(err).To(BeNil())
 	topicNamer, err := kafka2.NewTopicNamer("default", "seldon")
 	g.Expect(err).To(BeNil())

--- a/scheduler/pkg/kafka/gateway/worker_test.go
+++ b/scheduler/pkg/kafka/gateway/worker_test.go
@@ -88,7 +88,7 @@ func TestRestRequest(t *testing.T) {
 			logger := log.New()
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
-			config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
+			config := &ManagerConfig{SeldonKafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
 			ic, err := NewInferKafkaHandler(logger, config, kafka.ConfigMap{}, kafka.ConfigMap{}, "dummy")
 			g.Expect(err).To(BeNil())
 			tn, err := kafka2.NewTopicNamer("default", "seldon")
@@ -135,7 +135,7 @@ func TestProcessRequestRest(t *testing.T) {
 			logger := log.New()
 			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 			g.Expect(err).To(BeNil())
-			config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
+			config := &ManagerConfig{SeldonKafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
 			ic, err := NewInferKafkaHandler(logger, config, kafka.ConfigMap{}, kafka.ConfigMap{}, "dummy")
 			g.Expect(err).To(BeNil())
 			tn, err := kafka2.NewTopicNamer("default", "seldon")
@@ -209,7 +209,7 @@ func createInferWorkerWithMockConn(
 	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	tp, err := seldontracer.NewTraceProvider("test", nil, logger)
 	g.Expect(err).To(BeNil())
-	config := &ConsumerConfig{KafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: serverConfig, TraceProvider: tp, NumWorkers: 0}
+	config := &ManagerConfig{SeldonKafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: serverConfig, TraceProvider: tp, NumWorkers: 0}
 	ic, err := NewInferKafkaHandler(logger, config, kafka.ConfigMap{}, kafka.ConfigMap{}, "dummy")
 	g.Expect(err).To(BeNil())
 	topicNamer, err := kafka2.NewTopicNamer("default", "seldon")


### PR DESCRIPTION
Fixes: #4936 

At present the model gateway creates Kafka config every time a new consumer/producer is required. This is wasteful especially when TLS with k8s secrets are used as k8s calls to get the secret contents are required. This also seems to create a race condition as secrets are saved to disk at the same location. This change creates the config only once and copies it for each consumer/produced needed.

In future, we should change to pass the certificates directly now [this issue](https://github.com/confluentinc/confluent-kafka-go/issues/827) is fixed. However, we need to wait for a [splunk otel kafka PR](https://github.com/signalfx/splunk-otel-go/pull/2301) to upgrade to v2 of confluent kafka-go to allow an easy change as one needs to change to a new module version for confluent go v2 which  is where the issue fixed is released.

A future PR can do the kafka change to not use files for ca.crt and other certificates.