### PR TITLE
fix(dataflow): Do not skip events to remove old pipeline versions

### DIFF
--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -342,20 +342,19 @@ func (ps *PipelineStore) terminateOldUnterminatedPipelinesIfNeeded(pipeline *Pip
 func (ps *PipelineStore) SetPipelineState(name string, versionNumber uint32, uid string, status PipelineStatus, reason string, source string) error {
 	logger := ps.logger.WithField("func", "SetPipelineState")
 	logger.Debugf("Attempt to set state on pipeline %s:%d status:%s", name, versionNumber, status.String())
-	evts, err := ps.setPipelineStateImpl(name, versionNumber, uid, status, reason)
+	evts, err := ps.setPipelineStateImpl(name, versionNumber, uid, status, reason, source)
 	if err != nil {
 		return err
 	}
 	if ps.eventHub != nil {
 		for _, evt := range evts {
-			evt.Source = source
 			ps.eventHub.PublishPipelineEvent(setStatusPipelineEventSource, *evt)
 		}
 	}
 	return nil
 }
 
-func (ps *PipelineStore) setPipelineStateImpl(name string, versionNumber uint32, uid string, status PipelineStatus, reason string) ([]*coordinator.PipelineEventMsg, error) {
+func (ps *PipelineStore) setPipelineStateImpl(name string, versionNumber uint32, uid string, status PipelineStatus, reason, source string) ([]*coordinator.PipelineEventMsg, error) {
 	var evts []*coordinator.PipelineEventMsg
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
@@ -367,8 +366,12 @@ func (ps *PipelineStore) setPipelineStateImpl(name string, versionNumber uint32,
 					PipelineName:    pipelineVersion.Name,
 					PipelineVersion: pipelineVersion.Version,
 					UID:             pipelineVersion.UID,
+					Source:          source,
 				})
 				if status == PipelineReady {
+					// note that we are not setting the source for these events as we do not want to discard them in the chainer service
+					// i.e in handlePipelineEvent we want to process the termination events even though they are triggered by the chainer
+					// to set the status of the new version of the pipeline to ready
 					evts = append(evts, ps.terminateOldUnterminatedPipelinesIfNeeded(pipeline)...)
 				}
 				if !pipeline.Deleted && ps.db != nil {


### PR DESCRIPTION
In https://github.com/SeldonIO/seldon-core/pull/5080 there is a change to skip events coming from `chainer-server`, this essentially has stopped the flow of removing old version of pipelines during a rolling update. The reason being is that the logic that triggers the removal of old versions of the pipeline ([here](https://github.com/SeldonIO/seldon-core/blob/7d39456b5a38e24715f0dee002dbbd9e56d8f366/scheduler/pkg/store/pipeline/store.go#L371-L373)) is eventually coming from setting the status of the new version of the pipeline from an event sent from the chainer-server.

This PR then makes the change to not set the source of the events for deleting old version and therefore they can be processed further by chainer `handlePipelineEvent`.

This seems not very intuitive but I am not sure if there is a better way at the minute without a big refactor.
