### PR TITLE
feat(agent): only rclone specified artifact version directory

### DIFF
--- a/scheduler/pkg/agent/rclone/rclone.go
+++ b/scheduler/pkg/agent/rclone/rclone.go
@@ -42,11 +42,14 @@ const (
 	RcloneNoopPath            = "/rc/noop"
 	RcloneSyncCopyPath        = "/sync/copy"
 	RcloneOperationsPurgePath = "/operations/purge"
+	RcloneOperationsList      = "/operations/list"
+	RcloneOperationsCopyFile  = "/operations/copyfile"
 	RcloneConfigCreatePath    = "/config/create"
 	RcloneConfigUpdatePath    = "/config/update"
 	RcloneListRemotesPath     = "/config/listremotes"
 	RcloneConfigDeletePath    = "/config/delete"
 	RcloneConfigGetPath       = "/config/get"
+	TritonConfigFileName      = "config.pbtxt"
 )
 
 type RCloneClient struct {
@@ -58,6 +61,27 @@ type RCloneClient struct {
 	validate   *validator.Validate
 	namespace  string
 	configChan chan config.AgentConfiguration
+}
+
+type RcloneList struct {
+	Fs     string `json:"fs"`
+	Remote string `json:"remote"`
+}
+
+type RcloneListItem struct {
+	IsDir bool   `json:"isDir"`
+	Name  string `json:"name"`
+}
+
+type RcloneListItems struct {
+	Items []RcloneListItem `json:"list"`
+}
+
+type RcloneCopyFile struct {
+	SrcFs     string `json:"srcFs"`
+	SrcRemote string `json:"srcRemote"`
+	DstFs     string `json:"dstFs"`
+	DstRemote string `json:"dstRemote"`
 }
 
 type Noop struct {
@@ -229,11 +253,14 @@ func (r *RCloneClient) parseRcloneConfig(config []byte) (*RcloneConfigCreate, er
 
 // Creating a connection string with https://rclone.org/docs/#connection-strings
 func (r *RCloneClient) createUriWithConfig(uri string, rawConfig []byte) (string, error) {
+	
 	remoteName, err := getRemoteName(uri)
 	if err != nil {
 		return "", err
 	}
-
+	if len(rawConfig) == 0 {
+		return uri, nil
+	}
 	config, err := r.parseRcloneConfig(rawConfig)
 	if err != nil {
 		return "", err
@@ -310,18 +337,13 @@ func pathExists(path string) (bool, error) {
 }
 
 // Call Rclone /sync/copy
-func (r *RCloneClient) Copy(modelName string, srcUri string, config []byte) (string, error) {
-	logger := r.logger.WithField("func", "Copy")
-
-	var srcUpdated string
+func (r *RCloneClient) Copy(modelName string, srcUri string, artifactVersion *uint32, config []byte) (string, error) {
+	var srcUriWithConfig string
 	var err error
-	if len(config) > 0 {
-		srcUpdated, err = r.createUriWithConfig(srcUri, config)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		srcUpdated = srcUri
+	srcUri = strings.TrimSuffix(srcUri, "/")
+	srcUriWithConfig, err = r.createUriWithConfig(srcUri, config)
+	if err != nil {
+		return "", err
 	}
 
 	// Create key from srcUri plus modelName.
@@ -335,25 +357,53 @@ func (r *RCloneClient) Copy(modelName string, srcUri string, config []byte) (str
 	}
 
 	dst := fmt.Sprintf("%s/%d", r.localPath, hash)
-	copy := RcloneCopy{
-		SrcFs:              srcUpdated,
-		DstFs:              dst,
-		CreateEmptySrcDirs: true,
+
+	artifactVersionDirFound := false
+	tritonConfigFileFound := false
+	if artifactVersion != nil && *artifactVersion > 0 {
+		items, err := r.listDir(srcUriWithConfig)
+		if err != nil {
+			return "", fmt.Errorf("failed to list dir %s %w", srcUri, err)
+		}
+
+		artifactVersionStr := strconv.Itoa(int(*artifactVersion))
+		for _, item := range items {
+			if item.IsDir && item.Name == artifactVersionStr {
+				artifactVersionDirFound = true
+			} else if !item.IsDir && item.Name == TritonConfigFileName {
+				tritonConfigFileFound = true
+			}
+		}
 	}
 
-	logger.
-		WithField("source_uri", srcUri).
-		WithField("destination_uri", dst).
-		Info("will copy model artifacts")
+	if artifactVersionDirFound {
+		artifactVersionSrc := fmt.Sprintf("%s/%d", srcUri, *artifactVersion)
+		artifactVersionDst := fmt.Sprintf("%s/%d", dst, *artifactVersion)
+		artifactVersionSrcWithConfig, err := r.createUriWithConfig(artifactVersionSrc, config)
+		if err != nil {
+			return "", err
+		}
+		err = r.syncCopy(artifactVersionSrcWithConfig, artifactVersionDst)
+		if err != nil {
+			r.logger.WithError(err).Error("failed to sync/copy artifact version directory")
+			return "", err
+		}
 
-	b, err := json.Marshal(copy)
-	if err != nil {
-		return "", err
-	}
-
-	_, err = r.call(b, RcloneSyncCopyPath)
-	if err != nil {
-		return "", fmt.Errorf("Failed to sync/copy %s to %s %w", srcUri, dst, err)
+		if tritonConfigFileFound {
+			err = r.copyFile(srcUriWithConfig, TritonConfigFileName, dst, TritonConfigFileName)
+			if err != nil {
+				return "", err
+			}
+		}
+	} else {
+		r.logger.
+			WithField("source_uri", srcUri).
+			WithField("destination_uri", dst).
+			Info("will copy model artifacts")
+		err = r.syncCopy(srcUriWithConfig, dst)
+		if err != nil {
+			return "", fmt.Errorf("failed to sync/copy %s to %s %w", srcUri, dst, err)
+		}
 	}
 
 	// Even if we had success from rclone the src may be empty so need to check
@@ -362,10 +412,69 @@ func (r *RCloneClient) Copy(modelName string, srcUri string, config []byte) (str
 		return "", err
 	}
 	if !pathExists {
-		return "", fmt.Errorf("Failed to download from %s any files", srcUri)
+		return "", fmt.Errorf("failed to download from %s any files", srcUri)
 	}
 
 	return dst, nil
+}
+
+func (r *RCloneClient) listDir(fs string) ([]RcloneListItem, error) {
+	list := RcloneList{
+		Fs: fs,
+	}
+	b, err := json.Marshal(list)
+	if err != nil {
+		return nil, err
+	}
+	lsResponse, err := r.call(b, RcloneOperationsList)
+	if err != nil {
+		return nil, err
+	}
+	var listResponse RcloneListItems
+	err = json.Unmarshal(lsResponse, &listResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal rclone list response %s %w", lsResponse, err)
+	}
+
+	return listResponse.Items, nil
+}
+
+func (r *RCloneClient) syncCopy(src string, dst string) error {
+	copy := RcloneCopy{
+		SrcFs:              src,
+		DstFs:              dst,
+		CreateEmptySrcDirs: true,
+	}
+
+	b, err := json.Marshal(copy)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.call(b, RcloneSyncCopyPath)
+	return err
+}
+
+func (r *RCloneClient) copyFile(srcFs string, srcRemote string, dstFs string, dstRemote string) error {
+	copy := RcloneCopyFile{
+		SrcFs:     srcFs,
+		SrcRemote: srcRemote,
+		DstFs:     dstFs,
+		DstRemote: dstRemote,
+	}
+
+	r.logger.Infof("Copy file %s", copy)
+
+	b, err := json.Marshal(copy)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.call(b, RcloneOperationsCopyFile)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *RCloneClient) PurgeLocal(path string) error {

--- a/scheduler/pkg/agent/repository/model_repository.go
+++ b/scheduler/pkg/agent/repository/model_repository.go
@@ -85,7 +85,7 @@ func (r *V2ModelRepository) DownloadModelVersion(
 	logger.Debugf("running with model %s:%d srcUri %s", modelName, version, srcUri)
 
 	// Run rclone copy sync
-	rclonePath, err := r.rcloneClient.Copy(modelName, srcUri, config)
+	rclonePath, err := r.rcloneClient.Copy(modelName, srcUri, artifactVersion, config)
 	if err != nil {
 		return nil, err
 	}
@@ -100,11 +100,16 @@ func (r *V2ModelRepository) DownloadModelVersion(
 		return nil, err
 	}
 
+	artifactVersionInt := 0
+	if artifactVersion != nil {
+		artifactVersionInt = int(*artifactVersion)
+	}
+
 	logger.Debugf(
 		"Found model %s:%d artifactVersion %d for %s at %s ",
 		modelName,
 		version,
-		artifactVersion,
+		artifactVersionInt,
 		srcUri,
 		modelVersionFolder,
 	)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Only rclone specified artifact version directory to speed up the model loading process.

For tritonserver, agent clones the config.pbtxt file along with the specified artifact version directory.

**Which issue(s) this PR fixes**:
Fixes #5031 

**Special notes for your reviewer**:
