### PR TITLE
fix(gateway): wait for kafka topic creation

### DIFF
--- a/scheduler/pkg/kafka/config/auth.go
+++ b/scheduler/pkg/kafka/config/auth.go
@@ -63,7 +63,7 @@ func setupSASLSSLAuthentication(config kafka.ConfigMap) error {
 
 func withPasswordAuth(mechanism string, config kafka.ConfigMap) error {
 	// Set the SASL mechanism
-	config["security.protocol"] = "SASL_SSL"
+	config["security.protocol"] = tls.SecurityProtocolSASLSSL
 	config["sasl.mechanism"] = mechanism
 
 	// Set the SASL username and password

--- a/scheduler/pkg/kafka/gateway/constants.go
+++ b/scheduler/pkg/kafka/gateway/constants.go
@@ -19,8 +19,8 @@ const (
 	HeaderValueProtoRes = "proto/InferModelResponse"
 
 	// Topic creation retries
-	TopicCreateTimeout = time.Minute
-	TopicDescribeTimeout = time.Second
+	TopicCreateTimeout      = time.Minute
+	TopicDescribeTimeout    = time.Second
 	TopicDescribeMaxRetries = 60
 	TopicDescribeRetryDelay = time.Second
 )

--- a/scheduler/pkg/kafka/gateway/constants.go
+++ b/scheduler/pkg/kafka/gateway/constants.go
@@ -9,10 +9,18 @@ the Change License after the Change Date as each is defined in accordance with t
 
 package gateway
 
+import "time"
+
 const (
 	HeaderKeyType       = "seldon-infer-type"
 	HeaderValueJsonReq  = "json/inferModelRequest"
 	HeaderValueJsonRes  = "json/inferModelResponse"
 	HeaderValueProtoReq = "proto/InferModelRequest"
 	HeaderValueProtoRes = "proto/InferModelResponse"
+
+	// Topic creation retries
+	TopicCreateTimeout = time.Minute
+	TopicDescribeTimeout = time.Second
+	TopicDescribeMaxRetries = 60
+	TopicDescribeRetryDelay = time.Second
 )

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -11,7 +11,6 @@ package gateway
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -265,7 +264,7 @@ func (kc *InferKafkaHandler) ensureTopicsExist(topicNames []string) error {
 
 	for _, topicDescription := range topicsDescResult.TopicDescriptions {
 		if topicDescription.Error.Code() != kafka.ErrNoError {
-			return fmt.Errorf("topic description failure: %s", topicDescription.Error.Error)
+			return fmt.Errorf("topic description failure: %s", topicDescription.Error.Error())
 		}
 	}
 

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -196,7 +196,10 @@ func (kc *InferKafkaHandler) createTopics(topicNames []string) error {
 	logger := kc.logger.WithField("func", "createTopics")
 	if kc.adminClient == nil {
 		logger.Warnf("no kafka admin client, can't create any of the following topics: %v", topicNames)
-		return fmt.Errorf("no kafka admin client")
+		// An error would typically be returned here, but a missing adminClient typically
+		// indicates we're running tests. Instead of failing tests, we return nil here.
+		// TODO: find a better way of mocking kafka
+		return nil
 	}
 	t1 := time.Now()
 

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -249,24 +249,24 @@ func (kc *InferKafkaHandler) createTopics(topicNames []string) error {
 }
 
 func (kc *InferKafkaHandler) ensureTopicsExist(topicNames []string) error {
-		ctx, cancel := context.WithTimeout(context.Background(), 2 * time.Second)
-		defer cancel()
-		topicsDescResult, err := kc.adminClient.DescribeTopics(
-			ctx,
-			kafka.NewTopicCollectionOfTopicNames(topicNames),
-			kafka.SetAdminOptionIncludeAuthorizedOperations(false))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	topicsDescResult, err := kc.adminClient.DescribeTopics(
+		ctx,
+		kafka.NewTopicCollectionOfTopicNames(topicNames),
+		kafka.SetAdminOptionIncludeAuthorizedOperations(false))
 
-		if err != nil {
-			return err
+	if err != nil {
+		return err
+	}
+
+	for _, topicDescription := range topicsDescResult.TopicDescriptions {
+		if topicDescription.Error.Code() != kafka.ErrNoError {
+			return fmt.Errorf("topic description failure: %s", topicDescription.Error.Error)
 		}
+	}
 
-		for _, topicDescription := range topicsDescResult.TopicDescriptions {
-			if topicDescription.Error.Code() != kafka.ErrNoError {
-				return errors.New(fmt.Sprintf("topic description failure: %s", topicDescription.Error.Error))
-			}
-		}
-
-		return nil
+	return nil
 }
 
 func (kc *InferKafkaHandler) AddModel(modelName string) error {

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
 	log "github.com/sirupsen/logrus"
@@ -194,7 +195,7 @@ func (kc *InferKafkaHandler) GetNumModels() int {
 func (kc *InferKafkaHandler) createTopics(topicNames []string) error {
 	logger := kc.logger.WithField("func", "createTopics")
 	if kc.adminClient == nil {
-		logger.Warnf("Can't create topics %v as no admin client", topicNames)
+		logger.Warnf("no kafka admin client, can't create any of the following topics: %v", topicNames)
 		return nil
 	}
 	t1 := time.Now()
@@ -216,14 +217,44 @@ func (kc *InferKafkaHandler) createTopics(topicNames []string) error {
 		return err
 	}
 
+	// Wait for topic creation
+	logFailure := func(err error, delay time.Duration) {
+		logger.WithError(err).Errorf("waiting for topic creation")
+	}
+
+	logger.Infof("waiting for topic creation...")
+	retryPolicy := backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 60)
+	err = backoff.RetryNotify(
+		func() error {
+			return kc.ensureTopicsExist(topicNames)
+		},
+		retryPolicy,
+		logFailure)
+
+	if err != nil {
+		logger.WithError(err).Errorf("some topics not created, giving up")
+	} else {
+		logger.Infof("all topics created")
+	}
+
 	for _, result := range results {
-		logger.Debugf("Topic result for %s", result.String())
+		logger.Debugf("topic result for %s", result.String())
 	}
 
 	t2 := time.Now()
-	logger.Infof("Topic created in %d millis", t2.Sub(t1).Milliseconds())
+	logger.Infof("kafka topics created in %d millis", t2.Sub(t1).Milliseconds())
 
 	return nil
+}
+
+func (kc *InferKafkaHandler) ensureTopicsExist(topicNames []string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 2 * time.Second)
+		defer cancel()
+		_, err := kc.adminClient.DescribeTopics(
+			ctx,
+			kafka.NewTopicCollectionOfTopicNames(topicNames),
+			kafka.SetAdminOptionIncludeAuthorizedOperations(false))
+		return err
 }
 
 func (kc *InferKafkaHandler) AddModel(modelName string) error {
@@ -241,7 +272,7 @@ func (kc *InferKafkaHandler) AddModel(modelName string) error {
 	kc.subscribedTopics[inputTopic] = true
 	err := kc.subscribeTopics()
 	if err != nil {
-		kc.logger.WithError(err).Warn("Failed to subscribe to topics")
+		kc.logger.WithError(err).Errorf("failed to subscribe to topics")
 		return nil
 	}
 	return nil
@@ -255,7 +286,7 @@ func (kc *InferKafkaHandler) RemoveModel(modelName string) error {
 	if len(kc.subscribedTopics) > 0 {
 		err := kc.subscribeTopics()
 		if err != nil {
-			kc.logger.WithError(err).Errorf("Failed to subscribe to topics")
+			kc.logger.WithError(err).Errorf("failed to subscribe to topics")
 			return nil
 		}
 	}

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -243,7 +243,7 @@ func (iw *InferWorker) produce(
 	for k, vs := range headers {
 		for _, v := range vs {
 			if !existsKafkaHeader(kafkaHeaders, k, v) {
-				logger.Infof("Adding header to kafka response %s:%s", k, v)
+				logger.Debugf("Adding header to kafka response %s:%s", k, v)
 				kafkaHeaders = append(kafkaHeaders, kafka.Header{Key: k, Value: []byte(v)})
 			}
 		}

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -168,11 +168,12 @@ func (km *KafkaManager) loadOrStorePipeline(resourceName string, isModel bool) (
 			return nil, err
 		}
 
+		pipeline.wg.Add(1) // wait set to allow consumer to say when started
+
 		val, loaded := km.pipelines.LoadOrStore(key, pipeline)
 		if loaded { // we can still have a race condition where multiple "create" are happening, we have to store the first one
 			pipeline = val.(*Pipeline)
 		} else {
-			pipeline.wg.Add(1) // wait set to allow consumer to say when started
 			go func() {
 				err := km.consume(pipeline)
 				if err != nil {

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -167,7 +167,6 @@ func (km *KafkaManager) loadOrStorePipeline(resourceName string, isModel bool) (
 		if err != nil {
 			return nil, err
 		}
-
 		pipeline.wg.Add(1) // wait set to allow consumer to say when started
 
 		val, loaded := km.pipelines.LoadOrStore(key, pipeline)

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -167,12 +167,12 @@ func (km *KafkaManager) loadOrStorePipeline(resourceName string, isModel bool) (
 		if err != nil {
 			return nil, err
 		}
-		pipeline.wg.Add(1) // wait set to allow consumer to say when started
 
 		val, loaded := km.pipelines.LoadOrStore(key, pipeline)
 		if loaded { // we can still have a race condition where multiple "create" are happening, we have to store the first one
 			pipeline = val.(*Pipeline)
 		} else {
+			pipeline.wg.Add(1) // wait set to allow consumer to say when started
 			go func() {
 				err := km.consume(pipeline)
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Kafka topic creation happens asynchronously. This means that even when the
return value from createTopics(...) indicates that the topic has been created
successfuly, the topic can not be immediately subscribed to.

We retry DescribeTopics until all of the topics for the pipeline can be
described successfully. This indicates that the topic has been fully created at
least on one broker, and can now be subscribed to.

**Which issue(s) this PR fixes**:
Fixes gateway component for #INFRA-663 (internal): Pipeline creation goes into ERROR state