### PR TITLE
fix: Use mlserver 1.5.0

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -252,7 +252,7 @@ serverConfig:
       pullPolicy: IfNotPresent
       registry: docker.io
       repository: seldonio/mlserver
-      tag: 1.3.5
+      tag: 1.5.0
     serverCapabilities: "mlserver,alibi-detect,alibi-explain,huggingface,lightgbm,mlflow,python,sklearn,spark-mlib,xgboost"
     modelVolumeStorage: 1Gi
     resources:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -1272,7 +1272,7 @@ spec:
         value: "false"
       - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
         value: "1048576000"
-      image: 'docker.io/seldonio/mlserver:1.3.5'
+      image: 'docker.io/seldonio/mlserver:1.5.0'
       imagePullPolicy: 'IfNotPresent'
       lifecycle:
         preStop:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -4,7 +4,7 @@ DOCKERHUB_USERNAME ?= seldonio
 IMG ?= ${DOCKERHUB_USERNAME}/seldonv2-controller:${CUSTOM_IMAGE_TAG}
 AGENT_IMG ?= ${DOCKERHUB_USERNAME}/seldon-agent:${CUSTOM_IMAGE_TAG}
 RCLONE_IMG ?= ${DOCKERHUB_USERNAME}/seldon-rclone:${CUSTOM_IMAGE_TAG}
-MLSERVER_IMG ?= seldonio/mlserver:1.3.5
+MLSERVER_IMG ?= seldonio/mlserver:1.5.0
 TRITON_IMG ?= nvcr.io/nvidia/tritonserver:23.03-py3
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22

--- a/operator/config/serverconfigs/kustomization.yaml
+++ b/operator/config/serverconfigs/kustomization.yaml
@@ -9,7 +9,7 @@ images:
   newTag: latest
 - name: mlserver
   newName: seldonio/mlserver
-  newTag: 1.3.5
+  newTag: 1.5.0
 - name: rclone
   newName: seldonio/seldon-rclone
   newTag: latest

--- a/samples/models/hf-text-gen-custom-gpt2.yaml
+++ b/samples/models/hf-text-gen-custom-gpt2.yaml
@@ -3,7 +3,7 @@ kind: Model
 metadata:
   name: custom-gpt2-text-gen
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/huggingface-text-gen-custom-gpt2"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/huggingface-text-gen-custom-gpt2"
   requirements:
     - huggingface
   memory: 3Gi

--- a/samples/models/hf-text-gen-custom-tiny-stories.yaml
+++ b/samples/models/hf-text-gen-custom-tiny-stories.yaml
@@ -3,6 +3,6 @@ kind: Model
 metadata:
   name: custom-tiny-stories-text-gen
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/huggingface-text-gen-custom-tiny-stories"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/huggingface-text-gen-custom-tiny-stories"
   requirements:
     - huggingface

--- a/samples/models/income-explainer-pipeline.yaml
+++ b/samples/models/income-explainer-pipeline.yaml
@@ -3,7 +3,7 @@ kind: Model
 metadata:
   name: income-explainer
 spec:
-  storageUri: "gs://seldon-models/scv2/examples/mlserver_1.3.5/income/explainer"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/income-sklearn/anchor-explainer"
   explainer:
     type: anchor_tabular
     pipelineRef: income-prod

--- a/samples/models/income-explainer.yaml
+++ b/samples/models/income-explainer.yaml
@@ -3,7 +3,7 @@ kind: Model
 metadata:
   name: income-explainer
 spec:
-  storageUri: "gs://seldon-models/scv2/examples/mlserver_1.3.5/income/explainer"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/income-sklearn/anchor-explainer"
   explainer:
     type: anchor_tabular
     modelRef: income

--- a/samples/models/income-xgb.yaml
+++ b/samples/models/income-xgb.yaml
@@ -3,6 +3,6 @@ kind: Model
 metadata:
   name: income-xgb
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/income-xgb"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/income-xgb"
   requirements:
   - xgboost

--- a/samples/models/income.yaml
+++ b/samples/models/income.yaml
@@ -3,6 +3,6 @@ kind: Model
 metadata:
   name: income
 spec:
-  storageUri: "gs://seldon-models/scv2/examples/mlserver_1.3.5/income/classifier"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/income-sklearn/classifier"
   requirements:
   - sklearn

--- a/samples/models/moviesentiment-explainer.yaml
+++ b/samples/models/moviesentiment-explainer.yaml
@@ -3,7 +3,7 @@ kind: Model
 metadata:
   name: sentiment-explainer
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/moviesentiment-sklearn-explainer"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/moviesentiment-sklearn-explainer"
   explainer:
     type: anchor_text
     modelRef: sentiment

--- a/samples/models/moviesentiment.yaml
+++ b/samples/models/moviesentiment.yaml
@@ -3,6 +3,6 @@ kind: Model
 metadata:
   name: sentiment
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/moviesentiment-sklearn"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/moviesentiment-sklearn"
   requirements:
   - sklearn

--- a/samples/models/sklearn-iris-gs-baduri.yaml
+++ b/samples/models/sklearn-iris-gs-baduri.yaml
@@ -3,7 +3,7 @@ kind: Model
 metadata:
   name: iris
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/iris-notexistent-uri"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/iris-notexistent-uri"
   requirements:
   - sklearn
   memory: 100Ki

--- a/samples/models/sklearn-iris-gs.yaml
+++ b/samples/models/sklearn-iris-gs.yaml
@@ -3,7 +3,7 @@ kind: Model
 metadata:
   name: iris
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/iris-sklearn"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/iris-sklearn"
   requirements:
   - sklearn
   memory: 100Ki

--- a/samples/models/wine-mlflow.yaml
+++ b/samples/models/wine-mlflow.yaml
@@ -3,6 +3,6 @@ kind: Model
 metadata:
   name: wine
 spec:
-  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.3.5/wine-mlflow"
+  storageUri: "gs://seldon-models/scv2/samples/mlserver_1.5.0/wine-mlflow"
   requirements:
   - mlflow

--- a/samples/scripts/models/Makefile
+++ b/samples/scripts/models/Makefile
@@ -4,11 +4,12 @@ MLSERVER_FOLDER = mlserver_${MLSERVER_VERSION}
 TRITON_VERSION=$(shell grep 'nvidia/tritonserver' ../../../scheduler/Makefile | cut -d':' -f2 | cut -d'-' -f1 | tr '.' '-')
 TRITON_FOLDER=triton_${TRITON_VERSION}
 
+# note that income-lgb fails with new version of lightgbm
 .PHONY: train-all
-train-all: iris huggingface-text-gen-gpt2 huggingface-text-gen-tiny-stories moviesentiment income income-xgb income-lgb download-mnist-onnx download-cifar10-tensorflow wine-mlflow mnist-pytorch
+train-all: iris huggingface-text-gen-gpt2 huggingface-text-gen-tiny-stories moviesentiment income income-xgb download-mnist-onnx download-cifar10-tensorflow wine-mlflow mnist-pytorch
 
 .PHONY: upload-all
-upload-all: upload-iris upload-huggingface-text-gen-gpt2 upload-huggingface-text-gen-tiny-stories upload-moviesentiment upload-income upload-income-xgb upload-income-lgb upload-mnist-onnx upload-cifar10-tensorflow upload-wine-mlflow upload-mnist-pytorch
+upload-all: upload-iris upload-huggingface-text-gen-gpt2 upload-huggingface-text-gen-tiny-stories upload-moviesentiment upload-income upload-income-xgb upload-mnist-onnx upload-cifar10-tensorflow upload-wine-mlflow upload-mnist-pytorch
 
 .PHONY: env
 env:
@@ -103,6 +104,7 @@ upload-income-xgb:
 
 #
 # Income lightgbm model
+# note: this fails with current version of lightgbm
 #
 
 .PHONY: income-lgb

--- a/samples/scripts/models/Makefile
+++ b/samples/scripts/models/Makefile
@@ -121,7 +121,7 @@ upload-income-lgb:
 
 .PHONY: download-mnist-onnx
 download-mnist-onnx:
-	wget https://github.com/onnx/models/raw/main/vision/classification/mnist/model/mnist-12.onnx -O mnist-onnx/model.onnx
+	wget https://github.com/onnx/models/raw/main/validated/vision/classification/mnist/model/mnist-12.onnx -O mnist-onnx/model.onnx
 
 .PHONY: upload-mnist-onnx
 upload-mnist-onnx:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This change upgrades the "default" images for mlserver to point to `1.5.0` as it is now released.
Note that some models are still using the artifacts generated from mlserver `1.3.5` but they work with the new version.
I didnt regenerate the notebooks for now but happy to do if required.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

Model artifacts are generated and uploaded to [seldon public cloud storage](https://console.cloud.google.com/storage/browser/seldon-models/scv2/samples/mlserver_1.5.0?project=seldon-pub)

using `~/samples$ make train-all upload-all`