### PR TITLE
fix(controller): reload models upon reconnect to the scheduler

### DIFF
--- a/operator/controllers/mlops/model_controller.go
+++ b/operator/controllers/mlops/model_controller.go
@@ -96,7 +96,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return reconcile.Result{}, err
 	}
 
-	err, retry := r.Scheduler.LoadModel(ctx, model)
+	retry, err := r.Scheduler.LoadModel(ctx, model, nil)
 	if err != nil {
 		r.updateStatusFromError(ctx, logger, model, retry, err)
 		if retry {

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -31,6 +31,10 @@ import (
 	"github.com/seldonio/seldon-core/operator/v2/pkg/utils"
 )
 
+// LoadModel loads a model to the scheduler
+// If the connection is not provided, get a new one
+// In the case of errors we check if the error is retryable and return a boolean to indicate if the error is retryable
+// For the cases we think we should retry, check logic in `checkErrorRetryable`
 func (s *SchedulerClient) LoadModel(ctx context.Context, model *v1alpha1.Model, conn *grpc.ClientConn) (bool, error) {
 	logger := s.logger.WithName("LoadModel")
 	retryableError := false
@@ -331,6 +335,55 @@ func (s *SchedulerClient) handlePendingDeleteModels(
 			if retryUnload, err := s.UnloadModel(ctx, &model, conn); err != nil {
 				if retryUnload {
 					s.logger.Info("Failed to call unload model", "model", model.Name)
+					continue
+				} else {
+					// this is essentially a failed pre-condition (model does not exist in scheduler)
+					// we can remove
+					// note that there is still the chance the model is not updated from the different model servers
+					// upon reconnection of the scheduler
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						model.ObjectMeta.Finalizers = utils.RemoveStr(model.ObjectMeta.Finalizers, constants.ModelFinalizerName)
+						if errUpdate := s.Update(ctx, &model); errUpdate != nil {
+							s.logger.Error(err, "Failed to remove finalizer", "model", model.Name)
+							return errUpdate
+						}
+						s.logger.Info("Removed finalizer", "model", model.Name)
+						return nil
+					})
+					if retryErr != nil {
+						s.logger.Error(err, "Failed to remove finalizer after retries", "model", model.Name)
+					}
+				}
+			} else {
+				// if the model exists in the scheduler so we wait until we get the event from the subscription stream
+				s.logger.Info("Unload model called successfully, not removing finalizer", "model", model.Name)
+			}
+			break
+		}
+	}
+}
+
+// when need to reload the models that are marked in k8s as loaded, this is because there could be a
+// case where the scheduler has load the models state (if the scheduler and the model server restart at the same time)
+func (s *SchedulerClient) handleLoadedModels(
+	ctx context.Context, namespace string, conn *grpc.ClientConn) {
+	modelList := &v1alpha1.ModelList{}
+	// Get all models in the namespace
+	err := s.List(
+		ctx,
+		modelList,
+		client.InNamespace(namespace),
+	)
+	if err != nil {
+		return
+	}
+
+	for _, model := range modelList.Items {
+		// models that are not in the process of being deleted has DeletionTimestamp as zero
+		if model.ObjectMeta.DeletionTimestamp.IsZero() {
+			if retryLoad, err := s.LoadModel(ctx, &model, conn); err != nil {
+				if retryLoad {
+					s.logger.Info("Failed to call load model", "model", model.Name)
 					continue
 				} else {
 					// this is essentially a failed pre-condition (model does not exist in scheduler)

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -334,7 +334,7 @@ func (s *SchedulerClient) handlePendingDeleteModels(
 	// Check if any models are being deleted
 	for _, model := range modelList.Items {
 		if !model.ObjectMeta.DeletionTimestamp.IsZero() {
-			s.logger.Info("Calling Unload model (on reconnect)", "model", model.Name)
+			s.logger.V(1).Info("Calling Unload model (on reconnect)", "model", model.Name)
 			if retryUnload, err := s.UnloadModel(ctx, &model, conn); err != nil {
 				if retryUnload {
 					// caller will retry as this method is called on connection reconnect
@@ -363,7 +363,7 @@ func (s *SchedulerClient) handlePendingDeleteModels(
 				s.logger.Info("Unload model called successfully, not removing finalizer", "model", model.Name)
 			}
 		} else {
-			s.logger.Info("Model is not being deleted, not unloading", "model", model.Name)
+			s.logger.V(1).Info("Model is not being deleted, not unloading", "model", model.Name)
 		}
 	}
 }
@@ -386,15 +386,15 @@ func (s *SchedulerClient) handleLoadedModels(
 	for _, model := range modelList.Items {
 		// models that are not in the process of being deleted has DeletionTimestamp as zero
 		if model.ObjectMeta.DeletionTimestamp.IsZero() {
-			s.logger.Info("Calling Load model (on reconnect)", "model", model.Name)
+			s.logger.V(1).Info("Calling Load model (on reconnect)", "model", model.Name)
 			if _, err := s.LoadModel(ctx, &model, conn); err != nil {
 				// if this is a retryable error, we will retry on the next connection reconnect
 				s.logger.Error(err, "Failed to call load model", "model", model.Name)
 			} else {
-				s.logger.Info("Load model called successfully", "model", model.Name)
+				s.logger.V(1).Info("Load model called successfully", "model", model.Name)
 			}
 		} else {
-			s.logger.Info("Model is being deleted, not loading", "model", model.Name)
+			s.logger.V(1).Info("Model is being deleted, not loading", "model", model.Name)
 		}
 	}
 }

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -271,53 +271,6 @@ func (s *SchedulerClient) SubscribeModelEvents(ctx context.Context, conn *grpc.C
 	return nil
 }
 
-func (s *SchedulerClient) reconcileLoadedModels(
-	ctx context.Context, namespace string, conn *grpc.ClientConn) {
-	modelList := &v1alpha1.ModelList{}
-	// Get all models in the namespace
-	err := s.List(
-		ctx,
-		modelList,
-		client.InNamespace(namespace),
-	)
-	if err != nil {
-		return
-	}
-
-	// Check if any models are being deleted
-	for _, model := range modelList.Items {
-		if model.ObjectMeta.DeletionTimestamp.IsZero() {
-			if retryUnload, err := s.UnloadModel(ctx, &model, conn); err != nil {
-				if retryUnload {
-					s.logger.Info("Failed to call unload model", "model", model.Name)
-					continue
-				} else {
-					// this is essentially a failed pre-condition (model does not exist in scheduler)
-					// we can remove
-					// note that there is still the chance the model is not updated from the different model servers
-					// upon reconnection of the scheduler
-					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						model.ObjectMeta.Finalizers = utils.RemoveStr(model.ObjectMeta.Finalizers, constants.ModelFinalizerName)
-						if errUpdate := s.Update(ctx, &model); errUpdate != nil {
-							s.logger.Error(err, "Failed to remove finalizer", "model", model.Name)
-							return errUpdate
-						}
-						s.logger.Info("Removed finalizer", "model", model.Name)
-						return nil
-					})
-					if retryErr != nil {
-						s.logger.Error(err, "Failed to remove finalizer after retries", "model", model.Name)
-					}
-				}
-			} else {
-				// if the model exists in the scheduler so we wait until we get the event from the subscription stream
-				s.logger.Info("Unload model called successfully, not removing finalizer", "model", model.Name)
-			}
-			break
-		}
-	}
-}
-
 func (s *SchedulerClient) handlePendingDeleteModels(
 	ctx context.Context, namespace string, conn *grpc.ClientConn) {
 	modelList := &v1alpha1.ModelList{}

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -362,7 +362,8 @@ func (s *SchedulerClient) handlePendingDeleteModels(
 				// if the model exists in the scheduler so we wait until we get the event from the subscription stream
 				s.logger.Info("Unload model called successfully, not removing finalizer", "model", model.Name)
 			}
-			break
+		} else {
+			s.logger.Info("Model is not being deleted, not unloading", "model", model.Name)
 		}
 	}
 }
@@ -392,7 +393,8 @@ func (s *SchedulerClient) handleLoadedModels(
 			} else {
 				s.logger.Info("Load model called successfully", "model", model.Name)
 			}
-			break
+		} else {
+			s.logger.Info("Model is being deleted, not loading", "model", model.Name)
 		}
 	}
 }

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -334,6 +334,7 @@ func (s *SchedulerClient) handlePendingDeleteModels(
 	// Check if any models are being deleted
 	for _, model := range modelList.Items {
 		if !model.ObjectMeta.DeletionTimestamp.IsZero() {
+			s.logger.Info("Calling Unload model (on reconnect)", "model", model.Name)
 			if retryUnload, err := s.UnloadModel(ctx, &model, conn); err != nil {
 				if retryUnload {
 					// caller will retry as this method is called on connection reconnect
@@ -384,6 +385,7 @@ func (s *SchedulerClient) handleLoadedModels(
 	for _, model := range modelList.Items {
 		// models that are not in the process of being deleted has DeletionTimestamp as zero
 		if model.ObjectMeta.DeletionTimestamp.IsZero() {
+			s.logger.Info("Calling Load model (on reconnect)", "model", model.Name)
 			if _, err := s.LoadModel(ctx, &model, conn); err != nil {
 				// if this is a retryable error, we will retry on the next connection reconnect
 				s.logger.Error(err, "Failed to call load model", "model", model.Name)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

In Core 2, the scheduler state of the models are not persisted to local storage and the system relies on the model servers to keep this state. In the case the scheduler restarts, the models servers will reconnect and then announce to the scheduler the models that they have loaded, which allows the scheduler to recover this state.

However this suffers from the issue that if the model server AND the scheduler restart, then the models states that were handled by this model server is effectively lost.

In this case there is a mismatch between between the state of the scheduler (models from the restarted model server are gone) and the controller (models from the restarted model server are ready).

We rely on k8s etcd state to recover this state loss on the scheduler side and in this PR we reload models that are marked in k8s on the controller reconnecting to the scheduler.

Note that we need to holistically think about this issue in the future but for now we decided we recover the state from k8s.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes:
- #5032
- internal: INFRA_620

**Special notes for your reviewer**:
