### PR TITLE
fix(operator): Subscriptions to scheduler stop if scheduler restarts

### DIFF
--- a/operator/controllers/mlops/seldonruntime_controller.go
+++ b/operator/controllers/mlops/seldonruntime_controller.go
@@ -169,6 +169,12 @@ func (r *SeldonRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return reconcile.Result{}, err
 	}
 
+	if seldonRuntime.Status.IsConditionReady(mlopsv1alpha1.SchedulerReady) {
+		if err := r.Scheduler.KeepConnection(seldonRuntime.Namespace); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -130,6 +130,11 @@ func (s *SchedulerClient) RemoveConnection(namespace string) {
 	}
 }
 
+func (s *SchedulerClient) KeepConnection(namespace string) error {
+	_, err := s.getConnection(namespace)
+	return err
+}
+
 // A smoke test allows us to quickly check if we actually have a functional grpc connection to the scheduler
 func (s *SchedulerClient) smokeTestConnection(conn *grpc.ClientConn) error {
 	grcpClient := scheduler.NewSchedulerClient(conn)


### PR DESCRIPTION


**What this PR does / why we need it**:
Subscriptions to scheduler stop if scheduler stops or restarts. Further events, like model/server scaling, from scheduler will be ignored. To solve it, SeldonRuntimeController reconnects and subscribes to scheduler if its status is ready

