### PR TITLE
fix(scheduler): Send server statuses on controller reconnect

### DIFF
--- a/operator/controllers/mlops/server_controller.go
+++ b/operator/controllers/mlops/server_controller.go
@@ -74,6 +74,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// we'll ignore not-found errors, since they can't be fixed by an immediate
 			// requeue (we'll need to wait for a new notification), and we can get them
 			// on deleted requests.
+			logger.Error(err, "server not found", "name", req.Name, "namespace", req.Namespace)
 			return reconcile.Result{}, nil
 		}
 		logger.Error(err, "unable to fetch Server", "name", req.Name, "namespace", req.Namespace)

--- a/operator/controllers/mlops/server_controller.go
+++ b/operator/controllers/mlops/server_controller.go
@@ -84,7 +84,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Check if we are being deleted and return if so
 	// Cleanup of server is handled by the server pod itself informing the scheduler and waiting as models are
-	// recheculed (if possible).
+	// rescheduled (if possible).
 	if !server.ObjectMeta.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, nil
 	}

--- a/operator/controllers/mlops/server_controller.go
+++ b/operator/controllers/mlops/server_controller.go
@@ -74,7 +74,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// we'll ignore not-found errors, since they can't be fixed by an immediate
 			// requeue (we'll need to wait for a new notification), and we can get them
 			// on deleted requests.
-			logger.Error(err, "server not found", "name", req.Name, "namespace", req.Namespace)
+			logger.Error(err, "server not found, ignoring error", "name", req.Name, "namespace", req.Namespace)
 			return reconcile.Result{}, nil
 		}
 		logger.Error(err, "unable to fetch Server", "name", req.Name, "namespace", req.Namespace)

--- a/operator/controllers/reconcilers/seldon/statefulset_reconciler.go
+++ b/operator/controllers/reconcilers/seldon/statefulset_reconciler.go
@@ -195,14 +195,14 @@ func (s *ComponentStatefulSetReconciler) Reconcile() error {
 		logger.V(1).Info("StatefulSet Create", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 		err = s.Client.Create(s.Ctx, s.StatefulSet)
 		if err != nil {
-			logger.Error(err, "Failed to create statefuleset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
+			logger.Error(err, "Failed to create statefulset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 			return err
 		}
 	case constants.ReconcileUpdateNeeded:
 		logger.V(1).Info("StatefulSet Update", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 		err = s.Client.Update(s.Ctx, s.StatefulSet)
 		if err != nil {
-			logger.Error(err, "Failed to update statefuleset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
+			logger.Error(err, "Failed to update statefulset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 			return err
 		}
 	case constants.ReconcileNoChange:

--- a/operator/controllers/reconcilers/server/statefulset_reconciler.go
+++ b/operator/controllers/reconcilers/server/statefulset_reconciler.go
@@ -177,14 +177,14 @@ func (s *ServerStatefulSetReconciler) Reconcile() error {
 		logger.V(1).Info("StatefulSet Create", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 		err = s.Client.Create(s.Ctx, s.StatefulSet)
 		if err != nil {
-			logger.Error(err, "Failed to create statefuleset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
+			logger.Error(err, "Failed to create statefulset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 			return err
 		}
 	case constants.ReconcileUpdateNeeded:
 		logger.V(1).Info("StatefulSet Update", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 		err = s.Client.Update(s.Ctx, s.StatefulSet)
 		if err != nil {
-			logger.Error(err, "Failed to update statefuleset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
+			logger.Error(err, "Failed to update statefulset", "Name", s.StatefulSet.GetName(), "Namespace", s.StatefulSet.GetNamespace())
 			return err
 		}
 	case constants.ReconcileNoChange:

--- a/operator/scheduler/server.go
+++ b/operator/scheduler/server.go
@@ -57,6 +57,7 @@ func (s *SchedulerClient) ServerNotify(ctx context.Context, server *v1alpha1.Ser
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponential(SchedulerConnectBackoffScalar)),
 	)
 	if err != nil {
+		logger.Error(err, "Failed to send notify server to scheduler", "name", server.GetName(), "namespace", server.GetNamespace())
 		return err
 	}
 	return nil

--- a/operator/scheduler/server.go
+++ b/operator/scheduler/server.go
@@ -110,8 +110,6 @@ func (s *SchedulerClient) SubscribeServerEvents(ctx context.Context, conn *grpc.
 				return nil
 			}
 			// Handle status update
-			// This is key for finalizer to remove server when loaded models is zero
-			// note: now we are not using finalizers for servers
 			server.Status.LoadedModelReplicas = event.NumLoadedModelReplicas
 			return s.updateServerStatus(server)
 		})

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -132,7 +132,10 @@ func (s *SchedulerServer) SubscribeServerStatus(req *pb.ServerSubscriptionReques
 	s.serverEventStream.mu.Unlock()
 
 	// on reconnect we send the current state of the servers to the subscriber (controller) as we may have missed events
-	s.sendCurrentServerStatuses(stream)
+	err := s.sendCurrentServerStatuses(stream)
+	if err != nil {
+		return err
+	}
 
 	ctx := stream.Context()
 	// Keep this scope alive because once this scope exits - the stream is closed

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -734,8 +734,11 @@ func (m *MemoryStore) drainServerReplicaImpl(serverName string, replicaIdx int) 
 }
 
 func (m *MemoryStore) ServerNotify(request *pb.ServerNotifyRequest) error {
+	logger := m.logger.WithField("func", "MemoryServerNotify")
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	logger.Debugf("ServerNotify %v", request)
 
 	server, ok := m.store.servers[request.Name]
 	if !ok {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Similar to models, pipelines and experiments, we want to send the server statuses to the controller on connection to the scheduler server updates stream.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes INFRA-794 (internal)

**Special notes for your reviewer**:
