### PR TITLE
fix(dataflow): CVEs related to com.microsoft.azure:adal4j

### DIFF
--- a/scheduler/data-flow/build.gradle.kts
+++ b/scheduler/data-flow/build.gradle.kts
@@ -42,7 +42,9 @@ dependencies {
     implementation("com.michael-bull.kotlin-retry:kotlin-retry:1.0.9")
 
     // k8s
-    implementation("io.kubernetes:client-java:20.0.0")
+    implementation("io.kubernetes:client-java:20.0.1") {
+        exclude("com.microsoft.azure", "adal4j")
+    }
 
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.2")


### PR DESCRIPTION
com.microsof.azure:adal4j is a deprecated library, and an _optional_ dependency of io.kubernetes:client-java.

However, when building fat-jars, gradle and the "shadow" plugin fetches all transitive depdendencies, including optional ones (i.e ones which are not used).

In this case, we don't use any of the code in adal4j via io.kubernetes.

**UNTESTED** with confluent cloud due to external issue. 

This shouldn't make a difference; we are using MS Entra ID for OAUTHBEARER auth, and MS AD (Active Directory) was the previous name for that. 

adal4j is a deprecated library handling interactions with MS AD. 

However, we shouldn't need to use it via k8s. Rather, the kafka streams library will make the right HTTP calls to Entra ID to fetch a token. 

So this should be unrelated, but it would be good to make sure. Marked as draft because of not being able to test with Confluent Cloud yet.
