### PR TITLE
feat(agent) scale up model with infer delay metric

### DIFF
--- a/scheduler/cmd/agent/cli/cli.go
+++ b/scheduler/cmd/agent/cli/cli.go
@@ -27,53 +27,55 @@ import (
 )
 
 const (
-	envServerHttpPort                = "SELDON_SERVER_HTTP_PORT"
-	envServerGrpcPort                = "SELDON_SERVER_GRPC_PORT"
-	envReverseProxyHttpPort          = "SELDON_REVERSE_PROXY_HTTP_PORT"
-	envReverseProxyGrpcPort          = "SELDON_REVERSE_PROXY_GRPC_PORT"
-	envDebugGrpcPort                 = "SELDON_DEBUG_GRPC_PORT"
-	envMetricsPort                   = "SELDON_METRICS_PORT"
-	envPodName                       = "POD_NAME"
-	envSchedulerHost                 = "SELDON_SCHEDULER_HOST"
-	envSchedulerPort                 = "SELDON_SCHEDULER_PORT"
-	envSchedulerTlsPort              = "SELDON_SCHEDULER_TLS_PORT"
-	envReplicaConfig                 = "SELDON_REPLICA_CONFIG"
-	envLogLevel                      = "SELDON_LOG_LEVEL"
-	envServerType                    = "SELDON_SERVER_TYPE"
-	envMemoryRequest                 = "MEMORY_REQUEST"
-	envCapabilities                  = "SELDON_SERVER_CAPABILITIES"
-	envOverCommitPercentage          = "SELDON_OVERCOMMIT_PERCENTAGE"
-	envEnvoyHost                     = "SELDON_ENVOY_HOST"
-	envEnvoyPort                     = "SELDON_ENVOY_PORT"
-	envDrainerServicePort            = "SELDON_DRAINER_PORT"
-	envModelInferenceLagThreshold    = "SELDON_MODEL_INFERENCE_LAG_THRESHOLD"
-	envModelInactiveSecondsThreshold = "SELDON_MODEL_INACTIVE_SECONDS_THRESHOLD"
-	envScalingStatsPeriodSeconds     = "SELDON_SCALING_STATS_PERIOD_SECONDS"
+	envServerHttpPort                 = "SELDON_SERVER_HTTP_PORT"
+	envServerGrpcPort                 = "SELDON_SERVER_GRPC_PORT"
+	envReverseProxyHttpPort           = "SELDON_REVERSE_PROXY_HTTP_PORT"
+	envReverseProxyGrpcPort           = "SELDON_REVERSE_PROXY_GRPC_PORT"
+	envDebugGrpcPort                  = "SELDON_DEBUG_GRPC_PORT"
+	envMetricsPort                    = "SELDON_METRICS_PORT"
+	envPodName                        = "POD_NAME"
+	envSchedulerHost                  = "SELDON_SCHEDULER_HOST"
+	envSchedulerPort                  = "SELDON_SCHEDULER_PORT"
+	envSchedulerTlsPort               = "SELDON_SCHEDULER_TLS_PORT"
+	envReplicaConfig                  = "SELDON_REPLICA_CONFIG"
+	envLogLevel                       = "SELDON_LOG_LEVEL"
+	envServerType                     = "SELDON_SERVER_TYPE"
+	envMemoryRequest                  = "MEMORY_REQUEST"
+	envCapabilities                   = "SELDON_SERVER_CAPABILITIES"
+	envOverCommitPercentage           = "SELDON_OVERCOMMIT_PERCENTAGE"
+	envEnvoyHost                      = "SELDON_ENVOY_HOST"
+	envEnvoyPort                      = "SELDON_ENVOY_PORT"
+	envDrainerServicePort             = "SELDON_DRAINER_PORT"
+	envModelInferenceLagThreshold     = "SELDON_MODEL_INFERENCE_LAG_THRESHOLD"
+	envModelInferenceDelayMSThreshold = "SELDON_MODEL_INFERENCE_DELAY_MS_THRESHOLD"
+	envModelInactiveSecondsThreshold  = "SELDON_MODEL_INACTIVE_SECONDS_THRESHOLD"
+	envScalingStatsPeriodSeconds      = "SELDON_SCALING_STATS_PERIOD_SECONDS"
 
-	flagSchedulerHost                 = "scheduler-host"
-	flagSchedulerPlaintxtPort         = "scheduler-port"
-	flagSchedulerTlsPort              = "scheduler-tls-port"
-	flagServerName                    = "server-name"
-	flagServerIdx                     = "server-idx"
-	flagInferenceHttpPort             = "inference-http-port"
-	flagInferenceGrpcPort             = "inference-grpc-port"
-	flagReverseProxyHttpPort          = "reverse-proxy-http-port"
-	flagReverseProxyGrpcPort          = "reverse-proxy-grpc-port"
-	flagDebugGrpcPort                 = "debug-grpc-port"
-	flagMetricsPort                   = "metrics-port"
-	flagReplicaConfig                 = "replica-config"
-	flagLogLevel                      = "log-level"
-	flagServerType                    = "server-type"
-	flagMemoryBytes                   = "memory-bytes"
-	flagCapabilities                  = "capabilities"
-	flagOverCommitPercentage          = "over-commit-percentage"
-	flagTracingConfigPath             = "tracing-config-path"
-	flagEnvoyHost                     = "envoy-host"
-	flagEnvoyPort                     = "envoy-port"
-	flagDrainerServicePort            = "drainer-port"
-	flagModelInferenceLagThreshold    = "model-inference-lag-threshold"
-	flagModelInactiveSecondsThreshold = "model-inactive-seconds-threshold"
-	flagScalingStatsPeriodSeconds     = "scaling-stats-period-seconds"
+	flagSchedulerHost                  = "scheduler-host"
+	flagSchedulerPlaintxtPort          = "scheduler-port"
+	flagSchedulerTlsPort               = "scheduler-tls-port"
+	flagServerName                     = "server-name"
+	flagServerIdx                      = "server-idx"
+	flagInferenceHttpPort              = "inference-http-port"
+	flagInferenceGrpcPort              = "inference-grpc-port"
+	flagReverseProxyHttpPort           = "reverse-proxy-http-port"
+	flagReverseProxyGrpcPort           = "reverse-proxy-grpc-port"
+	flagDebugGrpcPort                  = "debug-grpc-port"
+	flagMetricsPort                    = "metrics-port"
+	flagReplicaConfig                  = "replica-config"
+	flagLogLevel                       = "log-level"
+	flagServerType                     = "server-type"
+	flagMemoryBytes                    = "memory-bytes"
+	flagCapabilities                   = "capabilities"
+	flagOverCommitPercentage           = "over-commit-percentage"
+	flagTracingConfigPath              = "tracing-config-path"
+	flagEnvoyHost                      = "envoy-host"
+	flagEnvoyPort                      = "envoy-port"
+	flagDrainerServicePort             = "drainer-port"
+	flagModelInferenceLagThreshold     = "model-inference-lag-threshold"
+	flagModelInferenceDelayMSThreshold = "model-inference-delay-ms-threshold"
+	flagModelInactiveSecondsThreshold  = "model-inactive-seconds-threshold"
+	flagScalingStatsPeriodSeconds      = "scaling-stats-period-seconds"
 )
 
 const (
@@ -88,45 +90,47 @@ const (
 	defaultDrainerServicePort       = 9007
 	statsPeriodSecondsDefault       = 5
 	lagThresholdDefault             = 30
+	delayMSThresholdDefault         = 1000
 	lastUsedThresholdSecondsDefault = 30
 )
 
 var (
-	agentHost                     string
-	ServerName                    string
-	ReplicaIdx                    uint
-	SchedulerHost                 string
-	SchedulerPort                 int
-	SchedulerTlsPort              int
-	RcloneHost                    string
-	RclonePort                    int
-	InferenceHost                 string
-	InferenceHttpPort             int
-	InferenceGrpcPort             int
-	ReverseProxyHttpPort          int
-	ReverseProxyGrpcPort          int
-	DebugGrpcPort                 int
-	MetricsPort                   int
-	AgentFolder                   string
-	Namespace                     string
-	ReplicaConfigStr              string
-	InferenceSvcName              string
-	ConfigPath                    string
-	LogLevel                      string
-	ServerType                    string
-	memoryBytes                   int
-	MemoryBytes64                 uint64
-	capabilitiesList              string
-	Capabilities                  []string
-	OverCommitPercentage          int
-	serverTypes                   = [...]string{"mlserver", "triton"}
-	TracingConfigPath             string
-	EnvoyHost                     string
-	EnvoyPort                     int
-	DrainerServicePort            int
-	ModelInferenceLagThreshold    int
-	ModelInactiveSecondsThreshold int
-	ScalingStatsPeriodSeconds     int
+	agentHost                      string
+	ServerName                     string
+	ReplicaIdx                     uint
+	SchedulerHost                  string
+	SchedulerPort                  int
+	SchedulerTlsPort               int
+	RcloneHost                     string
+	RclonePort                     int
+	InferenceHost                  string
+	InferenceHttpPort              int
+	InferenceGrpcPort              int
+	ReverseProxyHttpPort           int
+	ReverseProxyGrpcPort           int
+	DebugGrpcPort                  int
+	MetricsPort                    int
+	AgentFolder                    string
+	Namespace                      string
+	ReplicaConfigStr               string
+	InferenceSvcName               string
+	ConfigPath                     string
+	LogLevel                       string
+	ServerType                     string
+	memoryBytes                    int
+	MemoryBytes64                  uint64
+	capabilitiesList               string
+	Capabilities                   []string
+	OverCommitPercentage           int
+	serverTypes                    = [...]string{"mlserver", "triton"}
+	TracingConfigPath              string
+	EnvoyHost                      string
+	EnvoyPort                      int
+	DrainerServicePort             int
+	ModelInferenceLagThreshold     int
+	ModelInferenceDelayMSThreshold int
+	ModelInactiveSecondsThreshold  int
+	ScalingStatsPeriodSeconds      int
 )
 
 func init() {
@@ -161,6 +165,7 @@ func updateFlagsFromEnv() {
 	maybeUpdateEnvoyPort()
 	maybeUpdateDrainerPort()
 	maybeUpdateModelInferenceLagThreshold()
+	maybeUpdateModelInferenceDelayMSThreshold()
 	maybeUpdateModelInactiveSecondsThreshold()
 	maybeUpdateScalingStatsPeriodSeconds()
 }
@@ -171,6 +176,15 @@ func maybeUpdateModelInferenceLagThreshold() {
 		envModelInferenceLagThreshold,
 		&ModelInferenceLagThreshold,
 		"inference lag threshold",
+	)
+}
+
+func maybeUpdateModelInferenceDelayMSThreshold() {
+	maybeUpdateFromIntEnv(
+		flagModelInferenceDelayMSThreshold,
+		envModelInferenceDelayMSThreshold,
+		&ModelInferenceDelayMSThreshold,
+		"inference delay threshold in milliseconds",
 	)
 }
 

--- a/scheduler/cmd/agent/cli/flags.go
+++ b/scheduler/cmd/agent/cli/flags.go
@@ -56,6 +56,7 @@ func makeArgs() {
 	flag.IntVar(&EnvoyPort, flagEnvoyPort, defaultEnvoyPort, "Envoy port")
 	flag.IntVar(&DrainerServicePort, flagDrainerServicePort, defaultDrainerServicePort, "Drainer port")
 	flag.IntVar(&ModelInferenceLagThreshold, flagModelInferenceLagThreshold, lagThresholdDefault, "Model inference lag threshold")
+	flag.IntVar(&ModelInferenceDelayMSThreshold, flagModelInferenceDelayMSThreshold, delayMSThresholdDefault, "Model inference delay milliseconds threshold")
 	flag.IntVar(&ModelInactiveSecondsThreshold, flagModelInactiveSecondsThreshold, lastUsedThresholdSecondsDefault, "Model inactive seconds threshold")
 	flag.IntVar(&ScalingStatsPeriodSeconds, flagScalingStatsPeriodSeconds, statsPeriodSecondsDefault, "Scaling stats period seconds")
 }

--- a/scheduler/cmd/agent/cli/flags_test.go
+++ b/scheduler/cmd/agent/cli/flags_test.go
@@ -31,75 +31,77 @@ func TestAgentCliArgsDefault(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
-		name                                  string
-		args                                  []string
-		envs                                  []string
-		expectedAgentHost                     string
-		expectedServerName                    string
-		expectedReplicaIdx                    uint
-		expectedSchedulerHost                 string
-		expectedSchedulerPort                 int
-		expectedSchedulerTlsPort              int
-		expectedRcloneHost                    string
-		expectedRclonePort                    int
-		expectedInferenceHost                 string
-		expectedInferenceHttpPort             int
-		expectedInferenceGrpcPort             int
-		expectedReverseProxyHttpPort          int
-		expectedReverseProxyGrpcPort          int
-		expectedDebugGrpcPort                 int
-		expectedMetricsPort                   int
-		expectedAgentFolder                   string
-		expectedReplicaConfigStr              string
-		expectedNamespace                     string
-		expectedConfigPath                    string
-		expectedLogLevel                      string
-		expectedServerType                    string
-		expectedMemoryRequest                 uint64
-		expectedCapabilities                  []string
-		expectedOverCommitPercentage          int
-		expectedEnvoyHost                     string
-		expectedEnvoyPort                     int
-		expectedDrainerPort                   int
-		expectedModelInferenceLagThreshold    int
-		expectedModelInactiveSecondsThreshold int
-		expectedScalingStatsPeriodSeconds     int
+		name                                   string
+		args                                   []string
+		envs                                   []string
+		expectedAgentHost                      string
+		expectedServerName                     string
+		expectedReplicaIdx                     uint
+		expectedSchedulerHost                  string
+		expectedSchedulerPort                  int
+		expectedSchedulerTlsPort               int
+		expectedRcloneHost                     string
+		expectedRclonePort                     int
+		expectedInferenceHost                  string
+		expectedInferenceHttpPort              int
+		expectedInferenceGrpcPort              int
+		expectedReverseProxyHttpPort           int
+		expectedReverseProxyGrpcPort           int
+		expectedDebugGrpcPort                  int
+		expectedMetricsPort                    int
+		expectedAgentFolder                    string
+		expectedReplicaConfigStr               string
+		expectedNamespace                      string
+		expectedConfigPath                     string
+		expectedLogLevel                       string
+		expectedServerType                     string
+		expectedMemoryRequest                  uint64
+		expectedCapabilities                   []string
+		expectedOverCommitPercentage           int
+		expectedEnvoyHost                      string
+		expectedEnvoyPort                      int
+		expectedDrainerPort                    int
+		expectedModelInferenceLagThreshold     int
+		expectedModelInferenceDelayMSThreshold int
+		expectedModelInactiveSecondsThreshold  int
+		expectedScalingStatsPeriodSeconds      int
 	}
 	tests := []test{
 		{
-			name:                                  "default args",
-			args:                                  []string{},
-			envs:                                  []string{},
-			expectedAgentHost:                     "0.0.0.0",
-			expectedServerName:                    "mlserver",
-			expectedReplicaIdx:                    0,
-			expectedSchedulerHost:                 "0.0.0.0",
-			expectedSchedulerPort:                 defaultSchedulerPort,
-			expectedSchedulerTlsPort:              defaultSchedulerTlsPort,
-			expectedRcloneHost:                    "0.0.0.0",
-			expectedRclonePort:                    defaultRclonePort,
-			expectedInferenceHost:                 "0.0.0.0",
-			expectedInferenceHttpPort:             defaultInferenceHttpPort,
-			expectedInferenceGrpcPort:             defaultInferenceGrpcPort,
-			expectedReverseProxyHttpPort:          9999,
-			expectedReverseProxyGrpcPort:          9998,
-			expectedDebugGrpcPort:                 agent.GRPCDebugServicePort,
-			expectedMetricsPort:                   defaultMetricsPort,
-			expectedAgentFolder:                   "/mnt/agent",
-			expectedReplicaConfigStr:              "",
-			expectedNamespace:                     "",
-			expectedConfigPath:                    "/mnt/config",
-			expectedLogLevel:                      "debug",
-			expectedServerType:                    "mlserver",
-			expectedMemoryRequest:                 1000000,
-			expectedCapabilities:                  []string{"sklearn", "xgboost"},
-			expectedOverCommitPercentage:          0,
-			expectedEnvoyHost:                     defaultEnvoyHost,
-			expectedEnvoyPort:                     defaultEnvoyPort,
-			expectedDrainerPort:                   defaultDrainerServicePort,
-			expectedModelInferenceLagThreshold:    lagThresholdDefault,
-			expectedModelInactiveSecondsThreshold: lastUsedThresholdSecondsDefault,
-			expectedScalingStatsPeriodSeconds:     statsPeriodSecondsDefault,
+			name:                                   "default args",
+			args:                                   []string{},
+			envs:                                   []string{},
+			expectedAgentHost:                      "0.0.0.0",
+			expectedServerName:                     "mlserver",
+			expectedReplicaIdx:                     0,
+			expectedSchedulerHost:                  "0.0.0.0",
+			expectedSchedulerPort:                  defaultSchedulerPort,
+			expectedSchedulerTlsPort:               defaultSchedulerTlsPort,
+			expectedRcloneHost:                     "0.0.0.0",
+			expectedRclonePort:                     defaultRclonePort,
+			expectedInferenceHost:                  "0.0.0.0",
+			expectedInferenceHttpPort:              defaultInferenceHttpPort,
+			expectedInferenceGrpcPort:              defaultInferenceGrpcPort,
+			expectedReverseProxyHttpPort:           9999,
+			expectedReverseProxyGrpcPort:           9998,
+			expectedDebugGrpcPort:                  agent.GRPCDebugServicePort,
+			expectedMetricsPort:                    defaultMetricsPort,
+			expectedAgentFolder:                    "/mnt/agent",
+			expectedReplicaConfigStr:               "",
+			expectedNamespace:                      "",
+			expectedConfigPath:                     "/mnt/config",
+			expectedLogLevel:                       "debug",
+			expectedServerType:                     "mlserver",
+			expectedMemoryRequest:                  1000000,
+			expectedCapabilities:                   []string{"sklearn", "xgboost"},
+			expectedOverCommitPercentage:           0,
+			expectedEnvoyHost:                      defaultEnvoyHost,
+			expectedEnvoyPort:                      defaultEnvoyPort,
+			expectedDrainerPort:                    defaultDrainerServicePort,
+			expectedModelInferenceLagThreshold:     lagThresholdDefault,
+			expectedModelInferenceDelayMSThreshold: delayMSThresholdDefault,
+			expectedModelInactiveSecondsThreshold:  lastUsedThresholdSecondsDefault,
+			expectedScalingStatsPeriodSeconds:      statsPeriodSecondsDefault,
 		},
 		{
 			name: "good args",
@@ -132,40 +134,42 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"--envoy-port=2000",
 				"--drainer-port=2001",
 				"--model-inference-lag-threshold=20",
+				"--model-inference-delay-ms-threshold=2000",
 				"--model-inactive-seconds-threshold=30",
 				"--scaling-stats-period-seconds=40",
 			},
-			envs:                                  []string{},
-			expectedAgentHost:                     "1.1.1.1",
-			expectedServerName:                    "triton",
-			expectedReplicaIdx:                    1,
-			expectedSchedulerHost:                 "10.10.10.10",
-			expectedSchedulerPort:                 10,
-			expectedSchedulerTlsPort:              20,
-			expectedRcloneHost:                    "11.11.11.11",
-			expectedRclonePort:                    11,
-			expectedInferenceHost:                 "12.12.12.12",
-			expectedInferenceHttpPort:             12,
-			expectedInferenceGrpcPort:             122,
-			expectedReverseProxyHttpPort:          13,
-			expectedReverseProxyGrpcPort:          133,
-			expectedDebugGrpcPort:                 14,
-			expectedMetricsPort:                   15,
-			expectedAgentFolder:                   "/tmp",
-			expectedReplicaConfigStr:              "config",
-			expectedNamespace:                     "namespace",
-			expectedConfigPath:                    "/config",
-			expectedLogLevel:                      "info",
-			expectedServerType:                    "triton",
-			expectedMemoryRequest:                 300,
-			expectedCapabilities:                  []string{"a", "b"},
-			expectedOverCommitPercentage:          10,
-			expectedEnvoyHost:                     "2.2.2.2",
-			expectedEnvoyPort:                     2000,
-			expectedDrainerPort:                   2001,
-			expectedModelInferenceLagThreshold:    20,
-			expectedModelInactiveSecondsThreshold: 30,
-			expectedScalingStatsPeriodSeconds:     40,
+			envs:                                   []string{},
+			expectedAgentHost:                      "1.1.1.1",
+			expectedServerName:                     "triton",
+			expectedReplicaIdx:                     1,
+			expectedSchedulerHost:                  "10.10.10.10",
+			expectedSchedulerPort:                  10,
+			expectedSchedulerTlsPort:               20,
+			expectedRcloneHost:                     "11.11.11.11",
+			expectedRclonePort:                     11,
+			expectedInferenceHost:                  "12.12.12.12",
+			expectedInferenceHttpPort:              12,
+			expectedInferenceGrpcPort:              122,
+			expectedReverseProxyHttpPort:           13,
+			expectedReverseProxyGrpcPort:           133,
+			expectedDebugGrpcPort:                  14,
+			expectedMetricsPort:                    15,
+			expectedAgentFolder:                    "/tmp",
+			expectedReplicaConfigStr:               "config",
+			expectedNamespace:                      "namespace",
+			expectedConfigPath:                     "/config",
+			expectedLogLevel:                       "info",
+			expectedServerType:                     "triton",
+			expectedMemoryRequest:                  300,
+			expectedCapabilities:                   []string{"a", "b"},
+			expectedOverCommitPercentage:           10,
+			expectedEnvoyHost:                      "2.2.2.2",
+			expectedEnvoyPort:                      2000,
+			expectedDrainerPort:                    2001,
+			expectedModelInferenceLagThreshold:     20,
+			expectedModelInferenceDelayMSThreshold: 2000,
+			expectedModelInactiveSecondsThreshold:  30,
+			expectedScalingStatsPeriodSeconds:      40,
 		},
 		{
 			name: "good envs",
@@ -190,39 +194,41 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"SELDON_ENVOY_PORT=3000",
 				"SELDON_DRAINER_PORT=3001",
 				"SELDON_MODEL_INFERENCE_LAG_THRESHOLD=50",
+				"SELDON_MODEL_INFERENCE_DELAY_MS_THRESHOLD=3000",
 				"SELDON_MODEL_INACTIVE_SECONDS_THRESHOLD=60",
 				"SELDON_SCALING_STATS_PERIOD_SECONDS=70",
 			},
-			expectedAgentHost:                     "0.0.0.0",
-			expectedServerName:                    "mlserver",
-			expectedReplicaIdx:                    0,
-			expectedSchedulerHost:                 "10.10.10.10",
-			expectedSchedulerPort:                 100,
-			expectedSchedulerTlsPort:              111,
-			expectedRcloneHost:                    "0.0.0.0",
-			expectedRclonePort:                    defaultRclonePort,
-			expectedInferenceHost:                 "0.0.0.0",
-			expectedInferenceHttpPort:             10,
-			expectedInferenceGrpcPort:             20,
-			expectedReverseProxyHttpPort:          11,
-			expectedReverseProxyGrpcPort:          21,
-			expectedDebugGrpcPort:                 30,
-			expectedMetricsPort:                   40,
-			expectedAgentFolder:                   "/mnt/agent",
-			expectedReplicaConfigStr:              "config",
-			expectedNamespace:                     "",
-			expectedConfigPath:                    "/mnt/config",
-			expectedLogLevel:                      "info",
-			expectedServerType:                    "mlserver",
-			expectedMemoryRequest:                 400,
-			expectedCapabilities:                  []string{"c", "d"},
-			expectedOverCommitPercentage:          30,
-			expectedEnvoyHost:                     "3.3.3.3",
-			expectedEnvoyPort:                     3000,
-			expectedDrainerPort:                   3001,
-			expectedModelInferenceLagThreshold:    50,
-			expectedModelInactiveSecondsThreshold: 60,
-			expectedScalingStatsPeriodSeconds:     70,
+			expectedAgentHost:                      "0.0.0.0",
+			expectedServerName:                     "mlserver",
+			expectedReplicaIdx:                     0,
+			expectedSchedulerHost:                  "10.10.10.10",
+			expectedSchedulerPort:                  100,
+			expectedSchedulerTlsPort:               111,
+			expectedRcloneHost:                     "0.0.0.0",
+			expectedRclonePort:                     defaultRclonePort,
+			expectedInferenceHost:                  "0.0.0.0",
+			expectedInferenceHttpPort:              10,
+			expectedInferenceGrpcPort:              20,
+			expectedReverseProxyHttpPort:           11,
+			expectedReverseProxyGrpcPort:           21,
+			expectedDebugGrpcPort:                  30,
+			expectedMetricsPort:                    40,
+			expectedAgentFolder:                    "/mnt/agent",
+			expectedReplicaConfigStr:               "config",
+			expectedNamespace:                      "",
+			expectedConfigPath:                     "/mnt/config",
+			expectedLogLevel:                       "info",
+			expectedServerType:                     "mlserver",
+			expectedMemoryRequest:                  400,
+			expectedCapabilities:                   []string{"c", "d"},
+			expectedOverCommitPercentage:           30,
+			expectedEnvoyHost:                      "3.3.3.3",
+			expectedEnvoyPort:                      3000,
+			expectedDrainerPort:                    3001,
+			expectedModelInferenceLagThreshold:     50,
+			expectedModelInferenceDelayMSThreshold: 3000,
+			expectedModelInactiveSecondsThreshold:  60,
+			expectedScalingStatsPeriodSeconds:      70,
 		},
 	}
 

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -249,6 +249,7 @@ func main() {
 			modelLastUsedStatsWrapper.StatsKeeper,
 			modelDelayStatsWrapper.StatsKeeper,
 		},
