### PR TITLE
fix: Allow digits in topic prefix

### DIFF
--- a/scheduler/pkg/kafka/topics.go
+++ b/scheduler/pkg/kafka/topics.go
@@ -44,7 +44,7 @@ type TopicNamer struct {
 }
 
 var (
-	isValidPrefix = regexp.MustCompile(`^[A-Za-z._-]+$`).MatchString
+	isValidPrefix = regexp.MustCompile(`^[A-Za-z0-9._-]+$`).MatchString
 )
 
 // Topics can only have a-z, A-Z, 0-9, . (dot), _ (underscore), and - (dash)

--- a/scheduler/pkg/kafka/topics_test.go
+++ b/scheduler/pkg/kafka/topics_test.go
@@ -457,6 +457,12 @@ func TestNewTopicNamer(t *testing.T) {
 			topicPrefix: "my_prefix&",
 			err:         true,
 		},
+		{
+			name:        "prefix with digits",
+			namespace:   "seldon-mesh",
+			topicPrefix: "a51691-preprod-seldon",
+			err:         false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Adds missing digits to regexp checking topic prefix.

Fixes #5050
