### PR TITLE
fix(dataflow): wait for kafka topic creation

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
@@ -47,6 +47,12 @@ object Cli {
     val brokerSecret = Key("kafka.tls.broker.secret", stringType)
     val endpointIdentificationAlgorithm = Key("kafka.tls.endpoint.identification.algorithm", stringType)
 
+    // Kafka waiting for topic creation
+    val topicCreateTimeoutMillis = Key("topic.create.timeout.millis", intType)
+    val topicDescribeTimeoutMillis = Key("topic.describe.timeout.millis", longType)
+    val topicDescribeRetries = Key("topic.describe.retry.attempts", intType)
+    val topicDescribeRetryDelayMillis = Key("topic.describe.retry.delay.millis", longType)
+
     // Kafka SASL
     val saslUsername = Key("kafka.sasl.username", stringType)
     val saslSecret = Key("kafka.sasl.secret", stringType)
@@ -75,6 +81,10 @@ object Cli {
             clientSecret,
             brokerSecret,
             endpointIdentificationAlgorithm,
+            topicCreateTimeoutMillis,
+            topicDescribeTimeoutMillis,
+            topicDescribeRetries,
+            topicDescribeRetryDelayMillis,
             saslUsername,
             saslSecret,
             saslPasswordPath,

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Main.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Main.kt
@@ -81,12 +81,19 @@ object Main {
             useCleanState = config[Cli.kafkaUseCleanState],
             joinWindowMillis = config[Cli.kafkaJoinWindowMillis],
         )
+        val topicWaitRetryParams = TopicWaitRetryParams(
+            createTimeoutMillis = config[Cli.topicCreateTimeoutMillis],
+            describeTimeoutMillis = config[Cli.topicDescribeTimeoutMillis],
+            describeRetries = config[Cli.topicDescribeRetries],
+            describeRetryDelayMillis = config[Cli.topicDescribeRetryDelayMillis]
+        )
         val subscriber = PipelineSubscriber(
             "seldon-dataflow-engine",
             kafkaProperties,
             kafkaAdminProperties,
             kafkaStreamsParams,
             kafkaDomainParams,
+            topicWaitRetryParams,
             config[Cli.upstreamHost],
             config[Cli.upstreamPort],
             GrpcServiceConfigProvider.config,

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
@@ -105,7 +105,6 @@ class PipelineSubscriber(
                 }
             }
             .collect()
-        // TODO - error handling?
         // TODO - use supervisor job(s) for spawning coroutines?
     }
 
@@ -121,8 +120,20 @@ class PipelineSubscriber(
         kafkaConsumerGroupIdPrefix: String,
         namespace: String,
     ) {
-        logger.info("Create pipeline {pipelineName}  version: {pipelineVersion} id: {pipelineId}", metadata.name, metadata.version, metadata.id)
-        val (pipeline, err) = Pipeline.forSteps(metadata, steps, kafkaProperties, kafkaDomainParams, kafkaConsumerGroupIdPrefix, namespace)
+        logger.info(
+            "Create pipeline {pipelineName}  version: {pipelineVersion} id: {pipelineId}",
+            metadata.name,
+            metadata.version,
+            metadata.id
+        )
+        val (pipeline, err) = Pipeline.forSteps(
+            metadata,
+            steps,
+            kafkaProperties,
+            kafkaDomainParams,
+            kafkaConsumerGroupIdPrefix,
+            namespace
+        )
         if (err != null) {
             err.log(logger, Level.ERROR)
             client.pipelineUpdateEvent(

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
@@ -34,13 +34,14 @@ class PipelineSubscriber(
     kafkaAdminProperties: KafkaAdminProperties,
     kafkaStreamsParams: KafkaStreamsParams,
     private val kafkaDomainParams: KafkaDomainParams,
+    private val topicWaitRetryParams: TopicWaitRetryParams,
     private val upstreamHost: String,
     private val upstreamPort: Int,
     grpcServiceConfig: Map<String, Any>,
     private val kafkaConsumerGroupIdPrefix: String,
     private val namespace: String,
 ) {
-    private val kafkaAdmin = KafkaAdmin(kafkaAdminProperties, kafkaStreamsParams)
+    private val kafkaAdmin = KafkaAdmin(kafkaAdminProperties, kafkaStreamsParams, topicWaitRetryParams)
     private val channel = ManagedChannelBuilder
         .forAddress(upstreamHost, upstreamPort)
         .defaultServiceConfig(grpcServiceConfig)
@@ -144,7 +145,6 @@ class PipelineSubscriber(
                     reason = err.getDescription() ?: "failed to initialize dataflow engine"
                 )
             )
-
             return
         }
 

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
@@ -49,6 +49,13 @@ data class KafkaDomainParams(
     val joinWindowMillis: Long,
 )
 
+data class TopicWaitRetryParams(
+    val createTimeoutMillis: Int, // int required by the underlying kafka-streams library
+    val describeTimeoutMillis: Long,
+    val describeRetries: Int,
+    val describeRetryDelayMillis: Long
+)
+
 val kafkaTopicConfig = { maxMessageSizeBytes: Int ->
     mapOf(
         TopicConfig.MAX_MESSAGE_BYTES_CONFIG to maxMessageSizeBytes.toString(),

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
@@ -140,8 +140,8 @@ class Pipeline(
         ): Pair<Pipeline?, PipelineStatus.Error?> {
             val (topology, numSteps) = buildTopology(metadata, steps, kafkaDomainParams)
             val pipelineProperties = localiseKafkaProperties(kafkaProperties, metadata, numSteps, kafkaConsumerGroupIdPrefix, namespace)
-            var streamsApp : KafkaStreams? = null
-            var pipelineError: PipelineStatus.Error? = null
+            var streamsApp : KafkaStreams?
+            var pipelineError: PipelineStatus.Error?
             try {
                 streamsApp = KafkaStreams(topology, pipelineProperties)
             } catch (e: StreamsException) {

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
@@ -37,7 +37,7 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
         }
 
         // log status when logger is in a coroutine
-        override fun log(logger: Klogger, level: Level) {
+        override fun log(logger: Klogger, levelIfNoException: Level) {
             var exceptionMsg = this.exception?.message
             var exceptionCause = this.exception?.cause ?: Exception("")
             var statusMsg = this.message
@@ -47,17 +47,17 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
             }
             if (exceptionMsg != null) {
                 runBlocking {
-                    logger.log(level, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+                    logger.log(levelIfNoException, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
                 }
             } else {
                 runBlocking {
-                    logger.log(level, "$statusMsg")
+                    logger.log(levelIfNoException, "$statusMsg")
                 }
             }
         }
 
         // log status when logger is outside coroutines
-        override fun log(logger: NoCoLogger, level: Level) {
+        override fun log(logger: NoCoLogger, levelIfNoException: Level) {
             val exceptionMsg = this.exception?.message
             val exceptionCause = this.exception?.cause ?: Exception("")
             var statusMsg = this.message
@@ -66,9 +66,9 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
                 statusMsg += ", stop cause: $prevStateDescription"
             }
             if (exceptionMsg != null) {
-                logger.log(level, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+                logger.log(levelIfNoException, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
             } else {
-                logger.log(level, "$statusMsg")
+                logger.log(levelIfNoException, "$statusMsg")
             }
         }
     }

--- a/scheduler/data-flow/src/main/resources/local.properties
+++ b/scheduler/data-flow/src/main/resources/local.properties
@@ -21,3 +21,7 @@ kafka.sasl.username=seldon
 kafka.sasl.secret=
 kafka.sasl.password.path=
 kafka.sasl.mechanism=PLAIN
+topic.create.timeout.millis=60000
+topic.describe.timeout.millis=1000
+topic.describe.retry.attempts=60
+topic.describe.retry.delay.millis=1000


### PR DESCRIPTION
This is identical to the reviewed (and approved) https://github.com/lc525/seldon-core/pull/47 but rebased against current seldonio/v2 for merging

**What this PR does / why we need it:**
Kafka topic creation happens asynchronously. This means that even when the return value from `createTopics(...)` indicates that the topic has been created successfuly, the topic can not be immediately subscribed to.

Instead of verifying the status of the topic from the `createTopics` return value, here we're repeatedly calling `describeTopics` until all of the topics for the pipeline can be described successfully. This indicates that the topic has been fully created _at least_ on one broker, and can now be subscribed to.

**Which issue(s) this PR fixes:**
Fixes dataflow component for #INFRA-663 (internal): Pipeline creation goes into ERROR state