### PR TITLE
fix: remove last applied annotation in operator when adding annotations

### DIFF
--- a/operator/pkg/utils/utils.go
+++ b/operator/pkg/utils/utils.go
@@ -57,6 +57,7 @@ func MergeMaps(child map[string]string, parent map[string]string) map[string]str
 	// remove any keys we want to ignore
 	delete(merged, "meta.helm.sh/release-name")
 	delete(merged, "meta.helm.sh/release-namespace")
+	delete(merged, "kubectl.kubernetes.io/last-applied-configuration")
 	return merged
 }
 


### PR DESCRIPTION
We need to remove the annotation `kubectl.kubernetes.io/last-applied-configuration` if it appears in custom resources so they don't get pushed down to the owned resources causing all owned resources to be recreated on any change. This is most apprarent for stateful sets such as Servers where a change for `replicas` would cause always all underplying pods to be restarted even when you might need to just add or remove some replica pods.