### PR TITLE
fix: Change tracing to disable rather than enable flag

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
+++ b/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
@@ -8139,7 +8139,7 @@ spec:
                     type: object
                   tracingConfig:
                     properties:
-                      enable:
+                      disable:
                         type: boolean
                       otelExporterEndpoint:
                         type: string
@@ -8250,7 +8250,7 @@ spec:
                     type: object
                   tracingConfig:
                     properties:
-                      enable:
+                      disable:
                         type: boolean
                       otelExporterEndpoint:
                         type: string

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1470,7 +1470,7 @@ spec:
       grpcServicePrefix: '{{ .Values.services.serviceGRPCPrefix }}'
       serviceType: '{{ .Values.services.defaultServiceType }}'
     tracingConfig:
-      enable: {{ .Values.opentelemetry.enable }}
+      disable: {{ .Values.opentelemetry.disable }}
       otelExporterEndpoint: '{{ .Values.opentelemetry.endpoint }}'
       ratio: '{{ .Values.opentelemetry.ratio }}'
 {{ end }}

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -75,7 +75,7 @@ imagePullSecrets:
 opentelemetry:
   # This will need to be customized to your open telemetry installation endpoint
   endpoint: seldon-collector.seldon-mesh:4317
-  enable: true
+  disable: false
   ratio: 1
 
 hodometer:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -75,7 +75,7 @@ imagePullSecrets:
 opentelemetry:
   # This will need to be customized to your open telemetry installation endpoint
   endpoint: seldon-collector.seldon-mesh:4317
-  enable: true
+  disable: false
   ratio: 1
 
 hodometer:

--- a/k8s/kustomize/helm-components-sc/patch_tracingconfig.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_tracingconfig.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   config:
     tracingConfig:
-      enable: HACK_REMOVE_ME{{ .Values.opentelemetry.enable }}
+      disable: HACK_REMOVE_ME{{ .Values.opentelemetry.disable }}
       otelExporterEndpoint: '{{ .Values.opentelemetry.endpoint }}'
       ratio: '{{ .Values.opentelemetry.ratio }}'

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -1085,7 +1085,7 @@ spec:
       grpcServicePrefix: ''
       serviceType: 'LoadBalancer'
     tracingConfig:
-      enable: true
+      disable: false
       otelExporterEndpoint: 'seldon-collector.seldon-mesh:4317'
       ratio: '1'
 ---

--- a/k8s/yaml/crds.yaml
+++ b/k8s/yaml/crds.yaml
@@ -8144,7 +8144,7 @@ spec:
                     type: object
                   tracingConfig:
                     properties:
-                      enable:
+                      disable:
                         type: boolean
                       otelExporterEndpoint:
                         type: string
@@ -8256,7 +8256,7 @@ spec:
                     type: object
                   tracingConfig:
                     properties:
-                      enable:
+                      disable:
                         type: boolean
                       otelExporterEndpoint:
                         type: string

--- a/operator/apis/mlops/v1alpha1/seldonconfig_types.go
+++ b/operator/apis/mlops/v1alpha1/seldonconfig_types.go
@@ -78,7 +78,7 @@ type RcloneConfiguration struct {
 }
 
 type TracingConfig struct {
-	Enable               bool   `json:"enable,omitempty"`
+	Disable              bool   `json:"disable,omitempty"`
 	OtelExporterEndpoint string `json:"otelExporterEndpoint,omitempty"`
 	Ratio                string `json:"ratio,omitempty"`
 }

