### PR TITLE
feat(docs): [SCv1] Automatically create and upload a custom HF model to seldon-models in GCS on every version release

### DIFF
--- a/examples/upgrade-to-rclone/global-rclone-upgrade.ipynb
+++ b/examples/upgrade-to-rclone/global-rclone-upgrade.ipynb
@@ -10,7 +10,7 @@
     "In this documentation page we provide an example upgrade path from kfserving-based to rclone-based storage initializer. This is required due to the fact that secret format expected by these two storage initializers is different. \n",
     "\n",
     "Storage initializers are used by Seldon's pre-packaged model servers to download models binaries. \n",
-    "As it is explained in the [SC 1.8 upgrading notes](https://docs.seldon.io/projects/seldon-core/en/latest/reference/upgrading.html#upgrading-to-1-8) the [seldonio/rclone-storage-initializer](https://github.com/SeldonIO/seldon-core/tree/master/components/rclone-storage-initializer) became default storage initializer in v1.8.0. However, it is still possible to run with kfserving-based Storage Initializer as documented [here](https://docs.seldon.io/projects/seldon-core/en/latest/servers/kfserving-storage-initializer.html).\n",
+    "As it is explained in the [SC 1.8 upgrading notes](https://docs.seldon.io/projects/seldon-core/en/latest/reference/upgrading.html#upgrading-to-1-8) the [seldonio/rclone-storage-initializer](https://github.com/SeldonIO/seldon-core/tree/master/components/rclone-storage-initializer) became default storage initializer in v1.8.0.\n",
     "\n",
     "In this tutorial we aim to provide an intuition of the steps you will have to carry to migrate to the new rclone-based Storage Initializer with the context that every cluster configuration will be different, so you should be able to see this as something you can build from.\n",
     "\n",

--- a/examples/upgrade-to-rclone/rclone-upgrade.ipynb
+++ b/examples/upgrade-to-rclone/rclone-upgrade.ipynb
@@ -10,7 +10,7 @@
     "In this documentation page we provide an example upgrade path from kfserving-based to rclone-based storage initializer. This is required due to the fact that secret format expected by these two storage initializers is different. \n",
     "\n",
     "Storage initializers are used by Seldon's pre-packaged model servers to download models binaries. \n",
-    "As it is explained in the [SC 1.8 upgrading notes](https://docs.seldon.io/projects/seldon-core/en/latest/reference/upgrading.html#upgrading-to-1-8) the [seldonio/rclone-storage-initializer](https://github.com/SeldonIO/seldon-core/tree/master/components/rclone-storage-initializer) became default storage initializer in v1.8.0. However, it is still possible to run with kfserving-based Storage Initializer as documented [here](https://docs.seldon.io/projects/seldon-core/en/latest/servers/kfserving-storage-initializer.html).\n",
+    "As it is explained in the [SC 1.8 upgrading notes](https://docs.seldon.io/projects/seldon-core/en/latest/reference/upgrading.html#upgrading-to-1-8) the [seldonio/rclone-storage-initializer](https://github.com/SeldonIO/seldon-core/tree/master/components/rclone-storage-initializer) became default storage initializer in v1.8.0.\n",
     "\n",
     "In this tutorial we will show how to upgrade your configuration to new Storage Initializer with focus on getting the new format of a required secret right.\n",
     "\n",

--- a/servers/Makefile
+++ b/servers/Makefile
@@ -1,4 +1,4 @@
-models: mlflowserver-models sklearnserver-models
+models: mlflowserver-models sklearnserver-models huggingface-models
 
 
 mlflowserver-models:
@@ -8,3 +8,7 @@ mlflowserver-models:
 sklearnserver-models:
 	make -C sklearnserver/models/iris
 	make -C sklearnserver/models/moviesentiment
+
+
+huggingface-models:
+	make -C huggingface/models/text-generation

--- a/servers/huggingface/models/text-generation/.gitignore
+++ b/servers/huggingface/models/text-generation/.gitignore
@@ -1,0 +1,2 @@
+.env/
+text-generation-model-artefacts/

