### PR TITLE
fix: Pipeline state during disconnects

### DIFF
--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -13,7 +13,6 @@ import "os"
 
 const (
 	ModelFinalizerName      = "seldon.model.finalizer"
-	ServerFinalizerName     = "seldon.server.finalizer"
 	PipelineFinalizerName   = "seldon.pipeline.finalizer"
 	ExperimentFinalizerName = "seldon.experiment.finalizer"
 	RuntimeFinalizerName    = "seldon.runtime.finalizer"

--- a/operator/pkg/constants/constants.go
+++ b/operator/pkg/constants/constants.go
@@ -12,6 +12,7 @@ package constants
 import "os"
 
 const (
+	// note: we do not have a finalizer for servers as we rely on the draining logic to reschedule models
 	ModelFinalizerName      = "seldon.model.finalizer"
 	PipelineFinalizerName   = "seldon.pipeline.finalizer"
 	ExperimentFinalizerName = "seldon.experiment.finalizer"

--- a/operator/scheduler/pipeline.go
+++ b/operator/scheduler/pipeline.go
@@ -250,6 +250,7 @@ func (s *SchedulerClient) updatePipelineStatusImpl(pipeline *v1alpha1.Pipeline) 
 
 func canRemovePipelineFinalizer(state scheduler.PipelineVersionState_PipelineStatus) bool {
 	switch state {
+	// we should wait if the state is not terminal for deleting the finalizer, it should be Terminated in the case of delete
 	case scheduler.PipelineVersionState_PipelineTerminating, scheduler.PipelineVersionState_PipelineTerminate:
 		return false
 	default:

--- a/operator/scheduler/pipeline.go
+++ b/operator/scheduler/pipeline.go
@@ -132,7 +132,11 @@ func (s *SchedulerClient) SubscribePipelineEvents(ctx context.Context, conn *grp
 		}
 
 		if !pipeline.ObjectMeta.DeletionTimestamp.IsZero() {
-			logger.Info("Pipeline is pending deletion", "pipeline", pipeline.Name, "state", pv.State.Status.String())
+			logger.Info(
+				"Pipeline is pending deletion",
+				"pipeline", pipeline.Name,
+				"state", pv.State.Status.String(),
+			)
 			if canRemovePipelineFinalizer(pv.State.Status) {
 				retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					latestPipeline := &v1alpha1.Pipeline{}

--- a/operator/scheduler/pipeline.go
+++ b/operator/scheduler/pipeline.go
@@ -132,7 +132,7 @@ func (s *SchedulerClient) SubscribePipelineEvents(ctx context.Context, conn *grp
 		}
 
 		if !pipeline.ObjectMeta.DeletionTimestamp.IsZero() {
-			logger.Info("Pipeline is pending deletion", "pipeline", pipeline.Name)
+			logger.Info("Pipeline is pending deletion", "pipeline", pipeline.Name, "state", pv.State.Status.String())
 			if canRemovePipelineFinalizer(pv.State.Status) {
 				retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					latestPipeline := &v1alpha1.Pipeline{}
@@ -246,7 +246,7 @@ func (s *SchedulerClient) updatePipelineStatusImpl(pipeline *v1alpha1.Pipeline) 
 
 func canRemovePipelineFinalizer(state scheduler.PipelineVersionState_PipelineStatus) bool {
 	switch state {
-	case scheduler.PipelineVersionState_PipelineTerminating:
+	case scheduler.PipelineVersionState_PipelineTerminating, scheduler.PipelineVersionState_PipelineTerminate:
 		return false
 	default:
 		return true

--- a/operator/scheduler/server.go
+++ b/operator/scheduler/server.go
@@ -100,6 +100,7 @@ func (s *SchedulerClient) SubscribeServerEvents(ctx context.Context, conn *grpc.
 			}
 			// Handle status update
 			// This is key for finalizer to remove server when loaded models is zero
+			// note: now we are not using finalizers for servers
 			server.Status.LoadedModelReplicas = event.NumLoadedModelReplicas
 			return s.updateServerStatus(server)
 		})

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
@@ -138,7 +138,7 @@ class PipelineSubscriber(
             }
         } else {
             pipelineStarted = true
-            logger.warn("pipeline ${metadata.id} already exists")
+            logger.warn("pipeline ${metadata.name} with id ${metadata.id} already exists")
         }
 
         client.pipelineUpdateEvent(

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
@@ -53,9 +53,10 @@ class PipelineSubscriber(
     private val pipelines = ConcurrentHashMap<PipelineId, Pipeline>()
 
     suspend fun subscribe() {
-        logger.info("will connect to ${upstreamHost}:${upstreamPort}")
         while (true) {
+            logger.info("will connect to ${upstreamHost}:${upstreamPort}")
             retry(binaryExponentialBackoff(50..5_000L)) {
+                logger.debug("retrying to connect to ${upstreamHost}:${upstreamPort}")
                 subscribePipelines(kafkaConsumerGroupIdPrefix, namespace)
             }
         }

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
@@ -137,6 +137,7 @@ class PipelineSubscriber(
                 updateEventReason = "kafka topic error"
             }
         } else {
+            pipelineStarted = true
             logger.warn("pipeline ${metadata.id} already exists")
         }
 

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -396,7 +396,7 @@ func (c *ChainerServer) handlePipelineEvent(event coordinator.PipelineEventMsg) 
 			logger.WithField("pipeline", event.PipelineName).Warn(errMsg)
 
 			status := pv.State.Status
-			// if not dataflow engines available then we think we can terminate. however it might be a networking glitch
+			// if no dataflow engines available then we think we can terminate. however it might be a networking glitch
 			if pv.State.Status == pipeline.PipelineTerminating {
 				status = pipeline.PipelineTerminated
 			}

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -325,8 +325,10 @@ func contains(slice []string, val string) bool {
 
 func (c *ChainerServer) rebalance() {
 	logger := c.logger.WithField("func", "rebalance")
+	// note that we are not retrying PipelineFailed pipelines, consider adding this
 	evts := c.pipelineHandler.GetAllRunningPipelineVersions()
 	for _, event := range evts {
+		c.logger.Debugf("Rebalancing pipeline %s:%d with state $s", event.PipelineName, event.PipelineVersion)
 		pv, err := c.pipelineHandler.GetPipelineVersion(event.PipelineName, event.PipelineVersion, event.UID)
 		if err != nil {
 			logger.WithError(err).Errorf("Failed to get pipeline from event %s", event.String())

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -401,8 +401,9 @@ func (c *ChainerServer) handlePipelineEvent(event coordinator.PipelineEventMsg) 
 			logger.WithField("pipeline", event.PipelineName).Warn(errMsg)
 
 			status := pv.State.Status
-			// if no dataflow engines available then we think we can terminate. however it might be a networking glitch
-			if pv.State.Status == pipeline.PipelineTerminating {
+			// if no dataflow engines available then we think we can terminate pipelines.
+			// TODO: however it might be a networking glitch and we need to handle this better in future
+			if pv.State.Status == pipeline.PipelineTerminating || pv.State.Status == pipeline.PipelineTerminate {
 				status = pipeline.PipelineTerminated
 			}
 			err := c.pipelineHandler.SetPipelineState(pv.Name, pv.Version, pv.UID, status, errMsg, sourceChainerServer)

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -337,6 +337,7 @@ func (c *ChainerServer) rebalance() {
 		c.mu.Lock()
 		if len(c.streams) == 0 {
 			pipelineState := pipeline.PipelineCreate
+			// if no dataflow engines available then we think we can terminate pipelines.
 			if pv.State.Status == pipeline.PipelineTerminating {
 				pipelineState = pipeline.PipelineTerminated
 			}

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -336,11 +336,16 @@ func (c *ChainerServer) rebalance() {
 		c.logger.Debugf("Rebalancing pipeline %s:%d with state", event.PipelineName, event.PipelineVersion, pv.State.Status.String())
 		c.mu.Lock()
 		if len(c.streams) == 0 {
+			pipelineState := pipeline.PipelineCreate
+			if pv.State.Status == pipeline.PipelineTerminating {
+				pipelineState = pipeline.PipelineTerminated
+			}
+			c.logger.Debugf("No dataflow engines available to handle pipeline %s, setting state to %s", pv.String(), pipelineState.String())
 			if err := c.pipelineHandler.SetPipelineState(
 				pv.Name,
 				pv.Version,
 				pv.UID,
-				pipeline.PipelineCreate,
+				pipelineState,
 				"no dataflow engines available to handle pipeline",
 				sourceChainerServer,
 			); err != nil {

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -333,7 +333,7 @@ func (c *ChainerServer) rebalance() {
 			logger.WithError(err).Errorf("Failed to get pipeline from event %s", event.String())
 			continue
 		}
-		c.logger.Debugf("Rebalancing pipeline %s:%d with state", event.PipelineName, event.PipelineVersion, pv.State.Status.String())
+		c.logger.Debugf("Rebalancing pipeline %s:%d with state %s", event.PipelineName, event.PipelineVersion, pv.State.Status.String())
 		c.mu.Lock()
 		if len(c.streams) == 0 {
 			pipelineState := pipeline.PipelineCreate

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -328,12 +328,12 @@ func (c *ChainerServer) rebalance() {
 	// note that we are not retrying PipelineFailed pipelines, consider adding this
 	evts := c.pipelineHandler.GetAllRunningPipelineVersions()
 	for _, event := range evts {
-		c.logger.Debugf("Rebalancing pipeline %s:%d with state $s", event.PipelineName, event.PipelineVersion)
 		pv, err := c.pipelineHandler.GetPipelineVersion(event.PipelineName, event.PipelineVersion, event.UID)
 		if err != nil {
 			logger.WithError(err).Errorf("Failed to get pipeline from event %s", event.String())
 			continue
 		}
+		c.logger.Debugf("Rebalancing pipeline %s:%d with state", event.PipelineName, event.PipelineVersion, pv.State.Status.String())
 		c.mu.Lock()
 		if len(c.streams) == 0 {
 			if err := c.pipelineHandler.SetPipelineState(

--- a/scheduler/pkg/server/pipeline_status.go
+++ b/scheduler/pkg/server/pipeline_status.go
@@ -62,6 +62,7 @@ func (s *SchedulerServer) sendCurrentPipelineStatuses(stream pb.Scheduler_Subscr
 	}
 	for _, p := range pipelines {
 		resp := createPipelineStatus(p, allVersions)
+		s.logger.Debugf("Sending pipeline status %s", resp.String())
 		err = stream.Send(resp)
 		if err != nil {
 			return status.Errorf(codes.Internal, err.Error())

--- a/scheduler/pkg/server/server_test.go
+++ b/scheduler/pkg/server/server_test.go
@@ -531,7 +531,7 @@ func TestUnloadPipeline(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			path := fmt.Sprintf("%s/db", t.TempDir())
-			test.server.pipelineHandler.(*pipeline.PipelineStore).InitialiseOrRestoreDB(path)
+			_ = test.server.pipelineHandler.(*pipeline.PipelineStore).InitialiseOrRestoreDB(path)
 			if test.loadReq != nil {
 				err := test.server.pipelineHandler.AddPipeline(test.loadReq.Pipeline)
 				g.Expect(err).To(BeNil())

--- a/scheduler/pkg/server/server_test.go
+++ b/scheduler/pkg/server/server_test.go
@@ -11,6 +11,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -529,6 +530,8 @@ func TestUnloadPipeline(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			path := fmt.Sprintf("%s/db", t.TempDir())
+			test.server.pipelineHandler.(*pipeline.PipelineStore).InitialiseOrRestoreDB(path)
 			if test.loadReq != nil {
 				err := test.server.pipelineHandler.AddPipeline(test.loadReq.Pipeline)
 				g.Expect(err).To(BeNil())

--- a/scheduler/pkg/store/pipeline/db.go
+++ b/scheduler/pkg/store/pipeline/db.go
@@ -49,12 +49,13 @@ func (pdb *PipelineDBManager) save(pipeline *Pipeline) error {
 	})
 }
 
-func (pdb *PipelineDBManager) delete(pipeline *Pipeline) error {
-	return pdb.db.Update(func(txn *badger.Txn) error {
-		err := txn.Delete([]byte(pipeline.Name))
-		return err
-	})
-}
+// TODO: delete unused pipelines from the store as for now it increases indefinitely
+// func (pdb *PipelineDBManager) delete(pipeline *Pipeline) error {
+// 	return pdb.db.Update(func(txn *badger.Txn) error {
+// 		err := txn.Delete([]byte(pipeline.Name))
+// 		return err
+// 	})
+// }
 
 func (pdb *PipelineDBManager) restore(createPipelineCb func(pipeline *Pipeline)) error {
 	return pdb.db.View(func(txn *badger.Txn) error {

--- a/scheduler/pkg/store/pipeline/pipeline.go
+++ b/scheduler/pkg/store/pipeline/pipeline.go
@@ -68,13 +68,13 @@ type PipelineStatus uint32
 
 const (
 	PipelineStatusUnknown PipelineStatus = iota
-	PipelineCreate
-	PipelineCreating
-	PipelineReady
-	PipelineFailed
-	PipelineTerminate
-	PipelineTerminating
-	PipelineTerminated
+	PipelineCreate                       // Received signal to create pipeline.
+	PipelineCreating                     // In the process of creating pipeline.
+	PipelineReady                        // Pipeline is ready to be used.
+	PipelineFailed                       // Pipeline creation/deletion failed.
+	PipelineTerminate                    // Received signal that pipeline should be terminated.
+	PipelineTerminating                  // In the process of doing cleanup/housekeeping for pipeline termination.
+	PipelineTerminated                   // Pipeline has been terminated.
 )
 
 type PipelineState struct {

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -231,14 +231,9 @@ func (ps *PipelineStore) removePipelineImpl(name string) (*coordinator.PipelineE
 		case PipelineTerminated:
 			return nil, &PipelineAlreadyTerminatedErr{pipeline: name}
 		default:
-			if ps.db != nil {
-				err := ps.db.delete(pipeline)
-				if err != nil {
-					return nil, err
-				}
-			}
 			pipeline.Deleted = true
 			lastPipelineVersion.State.setState(PipelineTerminate, "pipeline removed")
+			ps.db.save(pipeline)
 			return &coordinator.PipelineEventMsg{
 				PipelineName:    lastPipelineVersion.Name,
 				PipelineVersion: lastPipelineVersion.Version,

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -309,13 +309,11 @@ func (ps *PipelineStore) GetPipelines() ([]*Pipeline, error) {
 
 	foundPipelines := []*Pipeline{}
 	for _, p := range ps.pipelines {
-		if !p.Deleted {
-			copied, err := copystructure.Copy(p)
-			if err != nil {
-				return nil, err
-			}
-			foundPipelines = append(foundPipelines, copied.(*Pipeline))
+		copied, err := copystructure.Copy(p)
+		if err != nil {
+			return nil, err
 		}
+		foundPipelines = append(foundPipelines, copied.(*Pipeline))
 	}
 
 	return foundPipelines, nil

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -293,7 +293,7 @@ func (ps *PipelineStore) GetAllRunningPipelineVersions() []coordinator.PipelineE
 	for _, p := range ps.pipelines {
 		pv := p.GetLatestPipelineVersion()
 		switch pv.State.Status {
-		case PipelineCreate, PipelineCreating, PipelineReady:
+		case PipelineCreate, PipelineCreating, PipelineReady, PipelineTerminating:
 			events = append(events, coordinator.PipelineEventMsg{
 				PipelineName:    pv.Name,
 				PipelineVersion: pv.Version,

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -226,7 +226,7 @@ func (ps *PipelineStore) removePipelineImpl(name string) (*coordinator.PipelineE
 		}
 		lastState := lastPipelineVersion.State
 		switch lastState.Status {
-		case PipelineTerminate:
+		case PipelineTerminating:
 			return nil, &PipelineTerminatingErr{pipeline: name}
 		case PipelineTerminated:
 			return nil, &PipelineAlreadyTerminatedErr{pipeline: name}

--- a/scheduler/pkg/store/pipeline/store_test.go
+++ b/scheduler/pkg/store/pipeline/store_test.go
@@ -398,7 +398,7 @@ func TestRemovePipeline(t *testing.T) {
 			} else {
 				g.Expect(err.Error()).To(Equal(test.err.Error()))
 			}
-			test.store.db.Stop()
+			_ = test.store.db.Stop()
 		})
 	}
 }

--- a/scheduler/pkg/store/pipeline/store_test.go
+++ b/scheduler/pkg/store/pipeline/store_test.go
@@ -10,6 +10,7 @@ the Change License after the Change Date as each is defined in accordance with t
 package pipeline
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -289,6 +290,7 @@ func TestRemovePipeline(t *testing.T) {
 					},
 				},
 			},
+			err: &PipelineTerminatingErr{pipeline: "pipeline"},
 		},
 		{
 			name:         "pipeline terminated err",
@@ -368,6 +370,10 @@ func TestRemovePipeline(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			logger := logrus.New()
+			path := fmt.Sprintf("%s/db", t.TempDir())
+			db, _ := newPipelineDbManager(getPipelineDbFolder(path), logger)
+			test.store.db = db
 			err := test.store.RemovePipeline(test.pipelineName)
 			if test.err == nil {
 				p := test.store.pipelines[test.pipelineName]
@@ -375,9 +381,24 @@ func TestRemovePipeline(t *testing.T) {
 				pv := p.GetLatestPipelineVersion()
 				g.Expect(pv).ToNot(BeNil())
 				g.Expect(pv.State.Status).To(Equal(PipelineTerminate))
+
+				// check db contains pipeline
+				pipelines := map[string]*Pipeline{}
+				restoreCb := func(pipeline *Pipeline) {
+					pipelines[pipeline.Name] = pipeline
+				}
+				_ = test.store.db.restore(restoreCb)
+				actualPipeline := pipelines[test.pipelineName]
+				expectedPipeline := test.store.pipelines[test.pipelineName]
+				// TODO: check all fields
+				g.Expect(actualPipeline.Deleted).To(Equal(expectedPipeline.Deleted))
+				g.Expect(actualPipeline.LastVersion).To(Equal(expectedPipeline.LastVersion))
+				g.Expect(len(actualPipeline.Versions)).To(Equal(len(expectedPipeline.Versions)))
+				g.Expect(len(actualPipeline.Versions)).To(Equal(len(expectedPipeline.Versions)))
 			} else {
 				g.Expect(err.Error()).To(Equal(test.err.Error()))
 			}
+			test.store.db.Stop()
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR fixes issues with regards to pipeline state inconsistency in cases of components failures (e.g. dataflow-engine, scheduler).

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes INFRA-716 (internal)

## Changes:
- Do not remove a pipeline from the scheduler local persistence store upon the user deleting this particular pipeline. This is required because if the scheduler restarts and before the pipeline delete is propagated and acknowledged by the different services (e.g. dataflow-engine and controller) then there is a risk that this state will become inconsistent. This has the drawback though that the internal state of the scheduler indefinitely increasing so we need to recycle it in a follow up work. For now we prioritise consistency over storage as we expect storage of protobuf control plan messages of these pipelines to be low.
- Fix a bug in dataflow-engine to report success when the pipeline topology is already running.
- Fix a bug in controller to not remove the finaliser of a pipeline if its state is `PipelineTerminate` (i.e. still to terminate).
- Return `PipelineTerminating` pipelines when calling `GetAllRunningPipelineVersions`, which allow us to handle the following case.
- For `PipelineTerminating` pipelines and no currently available dataflow-engines, set them to `PipelineTerminated`.
- If receiving an event for a pipeline with state `PipelineTermiante` or `PipelineTerminating` and no currently available dataflow-engines, set them to `PipelineTerminated`.
- We always send all pipelines (event deleted ones) when the controller connects as it might be that some messages have been missed during the disconnect.
## Testing

- Induced a 2 min delay in datafllow pipeline create and delete (to allow time to kill components).
```
    private suspend fun handleDelete(metadata: PipelineMetadata) {
        logger.info("Delete pipeline ${metadata.name} version: ${metadata.version} id: ${metadata.id}")
        Thread.sleep(120_000)

    private suspend fun handleCreate(
        metadata: PipelineMetadata,
        steps: List<PipelineStepUpdate>,
        kafkaConsumerGroupIdPrefix: String,
        namespace: String,
    ) {
        logger.info("Create pipeline ${metadata.name} version: ${metadata.version} id: ${metadata.id}")
        Thread.sleep(120_000)
```
- Killing dataflow-engine, controller and scheduler pods, them make sure state is eventually consistent.

**Special notes for your reviewer**:
