### PR TITLE
fix: runtime tracing config value in helm chart should be disable

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-runtime/templates/seldon-runtime.yaml
+++ b/k8s/helm-charts/seldon-core-v2-runtime/templates/seldon-runtime.yaml
@@ -53,6 +53,6 @@ spec:
       grpcServicePrefix: {{ .Values.config.serviceConfig.serviceGRPCPrefix }}
       serviceType: {{ .Values.config.serviceConfig.serviceType }}
     tracingConfig:
-      enable: {{ .Values.config.tracingConfig.enable }}
+      disable: {{ .Values.config.tracingConfig.disable }}
       otelExporterEndpoint: {{ .Values.config.tracingConfig.otelExporterEndpoint }}
       ratio: {{ .Values.config.tracingConfig.ratio }}

--- a/k8s/helm-charts/seldon-core-v2-runtime/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-runtime/values.yaml
@@ -39,7 +39,7 @@ config:
     producer:
     streams:
   tracingConfig:
-    enable:
+    disable:
     otelExporterEndpoint:
     ratio:
   serviceConfig:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing an inconsistency between the chart and the CRD.

**Which issue(s) this PR fixes**:
Fixes #5008 

**Special notes for your reviewer**:
N/A