### PR TITLE
ci(security): Remove linting steps from GHA security workflow

### DIFF
--- a/.github/workflows/security_tests_v2.yml
+++ b/.github/workflows/security_tests_v2.yml
@@ -21,7 +21,6 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         GOFLAGS: "-buildvcs=false"
       run: |
-        make -C operator fmt
         snyk test --file=operator/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-scheduler:
@@ -34,7 +33,6 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         GOFLAGS: "-buildvcs=false"
       run: |
-        make -C scheduler lint
         snyk test --file=scheduler/go.mod --fail-on=upgradable --severity-threshold=high
 
   security-image-operator:


### PR DESCRIPTION
# Why
## Motivation
Currently, the security workflow for GitHub Actions has steps that perform linting for the `scheduler/` and `operator/` directories.  The setup for this is not the same as for the linting action for PRs.  As a result, it seems that while the PR workflows succeed, the security tests can fail on linting.

There is no need for these to perform linting in any case, precisely because this is done for every PR, so all the code merged into the `v2` branch already meets linting requirements.  Removing this additional step is therefore removing redundancy and also removing a source of inconsistency.

The inclusion of linting was questioned [originally](https://github.com/SeldonIO/seldon-core/pull/4575#discussion_r1067886265) and included simply because it's what Core v1 does.  I firmly believe this is redundant and can safely be removed.

# What
## Changes
* Remove linting steps from GitHub Actions workflow.

## Testing
N/A