### PR TITLE
fix(manifests): rename components to allow install along core v1

### DIFF
--- a/ansible/roles/opentelemetry/tasks/install.yaml
+++ b/ansible/roles/opentelemetry/tasks/install.yaml
@@ -22,5 +22,5 @@
 - name: "Wait for OpenTelemetry Deployment"
   shell: "kubectl rollout status -n {{ opentelemetry_namespace }} deploy/{{ item }}"
   with_items:
-    - opentelemetry-operator-controller-manager
+    - opentelemetry-operator-v2-controller-manager
   when: opentelemetry_wait_for_deployments | bool

--- a/ansible/roles/opentelemetry/tasks/install.yaml
+++ b/ansible/roles/opentelemetry/tasks/install.yaml
@@ -22,5 +22,5 @@
 - name: "Wait for OpenTelemetry Deployment"
   shell: "kubectl rollout status -n {{ opentelemetry_namespace }} deploy/{{ item }}"
   with_items:
-    - opentelemetry-operator-v2-controller-manager
+    - opentelemetry-operator-controller-manager
   when: opentelemetry_wait_for_deployments | bool

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -20,7 +20,7 @@ create-helm-charts:
 	sed 's/HACK_REMOVE_ME//' ${HELM_SERVERS_BASE}/seldon-v2-servers.yaml \
 		> ${HELM_SERVERS_BASE}/.seldon-v2-servers.yaml
 	sed -zi 's#\(apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole.*\- get\n\-\-\-\)#{{- if .Values.controller.clusterwide -}}\n\1\n{{- end }}#' ${HELM_COMPONENTS_BASE}/seldon-v2-components.yaml
-	sed -zi 's#\(apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding.*ServiceAccount\n  name: seldon-controller-manager\n  namespace:[^-]\{27\}\n\-\-\-\)#{{- if .Values.controller.clusterwide -}}\n\1\n{{- end }}#' ${HELM_COMPONENTS_BASE}/seldon-v2-components.yaml
+	sed -zi 's#\(apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding.*ServiceAccount\n  name: seldon-v2-controller-manager\n  namespace:[^-]\{27\}\n\-\-\-\)#{{- if .Values.controller.clusterwide -}}\n\1\n{{- end }}#' ${HELM_COMPONENTS_BASE}/seldon-v2-components.yaml
 	mv ${HELM_SERVERS_BASE}/.seldon-v2-servers.yaml ${HELM_SERVERS_BASE}/seldon-v2-servers.yaml
 
 .PHONY: create-yaml

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -7,8 +7,46 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: seldon-v2-leader-election-role
+  namespace: '{{ .Release.Namespace }}'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   creationTimestamp: null
-  name: seldon-manager-role
+  name: seldon-v2-manager-role
   namespace: '{{ .Release.Namespace }}'
 rules:
 - apiGroups:
@@ -343,7 +381,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: seldon-manager-tls-role
+  name: seldon-v2-manager-tls-role
   namespace: '{{ .Release.Namespace }}'
 rules:
 - apiGroups:
@@ -354,44 +392,6 @@ rules:
   - get
   - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: seldon-v2-leader-election-role
