### PR TITLE
fix(operator) close smoke test connection to scheduler

### DIFF
--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -116,15 +116,14 @@ func (s *SchedulerClient) RemoveConnection(namespace string) {
 // A smoke test allows us to quicky check if we actually have a functional grpc connection to the scheduler
 func (s *SchedulerClient) smokeTestConnection(conn *grpc.ClientConn) error {
 	grcpClient := scheduler.NewSchedulerClient(conn)
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-	stream, err := grcpClient.SubscribeModelStatus(context.TODO(), &scheduler.ModelSubscriptionRequest{SubscriberName: "seldon manager"}, grpc_retry.WithMax(1))
+	_, err := grcpClient.SubscribeModelStatus(ctx, &scheduler.ModelSubscriptionRequest{SubscriberName: "seldon manager smoke test"}, grpc_retry.WithMax(1))
 	if err != nil {
 		return err
 	}
-	err = stream.CloseSend()
-	if err != nil {
-		return err
-	}
+
 	return nil
 }
 

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -38,12 +38,15 @@ func (s *SchedulerServer) SubscribeModelStatus(req *pb.ModelSubscriptionRequest,
 	}
 	s.modelEventStream.mu.Unlock()
 
-	err := s.sendCurrentModelStatuses(stream)
-	if err != nil {
-		return err
-	}
-
 	ctx := stream.Context()
+
+	go func() {
+		err := s.sendCurrentModelStatuses(stream)
+		if err != nil && ctx.Err() == nil {
+			logger.WithError(err).Errorf("failed to send current model statuses to subscriber %s", req.GetSubscriberName())
+		}
+	}()
+
 	// Keep this scope alive because once this scope exits - the stream is closed
 	for {
 		select {


### PR DESCRIPTION
**What this PR does / why we need it**:

Seldon v2 operator does not close smoke test connection to scheduler.

Moreover, the scheduler server sends the current model status in SubscribeModelStatus request handler and then observes close event. If the subscriber cancels the stream immediately after sending the subscription request, the scheduler will not receive the cancellation message and will not delete the stream. so the scheduler should send current model status asynchronously in goroutine.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
