### PR TITLE
fix(scheduler): Manual trigger envoy update

### DIFF
--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	grpcMaxConcurrentStreams           = 1_000_000
-	pendingSyncsQueueSize          int = 10
+	pendingSyncsQueueSize          int = 1000
 	modelEventHandlerName              = "agent.server.models"
 	modelScalingCoolingDownSeconds     = 60 // this is currently used in scale down events
 	serverDrainingExtraWaitMillis      = 500

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -38,7 +38,7 @@ type mockStore struct {
 
 var _ store.ModelStore = (*mockStore)(nil)
 
-func (m *mockStore) FailedScheduling(modelVersion *store.ModelVersion, reason string) {
+func (m *mockStore) FailedScheduling(modelVersion *store.ModelVersion, reason string, reset bool) {
 }
 
 func (m *mockStore) UpdateModel(config *pbs.LoadModelRequest) error {

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -655,6 +655,7 @@ func (p *IncrementalProcessor) callVersionCleanupIfNeeded(modelName string) {
 }
 
 func (p *IncrementalProcessor) triggerModelSyncIfNeeded() bool {
+	// the first time we trigger the batch update we need to set the time
 	if p.batchTriggerManual == nil {
 		p.batchTriggerManual = new(time.Time)
 		*p.batchTriggerManual = time.Now()

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -706,7 +706,6 @@ func (p *IncrementalProcessor) modelSync() {
 			continue
 		}
 
-		logger.Debugf("sherif: getting server model %s", mv.name)
 		s, err := p.modelStore.GetServer(v.Server(), false, false)
 		if err != nil {
 			logger.Debugf("Failed to get server for model %s server %s", mv.name, v.Server())

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -662,6 +662,7 @@ func (p *IncrementalProcessor) modelSyncWithLock() {
 
 func (p *IncrementalProcessor) modelSync() {
 	logger := p.logger.WithField("func", "modelSync")
+	logger.Debugf("Calling model sync")
 
 	envoyErr := p.updateEnvoy()
 	serverReplicaState := store.Available

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -625,8 +625,13 @@ func (p *IncrementalProcessor) modelUpdate(modelName string) error {
 	)
 
 	if p.batchTriggerManual == nil {
+		p.batchTriggerManual = new(time.Time)
 		*p.batchTriggerManual = time.Now()
 	} else if time.Since(*p.batchTriggerManual) > p.batchWaitMillis {
+		// we have waited long enough so we can trigger the batch update
+		// we do this inline so that we do not require to release and reacquire the lock
+		// which under heavy load there is no guarantee of order and therefore could lead
+		// to starvation of the batch update
 		p.modelSync()
 		p.batchTriggerManual = nil
 	}

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -766,7 +766,7 @@ func TestModelSync(t *testing.T) {
 			for _, op := range test.ops {
 				op(inc, g)
 			}
-			inc.modelSync()
+			inc.modelSyncWithLock()
 			for modelName, modelReplicas := range test.expectedReplicaStats {
 				model, err := inc.modelStore.GetModel(modelName)
 				g.Expect(err).To(BeNil())

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -149,7 +149,6 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 		filteredServers, debugTrail = s.filterServers(latestModel, servers, debugTrail)
 		s.sortServers(latestModel, filteredServers)
 		ok := false
-		resetServerInCaseOfError := true
 		logger.Debugf("Model %s with desired replicas %d candidate servers %v", modelName, latestModel.DesiredReplicas(), filteredServers)
 		// For each server filter and sort replicas and attempt schedule if enough replicas
 		for _, candidateServer := range filteredServers {
@@ -161,12 +160,6 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 			s.muSortAndUpdate.Lock()
 			candidateReplicas, debugTrail = s.filterReplicas(latestModel, candidateServer, debugTrail)
 			if len(candidateReplicas.ChosenReplicas) < latestModel.DesiredReplicas() {
-				if len(candidateReplicas.ChosenReplicas) > 0 {
-					// in this case we have some replicas but not enough, typically in the case where we are scaling up
-					// beyond the number of the server replicas we have
-					// therefore we do not want to reset the server as we will lose the replicas we have
-					resetServerInCaseOfError = false
-				}
 				s.muSortAndUpdate.Unlock()
 				continue
 			}
@@ -183,7 +176,8 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 		}
 		if !ok {
 			failureErrMsg := fmt.Sprintf("failed to schedule model %s. %v", modelName, debugTrail)
-			s.store.FailedScheduling(latestModel, failureErrMsg, resetServerInCaseOfError)
+			// we do not want to reset the server if it has live replicas
+			s.store.FailedScheduling(latestModel, failureErrMsg, !latestModel.HasLiveReplicas())
 			return fmt.Errorf(failureErrMsg)
 		}
 	}

--- a/scheduler/pkg/scheduler/scheduler_test.go
+++ b/scheduler/pkg/scheduler/scheduler_test.go
@@ -38,7 +38,7 @@ type mockStore struct {
 
 var _ store.ModelStore = (*mockStore)(nil)
 
-func (f mockStore) FailedScheduling(modelVersion *store.ModelVersion, reason string) {
+func (f mockStore) FailedScheduling(modelVersion *store.ModelVersion, reason string, reset bool) {
 }
 
 func (f mockStore) UnloadVersionModels(modelKey string, version uint32) (bool, error) {

--- a/scheduler/pkg/store/experiment/store.go
+++ b/scheduler/pkg/store/experiment/store.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	pendingSyncsQueueSize      int = 100
+	pendingSyncsQueueSize      int = 1000
 	experimentStartEventSource     = "experiment.store.start"
 	experimentStopEventSource      = "experiment.store.stop"
 	modelEventHandlerName          = "experiment.store.models"

--- a/scheduler/pkg/store/experiment/store_test.go
+++ b/scheduler/pkg/store/experiment/store_test.go
@@ -399,7 +399,7 @@ func (f fakeModelStore) DrainServerReplica(serverName string, replicaIdx int) ([
 	panic("implement me")
 }
 
-func (f fakeModelStore) FailedScheduling(modelVersion *store.ModelVersion, reason string) {
+func (f fakeModelStore) FailedScheduling(modelVersion *store.ModelVersion, reason string, reset bool) {
 	panic("implement me")
 }
 

--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -110,7 +110,7 @@ func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersio
 	}
 }
 
-func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string) {
+func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string, reset bool) {
 	modelVersion.state = ModelStatus{
 		State:               ScheduleFailed,
 		Reason:              reason,
@@ -118,8 +118,10 @@ func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string
 		AvailableReplicas:   modelVersion.state.AvailableReplicas,
 		UnavailableReplicas: modelVersion.GetModel().GetDeploymentSpec().GetReplicas() - modelVersion.state.AvailableReplicas,
 	}
-	// make sure we reset server
-	modelVersion.server = ""
+	// make sure we reset server but only if there are no available replicas
+	if reset {
+		modelVersion.server = ""
+	}
 	m.eventHub.PublishModelEvent(
 		modelFailureEventSource,
 		coordinator.ModelEventMsg{

--- a/scheduler/pkg/store/pipeline/status_test.go
+++ b/scheduler/pkg/store/pipeline/status_test.go
@@ -95,7 +95,7 @@ func (f fakeModelStore) RemoveServerReplica(serverName string, replicaIdx int) (
 	panic("implement me")
 }
 
-func (f fakeModelStore) FailedScheduling(modelVersion *store.ModelVersion, reason string) {
+func (f fakeModelStore) FailedScheduling(modelVersion *store.ModelVersion, reason string, reset bool) {
 	panic("implement me")
 }
 

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	pendingSyncsQueueSize             int = 100
+	pendingSyncsQueueSize             int = 1000
 	addPipelineEventSource                = "pipeline.store.addpipeline"
 	removePipelineEventSource             = "pipeline.store.removepipeline"
 	setStatusPipelineEventSource          = "pipeline.store.setstatus"

--- a/scheduler/pkg/store/store.go
+++ b/scheduler/pkg/store/store.go
@@ -126,6 +126,6 @@ type ModelStore interface {
 	ServerNotify(request *pb.ServerNotifyRequest) error
 	RemoveServerReplica(serverName string, replicaIdx int) ([]string, error) // return previously loaded models
 	DrainServerReplica(serverName string, replicaIdx int) ([]string, error)  // return previously loaded models
-	FailedScheduling(modelVersion *ModelVersion, reason string)
+	FailedScheduling(modelVersion *ModelVersion, reason string, reset bool)
 	GetAllModels() []string
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

In some cases under heavy load, periodic batched envoy model update does not get a fair chance to run due to lock contention. This fix introduces a manual trigger as well (which does not require to release the lock and therefore is guaranteed to proceed).

This PR also adds:
- increases the queue sizes of the event hub to 1000.
- do not reset servers for models that fail scheduling but have replicas still loaded on some.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
