### PR TITLE
fix(build): force update dependency of k8s java-client to fix high CVEs

### DIFF
--- a/scheduler/data-flow/build.gradle.kts
+++ b/scheduler/data-flow/build.gradle.kts
@@ -48,6 +48,13 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.2")
     testImplementation("io.strikt:strikt-core:0.34.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // transitive dependencies constraints
+    constraints {
+        implementation("org.apache.commons:commons-compress:1.26.0") {
+            because("version 1.24.0 pulled by io.kubernetes:client-java contains high CVEs")
+        }
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
In the dataflow component we use io.kubernetes:client-java for fetching k8s secrets needed for Kafka SaaS auth. 
The library has `org.apache.commons:commons-compress` as a dependency.

- The fix forces `org.apache.commons:commons-compress` update from 1.24.0 to 1.26.0 by defining an explicit gradle build dependency constraint

See https://docs.gradle.org/current/userguide/dependency_constraints.html for a description of how gradle may handle transitive dependency updates. This comes with its own disadvantages:
 - because we force the update ourselves, we have to test that our dependency indeed works with the updated package and delivers the same functionality we need
 - we need to remove the build constraint once the dependency updates its dependency, so that we don't "pin" that to an old version unnecessarily (this is why we have the following TODO)

- TODO(future): remove gradle constraint when io.kubernetes:client-java gets updated to a version directly depending on 1.26.0 or higher

Fixes high CVEs:
- [CVE-2024-26308](https://github.com/advisories/GHSA-4265-ccf5-phj5)
- [CVE-2024-25710](https://github.com/advisories/GHSA-4g9r-vxhx-9pgx)

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
