### PR TITLE
ci(github): Add GitHub PR template for Core v2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,9 @@
 ## Summary of changes
 
 ## Checklist
+- [ ] Added/updated unit tests
+- [ ] Added/updated documentation
+- [ ] Checked for typos in variable names, comments, etc.
+- [ ] Added licences for new files
 
 ## Testing

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Why
+## Issues
+
+## Motivation
+
+# What
+## Summary of changes
+
+## Checklist
+
+## Testing


### PR DESCRIPTION
**What this PR does / why we need it**:
Despite being a logically separate codebase, Core v2 inherits a number of things from the `master` branch of the Seldon Core repository.  One of these is the PR template used for GitHub.

This PR adds a new template which provides more structure and, as such, implicit guidance on what to cover in the PR description.  This is good for consistency, for reviewers, and for referring back to in the future.  It furthermore introduces a small checklist for things that are hard to automate.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A