+		logger,
 	)
 
 	rpHTTP := agent.NewReverseHTTPProxy(

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -786,10 +786,11 @@ func (c *Client) modelScalingEventsConsumer() {
 		}
 
 		c.logger.Debugf(
-			"Trigger model scaling event %d for model %s:%d with value %d",
+			"Trigger model scaling event %d for model %s:%d with %s %d",
 			e.EventType,
 			modelName,
 			modelVersion,
+			e.StatsData.Key,
 			e.StatsData.Value,
 		)
 

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -346,18 +346,18 @@ func TestLoadModel(t *testing.T) {
 			rpGRPC := FakeDependencyService{err: nil}
 			agentDebug := FakeDependencyService{err: nil}
 			lags := modelscaling.ModelScalingStatsWrapper{
-				Stats:     modelscaling.NewModelReplicaLagsKeeper(),
-				Operator:  interfaces.Gte,
-				Threshold: 10,
-				Reset:     true,
-				EventType: modelscaling.ScaleUpEvent,
+				StatsKeeper: modelscaling.NewModelReplicaLagsKeeper(),
+				Operator:    interfaces.Gte,
+				Threshold:   10,
+				Reset:       true,
+				EventType:   modelscaling.ScaleUpEvent,
 			}
 			lastUsed := modelscaling.ModelScalingStatsWrapper{
-				Stats:     modelscaling.NewModelReplicaLastUsedKeeper(),
-				Operator:  interfaces.Gte,
-				Threshold: 10,
-				Reset:     false,
-				EventType: modelscaling.ScaleDownEvent,
+				StatsKeeper: modelscaling.NewModelReplicaLastUsedKeeper(),
+				Operator:    interfaces.Gte,
+				Threshold:   10,
+				Reset:       false,
+				EventType:   modelscaling.ScaleDownEvent,
 			}
 			modelScalingService := modelscaling.NewStatsAnalyserService(
 				[]modelscaling.ModelScalingStatsWrapper{lags, lastUsed}, logger, 10)
@@ -387,14 +387,14 @@ func TestLoadModel(t *testing.T) {
 				// we have set model stats state if autoscaling is enabled
 				versionedModelName := util.GetVersionedModelName(test.op.GetModelVersion().Model.Meta.Name, test.op.GetModelVersion().GetVersion())
 				if test.autoscalingEnabled {
-					_, err := lags.Stats.Get(versionedModelName)
+					_, err := lags.StatsKeeper.Get(versionedModelName)
 					g.Expect(err).To(BeNil())
-					_, err = lastUsed.Stats.Get(versionedModelName)
+					_, err = lastUsed.StatsKeeper.Get(versionedModelName)
 					g.Expect(err).To(BeNil())
 				} else {
-					_, err := lags.Stats.Get(versionedModelName)
+					_, err := lags.StatsKeeper.Get(versionedModelName)
 					g.Expect(err).ToNot(BeNil())
-					_, err = lastUsed.Stats.Get(versionedModelName)
+					_, err = lastUsed.StatsKeeper.Get(versionedModelName)
 					g.Expect(err).ToNot(BeNil())
 				}
 			} else {
@@ -626,18 +626,18 @@ func TestUnloadModel(t *testing.T) {
 			rpGRPC := FakeDependencyService{err: nil}
 			agentDebug := FakeDependencyService{err: nil}
 			lags := modelscaling.ModelScalingStatsWrapper{
-				Stats:     modelscaling.NewModelReplicaLagsKeeper(),
-				Operator:  interfaces.Gte,
-				Threshold: 10,
-				Reset:     true,
-				EventType: modelscaling.ScaleUpEvent,
+				StatsKeeper: modelscaling.NewModelReplicaLagsKeeper(),
+				Operator:    interfaces.Gte,
+				Threshold:   10,
+				Reset:       true,
+				EventType:   modelscaling.ScaleUpEvent,
 			}
 			lastUsed := modelscaling.ModelScalingStatsWrapper{
-				Stats:     modelscaling.NewModelReplicaLastUsedKeeper(),
-				Operator:  interfaces.Gte,
-				Threshold: 10,
-				Reset:     false,
-				EventType: modelscaling.ScaleDownEvent,
+				StatsKeeper: modelscaling.NewModelReplicaLastUsedKeeper(),
+				Operator:    interfaces.Gte,
+				Threshold:   10,
+				Reset:       false,
+				EventType:   modelscaling.ScaleDownEvent,
 			}
 			modelScalingService := modelscaling.NewStatsAnalyserService(
 				[]modelscaling.ModelScalingStatsWrapper{lags, lastUsed}, logger, 10)
@@ -667,9 +667,9 @@ func TestUnloadModel(t *testing.T) {
 				g.Expect(client.stateManager.GetAvailableMemoryBytes()).To(Equal(test.expectedAvailableMemory))
 				// check model scaling stats removed
 				versionedModelName := util.GetVersionedModelName(test.unloadOp.GetModelVersion().Model.Meta.Name, test.unloadOp.GetModelVersion().GetVersion())
-				_, err := lags.Stats.Get(versionedModelName)
+				_, err := lags.StatsKeeper.Get(versionedModelName)
 				g.Expect(err).ToNot(BeNil())
-				_, err = lastUsed.Stats.Get(versionedModelName)
+				_, err = lastUsed.StatsKeeper.Get(versionedModelName)
 				g.Expect(err).ToNot(BeNil())
 			} else {
 				g.Expect(err).ToNot(BeNil())

--- a/scheduler/pkg/agent/interfaces/model_stats.go
+++ b/scheduler/pkg/agent/interfaces/model_stats.go
@@ -31,16 +31,18 @@ type ModelStatsKV struct {
 	ModelName string
 }
 
-type ModelScalingStats interface {
-	Inc(string, uint32) error
-	IncDefault(string) error
-	Dec(string, uint32) error
-	DecDefault(string) error
-	Reset(string) error
-	Set(string, uint32) error
-	Get(string) (uint32, error)
-	GetAll(uint32, LogicOperation, bool) ([]*ModelStatsKV, error)
-	Info() string
-	Delete(string) error
-	Add(string) error
+type ModelStatsKeeper interface {
+	ModelInferEnter(modelName, requestId string) error
+	ModelInferExit(modelName, requestId string) error
+	Add(modelName string) error
+	Delete(modelName string) error
+	Get(modelName string) (statValue uint32, err error)
+	GetAll(threshold uint32, op LogicOperation, reset bool) ([]*ModelStatsKV, error)
+}
+
+type ModelStats interface {
+	Enter(requestId string) error
+	Exit(requestId string) error
+	Get() uint32
+	Reset() error
 }

--- a/scheduler/pkg/agent/modelscaling/model_delay.go
+++ b/scheduler/pkg/agent/modelscaling/model_delay.go
@@ -67,7 +67,6 @@ func (stats *delayStats) Reset() error {
 	stats.mu.Lock()
 	defer stats.mu.Unlock()
 	stats.delays = []int64{}
-	stats.startTimes = make(map[string]time.Time)
 	return nil
 }
 

--- a/scheduler/pkg/agent/modelscaling/model_delay.go
+++ b/scheduler/pkg/agent/modelscaling/model_delay.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 Seldon Technologies Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelscaling
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
+)
+
+const (
+	ModelDelayKey = "delay"
+)
+
+type delayStats struct {
+	delays     []int64
+	startTimes map[string]time.Time
+	mu         sync.RWMutex
+}
+
+func newDelayStats() interfaces.ModelStats {
+	return &delayStats{
+		delays:     []int64{},
+		startTimes: make(map[string]time.Time),
+		mu:         sync.RWMutex{},
+	}
+}
+
+func (stats *delayStats) Enter(requestId string) error {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+	stats.startTimes[requestId] = time.Now()
+
+	return nil
+}
+
+func (stats *delayStats) Exit(requestId string) error {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+	if startTime, ok := stats.startTimes[requestId]; ok {
+		delete(stats.startTimes, requestId)
+		delay := time.Since(startTime).Milliseconds()
+		stats.delays = append(stats.delays, delay)
+	} else {
+		return fmt.Errorf("failed to find the start time of the request")
+	}
+	return nil
+}
+
+func (stats *delayStats) Reset() error {
+	stats.mu.Lock()
+	defer stats.mu.Unlock()
+	stats.delays = []int64{}
+	stats.startTimes = make(map[string]time.Time)
+	return nil
+}
+
+// Get average delay in milliseconds
+func (stats *delayStats) Get() uint32 {
+	stats.mu.RLock()
+	defer stats.mu.RUnlock()
+
+	if len(stats.delays) == 0 {
+		return uint32(0)
+	}
+	sum := int64(0)
+	for _, delay := range stats.delays {
+		sum += delay
+	}
+	average := sum / int64(len(stats.delays))
+	return uint32(average)
+}
+
+func NewModelReplicaDelaysKeeper() *modelStatsKeeper {
+	return NewModelStatsKeeper(ModelDelayKey, newDelayStats)
+}

--- a/scheduler/pkg/agent/modelscaling/model_delay_test.go
+++ b/scheduler/pkg/agent/modelscaling/model_delay_test.go
@@ -18,27 +18,29 @@ package modelscaling
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 )
 
-func TestModelLagsSimple(t *testing.T) {
+func TestModelDelaysSimple(t *testing.T) {
 	g := NewGomegaWithT(t)
-	t.Logf("Start!")
 
-	lag := &lagStats{
-		lag: 0,
-	}
+	dummyModelBase := "dummy_model_0"
+	t.Run("simple", func(t *testing.T) {
 
-	lag.Enter("")
-	g.Expect(lag.Get()).To(Equal(uint32(1)))
-	lag.Exit("")
-	g.Expect(lag.Get()).To(Equal(uint32(0)))
-	lag.Enter("")
-	lag.Enter("")
-	g.Expect(lag.Get()).To(Equal(uint32(2)))
-	lag.Reset()
-	g.Expect(lag.Get()).To(Equal(uint32(0)))
+		requestId := "request_id_0"
+		delays := NewModelReplicaDelaysKeeper()
 
-	t.Logf("Done!")
+		_, err := delays.Get(dummyModelBase)
+		g.Expect(err).To(Not(BeNil()))
+
+		delays.ModelInferEnter(dummyModelBase, requestId)
+		time.Sleep(time.Millisecond * time.Duration(10))
+		delays.ModelInferExit(dummyModelBase, requestId)
+
+		delay, err := delays.Get(dummyModelBase)
+		g.Expect(err).To(BeNil())
+		g.Expect(delay > 0).To(BeTrue())
+	})
 }

--- a/scheduler/pkg/agent/modelscaling/model_lag.go
+++ b/scheduler/pkg/agent/modelscaling/model_lag.go
@@ -17,50 +17,40 @@ limitations under the License.
 package modelscaling
 
 import (
-	"fmt"
-	"sync"
 	"sync/atomic"
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
-)
-
-type operation int
-
-const (
-	inc operation = iota
-	dec
-	reset
-	set
 )
 
 const (
 	ModelLagKey = "lag"
 )
 
-type lagKeeper struct {
+type lagStats struct {
 	lag uint32
 }
 
-func newLagKeeper() *lagKeeper {
-	return &lagKeeper{
+func newLagStats() interfaces.ModelStats {
+	return &lagStats{
 		lag: 0,
 	}
 }
 
-func (lagKeeper *lagKeeper) inc() {
-	atomic.AddUint32(&lagKeeper.lag, 1)
+func (stats *lagStats) Enter(requestId string) error {
+	atomic.AddUint32(&stats.lag, 1)
+	return nil
 }
 
-func (lagKeeper *lagKeeper) dec() {
+func (stats *lagStats) Exit(requestId string) error {
 	// we want to decrement by 1, however we do not want to go below zero,
 	// therfore we cannot use `AddUint32(&x, ^uint32(0))`.
 	// the for loop is essentially to make sure that no concurrent requests have
 	// changed the value of the `lag` while we are decrementing it.
 	for {
-		old := lagKeeper.get()
+		old := stats.Get()
 		if old > 0 {
 			new := old - 1
-			swapped := atomic.CompareAndSwapUint32(&lagKeeper.lag, old, new)
+			swapped := atomic.CompareAndSwapUint32(&stats.lag, old, new)
 			if swapped {
 				break
 			}
@@ -68,145 +58,18 @@ func (lagKeeper *lagKeeper) dec() {
 			break
 		}
 	}
-}
-
-func (lagKeeper *lagKeeper) reset() {
-	lagKeeper.set(uint32(0))
-}
-
-func (lagKeeper *lagKeeper) get() uint32 {
-	return atomic.LoadUint32(&lagKeeper.lag)
-}
-
-func (lagKeeper *lagKeeper) set(v uint32) {
-	atomic.StoreUint32(&lagKeeper.lag, v)
-}
-
-type ModelReplicaLagsKeeper struct {
-	lags map[string]*lagKeeper
-	mu   sync.RWMutex
-}
-
-func NewModelReplicaLagsKeeper() *ModelReplicaLagsKeeper {
-	return &ModelReplicaLagsKeeper{
-		lags: make(map[string]*lagKeeper),
-		mu:   sync.RWMutex{},
-	}
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) IncDefault(modelName string) error {
-	// note: value (0) not used
-	return lagsKeeper.apply(modelName, inc, 0)
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) DecDefault(modelName string) error {
-	// note: value (0) not used
-	return lagsKeeper.apply(modelName, dec, 0)
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) Reset(modelName string) error {
-	// note: value (0) not used
-	return lagsKeeper.apply(modelName, reset, 0)
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) Set(modelName string, value uint32) error {
-	return lagsKeeper.apply(modelName, set, value)
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) Inc(modelName string, _ uint32) error {
-	return lagsKeeper.IncDefault(modelName)
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) Dec(modelName string, _ uint32) error {
-	return lagsKeeper.DecDefault(modelName)
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) Info() string {
-	return "Model Replica Lag: incoming - outgoing requests"
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) Delete(modelName string) error {
-	lagsKeeper.mu.Lock()
-	delete(lagsKeeper.lags, modelName)
-	lagsKeeper.mu.Unlock()
 	return nil
 }
 
-func (luKeeper *ModelReplicaLagsKeeper) Add(modelName string) error {
-	return luKeeper.IncDefault(modelName)
+func (stats *lagStats) Get() uint32 {
+	return atomic.LoadUint32(&stats.lag)
 }
 
-func (lagsKeeper *ModelReplicaLagsKeeper) Get(modelName string) (uint32, error) {
-	lagsKeeper.mu.RLock()
-	defer lagsKeeper.mu.RUnlock()
-	lagKeeper, ok := lagsKeeper.lags[modelName]
-	if !ok {
-		return 0, fmt.Errorf("Model replica %s is not found", modelName)
-	}
-	return lagKeeper.get(), nil
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) GetAll(threshold uint32, op interfaces.LogicOperation, reset bool) ([]*interfaces.ModelStatsKV, error) {
-	if op == interfaces.Gte {
-		return lagsKeeper.getAllGte(threshold, reset)
-	} else {
-		return nil, fmt.Errorf("Operation not supported %d", op)
-	}
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) getAllGte(threshold uint32, reset bool) ([]*interfaces.ModelStatsKV, error) {
-	lagsKeeper.mu.RLock()
-	defer lagsKeeper.mu.RUnlock()
-
-	rets := []*interfaces.ModelStatsKV{}
-
-	for k, v := range lagsKeeper.lags {
-		lag := v.get()
-		if lag >= threshold {
-			rets = append(rets, &interfaces.ModelStatsKV{
-				ModelName: k,
-				Value:     lag,
-				Key:       ModelLagKey,
-			})
-			if reset {
-				v.reset()
-			}
-		}
-	}
-	return rets, nil
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) new(modelName string) {
-	lagsKeeper.mu.Lock()
-	lagsKeeper.lags[modelName] = newLagKeeper()
-	lagsKeeper.mu.Unlock()
-}
-
-func (lagsKeeper *ModelReplicaLagsKeeper) apply(modelName string, op operation, value uint32) error {
-	lagsKeeper.mu.RLock()
-	lagKeeper, ok := lagsKeeper.lags[modelName]
-	if !ok {
-		lagsKeeper.mu.RUnlock()
-		lagsKeeper.new(modelName)
-		//try again after creating the item in map
-		lagsKeeper.mu.RLock()
-		lagKeeper = lagsKeeper.lags[modelName]
-	}
-
-	defer lagsKeeper.mu.RUnlock()
-
-	switch op {
-	case inc:
-		lagKeeper.inc()
-	case dec:
-		lagKeeper.dec()
-	case reset:
-		lagKeeper.reset()
-	case set:
-		lagKeeper.set(value)
-	default:
-		return fmt.Errorf("operation not supported")
-	}
-
+func (stats *lagStats) Reset() error {
+	atomic.StoreUint32(&stats.lag, 0)
 	return nil
+}
+
+func NewModelReplicaLagsKeeper() *modelStatsKeeper {
+	return NewModelStatsKeeper(ModelLagKey, newLagStats)
 }

--- a/scheduler/pkg/agent/modelscaling/model_last_used.go
+++ b/scheduler/pkg/agent/modelscaling/model_last_used.go
@@ -28,31 +28,27 @@ const (
 	ModelLastUsedKey = "last_used"
 )
 
-type ModelReplicaLastUsedKeeper struct {
+type modelReplicaLastUsedKeeper struct {
 	// note that this a min-priority queue impl (i.e pop will return lowest value / highest priority)
 	// we use negative unix timestamp to pop least recently used item first
 	pq *cache.LRUCacheManager
 }
 
-func NewModelReplicaLastUsedKeeper() *ModelReplicaLastUsedKeeper {
-	return &ModelReplicaLastUsedKeeper{
+func NewModelReplicaLastUsedKeeper() *modelReplicaLastUsedKeeper {
+	return &modelReplicaLastUsedKeeper{
 		pq: cache.MakeLRU(map[string]int64{}),
 	}
 }
 
-func (luKeeper *ModelReplicaLastUsedKeeper) IncDefault(modelName string) error {
-	return luKeeper.Inc(modelName, 0) // 0 not used
+func (luKeeper *modelReplicaLastUsedKeeper) ModelInferEnter(modelName, requestId string) error {
+	return luKeeper.Add(modelName)
 }
 
-func (luKeeper *ModelReplicaLastUsedKeeper) Set(modelName string, ts uint32) error {
-	if err := luKeeper.pq.Update(modelName, -int64(ts)); err != nil {
-		return luKeeper.pq.Add(modelName, -int64(ts))
-	} else {
-		return err
-	}
+func (luKeeper *modelReplicaLastUsedKeeper) ModelInferExit(modelName, requestId string) error {
+	return nil
 }
 
-func (luKeeper *ModelReplicaLastUsedKeeper) Inc(modelName string, _ uint32) error {
+func (luKeeper *modelReplicaLastUsedKeeper) Add(modelName string) error {
 	ts := -time.Now().Unix() // this is in seconds resolution
 
 	// if we fail update, we assume the model does not exist and we add it.
@@ -65,19 +61,11 @@ func (luKeeper *ModelReplicaLastUsedKeeper) Inc(modelName string, _ uint32) erro
 	}
 }
 
-func (luKeeper *ModelReplicaLastUsedKeeper) Info() string {
-	return "Model last used"
-}
-
-func (luKeeper *ModelReplicaLastUsedKeeper) Delete(modelName string) error {
+func (luKeeper *modelReplicaLastUsedKeeper) Delete(modelName string) error {
 	return luKeeper.pq.Delete(modelName)
 }
 
-func (luKeeper *ModelReplicaLastUsedKeeper) Add(modelName string) error {
-	return luKeeper.IncDefault(modelName)
-}
-
-func (luKeeper *ModelReplicaLastUsedKeeper) Get(modelName string) (uint32, error) {
+func (luKeeper *modelReplicaLastUsedKeeper) Get(modelName string) (uint32, error) {
 	if ts, err := luKeeper.pq.Get(modelName); err != nil {
 		return 0, err
 	} else {
@@ -85,15 +73,15 @@ func (luKeeper *ModelReplicaLastUsedKeeper) Get(modelName string) (uint32, error
 	}
 }
 
-func (luKeeper *ModelReplicaLastUsedKeeper) GetAll(threshold uint32, op interfaces.LogicOperation, reset bool) ([]*interfaces.ModelStatsKV, error) {
+func (luKeeper *modelReplicaLastUsedKeeper) GetAll(threshold uint32, op interfaces.LogicOperation, reset bool) ([]*interfaces.ModelStatsKV, error) {
 	if op == interfaces.Gte {
 		return luKeeper.getAllGte(threshold, reset)
 	} else {
-		return nil, fmt.Errorf("Operation not supported %d", op)
+		return nil, fmt.Errorf("operation not supported %d", op)
 	}
 }
 
-func (luKeeper *ModelReplicaLastUsedKeeper) getAllGte(threshold uint32, reset bool) ([]*interfaces.ModelStatsKV, error) {
+func (luKeeper *modelReplicaLastUsedKeeper) getAllGte(threshold uint32, reset bool) ([]*interfaces.ModelStatsKV, error) {
 	type kv struct {
 		k string
 		v int64
@@ -135,16 +123,4 @@ func (luKeeper *ModelReplicaLastUsedKeeper) getAllGte(threshold uint32, reset bo
 	}
 
 	return rets, nil
-}
-
-func (luKeeper *ModelReplicaLastUsedKeeper) DecDefault(modelName string) error {
-	return fmt.Errorf("Not implemented")
-}
-
-func (luKeeper *ModelReplicaLastUsedKeeper) Reset(modelName string) error {
-	return fmt.Errorf("Not implemented")
-}
-
-func (luKeeper *ModelReplicaLastUsedKeeper) Dec(modelName string, _ uint32) error {
-	return fmt.Errorf("Not implemented")
 }

--- a/scheduler/pkg/agent/modelscaling/model_last_used_test.go
+++ b/scheduler/pkg/agent/modelscaling/model_last_used_test.go
@@ -26,12 +26,19 @@ import (
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
 )
 
-func TestModelLastUsedSimple(t *testing.T) {
+func setLastUsed(luKeeper *modelReplicaLastUsedKeeper, modelName string, ts uint32) error {
+	if err := luKeeper.pq.Update(modelName, -int64(ts)); err != nil {
+		return luKeeper.pq.Add(modelName, -int64(ts))
+	} else {
+		return err
+	}
+}
 
+func TestModelLastUsedSimple(t *testing.T) {
+	type operation uint
 	const (
 		inc operation = iota
 		del
-		set
 		add
 	)
 
@@ -57,18 +64,6 @@ func TestModelLastUsedSimple(t *testing.T) {
 			modelName: dummyModel,
 			op:        inc,
 			initial:   0,
-		},
-		{
-			name:      "set",
-			modelName: dummyModel,
-			op:        set,
-			initial:   0,
-		},
-		{
-			name:      "set new",
-			modelName: dummyModel,
-			op:        set,
-			initial:   1,
 		},
 		{
 			name:      "delete not there",
@@ -100,16 +95,14 @@ func TestModelLastUsedSimple(t *testing.T) {
 			lu := NewModelReplicaLastUsedKeeper()
 
 			if test.initial > 0 {
-				err := lu.Set(test.modelName, uint32(time.Now().Unix()))
+				err := setLastUsed(lu, test.modelName, uint32(time.Now().Unix()))
 				g.Expect(err).To(BeNil())
 			}
 			switch test.op {
 			case inc:
-				err := lu.IncDefault(test.modelName)
+				err := lu.ModelInferEnter(test.modelName, "")
 				g.Expect(err).To(BeNil())
-			case set:
-				err := lu.Set(test.modelName, uint32(time.Now().Unix()))
-				g.Expect(err).To(BeNil())
+
 			case del:
 				err := lu.Delete(test.modelName)
 				if test.initial > 0 {
@@ -164,14 +157,14 @@ func TestModelLastUsedThreshold(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			lu := NewModelReplicaLastUsedKeeper()
 			for i := 0; i < numModels/2; i++ {
-				err := lu.IncDefault(strconv.Itoa(i))
+				err := lu.ModelInferEnter(strconv.Itoa(i), "")
 				g.Expect(err).To(BeNil())
 			}
 
 			time.Sleep(time.Second * 1)
 
 			for i := numModels / 2; i < numModels; i++ {
-				err := lu.IncDefault(strconv.Itoa(i))
+				err := lu.ModelInferEnter(strconv.Itoa(i), "")
 				g.Expect(err).To(BeNil())
 			}
 

--- a/scheduler/pkg/agent/modelscaling/model_stats_keeper.go
+++ b/scheduler/pkg/agent/modelscaling/model_stats_keeper.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 Seldon Technologies Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelscaling
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
+)
+
+type modelStatsKeeper struct {
+	key         string
+	stats       map[string]interfaces.ModelStats
+	newStatsFunc func() interfaces.ModelStats
+	mu          sync.RWMutex
+}
+
+func NewModelStatsKeeper(key string, newStatFunc func() interfaces.ModelStats) *modelStatsKeeper {
+	return &modelStatsKeeper{
+		key:         key,
+		stats:       make(map[string]interfaces.ModelStats),
+		newStatsFunc: newStatFunc,
+		mu:          sync.RWMutex{},
+	}
+}
+
+func (keeper *modelStatsKeeper) ModelInferEnter(modelName, requestId string) error {
+	return keeper.applyWithModel(modelName, func(stat interfaces.ModelStats) error {
+		return stat.Enter(requestId)
+	})
+}
+
+func (keeper *modelStatsKeeper) ModelInferExit(modelName, requestId string) error {
+	return keeper.applyWithModel(modelName, func(stat interfaces.ModelStats) error {
+		return stat.Exit(requestId)
+	})
+}
+
+func (keeper *modelStatsKeeper) Add(modelName string) error {
+	return keeper.applyWithModel(modelName, func(stat interfaces.ModelStats) error {
+		return nil
+	})
+}
+func (keeper *modelStatsKeeper) Delete(modelName string) error {
+	keeper.mu.Lock()
+	delete(keeper.stats, modelName)
+	keeper.mu.Unlock()
+	return nil
+}
+
+func (keeper *modelStatsKeeper) Get(modelName string) (uint32, error) {
+	keeper.mu.RLock()
+	defer keeper.mu.RUnlock()
+	stat, ok := keeper.stats[modelName]
+	if !ok {
+		return 0, fmt.Errorf("model replica %s is not found", modelName)
+	}
+	return stat.Get(), nil
+}
+
+func (keeper *modelStatsKeeper) GetAll(threshold uint32, op interfaces.LogicOperation, reset bool) ([]*interfaces.ModelStatsKV, error) {
+	if op == interfaces.Gte {
+		return keeper.getAllGte(threshold, reset)
+	} else {
+		return nil, fmt.Errorf("operation not supported %d", op)
+	}
+}
+
+func (keeper *modelStatsKeeper) applyWithModel(modelName string, fn func(interfaces.ModelStats) error) error {
+	keeper.mu.RLock()
+	stat, ok := keeper.stats[modelName]
+	if !ok {
+		keeper.mu.RUnlock()
+
+		keeper.mu.Lock()
+		keeper.stats[modelName] = keeper.newStatsFunc()
+		keeper.mu.Unlock()
+
+		//try again after creating the item in map
+		keeper.mu.RLock()
+		stat = keeper.stats[modelName]
+	}
+
+	defer keeper.mu.RUnlock()
+	return fn(stat)
+}
+
+func (keeper *modelStatsKeeper) getAllGte(threshold uint32, reset bool) ([]*interfaces.ModelStatsKV, error) {
+	keeper.mu.RLock()
+	defer keeper.mu.RUnlock()
+
+	rets := []*interfaces.ModelStatsKV{}
+
+	for k, v := range keeper.stats {
+		statValue := uint32(v.Get())
+		if statValue >= threshold {
+			rets = append(rets, &interfaces.ModelStatsKV{
+				ModelName: k,
+				Value:     statValue,
+				Key:       keeper.key,
+			})
+			if reset {
+				v.Reset()
+			}
+		}
+	}
+	return rets, nil
+}

--- a/scheduler/pkg/agent/modelscaling/model_stats_keeper_test.go
+++ b/scheduler/pkg/agent/modelscaling/model_stats_keeper_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2022 Seldon Technologies Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelscaling
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
+)
+
+const (
+	ModelStatKey = "stat"
+)
+
+func getModelName(base string, idx int) string {
+	return fmt.Sprintf("%s_%d", base, idx)
+}
+
+type dummyModelStats struct {
+	value uint32
+}
+
+func (stats *dummyModelStats) Enter(requestId string) error {
+	stats.value += 1
+	return nil
+}
+func (stats *dummyModelStats) Exit(requestId string) error {
+	if stats.value != 0 {
+		stats.value -= 1
+	}
+	return nil
+}
+
+func (stats *dummyModelStats) Get() uint32 {
+	return stats.value
+}
+
+func (stats *dummyModelStats) Reset() error {
+	stats.value = 0
+	return nil
+}
+
+func TestModelStatsKeeperSimple(t *testing.T) {
+	dummyModel := "dummy_model"
+	g := NewGomegaWithT(t)
+	t.Logf("Start!")
+
+	type test struct {
+		name      string
+		modelName string
+		initial   uint32
+		expected  uint32
+	}
+	tests := []test{
+		{
+			name:      "increment",
+			modelName: dummyModel,
+			initial:   0,
+			expected:  1,
+		},
+		{
+			name:      "decrement",
+			modelName: dummyModel,
+			initial:   1,
+			expected:  0,
+		},
+		{
+			name:      "add",
+			modelName: dummyModel,
+			initial:   0,
+			expected:  0,
+		},
+		{
+			name:      "del",
+			modelName: dummyModel,
+			initial:   1,
+			expected:  0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keeper := NewModelStatsKeeper(ModelStatKey, func() interfaces.ModelStats {
+				return &dummyModelStats{
+					value: test.initial,
+				}
+			})
+
+			switch test.name {
+			case "increment":
+				err := keeper.ModelInferEnter(test.modelName, "")
+				g.Expect(err).To(BeNil())
+			case "decrement":
+				err := keeper.ModelInferExit(test.modelName, "")
+				g.Expect(err).To(BeNil())
+
+			case "add":
+				err := keeper.Add(test.modelName)
+				g.Expect(err).To(BeNil())
+			case "del":
+				err := keeper.Delete(test.modelName)
+				g.Expect(err).To(BeNil())
+			}
+
+			if test.name != "del" {
+				g.Expect(keeper.Get(test.modelName)).To(Equal(test.expected))
+			} else {
+				_, err := keeper.Get(test.modelName)
+				g.Expect(err).NotTo(BeNil())
+			}
+		})
+	}
+
+	t.Logf("Done!")
+}
+
+func TestModelStatsKeeperConcurrent(t *testing.T) {
+	dummyModelBase := "dummy_model"
+	maxNumModels := 100
+
+	g := NewGomegaWithT(t)
+	t.Logf("Start!")
+
+	fnWrapper := func(fn func(modelName, requestId string) error, modelName string, requestId string, wg *sync.WaitGroup) {
+		sleepMs := rand.Intn(100)
+		time.Sleep(time.Millisecond * time.Duration(sleepMs))
+		err := fn(modelName, requestId)
+		g.Expect(err).To(BeNil())
+		wg.Done()
+	}
+
+	type test struct {
+		name      string
+		numModels int
+	}
+	tests := []test{
+		{
+			name:      "increment",
+			numModels: maxNumModels,
+		},
+		{
+			name:      "decrement",
+			numModels: maxNumModels,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keeper := NewModelStatsKeeper("stat", func() interfaces.ModelStats {
+				return &dummyModelStats{
+					value: 0,
+				}
+			})
+			t.Logf("setup")
+			// we create state according to the model idx (i) for example
+			// dummy_model_10 -> 10
+			// up to numModels
+			for i := 0; i < test.numModels; i++ {
+				for j := 0; j < i; j++ {
+					requestId := fmt.Sprintf("request_id_%d_%d", i, j)
+					err := keeper.ModelInferEnter(getModelName(dummyModelBase, i), requestId)
+					g.Expect(err).To(BeNil())
+				}
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(test.numModels)
+
+			// we then create jobs one for each model according to the operation in the test
+			// each operation can wait an arbitrary amount of time before executing.
+			for i := 0; i < test.numModels; i++ {
+				requestId := fmt.Sprintf("request_id_%d_0", i)
+				switch test.name {
+				case "increment":
+					go fnWrapper(keeper.ModelInferEnter, getModelName(dummyModelBase, i), requestId, &wg)
+				case "decrement":
+					go fnWrapper(keeper.ModelInferExit, getModelName(dummyModelBase, i), requestId, &wg)
+				}
+			}
+
+			//wait for all operations to finish
+			wg.Wait()
+
+			t.Logf("check")
+
+			for i := 0; i < test.numModels; i++ {
+				switch test.name {
+				// note: state of the model is at i
+				case "increment":
+					// we add one to the state of the model, so it should be i + 1
+					g.Expect(keeper.Get(getModelName(dummyModelBase, i))).To(Equal(uint32(i + 1)))
+				case "decrement":
+					// we subtract one from the state of the model, so it should be i
+					if i > 0 {
+						g.Expect(keeper.Get(getModelName(dummyModelBase, i))).To(Equal(uint32(i - 1)))
+					} else {
+						g.Expect(keeper.Get(getModelName(dummyModelBase, i))).To(Equal(uint32(0)))
+					}
+				}
+			}
+		})
+	}
+
+	t.Logf("Done!")
+}
+
+func TestThreholdFilter(t *testing.T) {
+	g := NewGomegaWithT(t)
+	t.Logf("Start!")
+
+	type test struct {
+		name           string
+		init           map[string]uint32
+		threshold      uint32
+		op             interfaces.LogicOperation
+		expectedResult []interfaces.ModelStatsKV
+	}
+	tests := []test{
+		{
+			name: "withinrange",
+			init: map[string]uint32{
+				"1": 1,
+				"2": 2,
+				"3": 3,
+			},
+			op:        interfaces.Gte,
+			threshold: 2,
+			expectedResult: []interfaces.ModelStatsKV{
+				{
+					Value:     2,
+					Key:       ModelStatKey,
+					ModelName: "2",
+				},
+				{
+					Value:     3,
+					Key:       ModelStatKey,
+					ModelName: "3",
+				},
+			},
+		},
+		{
+			name: "outofrange",
+			init: map[string]uint32{
+				"1": 1,
+				"2": 2,
+				"3": 3,
+			},
+			op:             interfaces.Gte,
+			threshold:      4,
+			expectedResult: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			keeper := NewModelStatsKeeper("stat", func() interfaces.ModelStats {
+				return &dummyModelStats{
+					value: 0,
+				}
+			})
+			for model, lag := range test.init {
+				keeper.Add(model)
+				if stat, ok := keeper.stats[model]; ok {
+					stat.(*dummyModelStats).value = lag
+				}
+			}
+
+			result, err := keeper.GetAll(test.threshold, test.op, false)
+
+			if test.expectedResult != nil {
+				for _, item := range result {
+					found := false
+					for _, expectedItem := range test.expectedResult {
+						if item.ModelName == expectedItem.ModelName {
+							g.Expect(*item).To(Equal(expectedItem))
+							found = true
+						}
+					}
+					g.Expect(found).To(BeTrue())
+
+				}
+				g.Expect(len(result)).To(Equal(len(test.expectedResult)))
+			} else {
+				g.Expect(len(result)).To(Equal(0))
+			}
+			g.Expect(err).To(BeNil())
+
+			t.Logf("Check state without reset")
+			for _, item := range result {
+				g.Expect(keeper.Get(item.ModelName)).To(Equal(item.Value))
+			}
+
+			t.Logf("Check state with reset")
+			result, _ = keeper.GetAll(test.threshold, test.op, true)
+			for _, item := range result {
+				g.Expect(keeper.Get(item.ModelName)).To(Equal(uint32(0)))
+			}
+
+		})
+	}
+}

--- a/scheduler/pkg/agent/modelscaling/stats_analyser.go
+++ b/scheduler/pkg/agent/modelscaling/stats_analyser.go
@@ -44,11 +44,11 @@ type ModelScalingEvent struct {
 }
 
 type ModelScalingStatsWrapper struct {
-	Stats     interfaces.ModelScalingStats
-	Operator  interfaces.LogicOperation
-	Threshold uint
-	Reset     bool
-	EventType ModelScalingEventType
+	StatsKeeper interfaces.ModelStatsKeeper
+	Operator    interfaces.LogicOperation
+	Threshold   uint
+	Reset       bool
+	EventType   ModelScalingEventType
 }
 
 type StatsAnalyserService struct {
@@ -115,7 +115,7 @@ func (ss *StatsAnalyserService) DeleteModel(modelName string) error {
 		// delete from list of models to report back
 		ss.modelsEnabled.Delete(modelName)
 
-		if err := stats.Stats.Delete(modelName); err != nil {
+		if err := stats.StatsKeeper.Delete(modelName); err != nil {
 			return err
 		}
 	}
@@ -131,7 +131,7 @@ func (ss *StatsAnalyserService) AddModel(modelName string) error {
 		// add to list pf models to report back
 		ss.modelsEnabled.Store(modelName, struct{}{})
 
-		if err := stats.Stats.Add(modelName); err != nil {
+		if err := stats.StatsKeeper.Add(modelName); err != nil {
 			return err
 		}
 	}
@@ -182,7 +182,7 @@ func (ss *StatsAnalyserService) process() error {
 }
 
 func (ss *StatsAnalyserService) processImpl(statsWrapper ModelScalingStatsWrapper, timer *time.Timer) error {
-	modelsToScale, err := statsWrapper.Stats.GetAll(
+	modelsToScale, err := statsWrapper.StatsKeeper.GetAll(
 		uint32(statsWrapper.Threshold), statsWrapper.Operator, statsWrapper.Reset)
 	if err != nil {
 		return err

--- a/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
+++ b/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
@@ -160,7 +160,8 @@ func TestStatsAnalyserSoak(t *testing.T) {
 
 	lags := NewModelReplicaLagsKeeper()
 	lastUsed := NewModelReplicaLastUsedKeeper()
-	modelScalingStatsCollector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed}, nil)
+	logger := log.New()
+	modelScalingStatsCollector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed}, logger)
 	service := NewStatsAnalyserService(
 		[]ModelScalingStatsWrapper{
 			{
@@ -178,7 +179,7 @@ func TestStatsAnalyserSoak(t *testing.T) {
 				EventType:   ScaleDownEvent,
 			},
 		},
-		log.New(),
+		logger,
 		statsPeriodSecondsDefault,
 	)
 

--- a/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
+++ b/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package modelscaling
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -35,13 +36,13 @@ const (
 )
 
 func scalingMetricsSetup(
-	wg *sync.WaitGroup, internalModelName string, modelScalingStatsCollector *DataPlaneStatsCollector) error {
-	return modelScalingStatsCollector.ScalingMetricsSetup(wg, internalModelName)
+	internalModelName string, requestId string, modelScalingStatsCollector *DataPlaneStatsCollector) error {
+	return modelScalingStatsCollector.ModelInferEnter(internalModelName, requestId)
 }
 
-func scalingMetricsTearDown(wg *sync.WaitGroup, internalModelName string,
+func scalingMetricsTearDown(internalModelName string, requestId string,
 	jobsWg *sync.WaitGroup, modelScalingStatsCollector *DataPlaneStatsCollector) error {
-	err := modelScalingStatsCollector.ScalingMetricsTearDown(wg, internalModelName)
+	err := modelScalingStatsCollector.ModelInferExit(internalModelName, requestId)
 	jobsWg.Done()
 	return err
 }
@@ -57,18 +58,18 @@ func TestStatsAnalyserSmoke(t *testing.T) {
 	service := NewStatsAnalyserService(
 		[]ModelScalingStatsWrapper{
 			{
-				Stats:     lags,
-				Operator:  interfaces.Gte,
-				Threshold: lagThresholdDefault,
-				Reset:     true,
-				EventType: ScaleUpEvent,
+				StatsKeeper: lags,
+				Operator:    interfaces.Gte,
+				Threshold:   lagThresholdDefault,
+				Reset:       true,
+				EventType:   ScaleUpEvent,
 			},
 			{
-				Stats:     lastUsed,
-				Operator:  interfaces.Gte,
-				Threshold: lastUsedThresholdSecondsDefault,
-				Reset:     false,
-				EventType: ScaleDownEvent,
+				StatsKeeper: lastUsed,
+				Operator:    interfaces.Gte,
+				Threshold:   lastUsedThresholdSecondsDefault,
+				Reset:       false,
+				EventType:   ScaleDownEvent,
 			},
 		},
 		log.New(),
@@ -93,22 +94,16 @@ func TestStatsAnalyserSmoke(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	err = service.AddModel(dummyModelPrefix + "3")
 	g.Expect(err).To(BeNil())
+	lags.ModelInferEnter(dummyModelPrefix+"0", "")
+	lags.stats[dummyModelPrefix+"1"].(*lagStats).lag = lagThresholdDefault + 1
 
-	err = lags.Set(dummyModelPrefix+"0", lagThresholdDefault-1)
-	g.Expect(err).To(BeNil())
-	err = lags.Set(dummyModelPrefix+"1", lagThresholdDefault+1)
-	g.Expect(err).To(BeNil())
-	err = lags.Set(dummyModelPrefix+"2", lagThresholdDefault+1) //  model 2 not added so will not get returned to ch
-	g.Expect(err).To(BeNil())
 	event := <-ch
 	g.Expect(event.StatsData.ModelName).To(Equal(dummyModelPrefix + "1"))
 	g.Expect(event.StatsData.Value).To(Equal(uint32(lagThresholdDefault + 1)))
 	g.Expect(event.EventType).To(Equal(ScaleUpEvent))
 
 	t.Logf("Test last used")
-	err = lastUsed.Set(dummyModelPrefix+"3", uint32(time.Now().Unix())-lastUsedThresholdSecondsDefault)
-	g.Expect(err).To(BeNil())
-	err = lastUsed.Set(dummyModelPrefix+"4", uint32(time.Now().Unix())-lastUsedThresholdSecondsDefault) // model 4 not added
+	err = setLastUsed(lastUsed, dummyModelPrefix+"3", uint32(time.Now().Unix())-lastUsedThresholdSecondsDefault)
 	g.Expect(err).To(BeNil())
 	event = <-ch
 	g.Expect(event.StatsData.ModelName).To(Equal(dummyModelPrefix + "3"))
@@ -131,18 +126,18 @@ func TestStatsAnalyserEarlyStop(t *testing.T) {
 	service := NewStatsAnalyserService(
 		[]ModelScalingStatsWrapper{
 			{
-				Stats:     lags,
-				Operator:  interfaces.Gte,
-				Threshold: lagThresholdDefault,
-				Reset:     true,
-				EventType: ScaleUpEvent,
+				StatsKeeper: lags,
+				Operator:    interfaces.Gte,
+				Threshold:   lagThresholdDefault,
+				Reset:       true,
+				EventType:   ScaleUpEvent,
 			},
 			{
-				Stats:     lastUsed,
-				Operator:  interfaces.Gte,
-				Threshold: lastUsedThresholdSecondsDefault,
-				Reset:     false,
-				EventType: ScaleDownEvent,
+				StatsKeeper: lastUsed,
+				Operator:    interfaces.Gte,
+				Threshold:   lastUsedThresholdSecondsDefault,
+				Reset:       false,
+				EventType:   ScaleDownEvent,
 			},
 		},
 		log.New(),
@@ -165,22 +160,22 @@ func TestStatsAnalyserSoak(t *testing.T) {
 
 	lags := NewModelReplicaLagsKeeper()
 	lastUsed := NewModelReplicaLastUsedKeeper()
-	modelScalingStatsCollector := NewDataPlaneStatsCollector(lags, lastUsed)
+	modelScalingStatsCollector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed})
 	service := NewStatsAnalyserService(
 		[]ModelScalingStatsWrapper{
 			{
-				Stats:     lags,
-				Operator:  interfaces.Gte,
-				Threshold: lagThresholdDefault,
-				Reset:     true,
-				EventType: ScaleUpEvent,
+				StatsKeeper: lags,
+				Operator:    interfaces.Gte,
+				Threshold:   lagThresholdDefault,
+				Reset:       true,
+				EventType:   ScaleUpEvent,
 			},
 			{
-				Stats:     lastUsed,
-				Operator:  interfaces.Gte,
-				Threshold: lastUsedThresholdSecondsDefault,
-				Reset:     false,
-				EventType: ScaleDownEvent,
+				StatsKeeper: lastUsed,
+				Operator:    interfaces.Gte,
+				Threshold:   lastUsedThresholdSecondsDefault,
+				Reset:       false,
+				EventType:   ScaleDownEvent,
 			},
 		},
 		log.New(),
@@ -206,14 +201,18 @@ func TestStatsAnalyserSoak(t *testing.T) {
 
 	for i := 0; i < numberIterations; i++ {
 		for j := 0; j < numberModels; j++ {
+			requestId := fmt.Sprintf("request_id_%d_%d", i, j)
 			var wg sync.WaitGroup
 			wg.Add(1)
+
 			setupFn := func(x int) {
-				err := scalingMetricsSetup(&wg, dummyModelPrefix+strconv.Itoa(x), modelScalingStatsCollector)
+				err := scalingMetricsSetup(dummyModelPrefix+strconv.Itoa(x), requestId, modelScalingStatsCollector)
+				wg.Done()
 				g.Expect(err).To(BeNil())
 			}
 			teardownFn := func(x int) {
-				err := scalingMetricsTearDown(&wg, dummyModelPrefix+strconv.Itoa(x), &jobsWg, modelScalingStatsCollector)
+				wg.Wait()
+				err := scalingMetricsTearDown(dummyModelPrefix+strconv.Itoa(x), requestId, &jobsWg, modelScalingStatsCollector)
 				g.Expect(err).To(BeNil())
 			}
 			go setupFn(j)

--- a/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
+++ b/scheduler/pkg/agent/modelscaling/stats_analyser_test.go
@@ -160,7 +160,7 @@ func TestStatsAnalyserSoak(t *testing.T) {
 
 	lags := NewModelReplicaLagsKeeper()
 	lastUsed := NewModelReplicaLastUsedKeeper()
-	modelScalingStatsCollector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed})
+	modelScalingStatsCollector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed}, nil)
 	service := NewStatsAnalyserService(
 		[]ModelScalingStatsWrapper{
 			{

--- a/scheduler/pkg/agent/modelscaling/stats_collector_test.go
+++ b/scheduler/pkg/agent/modelscaling/stats_collector_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestStatsCollectorSmoke(t *testing.T) {
@@ -33,7 +34,7 @@ func TestStatsCollectorSmoke(t *testing.T) {
 	lags := NewModelReplicaLagsKeeper()
 	lastUsed := NewModelReplicaLastUsedKeeper()
 
-	collector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed}, nil)
+	collector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed}, log.New())
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/scheduler/pkg/agent/modelscaling/stats_collector_test.go
+++ b/scheduler/pkg/agent/modelscaling/stats_collector_test.go
@@ -33,7 +33,7 @@ func TestStatsCollectorSmoke(t *testing.T) {
 	lags := NewModelReplicaLagsKeeper()
 	lastUsed := NewModelReplicaLastUsedKeeper()
 
-	collector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed})
+	collector := NewDataPlaneStatsCollector([]interfaces.ModelStatsKeeper{lags, lastUsed}, nil)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/scheduler/pkg/agent/rproxy_grpc_test.go
+++ b/scheduler/pkg/agent/rproxy_grpc_test.go
@@ -47,7 +47,7 @@ func setupReverseGRPCService(numModels int, modelPrefix string, backEndGRPCPort,
 	localCacheManager := setupLocalTestManager(numModels, modelPrefix, v2Client, numModels-2, 1)
 	modelScalingStatsCollector := modelscaling.NewDataPlaneStatsCollector(
 		[]interfaces.ModelStatsKeeper{modelscaling.NewModelReplicaLagsKeeper(), modelscaling.NewModelReplicaLastUsedKeeper()},
-		nil,
+		logger,
 	)
 	rp := NewReverseGRPCProxy(
 		newFakeMetricsHandler(),

--- a/scheduler/pkg/agent/rproxy_grpc_test.go
+++ b/scheduler/pkg/agent/rproxy_grpc_test.go
@@ -47,6 +47,7 @@ func setupReverseGRPCService(numModels int, modelPrefix string, backEndGRPCPort,
 	localCacheManager := setupLocalTestManager(numModels, modelPrefix, v2Client, numModels-2, 1)
 	modelScalingStatsCollector := modelscaling.NewDataPlaneStatsCollector(
 		[]interfaces.ModelStatsKeeper{modelscaling.NewModelReplicaLagsKeeper(), modelscaling.NewModelReplicaLastUsedKeeper()},
+		nil,
 	)
 	rp := NewReverseGRPCProxy(
 		newFakeMetricsHandler(),

--- a/scheduler/pkg/agent/rproxy_grpc_test.go
+++ b/scheduler/pkg/agent/rproxy_grpc_test.go
@@ -31,6 +31,7 @@ import (
 
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
 
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/modelscaling"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
@@ -45,7 +46,7 @@ func setupReverseGRPCService(numModels int, modelPrefix string, backEndGRPCPort,
 	v2Client := testing_utils.NewV2RestClientForTest("localhost", backEndServerPort, logger)
 	localCacheManager := setupLocalTestManager(numModels, modelPrefix, v2Client, numModels-2, 1)
 	modelScalingStatsCollector := modelscaling.NewDataPlaneStatsCollector(
-		modelscaling.NewModelReplicaLagsKeeper(), modelscaling.NewModelReplicaLastUsedKeeper(),
+		[]interfaces.ModelStatsKeeper{modelscaling.NewModelReplicaLagsKeeper(), modelscaling.NewModelReplicaLastUsedKeeper()},
 	)
 	rp := NewReverseGRPCProxy(
 		newFakeMetricsHandler(),
@@ -149,8 +150,8 @@ func TestReverseGRPCServiceSmoke(t *testing.T) {
 	g.Expect(responseInfer.ModelVersion).To(Equal("")) // in practice this should be something else
 
 	t.Log("Testing model scaling stats")
-	g.Expect(rpGRPC.modelScalingStatsCollector.ModelLagStats.Get(dummyModelNamePrefix + "_0")).To(Equal(uint32(0)))
-	g.Expect(rpGRPC.modelScalingStatsCollector.ModelLastUsedStats.Get(dummyModelNamePrefix + "_0")).Should(BeNumerically("<=", time.Now().Unix())) // only triggered when we get results back
+	g.Expect(rpGRPC.modelScalingStatsCollector.StatKeepers[0].Get(dummyModelNamePrefix + "_0")).To(Equal(uint32(0)))
+	g.Expect(rpGRPC.modelScalingStatsCollector.StatKeepers[1].Get(dummyModelNamePrefix + "_0")).Should(BeNumerically("<=", time.Now().Unix())) // only triggered when we get results back
 
 	responseMeta, errMeta := doMeta("_0")
 	g.Expect(responseMeta.Name).To(Equal(dummyModelNamePrefix + "_0"))

--- a/scheduler/pkg/agent/rproxy_test.go
+++ b/scheduler/pkg/agent/rproxy_test.go
@@ -154,7 +154,9 @@ func setupReverseProxy(logger log.FieldLogger, numModels int, modelPrefix string
 	modelScalingStatsCollector := modelscaling.NewDataPlaneStatsCollector(
 		[]interfaces.ModelStatsKeeper{
 			modelscaling.NewModelReplicaLagsKeeper(),
-			modelscaling.NewModelReplicaLastUsedKeeper()},
+			modelscaling.NewModelReplicaLastUsedKeeper()
+		},
+		nil,
 	)
 	rp := NewReverseHTTPProxy(
 		logger,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
1. stats collector works in a general way
2. add support to use model infer delay to scale up model replicas
 
Stats collector had tight-coupling with lag and last used stats, that was not convenient to add more metric stats, such as model infer delay.

Now, stats collector is defined in a more general way. 

Stats collector has a list of ModelStatsKeepers, each `ModelStatsKeeper` keeps track of one kind of metric(lag, last used, delay) for all models.

`ModelReplicaLastUsedKeeper` is an implementation of `ModelStatsKeeper`, it uses LRU cache to record the last used time for each model.

For other metrics(lag, delay), a general `ModelStatsKeeper` is provided.

General `ModelStatsKeeper` uses `ModelStats` to calculate metric for each model.

LagStats and DelayStats implements `ModelStats` interface.

**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:

