### PR TITLE
fix(modelgateway): KafkaAdmin error when fetching OIDC token

### DIFF
--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -127,7 +127,7 @@ func (kc *InferKafkaHandler) setup(consumerConfig kafka.ConfigMap, producerConfi
 	logger.Infof("Created consumer %s", kc.consumer.String())
 
 	if kc.consumerConfig.SeldonKafkaConfig.HasKafkaBootstrapServer() {
-		kc.adminClient, err = kafka.NewAdminClient(&consumerConfig)
+		kc.adminClient, err = kafka.NewAdminClientFromProducer(kc.producer)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When a new model is added, modelgateway creates quite a few connections to the kafka cluster, in quick succession (producer, consumer, admin).

When using Confluent Cloud Kafka with OAUTHBEARER/OIDC token auth, the KafkaAdmin client failed to fetch the OIDC token sometimes. In tests we were using MS Entra ID, unsure if there is some rate-limiting on fetching tokens.

Because we're not using the admin and producer connections concurrently (admin mostly used to create topics on model add), here we're letting the kafka admin client reuse the producer connection (and the same token).

**Fixed issues**:
- INFRA-867: Modelgateway sometimes fails to fetch OIDC tokens