### PR TITLE
fix: Handle unload too quick after load

### DIFF
--- a/samples/stress-tests.sh
+++ b/samples/stress-tests.sh
@@ -101,7 +101,7 @@ function status() {
 # The following functions are the `task` options that can be called by the user.
 
 function tfsimple() {
-      echo ${1}
+      echo $i
       sed  's/name: tfsimple1/name: tfsimple'"$1"'/g' models/tfsimple1.yaml > /tmp/models/tfsimple${1}.yaml
       load model /tmp/models/tfsimple${1}.yaml
       status model tfsimple${1}
@@ -111,7 +111,7 @@ function tfsimple() {
 }
 
 function iris() {
-      echo ${1}
+      echo $i
       sed  's/name: iris/name: iris'"$1"'/g' models/iris-v1.yaml > /tmp/models/iris${1}.yaml
       load model /tmp/models/iris${1}.yaml
       status model iris${1}
@@ -121,48 +121,25 @@ function iris() {
 }
 
 function tfsimple_pipeline() {
-      echo ${1}
-      model_1=$((1 + $RANDOM % 20))
-      model_2=$((1 + $RANDOM % 20))
-      echo '''
-apiVersion: mlops.seldon.io/v1alpha1
-kind: Pipeline
-metadata:
-  name: tfsimples'${1}'
-spec:
-  steps:
-    - name: tfsimple'${model_1}'
-    - name: tfsimple'${model_2}'
-      inputs:
-      - tfsimple'${model_1}'
-      tensorMap:
-        tfsimple'${model_1}'.outputs.OUTPUT0: INPUT0
-        tfsimple'${model_1}'.outputs.OUTPUT1: INPUT1
-  output:
-    steps:
-    - tfsimple'${model_2}'
-''' > /tmp/pipelines/tfsimples${1}.yaml
-      
-      sed  's/name: tfsimple1/name: tfsimple'"${model_1}"'/g' models/tfsimple1.yaml > /tmp/models/tfsimple${model_1}.yaml
-      load model /tmp/models/tfsimple${model_1}.yaml
-
-      sed  's/name: tfsimple1/name: tfsimple'"${model_2}"'/g' models/tfsimple1.yaml > /tmp/models/tfsimple${model_2}.yaml
-      load model /tmp/models/tfsimple${model_2}.yaml
-
-      status model tfsimple${model_1}
-      status model tfsimple${model_2}
-
+      echo $i
+      sed  's/name: tfsimples/name: tfsimples'"$1"'/g' pipelines/tfsimples.yaml > /tmp/pipelines/tfsimples${1}.yaml
+      load model ./models/tfsimple1.yaml
+      load model ./models/tfsimple2.yaml
+      status model tfsimple1
+      status model tfsimple2
       load pipeline /tmp/pipelines/tfsimples${1}.yaml
       status pipeline tfsimples${1}
       seldon pipeline infer tfsimples${1} '{"inputs":[{"name":"INPUT0","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]}]}'
       seldon pipeline infer tfsimples${1} --inference-mode grpc '{"model_name":"simple","inputs":[{"name":"INPUT0","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]}]}'
       unload pipeline tfsimples${1} /tmp/pipelines/tfsimples${1}.yaml
-      unload model tfsimple${model_1} /tmp/models/tfsimple${model_1}.yaml
-      unload model tfsimple${model_2} /tmp/models/tfsimple${model_2}.yaml
+      # we cant unload the models here as they are used by other pipelines
+      # TODO: create sub models for each pipeline?
+      # unload model tfsimple1 ./models/tfsimple1.yaml
+      # unload model tfsimple2 ./models/tfsimple2.yaml
 }
 
 function tfsimple_join_pipeline() {
-      echo ${1}
+      echo $i
       sed  's/name: join/name: join'"$1"'/g' pipelines/tfsimples-join.yaml > /tmp/pipelines/tfsimples-join${1}.yaml
       load model ./models/tfsimple1.yaml
       load model ./models/tfsimple2.yaml
@@ -175,7 +152,7 @@ function tfsimple_join_pipeline() {
       seldon pipeline infer join${1} '{"inputs":[{"name":"INPUT0","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]}]}'
       seldon pipeline infer join${1} --inference-mode grpc '{"model_name":"simple","inputs":[{"name":"INPUT0","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]}]}'
       unload pipeline join${1} /tmp/pipelines/tfsimples-join${1}.yaml
-      # we cant unload the models here as they are used by other pipelines ?
+      # we cant unload the models here as they are used by other pipelines
       # TODO: create sub models for each pipeline?
       # unload model tfsimple1 ./models/tfsimple1.yaml
       # unload model tfsimple2 ./models/tfsimple2.yaml

--- a/samples/stress-tests.sh
+++ b/samples/stress-tests.sh
@@ -101,7 +101,7 @@ function status() {
 # The following functions are the `task` options that can be called by the user.
 
 function tfsimple() {
-      echo $i
+      echo ${1}
       sed  's/name: tfsimple1/name: tfsimple'"$1"'/g' models/tfsimple1.yaml > /tmp/models/tfsimple${1}.yaml
       load model /tmp/models/tfsimple${1}.yaml
       status model tfsimple${1}
@@ -111,7 +111,7 @@ function tfsimple() {
 }
 
 function iris() {
-      echo $i
+      echo ${1}
       sed  's/name: iris/name: iris'"$1"'/g' models/iris-v1.yaml > /tmp/models/iris${1}.yaml
       load model /tmp/models/iris${1}.yaml
       status model iris${1}
@@ -121,25 +121,48 @@ function iris() {
 }
 
 function tfsimple_pipeline() {
-      echo $i
-      sed  's/name: tfsimples/name: tfsimples'"$1"'/g' pipelines/tfsimples.yaml > /tmp/pipelines/tfsimples${1}.yaml
-      load model ./models/tfsimple1.yaml
-      load model ./models/tfsimple2.yaml
-      status model tfsimple1
-      status model tfsimple2
+      echo ${1}
+      model_1=$((1 + $RANDOM % 20))
+      model_2=$((1 + $RANDOM % 20))
+      echo '''
+apiVersion: mlops.seldon.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: tfsimples'${1}'
+spec:
+  steps:
+    - name: tfsimple'${model_1}'
+    - name: tfsimple'${model_2}'
+      inputs:
+      - tfsimple'${model_1}'
+      tensorMap:
+        tfsimple'${model_1}'.outputs.OUTPUT0: INPUT0
+        tfsimple'${model_1}'.outputs.OUTPUT1: INPUT1
+  output:
+    steps:
+    - tfsimple'${model_2}'
+''' > /tmp/pipelines/tfsimples${1}.yaml
+      
+      sed  's/name: tfsimple1/name: tfsimple'"${model_1}"'/g' models/tfsimple1.yaml > /tmp/models/tfsimple${model_1}.yaml
+      load model /tmp/models/tfsimple${model_1}.yaml
+
+      sed  's/name: tfsimple1/name: tfsimple'"${model_2}"'/g' models/tfsimple1.yaml > /tmp/models/tfsimple${model_2}.yaml
+      load model /tmp/models/tfsimple${model_2}.yaml
+
+      status model tfsimple${model_1}
+      status model tfsimple${model_2}
+
       load pipeline /tmp/pipelines/tfsimples${1}.yaml
       status pipeline tfsimples${1}
       seldon pipeline infer tfsimples${1} '{"inputs":[{"name":"INPUT0","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]}]}'
       seldon pipeline infer tfsimples${1} --inference-mode grpc '{"model_name":"simple","inputs":[{"name":"INPUT0","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]}]}'
       unload pipeline tfsimples${1} /tmp/pipelines/tfsimples${1}.yaml
-      # we cant unload the models here as they are used by other pipelines
-      # TODO: create sub models for each pipeline?
-      # unload model tfsimple1 ./models/tfsimple1.yaml
-      # unload model tfsimple2 ./models/tfsimple2.yaml
+      unload model tfsimple${model_1} /tmp/models/tfsimple${model_1}.yaml
+      unload model tfsimple${model_2} /tmp/models/tfsimple${model_2}.yaml
 }
 
 function tfsimple_join_pipeline() {
-      echo $i
+      echo ${1}
       sed  's/name: join/name: join'"$1"'/g' pipelines/tfsimples-join.yaml > /tmp/pipelines/tfsimples-join${1}.yaml
       load model ./models/tfsimple1.yaml
       load model ./models/tfsimple2.yaml
@@ -152,7 +175,7 @@ function tfsimple_join_pipeline() {
       seldon pipeline infer join${1} '{"inputs":[{"name":"INPUT0","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","data":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"datatype":"INT32","shape":[1,16]}]}'
       seldon pipeline infer join${1} --inference-mode grpc '{"model_name":"simple","inputs":[{"name":"INPUT0","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]},{"name":"INPUT1","contents":{"int_contents":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]},"datatype":"INT32","shape":[1,16]}]}'
       unload pipeline join${1} /tmp/pipelines/tfsimples-join${1}.yaml
-      # we cant unload the models here as they are used by other pipelines
+      # we cant unload the models here as they are used by other pipelines ?
       # TODO: create sub models for each pipeline?
       # unload model tfsimple1 ./models/tfsimple1.yaml
       # unload model tfsimple2 ./models/tfsimple2.yaml

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -207,7 +207,7 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 		// for example in the case that a model is just marked as loading on a particular server replica
 		// then it gets a delete request (before it is marked as loaded or available) we need to make sure
 		// that we can unload it from the server
-		s.store.FailedScheduling(latestModel, msg, !latestModel.HasLiveReplicas() && !latestModel.IsServerLoadingOrLoaded())
+		s.store.FailedScheduling(latestModel, msg, !latestModel.HasLiveReplicas() && !latestModel.IsLoadingOrLoadedOnServer())
 		return errors.New(msg)
 	}
 

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -119,7 +119,7 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 	}
 
 	if model.Deleted {
-		// we need to LoadedModels anyway:
+		// we need to call UpdateLoadedModels anyway:
 		// - in case where we are deleting a model that doesnt have a server (FailedSchedule), server is ""
 		// - otherwise proceed a normal
 		server := ""

--- a/scheduler/pkg/store/mesh.go
+++ b/scheduler/pkg/store/mesh.go
@@ -488,7 +488,7 @@ func (m *ModelVersion) IsLoadingOrLoaded(server string, replicaIdx int) bool {
 	return false
 }
 
-func (m *ModelVersion) IsServerLoadingOrLoaded() bool {
+func (m *ModelVersion) IsLoadingOrLoadedOnServer() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, v := range m.replicas {

--- a/scheduler/pkg/store/mesh.go
+++ b/scheduler/pkg/store/mesh.go
@@ -488,6 +488,17 @@ func (m *ModelVersion) IsLoadingOrLoaded(server string, replicaIdx int) bool {
 	return false
 }
 
+func (m *ModelVersion) IsServerLoadingOrLoaded() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, v := range m.replicas {
+		if v.State.AlreadyLoadingOrLoaded() {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *ModelVersion) HasLiveReplicas() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()


### PR DESCRIPTION
In the cases where we have a model load that is followed by unload/delete too quickly, there is an edge case where the unloading logic is confused because there is no server attached yet (while the model is being loaded from the first cmd). This change then adds another check to make sure that we consider cases where the model is still loading.

fixes INFRA-943 (internal)
Notes:
- sometimes in the model server agent we get this error now 
```
level=error msg="Failed to handle load model tfsimple1:1" Name=Client error="rpc error: code = Internal desc = State mismatch for tfsimple1:1 expected state Loading but was Unloading when trying to move to state Loaded"
```
This means that the state has changed beyond the expected flow, which is probably fine in this situation.