### PR TITLE
patchesJson6902 to patches quickfix

### DIFF
--- a/operator/config/cert/kustomization.yaml
+++ b/operator/config/cert/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 resources:
 - secret.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: admissionregistration.k8s.io
     version: v1

--- a/operator/config/controllerid/kustomization.yaml
+++ b/operator/config/controllerid/kustomization.yaml
@@ -11,7 +11,7 @@ patchesStrategicMerge:
 
 # Fix to get around bug in Kustomize that adds prefix to namespace name
 # See https://github.com/kubernetes-sigs/kustomize/issues/235
-patchesJson6902:
+patches:
 - target:
     version: v1
     kind: Namespace

--- a/operator/config/crd/kustomization.yaml
+++ b/operator/config/crd/kustomization.yaml
@@ -18,7 +18,7 @@ patchesStrategicMerge:
 - patches/cainjection_in_seldondeployments.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
-patchesJson6902:
+patches:
 # Ensure multiple levels of graph defn in OpenAPISpec as you can't have references let alone recursive refs
 # https://github.com/kubernetes/kubernetes/issues/54579  
 - target: 

--- a/operator/config/crd_v1_small/kustomization.yaml
+++ b/operator/config/crd_v1_small/kustomization.yaml
@@ -18,7 +18,7 @@ patchesStrategicMerge:
 - patches/cainjection_in_seldondeployments.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
-patchesJson6902:
+patches:
 # Ensure multiple levels of graph defn in OpenAPISpec as you can't have references let alone recursive refs
 # https://github.com/kubernetes/kubernetes/issues/54579  
 - target: 

--- a/operator/config/local/kustomization.yaml
+++ b/operator/config/local/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 patches:
 - service.yaml
 
-patchesJson6902:
+patches:
   - target:
       version: v1
       kind: Service

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -6,5 +6,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: docker.io/seldonio/seldon-core-operator
+  newName: seldonio/seldon-core-operator
   newTag: 1.18.0-dev

--- a/operator/config/namespaced/kustomization.yaml
+++ b/operator/config/namespaced/kustomization.yaml
@@ -18,7 +18,7 @@ patchesStrategicMerge:
 configurations:
 - webhook-config.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: admissionregistration.k8s.io
     version: v1

--- a/operator/config/namespaced1/kustomization.yaml
+++ b/operator/config/namespaced1/kustomization.yaml
@@ -9,7 +9,7 @@ bases:
 
 # Fix to get around bug in Kustomize that adds prefix to namespace name
 # See https://github.com/kubernetes-sigs/kustomize/issues/235
-patchesJson6902:
+patches:
 - target:
     version: v1
     kind: Namespace

--- a/operator/config/namespaced2/kustomization.yaml
+++ b/operator/config/namespaced2/kustomization.yaml
@@ -9,7 +9,7 @@ bases:
 
 # Fix to get around bug in Kustomize that adds prefix to namespace name
 # See https://github.com/kubernetes-sigs/kustomize/issues/235
-patchesJson6902:
+patches:
 - target:
     version: v1
     kind: Namespace

--- a/operator/config/scorecard/kustomization.yaml
+++ b/operator/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-# +kubebuilder:scaffold:patchesJson6902
+# +kubebuilder:scaffold:patches

--- a/operator/config/webhook/kustomization.yaml
+++ b/operator/config/webhook/kustomization.yaml
@@ -6,7 +6,7 @@ configurations:
 - kustomizeconfig.yaml
 
 # Comment this if you have a k8s cluster < 1.15 as objectSelector is only available in >=1.15
-patchesJson6902:
+patches:
 - target:
     group: admissionregistration.k8s.io
     version: v1


### PR DESCRIPTION
A quick fix to prevent the following warning:
```bash
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```