### PR TITLE
fix(scheduler): update otel-collector-config after jaeger endpoint does not supported

### DIFF
--- a/scheduler/all-base.yaml
+++ b/scheduler/all-base.yaml
@@ -102,7 +102,7 @@ services:
     ports:
       - "16686:16686"
       - "14268"
-      - "14250"
+      - "4317"
 
   kafka:
     image: "${KAFKA_IMAGE_AND_TAG}"

--- a/scheduler/otel-collector-config.yaml
+++ b/scheduler/otel-collector-config.yaml
@@ -15,8 +15,8 @@ exporters:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
     format: proto
 
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
+  otlp:
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 
@@ -36,7 +36,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, jaeger]
+      exporters: [logging, zipkin, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
With existing config: otel-collector-config.yaml, I got an error when try to run the `make deploy-local`, `otel-collector` container crashed with logs:

```
Error: failed to get config: cannot unmarshal the configuration: 1 error(s) decoding:

* error decoding 'exporters': unknown type: "jaeger" for id: "jaeger" (valid values: [file prometheusremotewrite skywalking splunk_hec cassandra dataset influxdb kafka awss3 otlp azuremonitor googlecloudpubsub loadbalancing zipkin logging datadog elasticsearch sapm sentry sumologic tanzuobservability tencentcloud_logservice debug carbon clickhouse mezmo prometheus azuredataexplorer awsxray f5cloud googlecloud pulsar syslog alibabacloud_logservice coralogix logzio loki opensearch awskinesis awscloudwatchlogs awsemf dynatrace googlemanagedprometheus honeycombmarker instana logicmonitor otlphttp signalfx opencensus])
2023/12/11 06:42:49 collector server run finished with error: failed to get config: cannot unmarshal the configuration: 1 error(s) decoding:

* error decoding 'exporters': unknown type: "jaeger" for id: "jaeger" (valid values: [file prometheusremotewrite skywalking splunk_hec cassandra dataset influxdb kafka awss3 otlp azuremonitor googlecloudpubsub loadbalancing zipkin logging datadog elasticsearch sapm sentry sumologic tanzuobservability tencentcloud_logservice debug carbon clickhouse mezmo prometheus azuredataexplorer awsxray f5cloud googlecloud pulsar syslog alibabacloud_logservice coralogix logzio loki opensearch awskinesis awscloudwatchlogs awsemf dynatrace googlemanagedprometheus honeycombmarker instana logicmonitor otlphttp signalfx opencensus])
```

I found the problem: `opentelemetry-collector-contrib` has removed jaeger and jaegerthrifthttp exporters from this commit: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26546. We need to update the endpoint to fix this issue (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15291#issuecomment-1826734333)

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:
