### PR TITLE
fix: Allow number of replicas in k6 tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19.0'
+          go-version: '1.19.10'
       - name: lint-operator
         uses: golangci/golangci-lint-action@v3
         with:

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -110,6 +110,13 @@ function inferBatchSize() {
     return [1]
 }
 
+function modelReplicas() {
+    if (__ENV.MODEL_NUM_REPLICAS) {
+        return __ENV.MODEL_NUM_REPLICAS.split(",").map( s => parseInt(s))
+    }
+    return [1]
+}
+
 function modelStartIdx() {
     if (__ENV.MODEL_START_IDX) {
         return parseInt(__ENV.MODEL_START_IDX)
@@ -217,5 +224,6 @@ export function getConfig() {
         "doWarmup": doWarmup(),
         "requestRate": requestRate(),
         "constantRateDurationSeconds": constantRateDurationSeconds(),
+        "modelReplicas": modelReplicas(),
     }
 }

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -22,7 +22,7 @@ export function setupBase(config ) {
         for (let j = 0; j < config.maxNumModels.length; j++) {        
             for (let i = 0; i < config.maxNumModels[j]; i++) {
                 const modelName = config.modelNamePrefix[j] + i.toString()
-                const model = generateModel(config.modelType[j], modelName, 1, 1, config.isSchedulerProxy, config.modelMemoryBytes[j], config.inferBatchSize[j])
+                const model = generateModel(config.modelType[j], modelName, 1, config.modelReplicas[j], config.isSchedulerProxy, config.modelMemoryBytes[j], config.inferBatchSize[j])
                 const modelDefn = model.modelDefn
                 const pipelineDefn = model.pipelineDefn
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Expose `MODEL_NUM_REPLICAS` in k6 tests to specify how many replicas to load.
This PR also fixes go version in github action linting.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