-  namespace: '{{ .Release.Namespace }}'
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 ---
 {{- if .Values.controller.clusterwide -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -732,40 +732,40 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: seldon-manager-rolebinding
-  namespace: '{{ .Release.Namespace }}'
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: seldon-manager-role
-subjects:
-- kind: ServiceAccount
-  name: seldon-v2-controller-manager
-  namespace: '{{ .Release.Namespace }}'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: seldon-manager-tls-rolebinding
-  namespace: '{{ .Release.Namespace }}'
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: seldon-manager-tls-role
-subjects:
-- kind: ServiceAccount
-  name: seldon-v2-controller-manager
-  namespace: '{{ .Release.Namespace }}'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: seldon-v2-leader-election-rolebinding
   namespace: '{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: seldon-v2-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-v2-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seldon-v2-manager-rolebinding
+  namespace: '{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-v2-manager-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-v2-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seldon-v2-manager-tls-rolebinding
+  namespace: '{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-v2-manager-tls-role
 subjects:
 - kind: ServiceAccount
   name: seldon-v2-controller-manager

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1,46 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
   namespace: '{{ .Release.Namespace }}'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: seldon-leader-election-role
-  namespace: '{{ .Release.Namespace }}'
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -392,6 +354,44 @@ rules:
   - get
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: seldon-v2-leader-election-role
+  namespace: '{{ .Release.Namespace }}'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 {{- if .Values.controller.clusterwide -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -732,20 +732,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: seldon-leader-election-rolebinding
-  namespace: '{{ .Release.Namespace }}'
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: seldon-leader-election-role
-subjects:
-- kind: ServiceAccount
-  name: seldon-controller-manager
-  namespace: '{{ .Release.Namespace }}'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: seldon-manager-rolebinding
   namespace: '{{ .Release.Namespace }}'
 roleRef:
@@ -754,7 +740,7 @@ roleRef:
   name: seldon-manager-role
 subjects:
 - kind: ServiceAccount
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -768,7 +754,21 @@ roleRef:
   name: seldon-manager-tls-role
 subjects:
 - kind: ServiceAccount
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seldon-v2-leader-election-rolebinding
+  namespace: '{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-v2-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-v2-controller-manager
   namespace: '{{ .Release.Namespace }}'
 ---
 {{- if .Values.controller.clusterwide -}}
@@ -782,7 +782,7 @@ roleRef:
   name: seldon-manager-role
 subjects:
 - kind: ServiceAccount
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
   namespace: '{{ .Release.Namespace }}'
 ---
 {{- end }}
@@ -809,20 +809,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
-  name: seldon-controller-manager
+    control-plane: v2-controller-manager
+  name: seldon-v2-controller-manager
   namespace: '{{ .Release.Namespace }}'
 spec:
   replicas: 1
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: v2-controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: v2-controller-manager
     spec:
       containers:
       - args:
@@ -884,7 +884,7 @@ spec:
 {{- end }}
       securityContext: {{- toYaml .Values.controller.securityContext
         | nindent 8 }}
-      serviceAccountName: seldon-controller-manager
+      serviceAccountName: seldon-v2-controller-manager
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: mlops.seldon.io/v1alpha1

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -398,7 +398,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: seldon-manager-role
+  name: seldon-v2-manager-role
 rules:
 - apiGroups:
   - ""
@@ -775,11 +775,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: seldon-manager-rolebinding
+  name: seldon-v2-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: seldon-manager-role
+  name: seldon-v2-manager-role
 subjects:
 - kind: ServiceAccount
   name: seldon-v2-controller-manager

--- a/k8s/kustomize/helm-components-sc/kustomization.yaml
+++ b/k8s/kustomize/helm-components-sc/kustomization.yaml
@@ -33,7 +33,7 @@ patches:
   target:
     version: v1
     kind: Deployment
-    name: seldon-controller-manager
+    name: seldon-v2-controller-manager
 - path: patch_envoy_json6902.yaml
   target:
     version: v1alpha1

--- a/k8s/kustomize/helm-components-sc/patch_controller.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
 spec:
   template:
     spec:
@@ -20,7 +20,7 @@ spec:
           - name: CLUSTERWIDE
             value: '{{ .Values.controller.clusterwide }}'
           - name: CONTROL_PLANE_SECURITY_PROTOCOL
-            value: '{{ .Values.security.controlplane.protocol }}'            
+            value: '{{ .Values.security.controlplane.protocol }}'
           - name: CONTROL_PLANE_CLIENT_TLS_SECRET_NAME
             value: '{{ .Values.security.controlplane.ssl.client.secret }}'
           - name: CONTROL_PLANE_SERVER_TLS_SECRET_NAME

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
 apiVersion: v1
@@ -23,44 +23,6 @@ data:
 kind: ConfigMap
 metadata:
   name: seldon-manager-config
----
-# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: seldon-leader-election-role
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -415,16 +377,41 @@ rules:
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
-  name: seldon-leader-election-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: seldon-leader-election-role
-subjects:
-- kind: ServiceAccount
-  name: seldon-controller-manager
+  name: seldon-v2-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -437,7 +424,7 @@ roleRef:
   name: seldon-manager-role
 subjects:
 - kind: ServiceAccount
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -450,26 +437,39 @@ roleRef:
   name: seldon-manager-tls-role
 subjects:
 - kind: ServiceAccount
-  name: seldon-controller-manager
+  name: seldon-v2-controller-manager
+---
+# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seldon-v2-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-v2-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-v2-controller-manager
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
-  name: seldon-controller-manager
+    control-plane: v2-controller-manager
+  name: seldon-v2-controller-manager
 spec:
   replicas: 1
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: v2-controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: v2-controller-manager
     spec:
       containers:
       - args:
@@ -528,7 +528,7 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
-      serviceAccountName: seldon-controller-manager
+      serviceAccountName: seldon-v2-controller-manager
       terminationGracePeriodSeconds: 10
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -28,8 +28,46 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: seldon-v2-leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   creationTimestamp: null
-  name: seldon-manager-role
+  name: seldon-v2-manager-role
 rules:
 - apiGroups:
   - ""
@@ -364,7 +402,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: seldon-manager-tls-role
+  name: seldon-v2-manager-tls-role
 rules:
 - apiGroups:
   - ""
@@ -377,70 +415,6 @@ rules:
 ---
 # Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: seldon-v2-leader-election-role
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
----
-# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: seldon-manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: seldon-manager-role
-subjects:
-- kind: ServiceAccount
-  name: seldon-v2-controller-manager
----
-# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: seldon-manager-tls-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: seldon-manager-tls-role
-subjects:
-- kind: ServiceAccount
-  name: seldon-v2-controller-manager
----
-# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: seldon-v2-leader-election-rolebinding
@@ -448,6 +422,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: seldon-v2-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-v2-controller-manager
+---
+# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seldon-v2-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-v2-manager-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-v2-controller-manager
+---
+# Source: seldon-core-v2-setup/templates/seldon-v2-components.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: seldon-v2-manager-tls-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-v2-manager-tls-role
 subjects:
 - kind: ServiceAccount
   name: seldon-v2-controller-manager

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -47,7 +47,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=v2-manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	sed -i '/namespace: seldon-mesh/d' config/rbac/role.yaml # remove namespace added by controller-gen
 	cp config/rbac/role.yaml config/rbac/namespace_role.yaml
 	sed -i 's/ClusterRole/Role/' config/rbac/namespace_role.yaml

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -28,7 +28,7 @@ bases:
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
-# If you want your controller-manager to expose the /metrics
+# If you want your v2-controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 #- manager_auth_proxy_patch.yaml
 

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: v2-controller-manager
   namespace: system
 spec:
   template:
@@ -27,4 +27,3 @@ spec:
         - "--leader-elect"
         - "--scheduler-host=$(SELDON_SCHEDULER_SVC)"
         - "--scheduler-port=$(SELDON_SCHEDULER_PORT)"
-

--- a/operator/config/default/manager_config_patch.yaml
+++ b/operator/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: v2-controller-manager
   namespace: system
 spec:
   template:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: v2-controller-manager
   labels:
-    control-plane: controller-manager
+    control-plane: v2-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: v2-controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: v2-controller-manager
     spec:
       securityContext:
         runAsNonRoot: true
@@ -58,5 +58,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-manager
+      serviceAccountName: v2-controller-manager
       terminationGracePeriodSeconds: 10

--- a/operator/config/prometheus/monitor.yaml
+++ b/operator/config/prometheus/monitor.yaml
@@ -4,8 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+    control-plane: v2-controller-manager
+  name: v2-controller-manager-metrics-monitor
 spec:
   endpoints:
     - path: /metrics
@@ -16,4 +16,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: v2-controller-manager

--- a/operator/config/rbac/auth_proxy_role_binding.yaml
+++ b/operator/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: v2-controller-manager
   namespace: system

--- a/operator/config/rbac/auth_proxy_service.yaml
+++ b/operator/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
+    control-plane: v2-controller-manager
+  name: v2-controller-manager-metrics-service
   namespace: system
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: v2-controller-manager

--- a/operator/config/rbac/leader_election_role.yaml
+++ b/operator/config/rbac/leader_election_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: v2-leader-election-role
 rules:
 - apiGroups:
   - ""

--- a/operator/config/rbac/leader_election_role_binding.yaml
+++ b/operator/config/rbac/leader_election_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: v2-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: v2-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: v2-controller-manager

--- a/operator/config/rbac/namespace_role.yaml
+++ b/operator/config/rbac/namespace_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: v2-manager-role
 rules:
 - apiGroups:
   - ""

--- a/operator/config/rbac/namespace_role_binding.yaml
+++ b/operator/config/rbac/namespace_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: manager-rolebinding
+  name: v2-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: manager-role
+  name: v2-manager-role
 subjects:
 - kind: ServiceAccount
   name: v2-controller-manager

--- a/operator/config/rbac/namespace_role_binding.yaml
+++ b/operator/config/rbac/namespace_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-
+  name: v2-controller-manager

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: v2-manager-role
 rules:
 - apiGroups:
   - ""

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: v2-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: v2-manager-role
 subjects:
 - kind: ServiceAccount
   name: v2-controller-manager

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-
+  name: v2-controller-manager

--- a/operator/config/rbac/service_account.yaml
+++ b/operator/config/rbac/service_account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
+  name: v2-controller-manager

--- a/operator/config/rbac/tls_role.yaml
+++ b/operator/config/rbac/tls_role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: manager-tls-role
+  name: v2-manager-tls-role
 rules:
 - apiGroups:
   - ""

--- a/operator/config/rbac/tls_role_binding.yaml
+++ b/operator/config/rbac/tls_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: manager-tls-rolebinding
+  name: v2-manager-tls-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: manager-tls-role
+  name: v2-manager-tls-role
 subjects:
 - kind: ServiceAccount
   name: v2-controller-manager

--- a/operator/config/rbac/tls_role_binding.yaml
+++ b/operator/config/rbac/tls_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: manager-tls-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-
+  name: v2-controller-manager


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR renames couple of resources created when installing Seldon Core v2 such that it can be installed in same namespace along Seldon Core v1.

The renamed resources are as follow:
- Service Account: `seldon-controller-manager` -> `seldon-v2-controller-manager`
- Cluster Role: `seldon-manager-role` -> `seldon-v2-manager-role`
- Role: `seldon-leader-election-role` -> `seldon-v2-leader-election-role`
- Role: `seldon-manager-role` -> `seldon-v2-manager-role`
- Role: `seldon-manager-tls-role` -> `seldon-v2-manager-tls-role`
- Role Binding: `seldon-leader-election-rolebinding` -> `seldon-v2-leader-election-rolebinding`
- Role Binding: `seldon-manager-rolebinding` -> `seldon-v2-manager-rolebinding`
- Role Binding: `seldon-manager-tls-rolebinding` -> `seldon-v2-manager-tls-rolebinding`
- Deployment: `seldon-controller-manager` -> `seldon-v2-controller-manager`

Change should be idempotent to regeneration of resources as running
```bash
make -C operator/ manifests 
make -C k8s/ create
```
does not bring any changes

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
