### PR TITLE
build(deps): bump dataflow dependency versions

### DIFF
--- a/scheduler/data-flow/build.gradle.kts
+++ b/scheduler/data-flow/build.gradle.kts
@@ -33,16 +33,16 @@ dependencies {
 
     // gRPC
     implementation("io.grpc:grpc-kotlin-stub:1.4.1")
-    implementation("io.grpc:grpc-stub:1.61.1")
-    implementation("io.grpc:grpc-protobuf:1.61.1")
-    runtimeOnly("io.grpc:grpc-netty-shaded:1.61.1")
-    implementation("com.google.protobuf:protobuf-java:3.25.2")
-    implementation("com.google.protobuf:protobuf-kotlin:3.25.2")
+    implementation("io.grpc:grpc-stub:1.62.2")
+    implementation("io.grpc:grpc-protobuf:1.62.2")
+    runtimeOnly("io.grpc:grpc-netty-shaded:1.62.2")
+    implementation("com.google.protobuf:protobuf-java:3.25.3")
+    implementation("com.google.protobuf:protobuf-kotlin:3.25.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     implementation("com.michael-bull.kotlin-retry:kotlin-retry:1.0.9")
 
     // k8s
-    implementation("io.kubernetes:client-java:19.0.0")
+    implementation("io.kubernetes:client-java:20.0.0")
 
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.2")
@@ -51,8 +51,8 @@ dependencies {
 
     // transitive dependencies constraints
     constraints {
-        implementation("org.apache.commons:commons-compress:1.26.0") {
-            because("version 1.24.0 pulled by io.kubernetes:client-java contains high CVEs")
+        implementation("org.apache.commons:commons-compress:1.26.1") {
+            because("version 1.25.0 pulled by io.kubernetes:client-java contains high CVEs")
         }
     }
 }

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/mtls/K8sCertSecretsProvider.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/mtls/K8sCertSecretsProvider.kt
@@ -44,14 +44,14 @@ object K8sCertSecretsProvider {
         Configuration.setDefaultApiClient(client)
 
         if (certs.clientSecret.isNotEmpty()) {
-            val clientSecret = CoreV1Api().readNamespacedSecret(certs.clientSecret, namespace, null)
+            val clientSecret = CoreV1Api().readNamespacedSecret(certs.clientSecret, namespace).execute()
             extractCertAndStore(clientSecret, certs.keyPath)
             extractCertAndStore(clientSecret, certs.certPath)
             extractCertAndStore(clientSecret, certs.caCertPath)
         }
 
         if (certs.brokerSecret.isNotEmpty()) {
-            val brokerSecret = CoreV1Api().readNamespacedSecret(certs.brokerSecret, namespace, null)
+            val brokerSecret = CoreV1Api().readNamespacedSecret(certs.brokerSecret, namespace).execute()
             extractCertAndStore(brokerSecret, certs.brokerCaCertPath)
         }
     }

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/sasl/KubernetesSecretProvider.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/sasl/KubernetesSecretProvider.kt
@@ -30,7 +30,7 @@ object KubernetesSecretProvider : SecretsProvider {
 
         return try {
             Configuration.setDefaultApiClient(client)
-            val secret = CoreV1Api().readNamespacedSecret(name, namespace, null)
+            val secret = CoreV1Api().readNamespacedSecret(name, namespace).execute()
             secret.data ?: mapOf()
         } catch (e: ApiException) {
             logger.warn("unable to read secret $name from namespace $namespace")


### PR DESCRIPTION
- bump io.grpc 1.61.1 -> 1.62.2
- bump google.protobuf 3.25.2 -> 3.25.3
- bump io.kubernetes:client-java 19.0.0 -> 20.0.0

minor API deprecation fixes were required for the k8s client-java version bump

**Special notes for your reviewer**:
- tested with Confluent Cloud via OAUTHBEARER connection (for k8s client-java secrets reading) and smoke-tests.sh. Runs just as well as before.