### PR TITLE
fix(executor): payloads are logged twice in Combiner

### DIFF
--- a/executor/predictor/predictor_process.go
+++ b/executor/predictor/predictor_process.go
@@ -260,27 +260,10 @@ func (p *PredictorProcess) aggregate(node *v1.PredictiveUnit, cmsg []payload.Sel
 	modelName := p.getModelName(node)
 
 	if callClient {
-		//Log Request
-		if node.Logger != nil && (node.Logger.Mode == v1.LogRequest || node.Logger.Mode == v1.LogAll) {
-			err := p.logPayload(node.Name, node.Logger, payloadLogger.InferenceRequest, msg, puid)
-			if err != nil {
-				return nil, err
-			}
-		}
 		p.RoutingMutex.Lock()
 		p.Routing[node.Name] = -1
 		p.RoutingMutex.Unlock()
-		tmsg, err := p.Client.Combine(p.Ctx, modelName, node.Endpoint.ServiceHost, p.getPort(node), cmsg, p.Meta.Meta)
-		if tmsg != nil && err == nil {
-			// Log Response
-			if node.Logger != nil && (node.Logger.Mode == v1.LogResponse || node.Logger.Mode == v1.LogAll) {
-				err := p.logPayload(node.Name, node.Logger, payloadLogger.InferenceResponse, tmsg, puid)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-		return tmsg, err
+		return p.Client.Combine(p.Ctx, modelName, node.Endpoint.ServiceHost, p.getPort(node), cmsg, p.Meta.Meta)
 	} else {
 		return cmsg[0], nil
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
The PR aims to fix Issue #5116.
The bug descriprtion is mirrored below for easy reference.
If the seldon-core >= 1.16 and there is a combiner in the graph with logger enabled, the payloads of the Combiner will be logged twice.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5116

**Special notes for your reviewer**:
As I mentioned on the issue page, its better to first clarify/define the concept of *operation/situation*. In other words, we need to figure out:

 **What is a  _opration/situation_ during a payload lifecycle within a graph node?** 

With a clear agreement on what the concept refers to, we can then move to the log rule/convetion proposed by @cliveseldon.
> the key is the ability to log any before and after situation so as long as that can happen while at the same time removing redundant calls

 Otherwise redundant logs are inevitable if we  log payloads wherever we consider an operation/situation. 
 
 From my point of view, we can clarify *situation/operation* by leveraging the logic of the `Predict` method as it outlines the complete life cycle of a payload within a node.
 See my comments below for details.
```go
func (p *PredictorProcess) Predict(node *v1.PredictiveUnit, msg payload.SeldonPayload) (payload.SeldonPayload, error) {
        // ...

        // payloads before and after transformation input operation are logged inside
	tmsg, err := p.transformInput(node, msg, puid)
	if err != nil {
		return tmsg, err
	}
        // Payloads before calling Children nodes and after collection/aggregation of children nodes' results are also logged
        // We don't need to log payloads again within aggregate
	cmsg, err := p.predictChildren(node, tmsg, puid)
	if err != nil {
		return cmsg, err
	}
        // payloads before and after transformation output operation are logged inside
	response, err := p.transformOutput(node, cmsg, puid)

        // ...
	return response, err
}
```
To summarize, as per the `Predict` method, a playload lifecycle within a graph node can be divided into 3 phases: `transformInput`, `predictChildren` and `transformOutput`.  **Each phase can be regardad as a _situation_**.
Note that if we restrict the definition of *siuation* to first function call level within `Predict` method, for the `predictChildren` method, no matter what type of node is `ROUTER` or `COMBINER`, we should just get the payloads log before sending payload to children nodes and after collecting/aggregating results from children nodes respectively.

Thus, we don't need to do redundant payload  logging  in the inner  `aggregate` or `route` function anymore.





