### PR TITLE
fix(adserver): adserver returns cloudevents compatible response

### DIFF
--- a/components/alibi-detect-server/adserver/base/storage.py
+++ b/components/alibi-detect-server/adserver/base/storage.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 import tempfile
-from distutils.util import strtobool
+from typing import Optional
 
 ARTIFACT_DOWNLOAD_LOCATION = os.environ.get("DRIFT_ARTIFACTS_DIR", "/tmp")
 
@@ -18,13 +18,13 @@ except ImportError:
 
 
 class Rclone:
-    def __init__(self, cfg_file: str = None):
+    def __init__(self, cfg_file: Optional[str] = None):
         self.cfg_file = cfg_file
 
-    def copy(self, src: str, dest: str = None):
+    def copy(self, src: str, dest: Optional[str] = None):
         if rclone is None:
             raise RuntimeError(
-                "rclone binary not found - rclone-based storage funcionality disabled"
+                "rclone binary not found - rclone-based storage functionality disabled"
             )
 
         if dest is None:

--- a/components/alibi-detect-server/adserver/cm_model.py
+++ b/components/alibi-detect-server/adserver/cm_model.py
@@ -21,7 +21,7 @@ SELDON_MODEL_ID = DEFAULT_LABELS["model_name"]
 SELDON_PREDICTOR_ID = DEFAULT_LABELS["predictor_name"]
 
 
-def _load_class_module(module_path: str) -> str:
+def _load_class_module(module_path: str):
     components = module_path.split(".")
     mod = __import__(".".join(components[:-1]))
     for comp in components[1:]:
@@ -32,7 +32,7 @@ def _load_class_module(module_path: str) -> str:
 
 class CustomMetricsModel(CEModel):  # pylint:disable=c-extension-no-member
     def __init__(
-        self, name: str, storage_uri: str, elasticsearch_uri: str = None, model=None
+        self, name: str, storage_uri: str, elasticsearch_uri: Optional[str] = None, model=None
     ):
         """
         Custom Metrics Model

--- a/components/alibi-detect-server/adserver/server.py
+++ b/components/alibi-detect-server/adserver/server.py
@@ -39,7 +39,7 @@ class CEServer(object):
         event_type: str,
         event_source: str,
         http_port: int = DEFAULT_HTTP_PORT,
-        reply_url: str = None,
+        reply_url: Optional[str] = None,
     ):
         """
         CloudEvents server

--- a/components/alibi-detect-server/adserver/tests/test_server.py
+++ b/components/alibi-detect-server/adserver/tests/test_server.py
@@ -4,6 +4,9 @@ from adserver.base import ModelResponse
 from typing import List, Dict, Optional, Union
 import json
 import requests_mock
+from cloudevents.sdk import converters
+from cloudevents.sdk import marshaller
+from cloudevents.sdk.event import v1
 
 
 class TestProtocol(AsyncHTTPTestCase):
@@ -74,11 +77,31 @@ class TestSeldonHttpModel(AsyncHTTPTestCase):
             )
             self.assertEqual(response.code, 200)
             expectedResponse = DummyModel.getResponse().data
+            # assert that the expected response conforms to the CloudEvent spec
+            event = v1.Event()
+            http_marshaller = marshaller.NewDefaultHTTPMarshaller()
+            try:
+                event = http_marshaller.FromRequest(
+                    event, response.headers, response.body, json.loads
+                )
+            except Exception as e:
+                assert False, f"Failed to unmarshall data with error: {type(e).__name__}('{e}')"
+
+            # assert cloud event properties have been set correctly in response
+            self.assertEqual(event.Data(), expectedResponse)
+            self.assertEqual(event.Source(), self.eventSource)
+            self.assertEqual(event.EventType(), self.eventType)
+            self.assertEqual(event.ContentType(), "application/json")
+            self.assertEqual(event.EventID(), "1234")
+            self.assertEqual(event.CloudEventVersion(), "1.0")
             self.assertEqual(response.body.decode("utf-8"), json.dumps(expectedResponse))
+
+            # assert requests have been made with the correct headers and data
             self.assertEqual(m.request_history[0].json(), expectedResponse)
             headers: Dict = m.request_history[0]._request.headers
             self.assertEqual(headers["ce-source"], self.eventSource)
             self.assertEqual(headers["ce-type"], self.eventType)
+            self.assertNotIn("ce-datacontenttype", headers)
 
 
 class TestKFservingV2HttpModel(AsyncHTTPTestCase):


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

The `adserver` is meant to be deployed as a knative serving service. However, it is currently not setting the appropriate headers in its http response in the POST handler for the response to be considered a CloudEvent message. As can be seen by the [spec](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#required-attributes), the following attributes must be present in the http message:
* id
* source
* specversion
* type

Previously, none of these attributes were set in the response (though they were set when the message was forwarded to the `replyUrl`)

This PR does the following:
1. Fixes some type checks
2. Adds extra assertions in the `test_server.py` file to check that responses are CE compatible
3. Refactors the server's POST handler to return CE messages
