### PR TITLE
fix(modelgateway): kafka topics with correct number of partitions

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1163,7 +1163,7 @@ spec:
           value: '{{ .Values.modelgateway.workers }}'
         - name: KAFKA_DEFAULT_REPLICATION_FACTOR
           value: '{{ .Values.kafka.topics.replicationFactor }}'
-        - name: KAFKA_DEFAULT_PARTITIONS_DEFAULT
+        - name: KAFKA_DEFAULT_NUM_PARTITIONS
           value: '{{ .Values.kafka.topics.numPartitions }}'
         - name: CONTROL_PLANE_SECURITY_PROTOCOL
           value: '{{ .Values.security.controlplane.protocol }}'

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -252,7 +252,7 @@ serverConfig:
       pullPolicy: IfNotPresent
       registry: docker.io
       repository: seldonio/mlserver
-      tag: 1.3.5
+      tag: 1.5.0
     serverCapabilities: "mlserver,alibi-detect,alibi-explain,huggingface,lightgbm,mlflow,python,sklearn,spark-mlib,xgboost"
     modelVolumeStorage: 1Gi
     resources:

--- a/k8s/kustomize/helm-components-sc/patch_modelgateway.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_modelgateway.yaml
@@ -14,7 +14,7 @@ spec:
             value: '{{ .Values.modelgateway.workers }}'
           - name: KAFKA_DEFAULT_REPLICATION_FACTOR
             value: '{{ .Values.kafka.topics.replicationFactor }}'
-          - name: KAFKA_DEFAULT_PARTITIONS_DEFAULT
+          - name: KAFKA_DEFAULT_NUM_PARTITIONS
             value: '{{ .Values.kafka.topics.numPartitions }}'
           - name: CONTROL_PLANE_SECURITY_PROTOCOL
             value: '{{ .Values.security.controlplane.protocol }}'

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -796,7 +796,7 @@ spec:
           value: '8'
         - name: KAFKA_DEFAULT_REPLICATION_FACTOR
           value: '1'
-        - name: KAFKA_DEFAULT_PARTITIONS_DEFAULT
+        - name: KAFKA_DEFAULT_NUM_PARTITIONS
           value: '1'
         - name: CONTROL_PLANE_SECURITY_PROTOCOL
           value: 'PLAINTEXT'


### PR DESCRIPTION
The number of partitions with which model-specific kafka topics is created needs to be the same as the number of partitions for other topics (pipelines/experiments/etc). This is a Kafka Streams constraint in order for joins to work correctly.

Until now, an incorrect environment variable was being passed to modelgateway, which meant that it was always creating topics with 1 partition. This in turn led to dataflow processing getting stuck whenever other topics were created with multiple partitions

**Fixed issues**:
- INFRA-822: Pipelines get stuck on triggers/joins
