### PR TITLE
fix: use python3 in k6 builder image

### DIFF
--- a/tests/k6/Dockerfile.k6
+++ b/tests/k6/Dockerfile.k6
@@ -1,7 +1,7 @@
 FROM alpine:3.6 AS builder
 
 RUN apk add --update \
- python \
+ python3 \
  curl \
  which \
  bash


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

We use python3 now for building Google Cloud CLI.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
