### PR TITLE
feat(docs): [SCv2] Automatically create and upload a custom HF model to seldon-models in GCS on every new MLServer version

### DIFF
--- a/samples/scripts/models/Makefile
+++ b/samples/scripts/models/Makefile
@@ -5,10 +5,10 @@ TRITON_VERSION=$(shell grep 'nvidia/tritonserver' ../../../scheduler/Makefile | 
 TRITON_FOLDER=triton_${TRITON_VERSION}
 
 .PHONY: train-all
-train-all: iris moviesentiment income income-xgb income-lgb download-mnist-onnx download-cifar10-tensorflow wine-mlflow mnist-pytorch
+train-all: iris text-generation-huggingface moviesentiment income income-xgb income-lgb download-mnist-onnx download-cifar10-tensorflow wine-mlflow mnist-pytorch
 
 .PHONY: upload-all
-upload-all: upload-iris upload-moviesentiment upload-income upload-income-xgb upload-income-lgb upload-mnist-onnx upload-cifar10-tensorflow upload-wine-mlflow upload-mnist-pytorch
+upload-all: upload-iris upload-text-generation-huggingface upload-moviesentiment upload-income upload-income-xgb upload-income-lgb upload-mnist-onnx upload-cifar10-tensorflow upload-wine-mlflow upload-mnist-pytorch
 
 .PHONY: env
 env:
@@ -20,6 +20,7 @@ env:
 		mlserver-mlflow==${MLSERVER_VERSION} \
 		mlserver-lightgbm==${MLSERVER_VERSION} \
 		mlserver-alibi-explain==${MLSERVER_VERSION} \
+		mlserver-huggingface==${MLSERVER_VERSION} \
 		requests
 	wget https://raw.githubusercontent.com/pytorch/examples/main/mnist/requirements.txt -O mnist-pytorch/requirements.txt
 	.env/bin/pip install -r mnist-pytorch/requirements.txt
@@ -35,6 +36,20 @@ iris: env
 .PHONY: upload-iris
 upload-iris:
 	gsutil cp iris/model.joblib gs://seldon-models/scv2/samples/${MLSERVER_FOLDER}/iris-sklearn/model.joblib
+
+#
+# HuggingFace text-generation model
+#
+
+.PHONY: text-generation-huggingface
+text-generation-huggingface: env
+	cd text-generation-huggingface && ../.env/bin/python3 train.py
+
+
+.PHONY: upload-text-generation-huggingface
+upload-text-generation-huggingface:
+	gsutil cp -r text-generation-huggingface/text-generation-model-artefacts/* gs://seldon-models/scv2/samples/${MLSERVER_FOLDER}/text-generation-huggingface/
+	gsutil cp text-generation-huggingface/model-settings.json gs://seldon-models/scv2/samples/${MLSERVER_FOLDER}/text-generation-huggingface/
 
 #
 # movie sentiment SKLearn model

--- a/samples/scripts/models/Makefile
+++ b/samples/scripts/models/Makefile
@@ -48,8 +48,8 @@ text-generation-huggingface: env
 
 .PHONY: upload-text-generation-huggingface
 upload-text-generation-huggingface:
-	gsutil cp -r text-generation-huggingface/text-generation-model-artefacts/* gs://seldon-models/scv2/samples/${MLSERVER_FOLDER}/text-generation-huggingface/
-	gsutil cp text-generation-huggingface/model-settings.json gs://seldon-models/scv2/samples/${MLSERVER_FOLDER}/text-generation-huggingface/
+	gsutil cp -r text-generation-huggingface/text-generation-model-artefacts/* gs://seldon-models/scv2/samples/${MLSERVER_FOLDER}/custom-text-generation-huggingface/
+	gsutil cp text-generation-huggingface/model-settings.json gs://seldon-models/scv2/samples/${MLSERVER_FOLDER}/custom-text-generation-huggingface/
 
 #
 # movie sentiment SKLearn model

--- a/samples/scripts/models/text-generation-huggingface/.gitignore
+++ b/samples/scripts/models/text-generation-huggingface/.gitignore
@@ -1,0 +1,1 @@
+text-generation-model-artefacts/

--- a/samples/scripts/models/text-generation-huggingface/model-settings.json
+++ b/samples/scripts/models/text-generation-huggingface/model-settings.json
@@ -1,0 +1,9 @@
+{
+  "name": "transformer",
+  "implementation": "mlserver_huggingface.HuggingFaceRuntime",
+  "parameters": {
+    "extra": {
+      "task": "text-generation"
+    }
+  }
+}

--- a/samples/scripts/models/text-generation-huggingface/train.py
+++ b/samples/scripts/models/text-generation-huggingface/train.py
@@ -1,0 +1,19 @@
+from transformers import (
+    GPT2Tokenizer,
+    TFGPT2LMHeadModel,
+    pipeline,
+)
+
+
+def main() -> None:
+    tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+    model = TFGPT2LMHeadModel.from_pretrained("gpt2")
+
+    p = pipeline(task="text-generation", model=model, tokenizer=tokenizer)
+
+    p.save_pretrained("text-generation-model-artefacts")
+
+
+if __name__ == "__main__":
+    print("Building a custom HuggingFace model...")
+    main()


### PR DESCRIPTION
**What this PR does / why we need it**:
The next version of MLServer will be allowing users to create custom HuggingFace models. Users will be able to specify a location in which model artefacts will be located and later used. This will allow users to customize certain model parameters, such as tokenizers, feature extractors, image processors, etc and then build a HuggingFace model and use it, not limiting themselves to existing models on the official hub.

Automating the creation and the upload of a simple custom HuggingFace model to our collection of models in our GCS bucket - seldon-models, will pave the way to use said model in upcoming demos, showcasing how users can actually load a custom model and use it in SCv2 or in our paid products.

By having this automation, we ensure that on every new MLServer version release, the custom HF model is added to our collection of models in the bucket and demo pages are kept up-to-date.

**Testing**
- [x] The resulted model was generated correctly by running `make text-generation-huggingface`
- [x] The generated model was uploaded correctly to a public GCS bucket(mine in this case) by running `make upload-text-generation-huggingface`
- [x] Used the Seldon CLI to load a `Model` K8s resource, pointing to a GCS location with a custom HF model and correctly predicted

**Seldon Deploy Testing**
- [x] Passed said model GCS location in Seldon Deploy Wizard and successfully created and predicted for a *Deployment* and for a *Pipeline*

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
