### PR TITLE
fix(data-flow): Example scripts redefine `main` function

### DIFF
--- a/scheduler/.golangci.yml
+++ b/scheduler/.golangci.yml
@@ -51,3 +51,9 @@ linters-settings:
       - prefix(github.com/seldonio/seldon-core/scheduler)
   goconst:
     min-occurrences: 5
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: data-flow/scripts/(common|producer|consumer).go
+      text: ".*main redeclared in this block.*"


### PR DESCRIPTION
These scripts are referenced/used from a Jupyter Notebook and from the Makefile. The `producer` and `consumer` scripts are intended to be built separately, but used in one example, hence why there's multiple `main` functions.

This will enable the V2 Security Tests workflow [1] to start passing again.

[1] https://github.com/SeldonIO/seldon-core/actions/workflows/security_tests_v2.yml