### PR TITLE
fix: Disable default logging for Kafka in Ansible Playbooks

### DIFF
--- a/ansible/playbooks/templates/values-seldon-core-v2-components.yaml.j2
+++ b/ansible/playbooks/templates/values-seldon-core-v2-components.yaml.j2
@@ -7,7 +7,6 @@ envoy:
     type: "{{ seldon_core_v2_type_svc_type }}"
 
 kafka:
-  debug: all
   bootstrap: "seldon-kafka-bootstrap.{{ seldon_kafka_namespace }}.svc.cluster.local:9093"
   topics:
     numPartitions: 4

--- a/ansible/playbooks/templates/values-seldon-core-v2-components.yaml.j2
+++ b/ansible/playbooks/templates/values-seldon-core-v2-components.yaml.j2
@@ -7,6 +7,7 @@ envoy:
     type: "{{ seldon_core_v2_type_svc_type }}"
 
 kafka:
+  debug:
   bootstrap: "seldon-kafka-bootstrap.{{ seldon_kafka_namespace }}.svc.cluster.local:9093"
   topics:
     numPartitions: 4


### PR DESCRIPTION
**What this PR does / why we need it**:
When running Seldon via Ansible playbooks, Kafka logs everything, which makes it difficult to inspect the logs of `seldon-pipelinegateway` when using pipelines.