### PR TITLE
fix: Start triton server via bash -c tritonserver instead of just tritonserver

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1869,14 +1869,12 @@ spec:
       - mountPath: /mnt/tracing
         name: tracing-config-volume
     - args:
-      - --model-repository=$(SERVER_MODELS_DIR)
-      - --http-port=$(SERVER_HTTP_PORT)
-      - --grpc-port=$(SERVER_GRPC_PORT)
-      - --log-verbose=1
-      - --model-control-mode=explicit
-      - --backend-config=python,shm-default-byte-size=16777216
+      - -c
+      - tritonserver --model-repository=$(SERVER_MODELS_DIR) --http-port=$(SERVER_HTTP_PORT)
+        --grpc-port=$(SERVER_GRPC_PORT) --log-verbose=1 --model-control-mode=explicit
+        --backend-config=python,shm-default-byte-size=16777216
       command:
-      - /opt/tritonserver/bin/tritonserver
+      - bash
       env:
       - name: SERVER_HTTP_PORT
         value: "9000"

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -1474,14 +1474,12 @@ spec:
       - mountPath: /mnt/tracing
         name: tracing-config-volume
     - args:
-      - --model-repository=$(SERVER_MODELS_DIR)
-      - --http-port=$(SERVER_HTTP_PORT)
-      - --grpc-port=$(SERVER_GRPC_PORT)
-      - --log-verbose=1
-      - --model-control-mode=explicit
-      - --backend-config=python,shm-default-byte-size=16777216
+      - -c
+      - tritonserver --model-repository=$(SERVER_MODELS_DIR) --http-port=$(SERVER_HTTP_PORT)
+        --grpc-port=$(SERVER_GRPC_PORT) --log-verbose=1 --model-control-mode=explicit
+        --backend-config=python,shm-default-byte-size=16777216
       command:
-      - /opt/tritonserver/bin/tritonserver
+      - bash
       env:
       - name: SERVER_HTTP_PORT
         value: "9000"

--- a/operator/config/serverconfigs/triton.yaml
+++ b/operator/config/serverconfigs/triton.yaml
@@ -116,14 +116,10 @@ spec:
         mountPath: /mnt/tracing
     - image: triton:latest
       command:
-      - /opt/tritonserver/bin/tritonserver
+      - bash
       args:
-      - --model-repository=$(SERVER_MODELS_DIR)
-      - --http-port=$(SERVER_HTTP_PORT)
-      - --grpc-port=$(SERVER_GRPC_PORT)
-      - --log-verbose=1
-      - --model-control-mode=explicit
-      - --backend-config=python,shm-default-byte-size=16777216
+      - -c
+      - tritonserver --model-repository=$(SERVER_MODELS_DIR) --http-port=$(SERVER_HTTP_PORT) --grpc-port=$(SERVER_GRPC_PORT) --log-verbose=1 --model-control-mode=explicit --backend-config=python,shm-default-byte-size=16777216
       imagePullPolicy: IfNotPresent
       env:
       - name: SERVER_HTTP_PORT


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
adjusted the components.yaml and the corresponding helm chart file, to be able to launch newer triton versions with gpu support, according to this [issue](https://github.com/triton-inference-server/server/issues/3877) in the triton repository.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5029 

**Special notes for your reviewer**:
