### PR TITLE
Add missing configmap ownership watch for manager

### DIFF
--- a/operator/controllers/mlops/seldonruntime_controller.go
+++ b/operator/controllers/mlops/seldonruntime_controller.go
@@ -255,6 +255,7 @@ func (r *SeldonRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&auth.Role{}).
 		Owns(&auth.RoleBinding{}).
 		Owns(&v1.ServiceAccount{}).
+		Owns(&v1.ConfigMap{}).
 		Watches(
 			&source.Kind{Type: &mlopsv1alpha1.SeldonConfig{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapSeldonRuntimesFromSeldonConfig),


### PR DESCRIPTION

ConfigMap watches were missing from operator.