### PR TITLE
fix(scheduler): Increase event hub buffer inline with other components

### DIFF
--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -588,6 +588,7 @@ func (p *IncrementalProcessor) modelUpdate(modelName string) error {
 			logger.Debugf("sync: No server - removing for %s", modelName)
 			if err := p.removeRouteForServerInEnvoyCache(modelName); err != nil {
 				logger.WithError(err).Errorf("Failed to remove model route from envoy %s", modelName)
+				p.modelStore.UnlockModel(modelName)
 				return err
 			}
 			modelRemoved = true

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -32,7 +32,7 @@ import (
 const (
 	grpcMaxConcurrentStreams     = 1_000_000
 	pipelineEventHandlerName     = "kafka.dataflow.server.pipelines"
-	pendingEventsQueueSize   int = 10
+	pendingEventsQueueSize   int = 1000
 	sourceChainerServer          = "chainer-server"
 )
 

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	grpcMaxConcurrentStreams       = 1_000_000
-	pendingEventsQueueSize     int = 10
+	pendingEventsQueueSize     int = 1000
 	modelEventHandlerName          = "scheduler.server.models"
 	serverEventHandlerName         = "scheduler.server.servers"
 	experimentEventHandlerName     = "scheduler.server.experiments"

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -40,7 +40,7 @@ const (
 	serverEventHandlerName         = "scheduler.server.servers"
 	experimentEventHandlerName     = "scheduler.server.experiments"
 	pipelineEventHandlerName       = "scheduler.server.pipelines"
-	defaultBatchWaitMillis         = 250 * time.Millisecond
+	defaultBatchWait               = 250 * time.Millisecond
 )
 
 var (
@@ -183,7 +183,7 @@ func NewSchedulerServer(
 		},
 		serverEventStream: ServerEventStream{
 			streams:         make(map[pb.Scheduler_SubscribeServerStatusServer]*ServerSubscription),
-			batchWaitMillis: defaultBatchWaitMillis,
+			batchWaitMillis: defaultBatchWait,
 			trigger:         nil,
 			pendingEvents:   map[string]struct{}{},
 		},

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -196,7 +196,7 @@ func (s *SchedulerServer) updateServerStatus(evt coordinator.ModelEventMsg) erro
 	// we are coalescing events so we only send one event (the latest status) per server
 	s.serverEventStream.pendingEvents[modelVersion.Server()] = struct{}{}
 	if s.serverEventStream.trigger == nil {
-		s.serverEventStream.trigger = time.AfterFunc(defaultBatchWaitMillis, s.sendServerStatus)
+		s.serverEventStream.trigger = time.AfterFunc(defaultBatchWait, s.sendServerStatus)
 	}
 	s.serverEventStream.pendingLock.Unlock()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This change increases the pending queues in the event hub (coordinator) for server and model events delivery. There is going to be a tradeoff, with a bigger buffer we allow more work to pile up if the producer is faster than the consumer. However in practice setting it to `1000` has worked fined in other cases, check [here](https://github.com/SeldonIO/seldon-core/blob/f8df070fb201aee625cb1abf764f4122ebb84b05/scheduler/pkg/envoy/processor/incremental.go#L37).

It also reduces the risk of deadlocks as producers will block otherwise when trying to publish on a queue that it full.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
- changing all pending queues sizes to 1000
- fix a missing unlock call from reviewing code around this area
