### PR TITLE
fix: relax pyyaml version range to allow install with new Cython 3

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -40,7 +40,7 @@ setup(
         # Addresses CVE SNYK-PYTHON-CRYPTOGRAPHY-3315328
         "cryptography >= 39.0.1, < 40.1",
         # Addresses CVE SNYK-PYTHON-PYYAML-590151
-        "PyYAML >= 5.4, < 5.5",
+        "PyYAML >= 5.4, <= 6.0.1",
         # Addresses CVE PRISMA-2021-0020
         "click >= 8.0.0a1, < 8.1",
         # Addresses CVE CVE-2019-11236 and CVE-2020-26137 and SNYK-PYTHON-URLLIB3-1533435


### PR DESCRIPTION
**What this PR does / why we need it**:
[Release of Cython v3 broke install of pyyaml versions < 6.0.1.
](https://github.com/yaml/pyyaml/issues/724)
6.0.1 has cython <v3 pinned in the install path.

**Which issue(s) this PR fixes**:

Fixes #5033 

**Special notes for your reviewer**:
