### PR TITLE
fix(kafka): Fix kafka credentials leaked into logs in Go components

### DIFF
--- a/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
+++ b/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
@@ -15,7 +15,7 @@ The referenced SASL/SCRAM YAML file looks like the below:
 This will use the Strimzi Helm chart provided in Core v2.
 This will call the Strimzi cluster Helm chart provided by the project with overrides for the cluster authentication type and will also create a user `seldon` with password credentials in a Kubernetes Secret.
 
-Install seldon with sasl settings using a custom values file.
+Install Core v2 with SASL settings using a custom values file.
 This sets the secret created by Strimzi for the user created above (`seldon`) and targets the server certificate authority secret from the name of the cluster created on install of the Kafka cluster (`seldon-cluster-ca-cert`).
 
 ```{literalinclude} ../../../../../../k8s/samples/values-strimzi-kafka-sasl-scram.yaml

--- a/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
+++ b/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
@@ -1,6 +1,7 @@
 # Strimzi SASL Example
 
-Create a Strimzi Kafka cluster with SASL_SSL enabled. This can be done with our Ansible scripts during ecosystem setup by running from the project ansible folder:
+Create a Strimzi Kafka cluster with SASL_SSL enabled.
+This can be done with our Ansible scripts by running the following from the `ansible/` folder:
 
 ```
 ansible-playbook playbooks/setup-ecosystem.yaml -e kafka_cluster_values_files=${PWD}/../k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml -e strimzi_kafka_operator_feature_gates=""

--- a/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
+++ b/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
@@ -4,16 +4,19 @@ Create a Strimzi Kafka cluster with SASL_SSL enabled.
 This can be done with our Ansible scripts by running the following from the `ansible/` folder:
 
 ```
-ansible-playbook playbooks/setup-ecosystem.yaml -e kafka_cluster_values_files=${PWD}/../k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml -e strimzi_kafka_operator_feature_gates=""
+ansible-playbook playbooks/setup-ecosystem.yaml -e @../k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml -e strimzi_kafka_operator_feature_gates=""
 ```
 
-This will call the Strimzi cluster Helm chart provided by the project with overrides for the cluster authentication type and will also create a user `seldon` with password credentials in a Kubernetes Secret:
-
+The referenced SASL/SCRAM YAML file looks like the below:
 ```{literalinclude} ../../../../../../k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml
 :language: yaml
 ```
 
-Install seldon with sasl settings using a custom values file. This sets the secret created by Strimzi for the user created above (`seldon`) and targets the server certificate authority secret from the name of the cluster created on install of the Kafka cluster (`seldon-cluster-ca-cert`). 
+This will use the Strimzi Helm chart provided in Core v2.
+This will call the Strimzi cluster Helm chart provided by the project with overrides for the cluster authentication type and will also create a user `seldon` with password credentials in a Kubernetes Secret.
+
+Install seldon with sasl settings using a custom values file.
+This sets the secret created by Strimzi for the user created above (`seldon`) and targets the server certificate authority secret from the name of the cluster created on install of the Kafka cluster (`seldon-cluster-ca-cert`).
 
 ```{literalinclude} ../../../../../../k8s/samples/values-strimzi-kafka-sasl-scram.yaml
 :language: yaml

--- a/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
+++ b/docs/source/contents/getting-started/kubernetes-installation/security/strimzi-sasl.md
@@ -3,7 +3,7 @@
 Create a Strimzi Kafka cluster with SASL_SSL enabled. This can be done with our Ansible scripts during ecosystem setup by running from the project ansible folder:
 
 ```
-ansible-playbook playbooks/setup-ecosystem.yaml -e kafka_cluster_values_files=${PWD}/../k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml -e strimzi_kafka_add_feature_gates=false
+ansible-playbook playbooks/setup-ecosystem.yaml -e kafka_cluster_values_files=${PWD}/../k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml -e strimzi_kafka_operator_feature_gates=""
 ```
 
 This will call the Strimzi cluster Helm chart provided by the project with overrides for the cluster authentication type and will also create a user `seldon` with password credentials in a Kubernetes Secret:

--- a/k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml
+++ b/k8s/samples/ansible-strimzi-kafka-sasl-scram.yaml
@@ -1,4 +1,5 @@
-broker:
-  tls:
-    authentication:
-      type: scram-sha-512
+seldon_kafka_cluster_values:
+  broker:
+    tls:
+      authentication:
+        type: scram-sha-512

--- a/scheduler/pkg/kafka/config/config.go
+++ b/scheduler/pkg/kafka/config/config.go
@@ -130,7 +130,7 @@ var secretConfigFields = map[string]struct{}{
 	"sasl.oauthbearer.client.secret": struct{}{},
 }
 
-func ToLogSafeConfig(c kafka.ConfigMap) kafka.ConfigMap {
+func WithoutSecrets(c kafka.ConfigMap) kafka.ConfigMap {
 	safe := make(kafka.ConfigMap)
 
 	for k, v := range c {

--- a/scheduler/pkg/kafka/config/config.go
+++ b/scheduler/pkg/kafka/config/config.go
@@ -38,6 +38,18 @@ const (
 	KafkaDebug            = "debug"
 )
 
+// Based on config options defined for librdkafka:
+// https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+var secretConfigFields = map[string]struct{}{
+	"ssl.key.password":               struct{}{},
+	"ssl.key.pem":                    struct{}{},
+	"ssl_key":                        struct{}{},
+	"ssl.keystore.password":          struct{}{},
+	"sasl.username":                  struct{}{},
+	"sasl.password":                  struct{}{},
+	"sasl.oauthbearer.client.secret": struct{}{},
+}
+
 func CloneKafkaConfigMap(m kafka.ConfigMap) kafka.ConfigMap {
 	m2 := make(kafka.ConfigMap)
 	for k, v := range m {
@@ -116,18 +128,6 @@ func convertConfigMap(cm kafka.ConfigMap) (kafka.ConfigMap, error) {
 func (kc KafkaConfig) HasKafkaBootstrapServer() bool {
 	bs := kc.Consumer[KafkaBootstrapServers]
 	return bs != nil && bs != ""
-}
-
-// Based on config options defined for librdkafka:
-// https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
-var secretConfigFields = map[string]struct{}{
-	"ssl.key.password":               struct{}{},
-	"ssl.key.pem":                    struct{}{},
-	"ssl_key":                        struct{}{},
-	"ssl.keystore.password":          struct{}{},
-	"sasl.username":                  struct{}{},
-	"sasl.password":                  struct{}{},
-	"sasl.oauthbearer.client.secret": struct{}{},
 }
 
 func WithoutSecrets(c kafka.ConfigMap) kafka.ConfigMap {

--- a/scheduler/pkg/kafka/config/config.go
+++ b/scheduler/pkg/kafka/config/config.go
@@ -33,6 +33,9 @@ type KafkaConfig struct {
 	TopicPrefix      string          `json:"topicPrefix,omitempty"`
 }
 
+type none = struct{}
+type stringSet = map[string]none
+
 const (
 	KafkaBootstrapServers = "bootstrap.servers"
 	KafkaDebug            = "debug"
@@ -40,14 +43,15 @@ const (
 
 // Based on config options defined for librdkafka:
 // https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+var empty = struct{}{}
 var secretConfigFields = map[string]struct{}{
-	"ssl.key.password":               struct{}{},
-	"ssl.key.pem":                    struct{}{},
-	"ssl_key":                        struct{}{},
-	"ssl.keystore.password":          struct{}{},
-	"sasl.username":                  struct{}{},
-	"sasl.password":                  struct{}{},
-	"sasl.oauthbearer.client.secret": struct{}{},
+	"ssl.key.password":               empty,
+	"ssl.key.pem":                    empty,
+	"ssl_key":                        empty,
+	"ssl.keystore.password":          empty,
+	"sasl.username":                  empty,
+	"sasl.password":                  empty,
+	"sasl.oauthbearer.client.secret": empty,
 }
 
 func CloneKafkaConfigMap(m kafka.ConfigMap) kafka.ConfigMap {

--- a/scheduler/pkg/kafka/config/config.go
+++ b/scheduler/pkg/kafka/config/config.go
@@ -44,7 +44,7 @@ const (
 // Based on config options defined for librdkafka:
 // https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
 var empty = struct{}{}
-var secretConfigFields = map[string]struct{}{
+var secretConfigFields = stringSet{
 	"ssl.key.password":               empty,
 	"ssl.key.pem":                    empty,
 	"ssl_key":                        empty,

--- a/scheduler/pkg/kafka/config/config.go
+++ b/scheduler/pkg/kafka/config/config.go
@@ -135,7 +135,9 @@ func WithoutSecrets(c kafka.ConfigMap) kafka.ConfigMap {
 
 	for k, v := range c {
 		_, isSecret := secretConfigFields[k]
-		if !isSecret {
+		if isSecret {
+			safe[k] = "***"
+		} else {
 			safe[k] = v
 		}
 	}

--- a/scheduler/pkg/kafka/config/config.go
+++ b/scheduler/pkg/kafka/config/config.go
@@ -117,3 +117,28 @@ func (kc KafkaConfig) HasKafkaBootstrapServer() bool {
 	bs := kc.Consumer[KafkaBootstrapServers]
 	return bs != nil && bs != ""
 }
+
+// Based on config options defined for librdkafka:
+// https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+var secretConfigFields = map[string]struct{}{
+	"ssl.key.password":               struct{}{},
+	"ssl.key.pem":                    struct{}{},
+	"ssl_key":                        struct{}{},
+	"ssl.keystore.password":          struct{}{},
+	"sasl.username":                  struct{}{},
+	"sasl.password":                  struct{}{},
+	"sasl.oauthbearer.client.secret": struct{}{},
+}
+
+func ToLogSafeConfig(c kafka.ConfigMap) kafka.ConfigMap {
+	safe := make(kafka.ConfigMap)
+
+	for k, v := range c {
+		_, isSecret := secretConfigFields[k]
+		if !isSecret {
+			safe[k] = v
+		}
+	}
+
+	return safe
+}

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	kafka2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/config"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
@@ -109,7 +110,8 @@ func (kc *InferKafkaHandler) setup(consumerConfig kafka.ConfigMap, producerConfi
 	logger := kc.logger.WithField("func", "setup")
 	var err error
 
-	kc.logger.Infof("Creating producer with config %v", producerConfig)
+	producerConfigWithoutSecrets := config.WithoutSecrets(producerConfig)
+	kc.logger.Infof("Creating producer with config %v", producerConfigWithoutSecrets)
 	kc.producer, err = kafka.NewProducer(&producerConfig)
 	if err != nil {
 		return err
@@ -121,7 +123,8 @@ func (kc *InferKafkaHandler) setup(consumerConfig kafka.ConfigMap, producerConfi
 	// for eg. hash(topic1) -> modelgateway-0
 	// this is done by the caller i.e. ConsumerManager (store.go)
 	consumerConfig["group.id"] = kc.consumerName
-	kc.logger.Infof("Creating consumer with config %v", consumerConfig)
+	consumerConfigWithoutSecrets := config.WithoutSecrets(consumerConfig)
+	kc.logger.Infof("Creating consumer with config %v", consumerConfigWithoutSecrets)
 	kc.consumer, err = kafka.NewConsumer(&consumerConfig)
 	if err != nil {
 		return err

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -65,11 +65,13 @@ type InferKafkaHandler struct {
 	producerActive    atomic.Bool
 }
 
-func NewInferKafkaHandler(logger log.FieldLogger,
+func NewInferKafkaHandler(
+	logger log.FieldLogger,
 	consumerConfig *ManagerConfig,
 	consumerConfigMap kafka.ConfigMap,
 	producerConfigMap kafka.ConfigMap,
-	consumerName string) (*InferKafkaHandler, error) {
+	consumerName string,
+) (*InferKafkaHandler, error) {
 	replicationFactor, err := util.GetIntEnvar(envDefaultReplicationFactor, defaultReplicationFactor)
 	if err != nil {
 		return nil, err
@@ -86,6 +88,7 @@ func NewInferKafkaHandler(logger log.FieldLogger,
 	if err != nil {
 		return nil, err
 	}
+
 	ic := &InferKafkaHandler{
 		logger:            logger.WithField("source", "InferConsumer"),
 		done:              make(chan bool),
@@ -207,15 +210,22 @@ func (kc *InferKafkaHandler) createTopics(topicNames []string) error {
 			ReplicationFactor: kc.replicationFactor,
 		})
 	}
-	results, err := kc.adminClient.CreateTopics(context.Background(), topicSpecs, kafka.SetAdminOperationTimeout(time.Minute))
+	results, err := kc.adminClient.CreateTopics(
+		context.Background(),
+		topicSpecs,
+		kafka.SetAdminOperationTimeout(time.Minute),
+	)
 	if err != nil {
 		return err
 	}
+
 	for _, result := range results {
 		logger.Debugf("Topic result for %s", result.String())
 	}
+
 	t2 := time.Now()
 	logger.Infof("Topic created in %d millis", t2.Sub(t1).Milliseconds())
+
 	return nil
 }
 

--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -83,37 +83,37 @@ func (cm *ConsumerManager) createKafkaConfigs(kafkaConfig *ManagerConfig) error 
 	logger := cm.logger.WithField("func", "createKafkaConfigs")
 	var err error
 
-	producerConfigMap := config.CloneKafkaConfigMap(kafkaConfig.SeldonKafkaConfig.Producer)
-	producerConfigMap["go.delivery.reports"] = true
-	err = config.AddKafkaSSLOptions(producerConfigMap)
+	producerConfig := config.CloneKafkaConfigMap(kafkaConfig.SeldonKafkaConfig.Producer)
+	producerConfig["go.delivery.reports"] = true
+	err = config.AddKafkaSSLOptions(producerConfig)
 	if err != nil {
 		return err
 	}
 
-	producerConfigWithoutSecrets := config.WithoutSecrets(producerConfigMap)
-	producerConfigAsJSON, err := json.Marshal(&producerConfigWithoutSecrets)
+	producerConfigMasked := config.WithoutSecrets(producerConfig)
+	producerConfigMaskedJSON, err := json.Marshal(&producerConfigMasked)
 	if err != nil {
-		logger.WithField("config", &producerConfigWithoutSecrets).Info("Creating producer config for use later")
+		logger.WithField("config", &producerConfigMasked).Info("Creating producer config for use later")
 	} else {
-		logger.WithField("config", string(producerConfigAsJSON)).Info("Creating producer config for use later")
+		logger.WithField("config", string(producerConfigMaskedJSON)).Info("Creating producer config for use later")
 	}
 
-	consumerConfigMap := config.CloneKafkaConfigMap(kafkaConfig.SeldonKafkaConfig.Consumer)
-	err = config.AddKafkaSSLOptions(consumerConfigMap)
+	consumerConfig := config.CloneKafkaConfigMap(kafkaConfig.SeldonKafkaConfig.Consumer)
+	err = config.AddKafkaSSLOptions(consumerConfig)
 	if err != nil {
 		return err
 	}
 
-	consumerConfigWithoutSecrets := config.WithoutSecrets(consumerConfigMap)
-	consumerConfigAsJson, err := json.Marshal(&consumerConfigWithoutSecrets)
+	consumerConfigMasked := config.WithoutSecrets(consumerConfig)
+	consumerConfigMaskedJson, err := json.Marshal(&consumerConfigMasked)
 	if err != nil {
-		logger.WithField("config", &consumerConfigWithoutSecrets).Info("Creating consumer config for use later")
+		logger.WithField("config", &consumerConfigMasked).Info("Creating consumer config for use later")
 	} else {
-		logger.WithField("config", string(consumerConfigAsJson)).Info("Creating consumer config for use later")
+		logger.WithField("config", string(consumerConfigMaskedJson)).Info("Creating consumer config for use later")
 	}
 
-	cm.consumerConfigMap = consumerConfigMap
-	cm.producerConfigMap = producerConfigMap
+	cm.consumerConfigMap = consumerConfig
+	cm.producerConfigMap = producerConfig
 	return nil
 }
 

--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -90,9 +90,10 @@ func (cm *ConsumerManager) createKafkaConfigs(kafkaConfig *ManagerConfig) error 
 		return err
 	}
 
-	producerConfigAsJSON, err := json.Marshal(&producerConfigMap)
+	producerConfigWithoutSecrets := config.WithoutSecrets(producerConfigMap)
+	producerConfigAsJSON, err := json.Marshal(&producerConfigWithoutSecrets)
 	if err != nil {
-		logger.WithField("config", &producerConfigMap).Info("Creating producer config for use later")
+		logger.WithField("config", &producerConfigWithoutSecrets).Info("Creating producer config for use later")
 	} else {
 		logger.WithField("config", string(producerConfigAsJSON)).Info("Creating producer config for use later")
 	}
@@ -103,9 +104,10 @@ func (cm *ConsumerManager) createKafkaConfigs(kafkaConfig *ManagerConfig) error 
 		return err
 	}
 
-	consumerConfigAsJson, err := json.Marshal(&consumerConfigMap)
+	consumerConfigWithoutSecrets := config.WithoutSecrets(consumerConfigMap)
+	consumerConfigAsJson, err := json.Marshal(&consumerConfigWithoutSecrets)
 	if err != nil {
-		logger.WithField("config", &consumerConfigMap).Info("Creating consumer config for use later")
+		logger.WithField("config", &consumerConfigWithoutSecrets).Info("Creating consumer config for use later")
 	} else {
 		logger.WithField("config", string(consumerConfigAsJson)).Info("Creating consumer config for use later")
 	}

--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -61,7 +61,11 @@ func cloneKafkaConfigMap(m kafka.ConfigMap) kafka.ConfigMap {
 	return m2
 }
 
-func NewConsumerManager(logger log.FieldLogger, managerConfig *ManagerConfig, maxNumConsumers int) (*ConsumerManager, error) {
+func NewConsumerManager(
+	logger log.FieldLogger,
+	managerConfig *ManagerConfig,
+	maxNumConsumers int,
+) (*ConsumerManager, error) {
 	cm := &ConsumerManager{
 		logger:          logger.WithField("source", "ConsumerManager"),
 		managerConfig:   managerConfig,
@@ -113,6 +117,7 @@ func (cm *ConsumerManager) createKafkaConfigs(kafkaConfig *ManagerConfig) error 
 
 func (cm *ConsumerManager) getInferKafkaConsumer(modelName string, create bool) (*InferKafkaHandler, error) {
 	logger := cm.logger.WithField("func", "getInferKafkaConsumer")
+
 	consumerBucketId := util.GetKafkaConsumerName(modelName, modelGatewayConsumerNamePrefix, cm.maxNumConsumers)
 	ic, ok := cm.consumers[consumerBucketId]
 	logger.Debugf("Getting consumer for model %s with bucket id %s", modelName, consumerBucketId)
@@ -130,6 +135,7 @@ func (cm *ConsumerManager) getInferKafkaConsumer(modelName string, create bool) 
 		if err != nil {
 			return nil, err
 		}
+
 		go ic.Serve()
 		logger.Debugf("Created consumer for model %s with bucket id %s", modelName, consumerBucketId)
 		cm.consumers[consumerBucketId] = ic

--- a/scheduler/pkg/kafka/pipeline/consumer_manager.go
+++ b/scheduler/pkg/kafka/pipeline/consumer_manager.go
@@ -53,11 +53,10 @@ func NewConsumerManager(
 	maxNumConsumers int,
 	tracer trace.Tracer,
 ) *ConsumerManager {
-	logger.Infof(
-		"Setting consumer manager with max num consumers: %d, max topics per consumers: %d",
-		maxNumConsumers,
-		maxNumTopicsPerConsumer,
-	)
+	logger.
+		WithField("max consumers", maxNumConsumers).
+		WithField("max topics per consumer", maxNumTopicsPerConsumer).
+		Info("creating consumer manager")
 
 	return &ConsumerManager{
 		logger:                  logger.WithField("source", "ConsumerManager"),

--- a/scheduler/pkg/kafka/pipeline/consumer_manager.go
+++ b/scheduler/pkg/kafka/pipeline/consumer_manager.go
@@ -46,8 +46,19 @@ type ConsumerManager struct {
 	tracer                  trace.Tracer
 }
 
-func NewConsumerManager(logger log.FieldLogger, consumerConfig *config.KafkaConfig, maxNumTopicsPerConsumer, maxNumConsumers int, tracer trace.Tracer) *ConsumerManager {
-	logger.Infof("Setting consumer manager with max num consumers: %d, max topics per consumers: %d", maxNumConsumers, maxNumTopicsPerConsumer)
+func NewConsumerManager(
+	logger log.FieldLogger,
+	consumerConfig *config.KafkaConfig,
+	maxNumTopicsPerConsumer,
+	maxNumConsumers int,
+	tracer trace.Tracer,
+) *ConsumerManager {
+	logger.Infof(
+		"Setting consumer manager with max num consumers: %d, max topics per consumers: %d",
+		maxNumConsumers,
+		maxNumTopicsPerConsumer,
+	)
+
 	return &ConsumerManager{
 		logger:                  logger.WithField("source", "ConsumerManager"),
 		consumerConfig:          consumerConfig,
@@ -62,10 +73,16 @@ func (cm *ConsumerManager) createConsumer() error {
 		return fmt.Errorf("Max number of consumers reached")
 	}
 
-	c, err := NewMultiTopicsKafkaConsumer(cm.logger, cm.consumerConfig, getKafkaConsumerName(kafkaConsumerNamePrefix, uuid.New().String()), cm.tracer)
+	c, err := NewMultiTopicsKafkaConsumer(
+		cm.logger,
+		cm.consumerConfig,
+		getKafkaConsumerName(kafkaConsumerNamePrefix, uuid.New().String()),
+		cm.tracer,
+	)
 	if err != nil {
 		return err
 	}
+
 	cm.consumers = append(cm.consumers, c)
 	return nil
 }

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -135,7 +135,8 @@ func (km *KafkaManager) createProducer() error {
 		return err
 	}
 
-	km.logger.Infof("Creating producer with config %v", producerConfigMap)
+	configWithoutSecrets := config.WithoutSecrets(producerConfigMap)
+	km.logger.Infof("Creating producer with config %v", configWithoutSecrets)
 
 	km.producer, err = kafka.NewProducer(&producerConfigMap)
 	return err

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -40,7 +40,14 @@ const (
 )
 
 type PipelineInferer interface {
-	Infer(ctx context.Context, resourceName string, isModel bool, data []byte, headers []kafka.Header, requestId string) (*Request, error)
+	Infer(
+		ctx context.Context,
+		resourceName string,
+		isModel bool,
+		data []byte,
+		headers []kafka.Header,
+		requestId string,
+	) (*Request, error)
 }
 
 type KafkaManager struct {
@@ -72,12 +79,19 @@ type Request struct {
 	errorModel string
 }
 
-func NewKafkaManager(logger logrus.FieldLogger, namespace string, kafkaConfig *config.KafkaConfig,
-	traceProvider *seldontracer.TracerProvider, maxNumConsumers, maxNumTopicsPerConsumer int) (*KafkaManager, error) {
+func NewKafkaManager(
+	logger logrus.FieldLogger,
+	namespace string,
+	kafkaConfig *config.KafkaConfig,
+	traceProvider *seldontracer.TracerProvider,
+	maxNumConsumers,
+	maxNumTopicsPerConsumer int,
+) (*KafkaManager, error) {
 	topicNamer, err := kafka2.NewTopicNamer(namespace, kafkaConfig.TopicPrefix)
 	if err != nil {
 		return nil, err
 	}
+
 	tracer := traceProvider.GetTraceProvider().Tracer("KafkaManager")
 	km := &KafkaManager{
 		kafkaConfig:     kafkaConfig,
@@ -87,18 +101,22 @@ func NewKafkaManager(logger logrus.FieldLogger, namespace string, kafkaConfig *c
 		consumerManager: NewConsumerManager(logger, kafkaConfig, maxNumTopicsPerConsumer, maxNumConsumers, tracer),
 		mu:              sync.RWMutex{},
 	}
+
 	err = km.createProducer()
 	if err != nil {
 		return nil, err
 	}
+
 	return km, nil
 }
 
 func (km *KafkaManager) Stop() {
 	logger := km.logger.WithField("func", "Stop")
 	logger.Info("Stopping pipelines")
+
 	km.mu.Lock()
 	defer km.mu.Unlock()
+
 	km.producer.Close()
 	km.consumerManager.Stop()
 	logger.Info("Stopped all pipelines")
@@ -116,7 +134,9 @@ func (km *KafkaManager) createProducer() error {
 	if err != nil {
 		return err
 	}
+
 	km.logger.Infof("Creating producer with config %v", producerConfigMap)
+
 	km.producer, err = kafka.NewProducer(&producerConfigMap)
 	return err
 }
@@ -173,7 +193,14 @@ func (km *KafkaManager) loadOrStorePipeline(resourceName string, isModel bool) (
 	}
 }
 
-func (km *KafkaManager) Infer(ctx context.Context, resourceName string, isModel bool, data []byte, headers []kafka.Header, requestId string) (*Request, error) {
+func (km *KafkaManager) Infer(
+	ctx context.Context,
+	resourceName string,
+	isModel bool,
+	data []byte,
+	headers []kafka.Header,
+	requestId string,
+) (*Request, error) {
 	logger := km.logger.WithField("func", "Infer")
 	km.mu.RLock()
 	pipeline, err := km.loadOrStorePipeline(resourceName, isModel)

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -66,25 +66,28 @@ func NewMultiTopicsKafkaConsumer(
 }
 
 func (c *MultiTopicsKafkaConsumer) createConsumer() error {
-
 	consumerConfig := config.CloneKafkaConfigMap(c.config.Consumer)
 	consumerConfig["group.id"] = c.id
 	err := config.AddKafkaSSLOptions(consumerConfig)
 	if err != nil {
 		return err
 	}
+
 	c.logger.Infof("Creating consumer with config %v", consumerConfig)
 	consumer, err := kafka.NewConsumer(&consumerConfig)
 	if err != nil {
 		return err
 	}
+
 	c.logger.Infof("Created consumer %s", c.id)
 	c.consumer = consumer
 	c.isActive.Store(true)
+
 	go func() {
 		err := c.pollAndMatch()
 		c.logger.WithError(err).Infof("Consumer %s failed and is ending", c.id)
 	}()
+
 	return nil
 }
 

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -46,7 +46,12 @@ type MultiTopicsKafkaConsumer struct {
 	tracer   trace.Tracer
 }
 
-func NewMultiTopicsKafkaConsumer(logger log.FieldLogger, consumerConfig *config.KafkaConfig, id string, tracer trace.Tracer) (*MultiTopicsKafkaConsumer, error) {
+func NewMultiTopicsKafkaConsumer(
+	logger log.FieldLogger,
+	consumerConfig *config.KafkaConfig,
+	id string,
+	tracer trace.Tracer,
+) (*MultiTopicsKafkaConsumer, error) {
 	consumer := &MultiTopicsKafkaConsumer{
 		logger:   logger.WithField("source", "MultiTopicsKafkaConsumer"),
 		config:   consumerConfig,

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -73,7 +73,8 @@ func (c *MultiTopicsKafkaConsumer) createConsumer() error {
 		return err
 	}
 
-	c.logger.Infof("Creating consumer with config %v", consumerConfig)
+	configWithoutSecrets := config.WithoutSecrets(consumerConfig)
+	c.logger.Infof("Creating consumer with config %v", configWithoutSecrets)
 	consumer, err := kafka.NewConsumer(&consumerConfig)
 	if err != nil {
 		return err

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -153,9 +153,12 @@ func (c *MultiTopicsKafkaConsumer) pollAndMatch() error {
 
 		switch e := ev.(type) {
 		case *kafka.Message:
-			logger.Debugf("Received message from %s with key %s", *e.TopicPartition.Topic, string(e.Key))
-			if val, ok := c.requests.Get(string(e.Key)); ok {
+			logger.
+				WithField("topic", *e.TopicPartition.Topic).
+				WithField("key", string(e.Key)).
+				Debugf("received message")
 
+			if val, ok := c.requests.Get(string(e.Key)); ok {
 				// Add tracing span
 				ctx := context.Background()
 				carrierIn := splunkkafka.NewMessageCarrier(e)


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to this PR, credentials in the Kafka config maps, such as SASL passwords, would be leaked through logs when creating producers and consumers.

This PR fixes that oversight by eliding such information, specifically replacing it with `***` so that users can see a key was set but do not have access to it.

There are some incidental formatting changes around long lines and whitespace for logical separation.

**Which issue(s) this PR fixes**:
N/A

## Testing
I created a cluster with:
```bash
$ ansible-playbook playbooks/kind-cluster.yaml 

# Using RafalSkolasinski/kctl
$ STRIMZI_NAMESPACE=seldon-mesh make install-strimzi create-cluster

# Already on my machine; don't need a newer version for the purposes of this PR
$ kind load docker-image --name seldon seldonio/mlserver:1.3.0

$ ansible-playbook playbooks/setup-seldon.yaml \
  -e seldon_install_runtime=no \
  -e seldon_install_servers=no \
  -e @playbooks/vars/custom.yaml 

$ k -n seldon-mesh apply -f - <<EOF
apiVersion: mlops.seldon.io/v1alpha1
kind: Server
metadata:
  name: mlserver
spec:
  serverConfig: mlserver
  replicas: 1
EOF
...
```

The contents of `custom.yaml` are given below.
<details>
<summary>custom.yaml</summary>

```yaml
seldon_core_v2_component_values:
  security:
    kafka:
      protocol: SASL_SSL
      sasl:
        client:
          username: sasl
          secret: sasl
      ssl:
        client:
          brokerValidationSecret: default-cluster-ca-cert

  kafka:
    bootstrap: default-kafka-sasl-bootstrap.seldon-mesh:9093

  modelgateway:
    image:
      repository: seldonio/seldon-modelgateway
      tag: latest
    resources:
      memory: 300M

  pipelinegateway:
    image:
      repository: seldonio/seldon-pipelinegateway
      tag: latest
    resources:
      memory: 300M

  dataflow:
    image:
      repository: seldonio/seldon-dataflow-engine
      tag: latest
    resources:
      memory: 500M

  serverConfig:
    mlserver:
      image:
        tag: 1.3.0
