### PR TITLE
fix: Fix test logic, get rid of k6 warning

### DIFF
--- a/tests/k6/components/v2.js
+++ b/tests/k6/components/v2.js
@@ -9,7 +9,7 @@ v2Client.load(['../../../apis/mlops/v2_dataplane/'], 'v2_dataplane.proto');
 export function inferHttp(endpoint, modelName, payload, viaEnvoy, pipelineSuffix) {
     const url = endpoint + "/v2/models/"+modelName+"/infer"
     const payloadStr = JSON.stringify(payload);
-    var headers = {
+    var metadata = {
         'Content-Type': 'application/json',
         'Host': modelName,
         // we add here either .model or .pipeline to test dataflow
@@ -18,10 +18,10 @@ export function inferHttp(endpoint, modelName, payload, viaEnvoy, pipelineSuffix
         'Accept-Encoding': 'entity',
     };
     if (viaEnvoy != true) {
-        headers['seldon-internal-model'] = modelName
+        metadata['seldon-internal-model'] = modelName
     }
     const params = {
-        headers:  headers
+        metadata:  metadata
     };
     //console.log("URL:",url,"Payload:",payloadStr,"Params:",JSON.stringify(params))
     const response = http.post(url, payloadStr, params);
@@ -36,15 +36,15 @@ export function inferHttpLoop(endpoint, modelName, payload, iterations, viaEnvoy
 }
 
 export function inferGrpc(modelName, payload, viaEnvoy, pipelineSuffix) {
-    var headers = {
+    var metadata = {
         // we add here either .model or .pipeline to test dataflow
         'seldon-model': generateDataFlowName(modelName, pipelineSuffix),
     };
     if (viaEnvoy != true) {
-        headers['seldon-internal-model'] = modelName
+        metadata['seldon-internal-model'] = modelName
     }
     const params = {
-        headers: headers
+        metadata: metadata
     };
     payload.model_name = modelName
     const response = v2Client.invoke('inference.GRPCInferenceService/ModelInfer', payload, params);
@@ -62,16 +62,16 @@ export function inferGrpcLoop(endpoint, modelName, payload, iterations, viaEnvoy
 
 export function modelStatusHttp(endpoint, modelName, viaEnvoy = true) {
     const url = endpoint + "/v2/models/"+modelName+"/ready"
-    var headers = {
+    var metadata = {
         'Content-Type': 'application/json',
         'Host' : modelName,
         'seldon-model' : modelName,
     };
     if (viaEnvoy != true) {
-        headers['seldon-internal-model'] = modelName
+        metadata['seldon-internal-model'] = modelName
     }
     const params = {
-        headers: headers
+        metadata: metadata
     };
     const response = http.get(url, params);
     return response.status

--- a/tests/k6/scenarios/infer_constant_vu.js
+++ b/tests/k6/scenarios/infer_constant_vu.js
@@ -31,11 +31,24 @@ export default function (config) {
 
     const modelNameWithVersion = modelName + getVersionSuffix(config.isSchedulerProxy)  // first version
 
-    const rand = Math.random()
-    if (rand > 0.5) {
+    // the settings here can be either 0/"0" or 1/"1"
+    // so we can use them in boolean context to check if a protocol is enabled for the test
+    var rest_enabled = Number(config.inferHttpIterations)
+    var grpc_enabled = Number(config.inferGrpcIterations)
+    if (rest_enabled && grpc_enabled) {
+        // if both protocols are enabled, choose one randomly
+        const rand = Math.random()
+        if (rand > 0.5) {
+            doInfer(modelName, modelNameWithVersion, config, true, idx) // rest
+        } else {
+            doInfer(modelName, modelNameWithVersion, config, false, idx) // grpc
+        }
+    } else if (rest_enabled) {
         doInfer(modelName, modelNameWithVersion, config, true, idx)
-    } else {
+    } else if (grpc_enabled) {
         doInfer(modelName, modelNameWithVersion, config, false, idx)
+    } else {
+        throw new Error('Both REST and GRPC protocols are disabled!')
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Two things:
1. Gets rid of "The headers property is deprecated, replace it with the metadata property, please." warning from k6
2. Fixes logic in "infer_constant_vu.js" scenario so that we don't skip iterations when using only one protocol for test

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
tested by running locally
