### PR TITLE
feat(scheduler): Report lack of dataflow engines in pipeline statuses

### DIFF
--- a/operator/scheduler/pipeline.go
+++ b/operator/scheduler/pipeline.go
@@ -203,7 +203,7 @@ func (s *SchedulerClient) SubscribePipelineEvents(ctx context.Context, conn *grp
 			case scheduler.PipelineVersionState_PipelineReady:
 				logger.Info(
 					"Setting pipeline to ready",
-					"pipeline", event.PipelineName,
+					"pipeline", pipeline.Name,
 					"generation", pipeline.Generation,
 				)
 				pipeline.Status.CreateAndSetCondition(
@@ -215,7 +215,7 @@ func (s *SchedulerClient) SubscribePipelineEvents(ctx context.Context, conn *grp
 			default:
 				logger.Info(
 					"Setting pipeline to not ready",
-					"pipeline", event.PipelineName,
+					"pipeline", pipeline.Name,
 					"generation", pipeline.Generation,
 				)
 				pipeline.Status.CreateAndSetCondition(

--- a/operator/scheduler/pipeline.go
+++ b/operator/scheduler/pipeline.go
@@ -209,8 +209,8 @@ func (s *SchedulerClient) SubscribePipelineEvents(ctx context.Context, conn *grp
 				pipeline.Status.CreateAndSetCondition(
 					v1alpha1.PipelineReady,
 					true,
-					pv.State.Status.String(),
 					pv.State.Reason,
+					pv.State.Status.String(),
 				)
 			default:
 				logger.Info(
@@ -221,8 +221,8 @@ func (s *SchedulerClient) SubscribePipelineEvents(ctx context.Context, conn *grp
 				pipeline.Status.CreateAndSetCondition(
 					v1alpha1.PipelineReady,
 					false,
-					pv.State.Status.String(),
 					pv.State.Reason,
+					pv.State.Status.String(),
 				)
 			}
 			// Set models ready

--- a/scheduler/pkg/coordinator/types.go
+++ b/scheduler/pkg/coordinator/types.go
@@ -56,6 +56,7 @@ type PipelineEventMsg struct {
 	UID               string
 	ExperimentUpdate  bool
 	ModelStatusChange bool
+	Source            string
 }
 
 func (p PipelineEventMsg) String() string {

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -341,7 +341,14 @@ func (c *ChainerServer) rebalance() {
 		}
 		c.mu.Lock()
 		if len(c.streams) == 0 {
-			if err := c.pipelineHandler.SetPipelineState(pv.Name, pv.Version, pv.UID, pipeline.PipelineCreate, "No servers available", sourceChainerServer); err != nil {
+			if err := c.pipelineHandler.SetPipelineState(
+				pv.Name,
+				pv.Version,
+				pv.UID,
+				pipeline.PipelineCreate,
+				"no dataflow engines available to handle pipeline",
+				sourceChainerServer,
+			); err != nil {
 				logger.WithError(err).Errorf("Failed to set pipeline state to creating for %s", pv.String())
 			}
 		} else {

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -40,6 +40,7 @@ const (
 	grpcMaxConcurrentStreams     = 1_000_000
 	pipelineEventHandlerName     = "kafka.dataflow.server.pipelines"
 	pendingEventsQueueSize   int = 10
+	sourceChainerServer          = "chainer-server"
 )
 
 type ChainerServer struct {
@@ -370,6 +371,9 @@ func (c *ChainerServer) rebalance() {
 func (c *ChainerServer) handlePipelineEvent(event coordinator.PipelineEventMsg) {
 	logger := c.logger.WithField("func", "handlePipelineEvent")
 	if event.ExperimentUpdate {
+		return
+	}
+	if sourceChainerServer == event.Source {
 		return
 	}
 

--- a/scheduler/pkg/store/experiment/state_test.go
+++ b/scheduler/pkg/store/experiment/state_test.go
@@ -742,7 +742,7 @@ func (f fakePipelineStore) GetPipelines() ([]*pipeline.Pipeline, error) {
 	panic("implement me")
 }
 
-func (f fakePipelineStore) SetPipelineState(name string, version uint32, uid string, state pipeline.PipelineStatus, reason string) error {
+func (f fakePipelineStore) SetPipelineState(name string, version uint32, uid string, state pipeline.PipelineStatus, reason string, source string) error {
 	panic("implement me")
 }
 

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -46,7 +46,7 @@ type PipelineHandler interface {
 	GetPipelineVersion(name string, version uint32, uid string) (*PipelineVersion, error)
 	GetPipeline(name string) (*Pipeline, error)
 	GetPipelines() ([]*Pipeline, error)
-	SetPipelineState(name string, version uint32, uid string, state PipelineStatus, reason string) error
+	SetPipelineState(name string, version uint32, uid string, state PipelineStatus, reason string, source string) error
 	GetAllRunningPipelineVersions() []coordinator.PipelineEventMsg
 }
 
@@ -349,7 +349,7 @@ func (ps *PipelineStore) terminateOldUnterminatedPipelinesIfNeeded(pipeline *Pip
 	return evts
 }
 
-func (ps *PipelineStore) SetPipelineState(name string, versionNumber uint32, uid string, status PipelineStatus, reason string) error {
+func (ps *PipelineStore) SetPipelineState(name string, versionNumber uint32, uid string, status PipelineStatus, reason string, source string) error {
 	logger := ps.logger.WithField("func", "SetPipelineState")
 	logger.Debugf("Attempt to set state on pipeline %s:%d status:%s", name, versionNumber, status.String())
 	evts, err := ps.setPipelineStateImpl(name, versionNumber, uid, status, reason)
@@ -358,6 +358,7 @@ func (ps *PipelineStore) SetPipelineState(name string, versionNumber uint32, uid
 	}
 	if ps.eventHub != nil {
 		for _, evt := range evts {
+			evt.Source = source
 			ps.eventHub.PublishPipelineEvent(setStatusPipelineEventSource, *evt)
 		}
 	}

--- a/scheduler/pkg/store/pipeline/store_test.go
+++ b/scheduler/pkg/store/pipeline/store_test.go
@@ -726,7 +726,7 @@ func TestSetPipelineState(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.store.SetPipelineState(test.pipelineName, test.pipelineVersion, test.uid, test.status, test.reason)
+			err := test.store.SetPipelineState(test.pipelineName, test.pipelineVersion, test.uid, test.status, test.reason, "")
 			if test.err == nil {
 				g.Expect(err).To(BeNil())
 				pv, err := test.store.GetPipelineVersion(test.pipelineName, test.pipelineVersion, test.uid)


### PR DESCRIPTION
# Why
## Issues
N/A

## Motivation
Currently, the pipeline status returned from the scheduler to the operator does not report if there are no dataflow engines available on which to schedule that pipeline.  The pipeline is left in state `PipelineCreate` with no further details; users must check the scheduler's logs in order to determine that this is the cause.

This PR ameliorates this situation by propagating this information back to the pipeline status in the scheduler-internal data store, which in turn is used to inform subscribers such as the Core v2 operator.

This PR may, at first glance, look like it changes more than required; there is good reason for this.  The chainer server (dataflow engine server) is both a consumer of pipeline events on the internal event bus and also a publisher to this particular stream of events.  The simple solution of just updating the pipeline state when no dataflow engines are registered causes a potentially infinite loop in which the server component receives an event, sees there are no engines, publishes an event, then listens to this same event it has just published.  This loop can run very quickly, constantly spawning new coroutines, in fact to the point that with a single pipeline it can OOM the scheduler (running with the default 1GB memory) in ~40 seconds.

To break this cycle, we need a mechanism for de-duplicating or otherwise ignoring events.  The solution provided here is to add an event _source_, such that the producer of a message can ignore anything produced by itself.  This is relatively simple and also quite generic in its approach--there is no need to cache particular event IDs or anything like that, or to split things up into many separate topics.

# What
## Summary of changes
* Set pipeline status message when no dataflow engines are available.
* Add source for pipeline events for publishers to ignore their own output.

## Testing
Prior to my changes, the pipeline status is:
```bash
k -n seldon get pipelines.mlops.seldon.io dummy-pipeline -o json \
  | jq '.status.conditions[] | select(.type == "PipelineReady")'
```
```json
{
  "lastTransitionTime": "2023-08-10T14:01:18Z",
  "reason": "PipelineCreate",
  "status": "False",
  "type": "PipelineReady"
}
```

By building a local scheduler image and pushing this into a `kind` cluster:
```bash
make -C scheduler docker-build-scheduler
make -C scheduler kind-image-install-scheduler
kubectl rollout restart -n seldon sts seldon-scheduler
```

then deleting and re-creating a dummy pipeline, the status now looks like:
```bash
kubectl -n seldon get pipelines.mlops.seldon.io dummy-pipeline -o json \
  | jq '.status.conditions[] | select(.type == "PipelineReady")'
```
```json
{
  "lastTransitionTime": "2023-08-09T11:11:09Z",
  "message": "no dataflow engines available to handle pipeline",
  "reason": "PipelineCreate",
  "status": "False",
  "type": "PipelineReady"
}
```
