### PR TITLE
fix(dataflow): handle pipeline errors and clear kafka streams state

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/DataflowStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/DataflowStatus.kt
@@ -1,0 +1,65 @@
+package io.seldon.dataflow
+
+import io.klogging.Klogger
+import io.klogging.Level
+import io.klogging.NoCoLogger
+import kotlinx.coroutines.runBlocking
+
+/**
+ * An interface designed for returning error or status information from various components.
+ *
+ * The idea is to leave exception throwing to program logic errors or checking invariants
+ * that can not be checked at compile time. Use implementations of this interface as function
+ * return values to indicate errors/status updates that require special handling in the code.
+ */
+interface DataflowStatus {
+    var exception : Exception?
+    var message : String?
+
+    fun getDescription() : String? {
+        val exceptionMsg = this.exception?.message
+        return if (exceptionMsg != null) {
+            "${this.message} Exception: $exceptionMsg"
+        } else {
+            this.message
+        }
+    }
+
+    // log status when logger is in a coroutine
+    fun log(logger: Klogger, level: Level) {
+        val exceptionMsg = this.exception?.message
+        val exceptionCause = this.exception?.cause ?: Exception("")
+        val statusMsg = this.message
+        if (exceptionMsg != null) {
+            runBlocking {
+                logger.log(level, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+            }
+        } else {
+            runBlocking {
+                logger.log(level, "$statusMsg")
+            }
+        }
+    }
+
+    // leg status when logger is outside coroutines
+    fun log(logger: NoCoLogger, level: Level) {
+        val exceptionMsg = this.exception?.message
+        val exceptionCause = this.exception?.cause ?: Exception("")
+        if (exceptionMsg != null) {
+            logger.log(level, exceptionCause, "${this.message}, Exception: {exception}", exceptionMsg)
+        } else {
+            logger.log(level, "${this.message}")
+        }
+    }
+}
+
+fun <T: DataflowStatus> T.withException(e: Exception) : T {
+    this.exception = e
+    return this
+}
+
+fun <T: DataflowStatus> T.withMessage(msg: String): T {
+    this.message = msg
+    return this
+}
+

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/DataflowStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/DataflowStatus.kt
@@ -26,29 +26,29 @@ interface DataflowStatus {
     }
 
     // log status when logger is in a coroutine
-    fun log(logger: Klogger, level: Level) {
+    fun log(logger: Klogger, levelIfNoException: Level) {
         val exceptionMsg = this.exception?.message
         val exceptionCause = this.exception?.cause ?: Exception("")
         val statusMsg = this.message
         if (exceptionMsg != null) {
             runBlocking {
-                logger.log(level, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+                logger.error(exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
             }
         } else {
             runBlocking {
-                logger.log(level, "$statusMsg")
+                logger.log(levelIfNoException, "$statusMsg")
             }
         }
     }
 
     // leg status when logger is outside coroutines
-    fun log(logger: NoCoLogger, level: Level) {
+    fun log(logger: NoCoLogger, levelIfNoException: Level) {
         val exceptionMsg = this.exception?.message
         val exceptionCause = this.exception?.cause ?: Exception("")
         if (exceptionMsg != null) {
-            logger.log(level, exceptionCause, "${this.message}, Exception: {exception}", exceptionMsg)
+            logger.error(exceptionCause, "${this.message}, Exception: {exception}", exceptionMsg)
         } else {
-            logger.log(level, "${this.message}")
+            logger.log(levelIfNoException, "${this.message}")
         }
     }
 }

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/DataflowStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/DataflowStatus.kt
@@ -41,7 +41,7 @@ interface DataflowStatus {
         }
     }
 
-    // leg status when logger is outside coroutines
+    // log status when logger is outside coroutines
     fun log(logger: NoCoLogger, levelIfNoException: Level) {
         val exceptionMsg = this.exception?.message
         val exceptionCause = this.exception?.cause ?: Exception("")

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Logging.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Logging.kt
@@ -11,7 +11,7 @@ package io.seldon.dataflow
 
 import io.klogging.Level
 import io.klogging.config.loggingConfiguration
-import io.klogging.rendering.RENDER_ANSI
+import io.klogging.rendering.RENDER_ISO8601
 import io.klogging.sending.STDOUT
 
 object Logging {
@@ -20,7 +20,7 @@ object Logging {
     fun configure(appLevel: Level = Level.INFO, kafkaLevel: Level = Level.WARN) =
         loggingConfiguration {
             kloggingMinLogLevel(appLevel)
-            sink(stdoutSink, RENDER_ANSI, STDOUT)
+            sink(stdoutSink, RENDER_ISO8601, STDOUT)
             logging {
                 fromLoggerBase("io.seldon")
                 toSink(stdoutSink)

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
@@ -153,7 +153,7 @@ class Pipeline(
 
             val uncaughtExceptionHandlerClass = pipelineProperties[KAFKA_UNCAUGHT_EXCEPTION_HANDLER_CLASS_CONFIG] as? Class<StreamsUncaughtExceptionHandler>?
             uncaughtExceptionHandlerClass?.let{
-                logger.info("Setting custom Kafka streams uncaught exception handler")
+                logger.debug("Setting custom Kafka streams uncaught exception handler")
                 streamsApp.setUncaughtExceptionHandler(it.getDeclaredConstructor().newInstance())
             }
             logger.info(

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
@@ -25,7 +25,7 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
         override fun getDescription() : String? {
             val exceptionMsg = this.exception?.message
             var statusMsg = this.message
-            val prevStateDescription = prevState?.getDescription()
+            val prevStateDescription = this.prevState?.getDescription()
             prevStateDescription?.let {
                 statusMsg += ", before stop: $prevStateDescription"
             }
@@ -41,7 +41,7 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
             var exceptionMsg = this.exception?.message
             var exceptionCause = this.exception?.cause ?: Exception("")
             var statusMsg = this.message
-            val prevStateDescription = prevState?.getDescription()
+            val prevStateDescription = this.prevState?.getDescription()
             prevStateDescription?.let {
                 statusMsg += ", before stop: $prevStateDescription"
             }
@@ -56,12 +56,12 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
             }
         }
 
-        // leg status when logger is outside coroutines
+        // log status when logger is outside coroutines
         override fun log(logger: NoCoLogger, level: Level) {
             val exceptionMsg = this.exception?.message
             val exceptionCause = this.exception?.cause ?: Exception("")
             var statusMsg = this.message
-            val prevStateDescription = prevState?.getDescription()
+            val prevStateDescription = this.prevState?.getDescription()
             prevStateDescription?.let {
                 statusMsg += ", stop cause: $prevStateDescription"
             }
@@ -85,7 +85,7 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
         override var message: String? = "pipeline data streams: ready"
     }
 
-    data class Error(val errorState: KafkaStreams.State?): PipelineStatus(errorState,true)
+    data class Error(val errorState: KafkaStreams.State?): PipelineStatus(errorState, true)
 
     override var exception: Exception? = null
     override var message: String? = null

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
@@ -1,0 +1,93 @@
+package io.seldon.dataflow.kafka
+
+import io.klogging.Klogger
+import io.klogging.Level
+import io.klogging.NoCoLogger
+import io.seldon.dataflow.DataflowStatus
+import kotlinx.coroutines.runBlocking
+import org.apache.kafka.streams.KafkaStreams
+
+open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) : DataflowStatus {
+    // Keep the previous state in case we're stopping the stream so that we can determine
+    // _why_ the stream was stopped.
+    class StreamStopped(var prevState: PipelineStatus?) : PipelineStatus(null, false) {
+        override var message: String? = "pipeline data streams: stopped"
+
+        init {
+            // Avoid nesting stopped states
+            val prev = this.prevState
+            if (prev is StreamStopped) {
+                this.prevState = prev.prevState
+            }
+            this.isError = this.prevState?.isError ?: false
+        }
+
+        override fun getDescription() : String? {
+            val exceptionMsg = this.exception?.message
+            var statusMsg = this.message
+            val prevStateDescription = prevState?.getDescription()
+            prevStateDescription?.let {
+                statusMsg += ", before stop: $prevStateDescription"
+            }
+            return if (exceptionMsg != null) {
+                "$statusMsg Exception: $exceptionMsg"
+            } else {
+                statusMsg
+            }
+        }
+
+        // log status when logger is in a coroutine
+        override fun log(logger: Klogger, level: Level) {
+            var exceptionMsg = this.exception?.message
+            var exceptionCause = this.exception?.cause ?: Exception("")
+            var statusMsg = this.message
+            val prevStateDescription = prevState?.getDescription()
+            prevStateDescription?.let {
+                statusMsg += ", before stop: $prevStateDescription"
+            }
+            if (exceptionMsg != null) {
+                runBlocking {
+                    logger.log(level, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+                }
+            } else {
+                runBlocking {
+                    logger.log(level, "$statusMsg")
+                }
+            }
+        }
+
+        // leg status when logger is outside coroutines
+        override fun log(logger: NoCoLogger, level: Level) {
+            val exceptionMsg = this.exception?.message
+            val exceptionCause = this.exception?.cause ?: Exception("")
+            var statusMsg = this.message
+            val prevStateDescription = prevState?.getDescription()
+            prevStateDescription?.let {
+                statusMsg += ", stop cause: $prevStateDescription"
+            }
+            if (exceptionMsg != null) {
+                logger.log(level, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+            } else {
+                logger.log(level, "$statusMsg")
+            }
+        }
+    }
+
+    class StreamStopping() : PipelineStatus(null, false) {
+        override var message: String? = "pipeline data streams: stopping"
+    }
+
+    class StreamStarting() : PipelineStatus(null, false) {
+        override var message: String? = "pipeline data streams: initializing"
+    }
+
+    class Started() : PipelineStatus(null, false) {
+        override var message: String? = "pipeline data streams: ready"
+    }
+
+    data class Error(val errorState: KafkaStreams.State?): PipelineStatus(errorState,true)
+
+    override var exception: Exception? = null
+    override var message: String? = null
+
+}

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/StreamErrorHandling.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/StreamErrorHandling.kt
@@ -1,0 +1,66 @@
+package io.seldon.dataflow.kafka
+
+import io.klogging.noCoLogger
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler
+import org.apache.kafka.streams.errors.ProductionExceptionHandler
+import org.apache.kafka.streams.errors.StreamsException
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler
+import org.apache.kafka.streams.processor.ProcessorContext
+
+class StreamErrorHandling {
+
+    class StreamsDeserializationErrorHandler: DeserializationExceptionHandler {
+
+        override fun configure(configs: MutableMap<String, *>?) {
+        }
+
+        override fun handle(
+            context: ProcessorContext?,
+            record: ConsumerRecord<ByteArray, ByteArray>?,
+            exception: Exception?
+        ): DeserializationExceptionHandler.DeserializationHandlerResponse {
+            if (exception != null) {
+                logger.error(exception, "Kafka streams: message deserialization error on ${record?.topic()}")
+            }
+            return DeserializationExceptionHandler.DeserializationHandlerResponse.CONTINUE
+        }
+    }
+
+    class StreamsRecordProducerErrorHandler: ProductionExceptionHandler {
+
+        override fun configure(configs: MutableMap<String, *>?) {
+        }
+
+        override fun handle(
+            record: ProducerRecord<ByteArray, ByteArray>?,
+            exception: Exception?
+        ): ProductionExceptionHandler.ProductionExceptionHandlerResponse {
+            if (exception != null) {
+                logger.error(exception, "Kafka streams: error when writing to ${record?.topic()}")
+            }
+            return ProductionExceptionHandler.ProductionExceptionHandlerResponse.CONTINUE
+        }
+
+    }
+
+    class StreamsCustomUncaughtExceptionHandler: StreamsUncaughtExceptionHandler {
+        override fun handle(exception: Throwable?): StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse {
+            if (exception is StreamsException) {
+                val originalException = exception.cause
+                originalException?.let {
+                    logger.error(it, "Kafka streams: stream processing exception")
+                    return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+                }
+            }
+            // try to continue
+            return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
+        }
+    }
+
+    companion object {
+        private val logger = noCoLogger(StreamErrorHandling::class)
+    }
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Because we're now continuously retrying the subscription to the scheduler when the subscription terminates, we need to also clean the kafka streams state of failed pipelines when the subscription is terminated with an error.

This commit also introduces a new way of handling errors and the changes in pipeline status. It moves us towards being able to inspect the status of the underlying kafka streams from outside the Pipeline object. The end-goal (not archieved here) is to react to pipelines reaching error states during their operation, rather than just when they are created for the first time (what's currently implemented). However, this PR does get us to a point where the pipeline creation status, including possible errors/exceptions are reported to the scheduler and can show up either in the seldon CLI or in k8s.

Instead of propagating exceptions, the idea is to return and handle common errors in a more similar way to golang.

**Which issue(s) this PR fixes**:
- Fixes #INFRA-755 (internal): Exceptions in pipeline creation/deletion are unrecoverable because of uncleaned Kafka Streams state
- Progress on #INFRA-617 (internal): Investigate high priority unhandled errors
- Progress on #INFRA-648 (internal): Handle dataflow [...] exceptions and present meaningful error messages

** PR Merge Sequencing GROUP 663 **
This is part of a sequence of PRs building on each-other, but split in order to simplify reviewing. 
This PR has sequence no: G663/1

Next to review in sequence: https://github.com/lc525/seldon-core/pull/47 : fix(dataflow): wait for kafka topic creation