### PR TITLE
Allow init containers if modelUri provided

### DIFF
--- a/notebooks/protocol_examples.ipynb
+++ b/notebooks/protocol_examples.ipynb
@@ -96,7 +96,7 @@
     {
      "data": {
       "text/plain": [
-       "'1.16.0-dev'"
+       "'1.17.0-dev'"
       ]
      },
      "execution_count": 5,
@@ -186,14 +186,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'data': {'names': ['proba'], 'ndarray': [[0.43782349911420193]]}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.16.0-dev'}}}\n"
+      "{'data': {'names': ['proba'], 'ndarray': [[0.43782349911420193]]}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.17.0-dev'}}}\n"
      ]
     }
    ],
@@ -208,14 +210,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.16.0-dev'}}, 'data': {'names': ['proba'], 'ndarray': [[0.43782349911420193]]}}\n"
+      "{'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.17.0-dev'}}, 'data': {'names': ['proba'], 'ndarray': [[0.43782349911420193]]}}\n"
      ]
     }
    ],
@@ -231,7 +233,143 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seldondeployment.machinelearning.seldon.io \"example-seldon\" deleted\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl delete -f resources/model_seldon.yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Seldon protocol Model with ModelUri with two custom models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writetemplate resources/model_seldon.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  name: example-seldon\n",
+    "spec:\n",
+    "  protocol: seldon\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/mock_classifier:{VERSION}\n",
+    "          name: classifier\n",
+    "        - image: seldonio/mock_classifier:{VERSION}\n",
+    "          name: classifier2\n",
+    "    graph:\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "      modelUri: gs://seldon-models/v1.17.0-dev/sklearn/iris\n",
+    "      children:\n",
+    "      - name: classifier2\n",
+    "        type: MODEL\n",
+    "        modelUri: gs://seldon-models/v1.17.0-dev/sklearn/iris\n",
+    "    name: model\n",
+    "    replicas: 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seldondeployment.machinelearning.seldon.io/example-seldon unchanged\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl apply -f resources/model_seldon.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seldondeployment.machinelearning.seldon.io/example-seldon condition met\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl wait --for condition=ready --timeout=300s sdep --all -n seldon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'data': {'names': ['proba'], 'ndarray': [[0.07735472603574542]]}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.17.0-dev', 'classifier2': 'seldonio/mock_classifier:1.17.0-dev'}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "X=!curl -s -d '{\"data\": {\"ndarray\":[[1.0, 2.0, 5.0]]}}' \\\n",
+    "   -X POST http://localhost:8003/seldon/seldon/example-seldon/api/v1.0/predictions \\\n",
+    "   -H \"Content-Type: application/json\"\n",
+    "d=json.loads(X[0])\n",
+    "print(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.17.0-dev', 'classifier2': 'seldonio/mock_classifier:1.17.0-dev'}}, 'data': {'names': ['proba'], 'ndarray': [[0.07735472603574542]]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "X=!cd ../executor/proto && grpcurl -d '{\"data\":{\"ndarray\":[[1.0,2.0,5.0]]}}' \\\n",
+    "         -rpc-header seldon:example-seldon -rpc-header namespace:seldon \\\n",
+    "         -plaintext \\\n",
+    "         -proto ./prediction.proto  0.0.0.0:8003 seldon.protos.Seldon/Predict\n",
+    "d=json.loads(\"\".join(X))\n",
+    "print(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {

--- a/operator/controllers/seldondeployment_controller.go
+++ b/operator/controllers/seldondeployment_controller.go
@@ -584,7 +584,7 @@ func (r *SeldonDeploymentReconciler) createComponents(ctx context.Context, mlDep
 		}
 
 		pi := NewPrePackedInitializer(ctx, r.ClientSet)
-		err = pi.createStandaloneModelServers(mlDep, &p, &c, &p.Graph, securityContext)
+		err = pi.addModelServersAndInitContainers(mlDep, &p, &c, &p.Graph, securityContext, log)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Allow init containers to be added for any predictive unit that defines the `modelURI` field.

Fixes #5054

