### PR TITLE
feat: Bump prometheus-client upperbound to 0.19.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -35,7 +35,7 @@ setup(
         "grpcio-reflection < 2.0.0",
         "gunicorn >= 19.9.0, < 20.2.0",
         "setuptools >= 65.5.1",
-        "prometheus_client >= 0.7.1, < 0.9.0",
+        "prometheus_client >= 0.7.1, <= 0.19.0",
         "werkzeug >= 2.1.1, < 2.3",
         # Addresses CVE SNYK-PYTHON-CRYPTOGRAPHY-3315328
         "cryptography >= 39.0.1, < 41.1",


### PR DESCRIPTION
Background
---
Proposing that we bump the upper bound of the [prometheus_client](https://github.com/prometheus/client_python/releases?page=1) library required by the `seldon-core` python sdk to include the latest `0.19.0`

Reasoning
---
We have projects that use the latest promethues_client library and are unable to use this library due to version restrictions:

```
pip._vendor.resolvelib.resolvers.ResolutionImpossible: [RequirementInformation(requirement=SpecifierRequirement('prometheus-client==0.17.1'), parent=None), RequirementInformation(requirement=SpecifierRequirement('prometheus-client<0.9.0,>=0.7.1'), parent=LinkCandidate('https://files.pythonhosted.org/packages/46/0a/261128eeae231b024aa0acf4f633be4c5b1f674e089298be360f338345b8/seldon_core-1.17.1-py3-none-any.whl (from https://pypi.org/simple/seldon-core/) (requires-python:>=3.6)'))]
```
