### PR TITLE
fix(dataflow): catch all exceptions when creating a KafkaStreams object

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
@@ -144,10 +144,10 @@ class Pipeline(
             var pipelineError: PipelineStatus.Error?
             try {
                 streamsApp = KafkaStreams(topology, pipelineProperties)
-            } catch (e: StreamsException) {
+            } catch (e: Exception) {
                 pipelineError = PipelineStatus.Error(null)
                     .withException(e)
-                    .withMessage("failed to initialize kafka streams app")
+                    .withMessage("failed to initialize kafka streams for pipeline")
                 return null to pipelineError
             }
 

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
@@ -30,7 +30,7 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
                 statusMsg += ", before stop: $prevStateDescription"
             }
             return if (exceptionMsg != null) {
-                "$statusMsg Exception: $exceptionMsg"
+                "$statusMsg, exception: $exceptionMsg"
             } else {
                 statusMsg
             }
@@ -47,7 +47,7 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
             }
             if (exceptionMsg != null) {
                 runBlocking {
-                    logger.log(levelIfNoException, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+                    logger.log(levelIfNoException, exceptionCause, "$statusMsg, exception: {exception}", exceptionMsg)
                 }
             } else {
                 runBlocking {
@@ -66,7 +66,7 @@ open class PipelineStatus(val state: KafkaStreams.State?, var isError: Boolean) 
                 statusMsg += ", stop cause: $prevStateDescription"
             }
             if (exceptionMsg != null) {
-                logger.log(levelIfNoException, exceptionCause, "$statusMsg, Exception: {exception}", exceptionMsg)
+                logger.log(levelIfNoException, exceptionCause, "$statusMsg, exception: {exception}", exceptionMsg)
             } else {
                 logger.log(levelIfNoException, "$statusMsg")
             }


### PR DESCRIPTION
Previously, we only caught a StreamsException. However, the creation might fail for many reasons (for example, incorrect configuration).

We want to catch any exception so that we mark the pipeline creation as failed and we don't stop the connection to the scheduler.

Previously, on configuration errors, the exception would be bubbled to the PipelineSubscriber event loop, and the connection to the scheduler would be broken. We would try to reconnect, but on reconnect the scheduler would try to re-init the problematic pipeline (with the same id). This then led to an error about existing uncleaned KafkaStreams state in /tmp. This latter error was being handled cleanly (i.e not breaking the connection to the scheduler anymore), but would mask the real reason for the failure when looking at the pipeline status (via k8s or seldon cli).