### PR TITLE
fix(dataflow, controller): Connection retries when scheduler restarts

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -121,6 +121,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
@@ -382,6 +384,7 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
+github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -106,7 +106,7 @@ func (s *SchedulerClient) RemoveConnection(namespace string) {
 	}
 }
 
-// A smoke test allows us to quicky check if we actually have a functional grpc connection to the scheduler
+// A smoke test allows us to quickly check if we actually have a functional grpc connection to the scheduler
 func (s *SchedulerClient) smokeTestConnection(conn *grpc.ClientConn) error {
 	grcpClient := scheduler.NewSchedulerClient(conn)
 

--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -74,7 +74,10 @@ func (s *SchedulerClient) startEventHanders(namespace string, conn *grpc.ClientC
 		}
 		backOffExp := backoff.NewExponentialBackOff()
 		backOffExp.MaxElapsedTime = 0 // Never stop due to large time between calls
-		err := backoff.RetryNotify(fn, backOffExp, logFailure)
+		fnWithArgs := func() error {
+			return fn(context, conn)
+		}
+		err := backoff.RetryNotify(fnWithArgs, backOffExp, logFailure)
 		if err != nil {
 			s.logger.Error(err, "Failed to connect to scheduler", "namespace", namespace)
 			return err


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

In some cases during  testing, `dataflow-engine` didnt reconnect to the new scheduler pod after a rolling update. The `controller` also suffers from the same issue. The fix is to retry (for now indefinitely) which is the same pattern used in `agent` ([link](https://github.com/seldonio/seldon-core/blob/acc55f09330f1a40564f7955ba34c8b1bad42840/scheduler/pkg/agent/client.go#L217)), `model-gateway` ([link](https://github.com/seldonio/seldon-core/blob/v2/scheduler/pkg/kafka/gateway/client.go)) and `pipeline-gateway` ([link](https://github.com/seldonio/seldon-core/blob/v2/scheduler/pkg/kafka/pipeline/status/client.go)).

Summary of changes:
- Add indefinite retry to `subscribePipelines` (dataflow)
- Add indefinite retry to `startEventHanders` (controller)



**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes INFRA-713 (internal)

**Special notes for your reviewer**:
