### PR TITLE
fix: Add TCP protocol defaults to CRD

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -962,16 +962,22 @@ spec:
         ports:
         - containerPort: 9002
           name: xds
+          protocol: TCP
         - containerPort: 9004
           name: scheduler
+          protocol: TCP
         - containerPort: 9044
           name: scheduler-mtls
+          protocol: TCP
         - containerPort: 9005
           name: agent
+          protocol: TCP
         - containerPort: 9055
           name: agent-mtls
+          protocol: TCP
         - containerPort: 9008
           name: dataflow
+          protocol: TCP
         resources:
           limits:
             memory: '{{ .Values.scheduler.resources.memory }}'
@@ -1351,8 +1357,10 @@ spec:
         ports:
         - containerPort: 9000
           name: http
+          protocol: TCP
         - containerPort: 9003
           name: envoy-admin
+          protocol: TCP
         resources:
           limits:
             memory: '{{ .Values.envoy.resources.memory }}'

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -602,16 +602,22 @@ spec:
         ports:
         - containerPort: 9002
           name: xds
+          protocol: TCP
         - containerPort: 9004
           name: scheduler
+          protocol: TCP
         - containerPort: 9044
           name: scheduler-mtls
+          protocol: TCP
         - containerPort: 9005
           name: agent
+          protocol: TCP
         - containerPort: 9055
           name: agent-mtls
+          protocol: TCP
         - containerPort: 9008
           name: dataflow
+          protocol: TCP
         resources:
           limits:
             memory: '1Gi'
@@ -974,8 +980,10 @@ spec:
         ports:
         - containerPort: 9000
           name: http
+          protocol: TCP
         - containerPort: 9003
           name: envoy-admin
+          protocol: TCP
         resources:
           limits:
             memory: '128Mi'

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -48,8 +48,10 @@ spec:
         ports:
         - containerPort: 9000
           name: http
+          protocol: TCP
         - containerPort: 9003
           name: envoy-admin
+          protocol: TCP
         resources:
           limits:
             memory: 128Mi
@@ -217,16 +219,22 @@ spec:
         ports:
         - containerPort: 9002
           name: xds
+          protocol: TCP
         - containerPort: 9004
           name: scheduler
+          protocol: TCP
         - containerPort: 9044
           name: scheduler-mtls
+          protocol: TCP
         - containerPort: 9005
           name: agent
+          protocol: TCP
         - containerPort: 9055
           name: agent-mtls
+          protocol: TCP
         - containerPort: 9008
           name: dataflow
+          protocol: TCP
         resources:
           limits:
             memory: 1G


### PR DESCRIPTION
Adds defaults to CRD for protocol. Even though [protocol has a default of TCP in a container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#containerport-v1-core). it could be related to [ArgoCD handling of CRDs](https://github.com/argoproj/argo-cd/issues/6939#issuecomment-910917402?).

Adding the default does not cause issues other than we will need to remember it for future port additions.

Fixes: #4976 
