### PR TITLE
fix(dataflow): do not create new KafkaStreams app for existing pipelines

### DIFF
--- a/scheduler/data-flow/Makefile
+++ b/scheduler/data-flow/Makefile
@@ -16,6 +16,10 @@ lint:
 format:
 	./gradlew ktlintFormat --no-daemon --no-build-cache
 
+.PHONY: test
+test:
+	./gradlew cleanTest test
+
 .PHONY: build
 build:
 	./gradlew build --no-daemon --no-build-cache

--- a/scheduler/data-flow/build.gradle.kts
+++ b/scheduler/data-flow/build.gradle.kts
@@ -69,6 +69,9 @@ sourceSets {
 
 tasks.test {
     useJUnitPlatform()
+    testLogging {
+        events("PASSED", "SKIPPED", "FAILED")
+    }
 }
 
 java {

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
@@ -182,6 +182,10 @@ class PipelineSubscriber(
                     metadata.id,
                     previous.status.getDescription(),
                 )
+                // Calling stop() here may be superfluous (depending on the state in which the pipeline is in),
+                // but we want to ensure that we clean up the KafkaStreams state of the pipeline because
+                // otherwise we have issues in re-starting it.
+                // Calling stop() on an already stopped pipeline is safe.
                 previous.stop()
             }
         } else { // pipeline doesn't exist

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStatus.kt
@@ -15,6 +15,7 @@ import io.klogging.NoCoLogger
 import io.seldon.dataflow.DataflowStatus
 import kotlinx.coroutines.runBlocking
 import org.apache.kafka.streams.KafkaStreams
+import java.util.Objects
 
 open class PipelineStatus(val state: KafkaStreams.State?, var hasError: Boolean) : DataflowStatus {
     // Keep the previous state in case we're stopping the stream so that we can determine
@@ -86,6 +87,18 @@ open class PipelineStatus(val state: KafkaStreams.State?, var hasError: Boolean)
                 logger.log(levelIfNoException, "$statusMsg")
             }
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is StreamStopped) return false
+
+            return this.prevState == other.prevState &&
+                super.equals(other)
+        }
+
+        override fun hashCode(): Int {
+            return Objects.hash(state, hasError, exception, message, prevState)
+        }
     }
 
     class StreamStopping() : PipelineStatus(null, false) {
@@ -130,5 +143,19 @@ open class PipelineStatus(val state: KafkaStreams.State?, var hasError: Boolean)
             -> true
             else -> this.hasError
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PipelineStatus) return false
+
+        return this.state == other.state &&
+            this.hasError == other.hasError &&
+            this.exception == other.exception &&
+            this.message == other.message
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(state, hasError, exception, message)
     }
 }

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
@@ -10,6 +10,7 @@ the Change License after the Change Date as each is defined in accordance with t
 package io.seldon.dataflow
 
 import io.seldon.dataflow.kafka.security.KafkaSaslMechanisms
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -20,6 +21,7 @@ import strikt.assertions.isSuccess
 import java.util.stream.Stream
 
 internal class CliTest {
+    @DisplayName("Passing auth mechanism via cli argument")
     @ParameterizedTest(name = "{0}")
     @MethodSource("saslMechanisms")
     fun getSaslMechanism(

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/kafka/PipelineStatusTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/kafka/PipelineStatusTest.kt
@@ -1,0 +1,172 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.kafka
+
+import org.apache.kafka.streams.KafkaStreams
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import strikt.api.expect
+import strikt.assertions.isEqualTo
+import java.util.stream.Stream
+
+internal class PipelineStatusTest {
+    @DisplayName("Test PipelineStatus States")
+    @ParameterizedTest(name = "{0} expected isActive:{1} | isError:{2}")
+    @MethodSource()
+    fun checkState(
+        testName: String,
+        expectedIsActive: Boolean,
+        expectedIsError: Boolean,
+        state: PipelineStatus,
+    ) {
+        val statusIsActive = state.isActive()
+        val statusIsError = state.isError()
+
+        expect {
+            that(statusIsActive).isEqualTo(expectedIsActive)
+            that(statusIsError).isEqualTo(expectedIsError)
+        }
+    }
+
+    companion object {
+        private const val IS_ACTIVE = true
+        private const val IS_ERROR = true
+
+        @JvmStatic
+        fun checkState(): Stream<Arguments> =
+            Stream.of(
+                arguments(
+                    "StreamStopped(prevState=null)",
+                    !IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus.StreamStopped(null),
+                ),
+                arguments(
+                    "StreamStopped(prevState=StreamStopping)",
+                    !IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus.StreamStopped(PipelineStatus.StreamStopping()),
+                ),
+                arguments(
+                    "StreamStopped(prevState=nested StreamStopped without error)",
+                    !IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus.StreamStopped(
+                        PipelineStatus.StreamStopped(
+                            PipelineStatus.Started(),
+                        ),
+                    ),
+                ),
+                arguments(
+                    "StreamStopping",
+                    !IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus.StreamStopping(),
+                ),
+                arguments(
+                    "StreamStopping",
+                    !IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus.StreamStopping(),
+                ),
+                arguments(
+                    "StreamStopped(prevState=Error)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus.StreamStopped(PipelineStatus.Error(null)),
+                ),
+                arguments(
+                    "StreamStopped(prevState=nested StreamStopped with Error)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus.StreamStopped(
+                        PipelineStatus.StreamStopped(
+                            PipelineStatus.Error(KafkaStreams.State.ERROR),
+                        ),
+                    ),
+                ),
+                arguments(
+                    "Error(errorState=null)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus.Error(null),
+                ),
+                arguments(
+                    "Error(errorState=non-error,active state)",
+                    IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus.Error(KafkaStreams.State.RUNNING),
+                ),
+                arguments(
+                    "Error(errorState=non-error,non-active state)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus.Error(KafkaStreams.State.NOT_RUNNING),
+                ),
+                arguments(
+                    "Error(errorState=error state)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus.Error(KafkaStreams.State.PENDING_ERROR),
+                ),
+                arguments(
+                    "PipelineStatus(state=error state, hasError=false)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus(KafkaStreams.State.PENDING_ERROR, false),
+                ),
+                arguments(
+                    "PipelineStatus(state=error state, hasError=true)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus(KafkaStreams.State.PENDING_ERROR, true),
+                ),
+                arguments(
+                    "PipelineStatus(state=non-error,non-active state, hasError=false)",
+                    !IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus(KafkaStreams.State.NOT_RUNNING, false),
+                ),
+                arguments(
+                    "PipelineStatus(state=non-error,non-active state, hasError=true)",
+                    !IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus(KafkaStreams.State.NOT_RUNNING, true),
+                ),
+                arguments(
+                    "PipelineStatus(state=non-error,active state, hasError=false)",
+                    IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus(KafkaStreams.State.CREATED, false),
+                ),
+                arguments(
+                    "PipelineStatus(state=non-error,active state, hasError=true)",
+                    IS_ACTIVE,
+                    IS_ERROR,
+                    PipelineStatus(KafkaStreams.State.CREATED, true),
+                ),
+                arguments(
+                    "StreamStarting",
+                    IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus.StreamStarting(),
+                ),
+                arguments(
+                    "Started",
+                    IS_ACTIVE,
+                    !IS_ERROR,
+                    PipelineStatus.Started(),
+                ),
+            )
+    }
+}


### PR DESCRIPTION
This fixes a dataflow-engine bug triggered when the scheduler sends/re-sends pipeline creation messages after a restart (because it's not aware of their status across various components).

Previous behaviour:
Dataflow-engine, on receiving a command to create a pipeline, would first create a new Kafka Streams application for this pipeline, before checking if one already exists and it's running.

Because of this, triggering a control-plane restart of the scheduler would result in dataflow errors for pipelines that kept internal state (mostly pipelines making use of triggers/joins). Kafka Streams would complain about an existing application using the same state directory, fail the newly created pipeline and inform the scheduler about this.

However, in actuality the old pipeline, if it was previously running ok, would continue doing so inside dataflow. This meant that a disconnect between the state of dataflow-engine and what the scheduler knew about it was being created

New behaviour:
The introduced changes mean that dataflow-engine first checks if a pipeline with the same id is already running. If its state is ok, dataflow simply informs the scheduler that the pipeline is created, without taking further action.

If a pipeline with the same id already exists but is in a failed state, it is first stopped (local Kafka Streams state is cleaned), then an attempt is made to re-create it, with the corresponding status being sent to the scheduler.


**Which issue(s) this PR fixes:**
- INFRA-978 (internal issue) Pipelines fail to start because Kafka Streams state hasn't been cleared

**Special notes for your reviewer**:
- Tested by restarting scheduler while a pipeline using state (a join) was running on dataflow engine
- Ran pipeline smoke-tests to confirm the change hasn't introduced unexpected behaviour