--- a/operator/apis/mlops/v1alpha1/seldonconfig_types_test.go
+++ b/operator/apis/mlops/v1alpha1/seldonconfig_types_test.go
@@ -58,6 +58,24 @@ func TestSeldonConfigurationAddDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "no tracing overrides",
+			defaults: SeldonConfiguration{
+				TracingConfig: TracingConfig{
+					Disable:              false,
+					OtelExporterEndpoint: "foo",
+					Ratio:                "0.5",
+				},
+			},
+			runtime: SeldonConfiguration{},
+			expected: SeldonConfiguration{
+				TracingConfig: TracingConfig{
+					Disable:              false,
+					OtelExporterEndpoint: "foo",
+					Ratio:                "0.5",
+				},
+			},
+		},
+		{
 			name: "kafka overrides",
 			defaults: SeldonConfiguration{
 				KafkaConfig: KafkaConfig{

--- a/operator/apis/mlops/v1alpha1/seldonconfig_types_test.go
+++ b/operator/apis/mlops/v1alpha1/seldonconfig_types_test.go
@@ -44,12 +44,14 @@ func TestSeldonConfigurationAddDefaults(t *testing.T) {
 			},
 			runtime: SeldonConfiguration{
 				TracingConfig: TracingConfig{
+					Disable:              true,
 					OtelExporterEndpoint: "bar",
 				},
 				KafkaConfig: KafkaConfig{},
 			},
 			expected: SeldonConfiguration{
 				TracingConfig: TracingConfig{
+					Disable:              true,
 					OtelExporterEndpoint: "bar",
 					Ratio:                "0.5",
 				},

--- a/operator/config/crd/bases/mlops.seldon.io_seldonconfigs.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_seldonconfigs.yaml
@@ -7608,7 +7608,7 @@ spec:
                     type: object
                   tracingConfig:
                     properties:
-                      enable:
+                      disable:
                         type: boolean
                       otelExporterEndpoint:
                         type: string

--- a/operator/config/crd/bases/mlops.seldon.io_seldonruntimes.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_seldonruntimes.yaml
@@ -92,7 +92,7 @@ spec:
                     type: object
                   tracingConfig:
                     properties:
-                      enable:
+                      disable:
                         type: boolean
                       otelExporterEndpoint:
                         type: string

--- a/operator/controllers/reconcilers/seldon/configmap_reconciler.go
+++ b/operator/controllers/reconcilers/seldon/configmap_reconciler.go
@@ -134,7 +134,7 @@ func getTracingConfigMap(tracingConfig mlopsv1alpha1.TracingConfig, namespace st
 		},
 		Data: map[string]string{
 			"tracing.json":                string(tracingJson),
-			"OTEL_JAVAAGENT_ENABLED":      strconv.FormatBool(tracingConfig.Enable),
+			"OTEL_JAVAAGENT_ENABLED":      strconv.FormatBool(!tracingConfig.Disable),
 			"OTEL_EXPORTER_OTLP_ENDPOINT": fmt.Sprintf("http://%s", tracingConfig.OtelExporterEndpoint),
 		},
 	}, nil

--- a/scheduler/config/tracing-host.json
+++ b/scheduler/config/tracing-host.json
@@ -1,5 +1,5 @@
 {
-  "enable": true,
+  "disable": false,
   "otelExporterEndpoint": "0.0.0.0:4317",
   "ratio": "1"
 }

--- a/scheduler/config/tracing-internal.json
+++ b/scheduler/config/tracing-internal.json
@@ -1,5 +1,5 @@
 {
-  "enable": true,
+  "disable": false,
   "otelExporterEndpoint": "otel-collector:4317",
   "ratio": "1"
 }

--- a/scheduler/pkg/tracing/provider.go
+++ b/scheduler/pkg/tracing/provider.go
@@ -46,7 +46,7 @@ type TracerProvider struct {
 }
 
 type TracingConfig struct {
-	Enable               bool   `json:"enable"`
+	Disable              bool   `json:"disable"`
 	OtelExporterEndpoint string `json:"otelExporterEndpoint"`
 	Ratio                string `json:"Ratio"`
 }
@@ -88,7 +88,7 @@ func (t *TracerProvider) loadConfig(path *string) error {
 	var config *TracingConfig
 	if path == nil || *path == "" {
 		config = &TracingConfig{
-			Enable: false,
+			Disable: true,
 		}
 		logger.Info("No tracing path provided so setting NOOP TraceProvider")
 	} else {
@@ -104,7 +104,7 @@ func (t *TracerProvider) loadConfig(path *string) error {
 		if err != nil {
 			return err
 		}
-		if tc.Enable { // Only check ratio is valid if enabled
+		if !tc.Disable { // Only check ratio is valid if enabled
 			// Check ratio
 			_, err = strconv.ParseFloat(tc.Ratio, 64)
 			if err != nil {
@@ -119,7 +119,7 @@ func (t *TracerProvider) loadConfig(path *string) error {
 func (t *TracerProvider) recreateTracerProvider(config *TracingConfig) error {
 	logger := t.logger.WithField("func", "recreateTracerProvider")
 	// add further check for config semantic validity
-	if config.Enable {
+	if !config.Disable {
 		if config.OtelExporterEndpoint == "" {
 			return fmt.Errorf("Trace enabled but Otel endpoint empty")
 		}
@@ -127,7 +127,7 @@ func (t *TracerProvider) recreateTracerProvider(config *TracingConfig) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.config = config
-	if t.config.Enable {
+	if !t.config.Disable {
 
 		traceClient := otlptracegrpc.NewClient(
 			otlptracegrpc.WithInsecure(),

--- a/scheduler/pkg/tracing/provider_test.go
+++ b/scheduler/pkg/tracing/provider_test.go
@@ -39,7 +39,7 @@ func TestRecreateTracerProvider(t *testing.T) {
 		{
 			name: "enabled",
 			config: &TracingConfig{
-				Enable:               true,
+				Disable:              false,
 				OtelExporterEndpoint: "0.0.0.0:1234",
 				Ratio:                "1",
 			},
@@ -47,21 +47,21 @@ func TestRecreateTracerProvider(t *testing.T) {
 		{
 			name: "disabled",
 			config: &TracingConfig{
-				Enable: false,
+				Disable: true,
 			},
 		},
 		{
 			name: "invalid ratio zero",
 			config: &TracingConfig{
-				Enable: true,
+				Disable: false,
 			},
 			err: true,
 		},
 		{
 			name: "invalid no otel endpoint",
 			config: &TracingConfig{
-				Enable: true,
-				Ratio:  "10",
+				Disable: false,
+				Ratio:   "10",
 			},
 			err: true,
 		},
@@ -99,23 +99,23 @@ func TestLoadConfig(t *testing.T) {
 	tests := []test{
 		{
 			name:   "disabled",
-			config: `{"enable":false}`,
+			config: `{"disable":true}`,
 			expectedConfig: &TracingConfig{
-				Enable: false,
+				Disable: true,
 			},
 		},
 		{
 			name:   "enabled",
-			config: `{"enable":true, "otelExporterEndpoint":"0.0.0.0:1234","ratio":"0.5"}`,
+			config: `{"disable":false, "otelExporterEndpoint":"0.0.0.0:1234","ratio":"0.5"}`,
 			expectedConfig: &TracingConfig{
-				Enable:               true,
+				Disable:              false,
 				OtelExporterEndpoint: "0.0.0.0:1234",
 				Ratio:                "0.5",
 			},
 		},
 		{
 			name:   "bad ratio",
-			config: `{"enable":true, "otelExporterEndpoint":"0.0.0.0:1234","ratio":"foo"}`,
+			config: `{"disable":false, "otelExporterEndpoint":"0.0.0.0:1234","ratio":"foo"}`,
 			err:    true,
 		},
 		{


### PR DESCRIPTION
Fixes: #4998 

To allow tracing to be on by default if no config override is set we swap the tracing `enable` to `disable` to allow the default to be `disable:false`
