### PR TITLE
fix(agent): set context deadline for grpc model server control plane

### DIFF
--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -797,7 +797,8 @@ func TestAgentStopOnSubServicesFailure(t *testing.T) {
 
 			time.Sleep(50 * time.Millisecond)
 
-			v2Client := oip.NewV2Client("", backEndGRPCPort, log.New())
+			v2Client := oip.NewV2Client(
+				oip.GetV2ConfigWithDefaults("", backEndGRPCPort), log.New())
 
 			modelRepository := FakeModelRepository{}
 			rpHTTP := FakeDependencyService{err: nil}

--- a/scheduler/pkg/agent/internal/testing_utils/mock_grpc_server.go
+++ b/scheduler/pkg/agent/internal/testing_utils/mock_grpc_server.go
@@ -75,12 +75,13 @@ func (s *V2State) IsModelLoaded(modelId string) bool {
 }
 
 type MockGRPCMLServer struct {
-	listener    net.Listener
-	server      *grpc.Server
-	models      []interfaces.ServerModelInfo
-	isReady     bool
-	LoadSleep   time.Duration
-	UnloadSleep time.Duration
+	listener          net.Listener
+	server            *grpc.Server
+	models            []interfaces.ServerModelInfo
+	isReady           bool
+	LoadSleep         time.Duration
+	UnloadSleep       time.Duration
+	ControlPlaneSleep time.Duration
 	v2.UnimplementedGRPCInferenceServiceServer
 }
 
@@ -123,6 +124,8 @@ func (m *MockGRPCMLServer) ServerReady(ctx context.Context, r *v2.ServerReadyReq
 }
 
 func (m *MockGRPCMLServer) ServerLive(ctx context.Context, r *v2.ServerLiveRequest) (*v2.ServerLiveResponse, error) {
+	// by default ControlPlaneSleep is 0
+	time.Sleep(m.ControlPlaneSleep)
 	return &v2.ServerLiveResponse{Live: true}, nil
 }
 
@@ -142,6 +145,8 @@ func (m *MockGRPCMLServer) RepositoryModelUnload(ctx context.Context, r *v2.Repo
 }
 
 func (m *MockGRPCMLServer) RepositoryIndex(ctx context.Context, r *v2.RepositoryIndexRequest) (*v2.RepositoryIndexResponse, error) {
+	// by default ControlPlaneSleep is 0
+	time.Sleep(m.ControlPlaneSleep)
 	ret := make([]*v2.RepositoryIndexResponse_ModelIndex, len(m.models))
 	for idx, model := range m.models {
 		ret[idx] = &v2.RepositoryIndexResponse_ModelIndex{Name: model.Name, State: string(model.State)}

--- a/scheduler/pkg/agent/internal/testing_utils/mock_grpc_server.go
+++ b/scheduler/pkg/agent/internal/testing_utils/mock_grpc_server.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"google.golang.org/grpc"
@@ -74,10 +75,12 @@ func (s *V2State) IsModelLoaded(modelId string) bool {
 }
 
 type MockGRPCMLServer struct {
-	listener net.Listener
-	server   *grpc.Server
-	models   []interfaces.ServerModelInfo
-	isReady  bool
+	listener    net.Listener
+	server      *grpc.Server
+	models      []interfaces.ServerModelInfo
+	isReady     bool
+	LoadSleep   time.Duration
+	UnloadSleep time.Duration
 	v2.UnimplementedGRPCInferenceServiceServer
 }
 
@@ -124,10 +127,12 @@ func (m *MockGRPCMLServer) ServerLive(ctx context.Context, r *v2.ServerLiveReque
 }
 
 func (m *MockGRPCMLServer) RepositoryModelLoad(ctx context.Context, r *v2.RepositoryModelLoadRequest) (*v2.RepositoryModelLoadResponse, error) {
+	time.Sleep(m.LoadSleep)
 	return &v2.RepositoryModelLoadResponse{}, nil
 }
 
 func (m *MockGRPCMLServer) RepositoryModelUnload(ctx context.Context, r *v2.RepositoryModelUnloadRequest) (*v2.RepositoryModelUnloadResponse, error) {
+	time.Sleep(m.UnloadSleep)
 	if r.ModelName == ModelNameMissing {
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Model %s not found", r.ModelName))
 	}

--- a/scheduler/pkg/agent/internal/testing_utils/mock_grpc_server.go
+++ b/scheduler/pkg/agent/internal/testing_utils/mock_grpc_server.go
@@ -127,11 +127,13 @@ func (m *MockGRPCMLServer) ServerLive(ctx context.Context, r *v2.ServerLiveReque
 }
 
 func (m *MockGRPCMLServer) RepositoryModelLoad(ctx context.Context, r *v2.RepositoryModelLoadRequest) (*v2.RepositoryModelLoadResponse, error) {
+	// by default LoadSleep is 0
 	time.Sleep(m.LoadSleep)
 	return &v2.RepositoryModelLoadResponse{}, nil
 }
 
 func (m *MockGRPCMLServer) RepositoryModelUnload(ctx context.Context, r *v2.RepositoryModelUnloadRequest) (*v2.RepositoryModelUnloadResponse, error) {
+	// by default UnloadSleep is 0
 	time.Sleep(m.UnloadSleep)
 	if r.ModelName == ModelNameMissing {
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Model %s not found", r.ModelName))

--- a/scheduler/pkg/agent/modelserver_controlplane/factory/factory.go
+++ b/scheduler/pkg/agent/modelserver_controlplane/factory/factory.go
@@ -19,5 +19,6 @@ func CreateModelServerControlPlane(
 	config interfaces.ModelServerConfig,
 ) (interfaces.ModelServerControlPlaneClient, error) {
 	// we only support v2 for now
-	return oip.NewV2Client(config.Host, config.Port, config.Logger), nil
+	return oip.NewV2Client(
+		oip.GetV2ConfigWithDefaults(config.Host, config.Port), config.Logger), nil
 }

--- a/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
+++ b/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
@@ -34,7 +34,7 @@ type V2Config struct {
 	GRPRetryMaxCount             uint
 	GRPCMaxMsgSizeBytes          int
 	GRPCModelServerLoadTimeout   time.Duration
-	GRPcModelServerUnloadTimeout time.Duration
+	GRPCModelServerUnloadTimeout time.Duration
 }
 
 type V2Client struct {
@@ -84,7 +84,7 @@ func GetV2ConfigWithDefaults(host string, port int) V2Config {
 		GRPRetryMaxCount:             util.GRPCRetryMaxCount,
 		GRPCMaxMsgSizeBytes:          util.GRPCMaxMsgSizeBytes,
 		GRPCModelServerLoadTimeout:   util.GRPCModelServerLoadTimeout,
-		GRPcModelServerUnloadTimeout: util.GRPCModelServerUnloadTimeout,
+		GRPCModelServerUnloadTimeout: util.GRPCModelServerUnloadTimeout,
 	}
 }
 
@@ -143,7 +143,7 @@ func (v *V2Client) UnloadModel(name string) *interfaces.ControlPlaneErr {
 }
 
 func (v *V2Client) unloadModelGrpc(name string) *interfaces.ControlPlaneErr {
-	ctx, cancel := context.WithTimeout(context.Background(), v.v2Config.GRPcModelServerUnloadTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), v.v2Config.GRPCModelServerUnloadTimeout)
 	defer cancel()
 
 	req := &v2.RepositoryModelUnloadRequest{

--- a/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
+++ b/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
@@ -91,7 +91,8 @@ func (v *V2Client) LoadModel(name string) *interfaces.ControlPlaneErr {
 }
 
 func (v *V2Client) loadModelGrpc(name string) *interfaces.ControlPlaneErr {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), util.GrpcModelServerLoadTimeout)
+	defer cancel()
 
 	req := &v2.RepositoryModelLoadRequest{
 		ModelName: name,
@@ -122,7 +123,8 @@ func (v *V2Client) UnloadModel(name string) *interfaces.ControlPlaneErr {
 }
 
 func (v *V2Client) unloadModelGrpc(name string) *interfaces.ControlPlaneErr {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), util.GrpcModelServerUnloadTimeout)
+	defer cancel()
 
 	req := &v2.RepositoryModelUnloadRequest{
 		ModelName: name,

--- a/scheduler/pkg/agent/modelserver_controlplane/oip/v2_test.go
+++ b/scheduler/pkg/agent/modelserver_controlplane/oip/v2_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/internal/testing_utils"
 	testing_utils2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
 func TestCommunicationErrors(t *testing.T) {
@@ -119,6 +120,20 @@ func TestGRPCV2Timeout(t *testing.T) {
 	g.Expect(err).NotTo(BeNil())
 	e, _ = status.FromError(err)
 	g.Expect(e.Code()).To(Equal(codes.DeadlineExceeded))
+}
+
+func TestDefaultV2Config(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	v2Config := GetV2ConfigWithDefaults("", 0)
+	g.Expect(v2Config.GRPCModelServerLoadTimeout).To(Equal(util.GRPCModelServerLoadTimeout))
+	g.Expect(v2Config.GRPCModelServerUnloadTimeout).To(Equal(util.GRPCModelServerUnloadTimeout))
+	g.Expect(v2Config.GRPCMaxMsgSizeBytes).To(Equal(util.GRPCMaxMsgSizeBytes))
+	g.Expect(v2Config.GRPCControlPlaneTimeout).To(Equal(util.GRPCControlPlaneTimeout))
+	g.Expect(v2Config.GRPCRetryBackoff).To(Equal(util.GRPCRetryBackoff))
+	g.Expect(v2Config.GRPRetryMaxCount).To(Equal(uint(util.GRPCRetryMaxCount)))
+	g.Expect(v2Config.Host).To(Equal(""))
+	g.Expect(v2Config.GRPCPort).To(Equal(0))
 }
 
 func TestGrpcV2WithError(t *testing.T) {

--- a/scheduler/pkg/agent/rproxy_grpc.go
+++ b/scheduler/pkg/agent/rproxy_grpc.go
@@ -110,8 +110,8 @@ func (rp *reverseGRPCProxy) Start() error {
 		opts = append(opts, grpc.Creds(rp.tlsOptions.Cert.CreateServerTransportCredentials()))
 	}
 	opts = append(opts, grpc.MaxConcurrentStreams(grpcProxyMaxConcurrentStreams))
-	opts = append(opts, grpc.MaxRecvMsgSize(util.GrpcMaxMsgSizeBytes))
-	opts = append(opts, grpc.MaxSendMsgSize(util.GrpcMaxMsgSizeBytes))
+	opts = append(opts, grpc.MaxRecvMsgSize(util.GRPCMaxMsgSizeBytes))
+	opts = append(opts, grpc.MaxSendMsgSize(util.GRPCMaxMsgSizeBytes))
 	opts = append(opts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
 	opts = append(opts, grpc.UnaryInterceptor(rp.metrics.UnaryServerInterceptor()))
 	grpcServer := grpc.NewServer(opts...)
@@ -322,7 +322,8 @@ func (rp *reverseGRPCProxy) createV2CRPCClients(backendGRPCServerHost string, ba
 		return nil, nil, err
 	}
 	for i := 0; i < size; i++ {
-		conn, err := oip.CreateV2GrpcConnection(backendGRPCServerHost, backendGRPCServerPort)
+		conn, err := oip.CreateV2GrpcConnection(
+			oip.GetV2ConfigWithDefaults(backendGRPCServerHost, backendGRPCServerPort))
 
 		if err != nil {
 			// TODO: this could fail in later iterations, so close earlier connections

--- a/scheduler/pkg/agent/rproxy_test.go
+++ b/scheduler/pkg/agent/rproxy_test.go
@@ -387,7 +387,7 @@ func TestLazyLoadRoundTripper(t *testing.T) {
 				_ = mlserver.ListenAndServe()
 			}()
 
-			time.Sleep(util.GrpcRetryBackoffMillisecs * time.Millisecond)
+			time.Sleep(util.GRPCRetryBackoff)
 
 			defer func() {
 				_ = mlserver.Shutdown(context.Background())

--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -489,7 +489,7 @@ func (s *Server) drainServerReplicaImpl(serverName string, serverReplicaIdx int)
 	s.waiter.wait(serverName, serverReplicaIdx)
 
 	// as we update envoy in batches and envoy is eventual consistent, give it time to settle down
-	time.Sleep(util.EnvoyUpdateDefaultBatchWaitMillis + (time.Millisecond * serverDrainingExtraWaitMillis))
+	time.Sleep(util.EnvoyUpdateDefaultBatchWait + (time.Millisecond * serverDrainingExtraWaitMillis))
 	s.logger.Debugf("Finished draining models %v from server %s:%d", modelsChanged, serverName, serverReplicaIdx)
 }
 

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -53,7 +53,7 @@ type IncrementalProcessor struct {
 	pipelineHandler      pipeline.PipelineHandler
 	runEnvoyBatchUpdates bool
 	batchTrigger         *time.Timer
-	batchWaitMillis      time.Duration
+	batchWait            time.Duration
 	pendingModelVersions []*pendingModelVersion
 	versionCleaner       cleaner.ModelVersionCleaner
 	batchTriggerManual   *time.Time
@@ -86,7 +86,7 @@ func NewIncrementalProcessor(
 		pipelineHandler:      pipelineHandler,
 		runEnvoyBatchUpdates: true,
 		batchTrigger:         nil,
-		batchWaitMillis:      util.EnvoyUpdateDefaultBatchWaitMillis,
+		batchWait:            util.EnvoyUpdateDefaultBatchWait,
 		versionCleaner:       versionCleaner,
 		batchTriggerManual:   nil,
 	}
@@ -629,7 +629,7 @@ func (p *IncrementalProcessor) modelUpdate(modelName string) error {
 	if !triggered {
 		// we still need to enable the cron timer as there is no guarantee that the manual trigger will be called
 		if p.batchTrigger == nil && p.runEnvoyBatchUpdates {
-			p.batchTrigger = time.AfterFunc(p.batchWaitMillis, p.modelSyncWithLock)
+			p.batchTrigger = time.AfterFunc(p.batchWait, p.modelSyncWithLock)
 		}
 	}
 
@@ -653,7 +653,7 @@ func (p *IncrementalProcessor) triggerModelSyncIfNeeded() bool {
 		p.batchTriggerManual = new(time.Time)
 		*p.batchTriggerManual = time.Now()
 	}
-	if time.Since(*p.batchTriggerManual) > p.batchWaitMillis {
+	if time.Since(*p.batchTriggerManual) > p.batchWait {
 		// we have waited long enough so we can trigger the batch update
 		// we do this inline so that we do not require to release and reacquire the lock
 		// which under heavy load there is no guarantee of order and therefore could lead

--- a/scheduler/pkg/envoy/processor/incremental_benchmark_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_benchmark_test.go
@@ -141,7 +141,7 @@ func benchmarkModelUpdate(
 		)
 		require.NoError(b, err)
 
-		ip.batchWaitMillis = time.Duration(batchWaitMillis) * time.Millisecond
+		ip.batchWait = time.Duration(batchWaitMillis) * time.Millisecond
 
 		addServer(ip, serverName, numServerReplicas, b)
 

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
@@ -111,8 +110,8 @@ func getRestUrl(tls bool, host string, port int, modelName string) *url.URL {
 func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceServiceClient, error) {
 	logger := iw.logger.WithField("func", "getGrpcClient")
 	retryOpts := []grpc_retry.CallOption{
-		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(util.GrpcRetryBackoffMillisecs * time.Millisecond)),
-		grpc_retry.WithMax(util.GrpcRetryMaxCount), // retry envoy connection
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(util.GRPCRetryBackoff)),
+		grpc_retry.WithMax(util.GRPCRetryMaxCount), // retry envoy connection
 	}
 
 	var creds credentials.TransportCredentials
@@ -127,8 +126,8 @@ func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceSer
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(util.GrpcMaxMsgSizeBytes),
-			grpc.MaxCallSendMsgSize(util.GrpcMaxMsgSizeBytes),
+			grpc.MaxCallRecvMsgSize(util.GRPCMaxMsgSizeBytes),
+			grpc.MaxCallSendMsgSize(util.GRPCMaxMsgSizeBytes),
 		),
 		grpc.WithStatsHandler(
 			otelgrpc.NewClientHandler(),

--- a/scheduler/pkg/kafka/pipeline/grpcserver.go
+++ b/scheduler/pkg/kafka/pipeline/grpcserver.go
@@ -80,8 +80,8 @@ func (g *GatewayGrpcServer) Start() error {
 		opts = append(opts, grpc.Creds(g.tlsOptions.Cert.CreateServerTransportCredentials()))
 	}
 	opts = append(opts, grpc.MaxConcurrentStreams(maxConcurrentStreams))
-	opts = append(opts, grpc.MaxRecvMsgSize(util.GrpcMaxMsgSizeBytes))
-	opts = append(opts, grpc.MaxSendMsgSize(util.GrpcMaxMsgSizeBytes))
+	opts = append(opts, grpc.MaxRecvMsgSize(util.GRPCMaxMsgSizeBytes))
+	opts = append(opts, grpc.MaxSendMsgSize(util.GRPCMaxMsgSizeBytes))
 	opts = append(opts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
 	g.grpcServer = grpc.NewServer(opts...)
 	v2.RegisterGRPCInferenceServiceServer(g.grpcServer, g)

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -29,4 +29,5 @@ const (
 	EnvoyUpdateDefaultBatchWait  = 250 * time.Millisecond
 	GRPCModelServerLoadTimeout   = 30 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
 	GRPCModelServerUnloadTimeout = 2 * time.Minute
+	GRPCControlPlaneTimeout      = 1 * time.Minute // For control plane operations except load/unload
 )

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -23,8 +23,10 @@ const (
 )
 
 const (
-	GrpcRetryBackoffMillisecs         = 100
-	GrpcRetryMaxCount                 = 5 // around 3.2s in total wait duration
-	GrpcMaxMsgSizeBytes               = 1000 * 1024 * 1024
-	EnvoyUpdateDefaultBatchWaitMillis = 250 * time.Millisecond
+	GrpcRetryBackoffMillisecs    = 100
+	GrpcRetryMaxCount            = 5 // around 3.2s in total wait duration
+	GrpcMaxMsgSizeBytes          = 1000 * 1024 * 1024
+	EnvoyUpdateDefaultBatchWait  = 250 * time.Millisecond
+	GrpcModelServerLoadTimeout   = 30 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
+	GrpcModelServerUnloadTimeout = 1 * time.Minute
 )

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -28,5 +28,5 @@ const (
 	GrpcMaxMsgSizeBytes          = 1000 * 1024 * 1024
 	EnvoyUpdateDefaultBatchWait  = 250 * time.Millisecond
 	GrpcModelServerLoadTimeout   = 30 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
-	GrpcModelServerUnloadTimeout = 1 * time.Minute
+	GrpcModelServerUnloadTimeout = 2 * time.Minute
 )

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -23,10 +23,10 @@ const (
 )
 
 const (
-	GrpcRetryBackoffMillisecs    = 100
-	GrpcRetryMaxCount            = 5 // around 3.2s in total wait duration
-	GrpcMaxMsgSizeBytes          = 1000 * 1024 * 1024
+	GRPCRetryBackoff             = 100 * time.Millisecond
+	GRPCRetryMaxCount            = 5 // around 3.2s in total wait duration
+	GRPCMaxMsgSizeBytes          = 1000 * 1024 * 1024
 	EnvoyUpdateDefaultBatchWait  = 250 * time.Millisecond
-	GrpcModelServerLoadTimeout   = 30 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
-	GrpcModelServerUnloadTimeout = 2 * time.Minute
+	GRPCModelServerLoadTimeout   = 30 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
+	GRPCModelServerUnloadTimeout = 2 * time.Minute
 )


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Previously we have a `Background` context used in the control plane operations (load/unload) issued from the agent to the model servers (mlserver and triton). The background context will wait indefinitely if the model servers do not respond back and we have seen cases (on unload) that mlserver did not respond back to the unload (not sure why). 

Anyway in the case that mlserver did not respond back the agent will be stuck indefinitely on this particular model and therefore the scheduler state of this model is also stuck.

To get around that we use a `Deadline` context now on these control plane operations as follows:

- `GRPCModelServerLoadTimeout`   = 30  Minutes 
- `GRPCModelServerUnloadTimeout` = 2 Minutes
- `GRPCControlPlaneTimeout` = 1 Minutes (for other control plane ops)

We currently use the hardocded defaults and perhaps in a future PR we can make these configurable (per model?).


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes INFRA-751 (internal)

**Special notes for your reviewer**:
- Introduced `GRPCModelServerLoadTimeout`, `GRPCModelServerUnloadTimeout` and `GRPCControlPlaneTimeout`
- Refactor code to define a `V2Config` where these parameters and others can be set and used (so that in the future can be configured)
- Added unit test
