### PR TITLE
docs: replace references to Seldon Deploy with Seldon Enterprise Platform

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Seldon Core v2'
-copyright = '2021-2022 Seldon Technologies Ltd.'
+copyright = '2024 Seldon Technologies Ltd.'
 author = "Seldon Technologies Ltd"
 
 # -- General configuration ---------------------------------------------------
@@ -137,12 +137,12 @@ html_theme_options = {
         {
             "href": "https://deploy.seldon.io",
             "internal": False,
-            "title": "Seldon Deploy (Enterprise)",
+            "title": "Seldon Enterprise Platform",
         },
         {
             "href": "https://github.com/SeldonIO/seldon-deploy-sdk#seldon-deploy-sdk",
             "internal": False,
-            "title": "Seldon Deploy SDK (Enterprise)",
+            "title": "Seldon Enterprise Platform SDK",
         },
     ],
 


### PR DESCRIPTION
This is a straightforward PR that only touches 1 file to change Seldon Deploy to Seldon Enterprise Platform.