### PR TITLE
fix: Deal with multi model env vars

### DIFF
--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -102,8 +102,11 @@ function isEnvoy() {
 function modelMemoryBytes() {
     if (__ENV.MODEL_MEMORY_BYTES) {
         return __ENV.MODEL_MEMORY_BYTES.split(",")
+    } else if (__ENV.MODEL_TYPE) {
+        const num =  __ENV.MODEL_TYPE.split(",").length
+        return Array(num).fill(0)
     }
-    return [null]
+    return [0]
 }
 
 function inferBatchSize() {

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -79,7 +79,7 @@ function maxNumModels() {
     if (__ENV.MAX_NUM_MODELS) {
         return __ENV.MAX_NUM_MODELS.split(",")
     } else if (__ENV.MODEL_TYPE) {
-        num =  __ENV.MODEL_TYPE.split(",").length
+        const num =  __ENV.MODEL_TYPE.split(",").length
         return Array(num).fill(1)
     }
     return [1]
@@ -110,7 +110,7 @@ function inferBatchSize() {
     if (__ENV.INFER_BATCH_SIZE) {
         return __ENV.INFER_BATCH_SIZE.split(",").map( s => parseInt(s))
     } else if (__ENV.MODEL_TYPE) {
-        num =  __ENV.MODEL_TYPE.split(",").length
+        const num =  __ENV.MODEL_TYPE.split(",").length
         return Array(num).fill(1)
     }
     return [1]
@@ -120,7 +120,7 @@ function modelReplicas() {
     if (__ENV.MODEL_NUM_REPLICAS) {
         return __ENV.MODEL_NUM_REPLICAS.split(",").map( s => parseInt(s))
     } else if (__ENV.MODEL_TYPE) {
-        num =  __ENV.MODEL_TYPE.split(",").length
+        const num =  __ENV.MODEL_TYPE.split(",").length
         return Array(num).fill(1)
     }
     return [1]

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -78,8 +78,11 @@ function unloadExperiment() {
 function maxNumModels() {
     if (__ENV.MAX_NUM_MODELS) {
         return __ENV.MAX_NUM_MODELS.split(",")
+    } else if (__ENV.MODEL_TYPE) {
+        num =  __ENV.MODEL_TYPE.split(",").length
+        return Array(num).fill(1)
     }
-    return [10]
+    return [1]
 }
 
 function isSchedulerProxy() {
@@ -106,6 +109,9 @@ function modelMemoryBytes() {
 function inferBatchSize() {
     if (__ENV.INFER_BATCH_SIZE) {
         return __ENV.INFER_BATCH_SIZE.split(",").map( s => parseInt(s))
+    } else if (__ENV.MODEL_TYPE) {
+        num =  __ENV.MODEL_TYPE.split(",").length
+        return Array(num).fill(1)
     }
     return [1]
 }
@@ -113,6 +119,9 @@ function inferBatchSize() {
 function modelReplicas() {
     if (__ENV.MODEL_NUM_REPLICAS) {
         return __ENV.MODEL_NUM_REPLICAS.split(",").map( s => parseInt(s))
+    } else if (__ENV.MODEL_TYPE) {
+        num =  __ENV.MODEL_TYPE.split(",").length
+        return Array(num).fill(1)
     }
     return [1]
 }
@@ -148,6 +157,8 @@ function dataflowTag() {
 function modelNamePrefix() {
     if (__ENV.MODELNAME_PREFIX) {
         return __ENV.MODELNAME_PREFIX.split(",")
+    } else if (__ENV.MODEL_TYPE) {
+        return  __ENV.MODEL_TYPE.split(",")
     }
     return ["model"]
 }


### PR DESCRIPTION
In our k6 tests the use can specify `MODEL_TYPE` as a comma separated list. This change allows envars to be constructed based on this list without having to be explicitly specified by the user.

The main issue we are fixing with this PR is really `MODEL_NUM_REPLICAS` so it is defaults to 1s.

FIXES INFRA_944 (internal)