### PR TITLE
feat(helm): Make SeldonConfig configurable in SeldonRuntime Helm chart

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-runtime/templates/seldon-runtime.yaml
+++ b/k8s/helm-charts/seldon-core-v2-runtime/templates/seldon-runtime.yaml
@@ -4,7 +4,7 @@ metadata:
   name: seldon
   namespace: '{{ .Release.Namespace }}'  
 spec:
-  seldonConfig: default
+  seldonConfig: {{ .Values.seldonConfig }}
   disableAutoUpdate: {{ .Values.disableAutoUpdate }}
   overrides:
   - name: hodometer

--- a/k8s/helm-charts/seldon-core-v2-runtime/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-runtime/values.yaml
@@ -1,4 +1,5 @@
 disableAutoUpdate: false
+seldonConfig: default
 
 hodometer:
   disable: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes `SeldonConfig` configurable for `SeldonRuntime`.

**Which issue(s) this PR fixes**:
Fixes #5013 

**Special notes for your reviewer**:
