### PR TITLE
fix(pipelinegateway): Use composite key for Kafka when x-request-id header is specified

### DIFF
--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
+
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	kafka2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka"
 	pipeline "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/pipeline"

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -202,27 +202,28 @@ func (km *KafkaManager) Infer(
 		km.mu.RUnlock()
 		return nil, err
 	}
-	key := getCompositeKey(resourceName, requestId, ".")
+	// Use composite key to differentiate multiple piplines (i.e. mirror) using the same message
+	compositeKey := getCompositeKey(resourceName, requestId, ".")
 	request := &Request{
 		active: true,
 		wg:     new(sync.WaitGroup),
-		key:    key,
+		key:    compositeKey,
 	}
-	pipeline.consumer.requests.Set(key, request)
-	defer pipeline.consumer.requests.Remove(key)
+	pipeline.consumer.requests.Set(compositeKey, request)
+	defer pipeline.consumer.requests.Remove(compositeKey)
 	request.wg.Add(1)
 
 	outputTopic := km.topicNamer.GetPipelineTopicInputs(resourceName)
 	if isModel {
 		outputTopic = km.topicNamer.GetModelTopicInputs(resourceName)
 	}
-	logger.Debugf("Produce on topic %s with key %s", outputTopic, key)
+	logger.Debugf("Produce on topic %s with key %s", outputTopic, compositeKey)
 	kafkaHeaders := append(headers, kafka.Header{Key: resources.SeldonPipelineHeader, Value: []byte(resourceName)})
 	kafkaHeaders = addRequestIdToKafkaHeadersIfMissing(kafkaHeaders, requestId)
 
 	msg := &kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: &outputTopic, Partition: kafka.PartitionAny},
-		Key:            []byte(key),
+		Key:            []byte(compositeKey),
 		Value:          data,
 		Headers:        kafkaHeaders,
 	}
@@ -246,9 +247,9 @@ func (km *KafkaManager) Infer(
 		span.End()
 	}()
 	km.mu.RUnlock()
-	logger.Debugf("Waiting for response for request id %s", requestId)
+	logger.Debugf("Waiting for response for request id %s for resource %s", requestId, resourceName)
 	request.wg.Wait()
-	logger.Debugf("Got response for request id %s", requestId)
+	logger.Debugf("Got response for request id %s for resource %s", requestId, resourceName)
 	return request, nil
 }
 

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -202,7 +202,7 @@ func (km *KafkaManager) Infer(
 		km.mu.RUnlock()
 		return nil, err
 	}
-	key := fmt.Sprintf("%s.%s", resourceName, requestId)
+	key := getCompositeKey(resourceName, requestId, ".")
 	request := &Request{
 		active: true,
 		wg:     new(sync.WaitGroup),

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -163,7 +163,7 @@ func (c *MultiTopicsKafkaConsumer) pollAndMatch() error {
 				// Add tracing span
 				_, span := c.tracer.Start(ctx, "Consume")
 				// Use the original request id from kafka headers, as key here is a composite key with the resource name
-				requestId := getRequestIdFromKafkaHeaders(e.Headers)
+				requestId := GetRequestIdFromKafkaHeaders(e.Headers)
 				if requestId == "" {
 					logger.Warnf("Missing request id in Kafka headers for key %s", string(e.Key))
 				}

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -11,6 +11,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -161,7 +162,7 @@ func (c *MultiTopicsKafkaConsumer) pollAndMatch() error {
 				carrierIn := splunkkafka.NewMessageCarrier(e)
 				ctx = otel.GetTextMapPropagator().Extract(ctx, carrierIn)
 				_, span := c.tracer.Start(ctx, "Consume")
-				span.SetAttributes(attribute.String(util.RequestIdHeader, string(e.Key)))
+				span.SetAttributes(attribute.String(util.RequestIdHeader, strings.Split(string(e.Key), ".")[1])) // set original requestId
 
 				request := val.(*Request)
 				request.mu.Lock()

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -162,6 +162,7 @@ func (c *MultiTopicsKafkaConsumer) pollAndMatch() error {
 
 				// Add tracing span
 				_, span := c.tracer.Start(ctx, "Consume")
+				// Use the original request id from kafka headers, as key here is a composite key with the resource name
 				requestId := getRequestIdFromKafkaHeaders(e.Headers)
 				if requestId == "" {
 					logger.Warnf("Missing request id in Kafka headers for key %s", string(e.Key))

--- a/scheduler/pkg/kafka/pipeline/utils.go
+++ b/scheduler/pkg/kafka/pipeline/utils.go
@@ -108,15 +108,15 @@ func convertKafkaHeadersToGrpcMetadata(kafkaHeaders []kafka.Header) metadata.MD 
 	return grpcMetadata
 }
 
-func getRequestIdFromKafkaHeaders(headers []kafka.Header) string {
+func getCompositeKey(key1 string, key2 string, separator string) string {
+	return fmt.Sprintf("%s%s%s", key1, separator, key2)
+}
+
+func GetRequestIdFromKafkaHeaders(headers []kafka.Header) string {
 	for _, kafkaHeader := range headers {
 		if kafkaHeader.Key == util.RequestIdHeader {
 			return string(kafkaHeader.Value)
 		}
 	}
 	return ""
-}
-
-func getCompositeKey(key1 string, key2 string, separator string) string {
-	return fmt.Sprintf("%s%s%s", key1, separator, key2)
 }

--- a/scheduler/pkg/kafka/pipeline/utils.go
+++ b/scheduler/pkg/kafka/pipeline/utils.go
@@ -107,3 +107,16 @@ func convertKafkaHeadersToGrpcMetadata(kafkaHeaders []kafka.Header) metadata.MD 
 	}
 	return grpcMetadata
 }
+
+func getRequestIdFromKafkaHeaders(headers []kafka.Header) string {
+	for _, kafkaHeader := range headers {
+		if kafkaHeader.Key == util.RequestIdHeader {
+			return string(kafkaHeader.Value)
+		}
+	}
+	return ""
+}
+
+func getCompositeKey(key1 string, key2 string, separator string) string {
+	return fmt.Sprintf("%s%s%s", key1, separator, key2)
+}

--- a/scheduler/pkg/kafka/pipeline/utils_test.go
+++ b/scheduler/pkg/kafka/pipeline/utils_test.go
@@ -259,3 +259,47 @@ func TestAddRequestIdToKafkaHeaders(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRequestIdFromKafkaheaders(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name              string
+		headers           []kafka.Header
+		expectedRequestId string
+	}
+
+	tests := []test{
+		{
+			name: "request id header exists",
+			headers: []kafka.Header{
+				{
+					Key:   "a",
+					Value: []byte("v1"),
+				},
+				{
+					Key:   util.RequestIdHeader,
+					Value: []byte("bar"),
+				},
+			},
+			expectedRequestId: "bar",
+		},
+		{
+			name: "request id header does not exists",
+			headers: []kafka.Header{
+				{
+					Key:   "a",
+					Value: []byte("v1"),
+				},
+			},
+			expectedRequestId: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requestId := getRequestIdFromKafkaHeaders(test.headers)
+			g.Expect(requestId).To(Equal(test.expectedRequestId))
+		})
+	}
+}

--- a/scheduler/pkg/kafka/pipeline/utils_test.go
+++ b/scheduler/pkg/kafka/pipeline/utils_test.go
@@ -298,7 +298,7 @@ func TestGetRequestIdFromKafkaheaders(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			requestId := getRequestIdFromKafkaHeaders(test.headers)
+			requestId := GetRequestIdFromKafkaHeaders(test.headers)
 			g.Expect(requestId).To(Equal(test.expectedRequestId))
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

## Issue
Currently, there's a bug in the shadow deployment where sending a request to the main pipeline with a `x-request-id` header returns a 504 timeout error. 

In https://github.com/SeldonIO/seldon-core/blob/v2/samples/local-experiments.md, the following inference request to the main pipeline (which is then replicated to the shadow deployment) works if the `x-request-id` is not specified i.e.

```bash
seldon pipeline infer pipeline-add10 -i 1 --inference-mode grpc \
 '{"model_name":"add10","inputs":[{"name":"INPUT","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[4]}]}'
```

but fails if it's specified
```bash
seldon pipeline infer pipeline-add10 -i 1 --inference-mode grpc --header x-request-id=12345 \
 '{"model_name":"add10","inputs":[{"name":"INPUT","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[4]}]}'
```
This is due to the requests being dropped from the consumer based on the specified key, which is the same as the request id in the current implementation.

Specifying request ids is a common use case for shadow deployments as suggested in  https://github.com/SeldonIO/seldon-core/issues/4918#issuecomment-1592643099.

## Fix

This PR fixes this issue by creating a composite key for multi topic consumers with the pipeline name (i.e. `add10-pipeline.12345` for default pipeline and `mul10-pipeline.12345` for the shadow pipeline such that the requests that still need to be processed are not dropped.


## Steps to reproduce
```
$ cd samples
$ seldon model load -f ./models/add10.yaml
$ seldon model load -f ./models/mul10.yaml
$ seldon pipeline load -f ./pipelines/add10.yaml
$ seldon pipeline load -f ./pipelines/mul10.yaml
$ seldon experiment start -f ./experiments/addmul10-mirror.yaml 
$ seldon pipeline infer pipeline-add10 -i 1 --inference-mode grpc --header x-request-id=12345 \
 '{"model_name":"mul10","inputs":[{"name":"INPUT","contents":{"fp32_contents":[1,2,3,4]},"datatype":"FP32","shape":[4]}]}'
```