```
</details>

To confirm the issue, I used the existing `seldonio` images, then to confirm the fix I loaded locally built images into the kind cluster.

Before my changes, I see logs like the below:
```
# Model gateway
time="2023-06-30T15:23:40Z" level=info msg="Creating producer config for use later" config="{\"bootstrap.servers\":\"default-kafka-sasl-bootstrap.seldon-mesh:9093\",\"go.delivery.reports\":true,\"linger.ms\":\"0\",\"message.max.bytes\":\"1000000000\",\"sasl.mechanism\":\"SCRAM-SHA-512\",\"sasl.password\":\"CyOgjqZmGOU3XZh0xUVPFUKZkGgHK4lT\",\"sasl.username\":\"sasl\",\"security.protocol\":\"SASL_SSL\",\"ssl.ca.location\":\"/tmp/certs/kafka/broker/ca.crt\",\"ssl.endpoint.identification.algorithm\":\"none\"}" func=createKafkaConfigs source=ConsumerManager
...
time="2023-06-30T15:30:02Z" level=info msg="Creating consumer config for use later" config="{\"auto.offset.reset\":\"earliest\",\"bootstrap.servers\":\"default-kafka-sasl-bootstrap.seldon-mesh:9093\",\"message.max.bytes\":\"1000000000\",\"sasl.mechanism\":\"SCRAM-SHA-512\",\"sasl.password\":\"CyOgjqZmGOU3XZh0xUVPFUKZkGgHK4lT\",\"sasl.username\":\"sasl\",\"security.protocol\":\"SASL_SSL\",\"session.timeout.ms\":\"6000\",\"ssl.ca.location\":\"/tmp/certs/kafka/broker/ca.crt\",\"ssl.endpoint.identification.algorithm\":\"none\",\"topic.metadata.propagation.max.ms\":\"300000\"}" func=createKafkaConfigs source=ConsumerManager

# Pipeline gateway
time="2023-06-30T15:23:40Z" level=info msg="Creating producer with config map[bootstrap.servers:default-kafka-sasl-bootstrap.seldon-mesh:9093 go.delivery.reports:true linger.ms:0 message.max.bytes:1000000000 sasl.mechanism:SCRAM-SHA-512 sasl.password:CyOgjqZmGOU3XZh0xUVPFUKZkGgHK4lT sasl.username:sasl security.protocol:SASL_SSL ssl.ca.location:/tmp/certs/kafka/broker/ca.crt ssl.endpoint.identification.algorithm:none]" source=KafkaManager
```

To apply my changes, I build the Docker images, loaded them into the `kind` cluster, and updated the components:
```bash
$ make -C scheduler docker-build-modelgateway docker-build-pipelinegateway

$ kind load docker-image --name seldon seldonio/seldon-modelgateway:latest
Image: "seldonio/seldon-modelgateway:latest" with ID "sha256:93a9a969e45f6289e3766186fa5b968649f0436b0498eab0bc61336219ada64b" not yet present on node "seldon-control-plane", loading...

ansible (kind-seldon) (15:38:50) $ kind load docker-image --name seldon seldonio/seldon-pipelinegateway:latest 
Image: "seldonio/seldon-pipelinegateway:latest" with ID "sha256:ea3c083a7622a8939731faad4725ff880f67ce7ffc857517120735bb757a479a" not yet present on node "seldon-control-plane", loading...