--- a/servers/huggingface/models/text-generation/Makefile
+++ b/servers/huggingface/models/text-generation/Makefile
@@ -1,0 +1,16 @@
+VERSION := $(shell cat ../../../../version.txt)
+
+all: env train upload
+
+model: env train
+
+env:
+	python3 -m venv .env
+	./.env/bin/pip install --upgrade pip setuptools
+	./.env/bin/pip install -r requirements.txt
+
+train:
+	.env/bin/python train.py
+
+upload:
+	gsutil cp -r text-generation-model-artefacts/* gs://seldon-models/v${VERSION}/huggingface/text-generation/

--- a/servers/huggingface/models/text-generation/Makefile
+++ b/servers/huggingface/models/text-generation/Makefile
@@ -13,4 +13,4 @@ train:
 	.env/bin/python train.py
 
 upload:
-	gsutil cp -r text-generation-model-artefacts/* gs://seldon-models/v${VERSION}/huggingface/text-generation/
+	gsutil cp -r text-generation-model-artefacts/* gs://seldon-models/v${VERSION}/huggingface/custom-text-generation/

--- a/servers/huggingface/models/text-generation/requirements.txt
+++ b/servers/huggingface/models/text-generation/requirements.txt
@@ -1,0 +1,3 @@
+seldon_core
+transformers >=4.30,<4.32
+tensorflow == 2.12.0

--- a/servers/huggingface/models/text-generation/train.py
+++ b/servers/huggingface/models/text-generation/train.py
@@ -1,0 +1,19 @@
+from transformers import (
+    GPT2Tokenizer,
+    TFGPT2LMHeadModel,
+    pipeline,
+)
+
+
+def main() -> None:
+    tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+    model = TFGPT2LMHeadModel.from_pretrained("gpt2")
+
+    p = pipeline(task="text-generation", model=model, tokenizer=tokenizer)
+
+    p.save_pretrained("text-generation-model-artefacts")
+
+
+if __name__ == "__main__":
+    print("Building a custom HuggingFace model...")
+    main()


### PR DESCRIPTION
**What this PR does / why we need it**:
The next version of MLServer will be allowing users to create custom HuggingFace models. Users will be able to specify a location in which model artefacts will be located and later used. This will allow users to customize certain model parameters, such as tokenizers, feature extractors, image processors, etc and then build a HuggingFace model and use it, not limiting themselves to existing models on the official hub.

Automating the creation and the upload of a simple custom HuggingFace model to our collection of models in our GCS bucket - seldon-models, will pave the way to use said model in upcoming demos, showcasing how users can actually load a custom model and use it in SCv2 or in our paid products.

By having this automation, we ensure that on every new MLServer version release, the custom HF model is added to our collection of models in the bucket and demo pages are kept up-to-date.

By having this change separated from [a similar SCv2-related change](https://github.com/SeldonIO/seldon-core/pull/5103), I am ensuring that SCv1 related demo pages are using models uploaded in non-SCv2 folders in GCS. This will avoid confusion as to  why a SCv1-related demo is using a model uploaded to gs://seldon-models/scv2/... folder.

**Testing**
- [x] The resulted model was generated correctly by running `make env && make train`
- [x] The generated model was uploaded correctly to a public GCS bucket(mine in this case) by running `make upload`
- [x] The uploaded model was used correctly by creating a K8s `SeldonDeployment` resource and was able to correctly make a prediction without any additional downloads
```
apiVersion: machinelearning.seldon.io/v1alpha2
kind: SeldonDeployment
metadata:
  name: huggingface-model
spec:
  protocol: v2
  predictors:
  - graph:
      name: transformer
      implementation: HUGGINGFACE_SERVER
      modelUri: gs://viktor-models/v1.18.0-dev/huggingface/text-generation
      parameters:
      - name: task
        type: STRING
        value: text-generation
    componentSpecs:
      - spec:
          containers:
            - name: transformer
              resources:
                limits:
                  cpu: 1
                  memory: 4Gi
                requests:
                  cpu: 100m
                  memory: 3Gi
    name: default
    replicas: 1

```  
![image](https://github.com/SeldonIO/seldon-core/assets/13816060/98e72563-f12e-48a0-ae41-752fb4eca9a8)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
