### PR TITLE
update missing value of MANAGER_LEADER_ELECTION_RETRY_PERIOD_SECS

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
         - name: MANAGER_LEADER_ELECTION_RENEW_DEADLINE_SECS
           value: "0"
         - name: MANAGER_LEADER_ELECTION_RETRY_PERIOD_SECS
-          value: ""
+          value: "0"
         - name: MANAGER_LOG_LEVEL
           value: "INFO"
         - name: WATCH_NAMESPACE


### PR DESCRIPTION
Fixes https://github.com/SeldonIO/seldon-core/issues/5086 and updated the missing value of `MANAGER_LEADER_ELECTION_RETRY_PERIOD_SECS` initiating the error mentioned in the issue. I followed the same value of similar fields https://github.com/SeldonIO/seldon-core/blob/b5b5a10979220a19da312bab138ad51341ef2f21/operator/config/manager/manager.yaml#L53

Alternatively, we can use the helm default values:
https://github.com/SeldonIO/seldon-core/blob/b5b5a10979220a19da312bab138ad51341ef2f21/helm-charts/seldon-core-operator/values.yaml#L92
Plz let me know if that's preferred.