### PR TITLE
Allow protobuf 4

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ setup(
         "Flask-cors<4.0.0",
         "requests<3.0.0",
         "numpy<2.0.0",
-        "protobuf>=3.20.2,<4.0.0",
+        "protobuf>=3.20.2,<5.0.0",
         "grpcio<2.0.0",
         "Flask-OpenTracing >= 1.1.0, < 1.2.0",
         "opentracing >= 2.2.0, < 2.5.0",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

protobuf 3 is quite old.
I want to use Python 3.11 and grpcio-tools, but grpcio-tools 1.49 which provides wheels for 3.11 (see [this PyPI link](https://pypi.org/project/grpcio-tools/1.49.1/#files)) depends on protobuf 4.21.3 (see [this link](https://github.com/grpc/grpc/blob/v1.49.1/tools/distrib/python/grpcio_tools/setup.py#L293)), which is not allowed by seldon-core 1.17.1.

It'd be appreciated if you could release the next version after this PR is merged as this is blocking me.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
