### PR TITLE
Remove Python 3.6 s2i wrapper

### DIFF
--- a/doc/source/python/python_wrapping_s2i.md
+++ b/doc/source/python/python_wrapping_s2i.md
@@ -97,10 +97,6 @@ See below for the possible keys and values for this file.
 ## Step 3 - Build your image
 Use `s2i build` to create your Docker image from source code. You will need Docker installed on the machine and optionally git if your source code is in a public git repo. You can choose from three python builder images
 
- * Python 3.6 : seldonio/seldon-core-s2i-python36:1.17.0-dev seldonio/seldon-core-s2i-python3:1.17.0-dev
-   * Note there are [issues running TensorFlow under Python 3.7](https://github.com/tensorflow/tensorflow/issues/20444) (Nov 2018) and Python 3.7 is not officially supported by TensorFlow (Dec 2018).
- * Python 3.6 plus ONNX support via [Intel nGraph](https://github.com/NervanaSystems/ngraph) : seldonio/seldon-core-s2i-python3-ngraph-onnx:0.1
-
 Using s2i you can build directly from a git repo or from a local source folder. See the [s2i docs](https://github.com/openshift/source-to-image/blob/master/docs/cli.md#s2i-build) for further details. The general format is:
 
 ```bash

--- a/doc/source/reference/images.md
+++ b/doc/source/reference/images.md
@@ -22,10 +22,8 @@
 | Description | Image URL | Stable Version | Development |
 |-------------|-----------|----------------|-------------|
 | [Seldon Python 3 (3.8) Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python3](https://hub.docker.com/r/seldonio/seldon-core-s2i-python3/tags/) | 1.16.0 | 1.17.0-dev |
-| [Seldon Python 3.6 Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python36](https://hub.docker.com/r/seldonio/seldon-core-s2i-python36/tags/) | 1.16.0 | 1.17.0-dev |
 | [Seldon Python 3.7 Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python37](https://hub.docker.com/r/seldonio/seldon-core-s2i-python37/tags/) | 1.16.0 | 1.17.0-dev |
 | [Seldon Python 3.8 Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python38](https://hub.docker.com/r/seldonio/seldon-core-s2i-python38/tags/) |  1.16.0  | 1.17.0-dev |
-| [Seldon Python 3.6 GPU Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python36-gpu](https://hub.docker.com/r/seldonio/seldon-core-s2i-python36-gpu/tags/) | 1.16.0 | 1.17.0-dev |
 | [Seldon Python 3.7 GPU Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python37-gpu](https://hub.docker.com/r/seldonio/seldon-core-s2i-python37-gpu/tags/) | 1.16.0 | 1.17.0-dev |
 | [Seldon Python 3.8 GPU Wrapper for S2I](../python/python_wrapping_s2i.md) | [seldonio/seldon-core-s2i-python38-gpu](https://hub.docker.com/r/seldonio/seldon-core-s2i-python38-gpu/tags/) | 1.16.0 | 1.17.0-dev |
 

--- a/examples/cicd/sig-mlops-jenkins-classic/models/image_classifier/seldon_custom_server_README.ipynb
+++ b/examples/cicd/sig-mlops-jenkins-classic/models/image_classifier/seldon_custom_server_README.ipynb
@@ -494,7 +494,7 @@
    ],
    "source": [
     "%%bash\n",
-    "SELDON_BASE_WRAPPER=\"seldonio/seldon-core-s2i-python36:1.17.0-dev
+    "SELDON_BASE_WRAPPER=\"seldonio/seldon-core-s2i-python37:1.17.0-dev
     "s2i build src/. $SELDON_BASE_WRAPPER sklearn-server:0.1 \\\n",
     "    --environment-file src/seldon_model.conf"
    ]

--- a/examples/cicd/sig-mlops-jenkins-classic/models/news_classifier/seldon_custom_server_README.ipynb
+++ b/examples/cicd/sig-mlops-jenkins-classic/models/news_classifier/seldon_custom_server_README.ipynb
@@ -494,7 +494,7 @@
    ],
    "source": [
     "%%bash\n",
-    "SELDON_BASE_WRAPPER=\"seldonio/seldon-core-s2i-python36:1.17.0-dev
+    "SELDON_BASE_WRAPPER=\"seldonio/seldon-core-s2i-python37:1.17.0-dev
     "s2i build src/. $SELDON_BASE_WRAPPER sklearn-server:0.1 \\\n",
     "    --environment-file src/seldon_model.conf"
    ]

--- a/examples/cicd/sig-mlops-seldon-jenkins-x/seldon_custom_server_README.ipynb
+++ b/examples/cicd/sig-mlops-seldon-jenkins-x/seldon_custom_server_README.ipynb
@@ -494,7 +494,7 @@
    ],
    "source": [
     "%%bash\n",
-    "SELDON_BASE_WRAPPER=\"seldonio/seldon-core-s2i-python36:1.17.0-dev
+    "SELDON_BASE_WRAPPER=\"seldonio/seldon-core-s2i-python37:1.17.0-dev
     "s2i build src/. $SELDON_BASE_WRAPPER sklearn-server:0.1 \\\n",
     "    --environment-file src/seldon_model.conf"
    ]

--- a/examples/explainers/imagenet/resources/transformer/Makefile
+++ b/examples/explainers/imagenet/resources/transformer/Makefile
@@ -2,7 +2,7 @@ IMAGE_VERSION=0.3
 IMAGE_NAME=docker.io/seldonio/imagenet-transformer
 
 build:
-	s2i build -E environment . seldonio/seldon-core-s2i-python36:1.17.0-dev $(IMAGE_NAME):$(IMAGE_VERSION)
+	s2i build -E environment . seldonio/seldon-core-s2i-python37:1.17.0-dev $(IMAGE_NAME):$(IMAGE_VERSION)
 
 push_to_dockerhub:
 	docker push $(IMAGE_NAME):$(IMAGE_VERSION)

--- a/examples/models/alibaba_ack_deep_mnist/alibaba_cloud_ack_deep_mnist.ipynb
+++ b/examples/models/alibaba_ack_deep_mnist/alibaba_cloud_ack_deep_mnist.ipynb
@@ -288,7 +288,7 @@
     }
    ],
    "source": [
-    "!s2i build . seldonio/seldon-core-s2i-python36:1.17.0-dev deep-mnist:0.1"
+    "!s2i build . seldonio/seldon-core-s2i-python37:1.17.0-dev deep-mnist:0.1"
    ]
   },
   {

--- a/examples/models/aws_eks_deep_mnist/aws_eks_deep_mnist.ipynb
+++ b/examples/models/aws_eks_deep_mnist/aws_eks_deep_mnist.ipynb
@@ -185,7 +185,7 @@
     }
    ],
    "source": [
-    "!s2i build . seldonio/seldon-core-s2i-python36:1.17.0-dev deep-mnist:0.1"
+    "!s2i build . seldonio/seldon-core-s2i-python37:1.17.0-dev deep-mnist:0.1"
    ]
   },
   {

--- a/examples/models/azure_aks_deep_mnist/azure_aks_deep_mnist.ipynb
+++ b/examples/models/azure_aks_deep_mnist/azure_aks_deep_mnist.ipynb
@@ -218,7 +218,7 @@
     }
    ],
    "source": [
-    "!s2i build . seldonio/seldon-core-s2i-python36:1.17.0-dev deep-mnist:0.1"
+    "!s2i build . seldonio/seldon-core-s2i-python37:1.17.0-dev deep-mnist:0.1"
    ]
   },
   {

--- a/examples/models/resnet/Makefile
+++ b/examples/models/resnet/Makefile
@@ -1,7 +1,7 @@
 
 
 build_image:
-	s2i build -E environment_grpc . seldonio/seldon-core-s2i-python36:1.17.0-dev seldon-resnet2.4
+	s2i build -E environment_grpc . seldonio/seldon-core-s2i-python37:1.17.0-dev seldon-resnet2.4
 
 
 clean:

--- a/examples/models/resnet/reset.ipynb
+++ b/examples/models/resnet/reset.ipynb
@@ -110,7 +110,7 @@
     }
    ],
    "source": [
-    "!s2i build -E environment_grpc . seldonio/seldon-core-s2i-python36:1.17.0-dev seldon-resnet2.4"
+    "!s2i build -E environment_grpc . seldonio/seldon-core-s2i-python37:1.17.0-dev seldon-resnet2.4"
    ]
   },
   {

--- a/wrappers/s2i/python/Makefile
+++ b/wrappers/s2i/python/Makefile
@@ -68,7 +68,6 @@ clean:
 	rm -rf test/transformer-template-app/.git
 
 after_build_image_seldon_core_check:
-	docker run --rm -it docker.io/seldonio/seldon-core-s2i-python36:$(IMAGE_VERSION) python -c 'import seldon_core; print(seldon_core.version.__version__)'
 	docker run --rm -it docker.io/seldonio/seldon-core-s2i-python37:$(IMAGE_VERSION) python -c 'import seldon_core; print(seldon_core.version.__version__)'
 
 

--- a/wrappers/s2i/python/build_scripts/build_all.sh
+++ b/wrappers/s2i/python/build_scripts/build_all.sh
@@ -2,14 +2,13 @@
 make -C ../ build_conda_base
 
 # Build standard wrapper images
-make -C ../ build PYTHON_VERSION=3.6
-make -C ../ build PYTHON_VERSION=3.7.10
+# NOTE: Conda 23.1.0 is the last version to support Python 3.7
+make -C ../ build PYTHON_VERSION=3.7.10 CONDA_VERSION=23.1.0
 make -C ../ build PYTHON_VERSION=3.8.10
 
 # Tag the default image
 make -C ../ tag_base_python PYTHON_VERSION=3.8.10
 
 # Build GPU images
-make -C ../ build_gpu PYTHON_VERSION=3.6
-make -C ../ build_gpu PYTHON_VERSION=3.7.10
+make -C ../ build_gpu PYTHON_VERSION=3.7.10 CONDA_VERSION=23.1.0
 make -C ../ build_gpu PYTHON_VERSION=3.8.10


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Python 3.6 has been long deprecated - so this PR removes the s2i wrapper, which we were still building.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
