### PR TITLE
fix: replace assert with if in egreedy router

### DIFF
--- a/components/routers/epsilon-greedy/EpsilonGreedy.py
+++ b/components/routers/epsilon-greedy/EpsilonGreedy.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class EpsilonGreedy(object):
-    """ Multi-armed bandit routing using epsilon-greedy strategy.
+    """Multi-armed bandit routing using epsilon-greedy strategy.
 
     This class implements epsilon-greedy routing. The rewards are assumed to
     come from a Bernoulli distribution. The reward is assumed to be a single
@@ -57,8 +57,10 @@ class EpsilonGreedy(object):
 
         try:
             n_branches = int(n_branches)
-            assert n_branches > 0
-        except (TypeError, ValueError, AssertionError) as e:
+
+            if n_branches < 1:
+                raise ValueError("n_branches must be greater than 0")
+        except (TypeError, ValueError) as e:
             logger.exception("n_branches parameter must be given")
             raise
 

--- a/components/routers/epsilon-greedy/test_EpsilonGreedy.py
+++ b/components/routers/epsilon-greedy/test_EpsilonGreedy.py
@@ -3,13 +3,16 @@ import numpy as np
 from collections import Counter
 from EpsilonGreedy import EpsilonGreedy
 
+
 def test_no_branches():
     with pytest.raises(TypeError):
         eg = EpsilonGreedy()
 
+
 def test_negative_branches():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         eg = EpsilonGreedy(n_branches=-1)
+
 
 def test_init():
     eg = EpsilonGreedy(n_branches=3, epsilon=0.15, seed=1)
@@ -18,8 +21,9 @@ def test_init():
     assert eg.epsilon == 0.15
     assert np.array_equal(eg.branch_values, np.zeros_like(eg.branch_values))
 
+
 def test_statistics():
     eg = EpsilonGreedy(n_branches=3, epsilon=0.1, seed=1, best_branch=0)
-    routes = [eg.route(features=None,feature_names=None) for _ in range(100000)]
+    routes = [eg.route(features=None, feature_names=None) for _ in range(100000)]
     counter = Counter(routes)
-    assert np.isclose(counter[0]/100000, 1-eg.epsilon, atol=0, rtol=0.01)
+    assert np.isclose(counter[0] / 100000, 1 - eg.epsilon, atol=0, rtol=0.01)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR fixes an improper use of `assert` in the Epsilon Greedy Router. An `assert` is currently used to ensure that a passed in argument `n_branches` is greater than 0. However, if this code is running in production with the `-O` optimize flag, then this assert will be ignored by Python and potentially cause a later `IndexError`.

To replicate this issue, you can run the test suite for this file by `cd`ing into the `components/routers/epsilon-greedy` directory, then running `pytest`. The tests will pass as expected. However, if you run `python -O -m pytest`, one test will fail since the assertion is ignored, leading to an `IndexError` thrown by a later `random.choice` with less than 1 choice.

The code changes the `assert` to an `if` conditional that raises a `ValueError` explaining the mistake.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Aside from the change in error type on line 13 of `test_EpsilonGreedy.py`, the changes are due only to black.

```release-note
Changes EpsilonGreedy router to raise a ValueError instead of an AssertionError on an improper argument
```