$ ansible-playbook playbooks/setup-seldon.yaml -e full_install=no -e seldon_install_components=yes -e @playbooks/vars/custom.yaml 
```

After my changes, I see logs like the below:
```
# Model gateway
time="2023-06-30T15:39:43Z" level=info msg="Creating producer config for use later" config="{\"bootstrap.servers\":\"default-kafka-sasl-bootstrap.seldon-mesh:9093\",\"go.delivery.reports\":true,\"linger.ms\":\"0\",\"message.max.bytes\":\"1000000000\",\"sasl.mechanism\":\"SCRAM-SHA-512\",\"sasl.password\":\"***\",\"sasl.username\":\"***\",\"security.protocol\":\"SASL_SSL\",\"ssl.ca.location\":\"/tmp/certs/kafka/broker/ca.crt\",\"ssl.endpoint.identification.algorithm\":\"none\"}" func=createKafkaConfigs source=ConsumerManager

time="2023-06-30T15:39:43Z" level=info msg="Creating consumer config for use later" config="{\"auto.offset.reset\":\"earliest\",\"bootstrap.servers\":\"default-kafka-sasl-bootstrap.seldon-mesh:9093\",\"message.max.bytes\":\"1000000000\",\"sasl.mechanism\":\"SCRAM-SHA-512\",\"sasl.password\":\"***\",\"sasl.username\":\"***\",\"security.protocol\":\"SASL_SSL\",\"session.timeout.ms\":\"6000\",\"ssl.ca.location\":\"/tmp/certs/kafka/broker/ca.crt\",\"ssl.endpoint.identification.algorithm\":\"none\",\"topic.metadata.propagation.max.ms\":\"300000\"}" func=createKafkaConfigs source=ConsumerManager

# Pipeline gateway
time="2023-06-30T15:39:43Z" level=info msg="Creating producer with config map[bootstrap.servers:default-kafka-sasl-bootstrap.seldon-mesh:9093 go.delivery.reports:true linger.ms:0 message.max.bytes:1000000000 sasl.mechanism:SCRAM-SHA-512 sasl.password:*** sasl.username:*** security.protocol:SASL_SSL ssl.ca.location:/tmp/certs/kafka/broker/ca.crt ssl.endpoint.identification.algorithm:none]" source=KafkaManager
```