### PR TITLE
fix(logging): adserver is very noisy for feedback requests, possibly affecting performance

### DIFF
--- a/components/alibi-detect-server/adserver/cm_model.py
+++ b/components/alibi-detect-server/adserver/cm_model.py
@@ -97,8 +97,7 @@ class CustomMetricsModel(CEModel):  # pylint:disable=c-extension-no-member
 
         """
         logging.info("PROCESSING Feedback Event.")
-        logging.info(str(headers))
-        logging.info("----")
+        logging.debug(str(headers))
 
         metrics: List[Dict] = []
         output: Dict = {}
@@ -161,7 +160,7 @@ class CustomMetricsModel(CEModel):  # pylint:disable=c-extension-no-member
                 error, status_code=400, reason="METRICS_SERVER_ERROR"
             )
 
-        logging.error(f"{truth}, {response}")
+        logging.info(f"truth: {truth}, response: {response}")
         metrics_transformed = self.model.transform(truth, response)
 
         metrics.extend(metrics_transformed.metrics)

--- a/components/alibi-detect-server/adserver/server.py
+++ b/components/alibi-detect-server/adserver/server.py
@@ -260,10 +260,10 @@ class EventHandler(tornado.web.RequestHandler):
 
             if not self.reply_url == "":
                 logging.debug(json.dumps(revent.Properties()))
-                logging.info("binary CloudEvent")
+                logging.debug("binary CloudEvent")
                 for k, v in revent_headers.items():
-                    logging.info("{0}: {1}\r\n".format(k, v))
-                logging.info(revent_data)
+                    logging.debug("{0}: {1}\r\n".format(k, v))
+                logging.debug(revent_data)
                 forward_request(revent_headers, revent_data, self.reply_url)
 
             self.set_header("Content-Type", "application/json")


### PR DESCRIPTION
This currently produces the below for every single Feedback requests (and there can be 10s of thousands) - this is not helping with performance or readability.

```
│ INFO:root:PROCESSING Feedback Event.                                                                                                                                                                             │
│ INFO:root:{'Host': 'seldon-sd-ml-iris-accuracy-metrics-ml-multiclass.seldon.svc.cluster.local', 'User-Agent': 'Go-http-client/1.1', 'Content-Length': '77', 'Accept-Encoding': 'gzip', 'Ce-Endpoint': 'default', │
│ INFO:root:----                                                                                                                                                                                                   │
│ ERROR:root:[0], [1]                                                                                                                                                                                              │
│ INFO:root:binary CloudEvent                                                                                                                                                                                      │
│ INFO:root:ce-specversion: 1.0                                                                                                                                                                                    │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-id: dd4607a0-5e45-4095-a128-fc4042e481db                                                                                                                                                            │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-source: io.seldon.serving.ml-iris-accuracy-ml-multiclass                                                                                                                                            │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-type: io.seldon.serving.feedback.metrics                                                                                                                                                            │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-endpoint: default                                                                                                                                                                                   │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-inferenceservicename: ml-iris-accuracy                                                                                                                                                              │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-knativearrivaltime: 2024-02-20T14:24:46.696630186Z                                                                                                                                                  │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-modelid: ml-iris-accuracy-container                                                                                                                                                                 │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-namespace: seldon                                                                                                                                                                                   │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-protocol: seldon                                                                                                                                                                                    │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-requestid: cdd01f83-e402-4ba5-9a9c-f40e180d229a                                                                                                                                                     │
│                                                                                                                                                                                                                  │
│ INFO:root:ce-traceparent: 00-6c57b179c8b17780515515cdccc33e93-8b8c8dc339a1c913-00                                                                                                                                │
│                                                                                                                                                                                                                  │
│ INFO:root:b'{}'
```