### PR TITLE
fix: Remove timeout in envoy

### DIFF
--- a/scheduler/pkg/envoy/resources/resource.go
+++ b/scheduler/pkg/envoy/resources/resource.go
@@ -55,7 +55,7 @@ const (
 	SeldonRouteSeparator          = ":" // Tried % but this seemed to break envoy matching. Maybe % is a special character or connected to regexp. A bug?
 	SeldonModelHeaderSuffix       = "model"
 	SeldonPipelineHeaderSuffix    = "pipeline"
-	DefaultRouteTimeoutSecs       = 60 //TODO allow configurable override
+	DefaultRouteTimeoutSecs       = 0 //TODO allow configurable override
 	ExternalHeaderPrefix          = "x-"
 	DefaultRouteConfigurationName = "listener_0"
 	MirrorRouteConfigurationName  = "listener_1"


### PR DESCRIPTION
Provides a short term fix for hard-wired timeouts in Envoy of 60s by setting to 0 (no timeout).
Ideally, in future this should be configurable on a per Model/Pipleine basis