### PR TITLE
build(ansible): add options to install grafana and dashboards

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -127,6 +127,7 @@ will only install Kafka when setting up the ecosystem.
 | full_install            | bool   | yes                           | enables full ecosystem installation                      |
 | install_kafka           | bool   | `{{ full_install }}`          | installs Strimzi Kafka Operator                          |
 | install_prometheus      | bool   | `{{ full_install }}`          | installs Prometheus Operator                             |
+| install_grafana         | bool   | `{{ full_install }}`          | installs Grafana Operator                                |
 | install_certmanager     | bool   | `{{ full_install }}`          | installs Cert Manager                                    |
 | install_jaeger          | bool   | `{{ full_install }}`          | installs Jaeger                                          |
 | install_opentelemetry   | bool   | `{{ full_install }}`          | installs OpenTelemetry                                   |

--- a/ansible/playbooks/setup-ecosystem.yaml
+++ b/ansible/playbooks/setup-ecosystem.yaml
@@ -7,12 +7,14 @@
     full_install: yes
 
     install_prometheus: "{{ full_install }}"
+    install_grafana: "{{ full_install }}"
     install_kafka: "{{ full_install }}"
     install_certmanager: "{{ full_install }}"
     install_jaeger: "{{ full_install }}"
     install_opentelemetry: "{{ full_install }}"
 
     configure_prometheus: "{{ install_prometheus }}"
+    configure_grafana: "{{ install_grafana }}"
     configure_kafka: "{{ install_kafka }}"
     configure_jaeger: "{{ install_jaeger }}"
     configure_opentelemetry: "{{ install_opentelemetry }}"

--- a/ansible/playbooks/vars/default.yaml
+++ b/ansible/playbooks/vars/default.yaml
@@ -2,6 +2,14 @@
 # Default credentials.
 # These credentials are used as defaults for:
 #   - the grafana install, when configured
+#
+# For grafana, once the cluster is up and running, you may fetch the randomly generated password
+# by running (change `seldon-monitoring` to the value of the seldon_monitoring_namespace
+# variable):
+#
+# kubectl get secret --namespace seldon-monitoring grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+#
+
 # Overwrite by passing sd_user and/or sd_password variables when running the playbook
 seldon_admin_user: "admin"
 seldon_random_gen_password: "{{ lookup('password', '/dev/null chars=digits length=6') }}"

--- a/ansible/playbooks/vars/default.yaml
+++ b/ansible/playbooks/vars/default.yaml
@@ -1,4 +1,11 @@
 ---
+# Default credentials.
+# These credentials are used as defaults for:
+#   - the grafana install, when configured
+# Overwrite by passing sd_user and/or sd_password variables when running the playbook
+seldon_admin_user: "admin"
+seldon_random_gen_password: "{{ lookup('password', '/dev/null chars=digits length=6') }}"
+
 # Seldon Configuration
 seldon_mesh_namespace: seldon-mesh
 
@@ -9,7 +16,11 @@ seldon_core_v2_type_svc_type: LoadBalancer
 seldon_core_v2_scheduler_svc_type: LoadBalancer
 
 # Prometheus Operator Configuration
+seldon_monitoring_prometheus_name_generated: seldon-monitoring-prometheus
+seldon_monitoring_prometheus_url: "http://{{ seldon_monitoring_prometheus_name_generated }}.{{ seldon_monitoring_namespace }}:9090"
 seldon_monitoring_namespace: seldon-monitoring
+# Grafana
+seldon_monitoring_grafana_web_ui_port: 3000
 
 # Strimzi Kafka Configuration
 strimzi_kafka_operator_namespace: "{{ seldon_mesh_namespace }}"

--- a/ansible/roles/ecosystem/defaults/main.yaml
+++ b/ansible/roles/ecosystem/defaults/main.yaml
@@ -4,6 +4,7 @@ seldon_mesh_namespace: seldon-mesh
 
 # Installation on/off flags
 install_prometheus: true
+install_grafana: false
 install_kafka: true
 install_certmanager: true
 install_jaeger: true
@@ -11,6 +12,7 @@ install_opentelemetry: true
 
 # Configuration on/off flags
 configure_prometheus: "{{ install_prometheus }}"
+configure_grafana: "{{ install_grafana }}"
 enable_kraft: "{{ install_kafka }}"
 configure_kafka: "{{ install_kafka }}"
 configure_jaeger: "{{ install_jaeger }}"

--- a/ansible/roles/ecosystem/tasks/grafana.yaml
+++ b/ansible/roles/ecosystem/tasks/grafana.yaml
@@ -1,0 +1,15 @@
+---
+- name: Set default user
+  ansible.builtin.set_fact:
+    sd_user: "{{ seldon_admin_user }}"
+  when: sd_user is not defined
+
+- name: Set default password
+  ansible.builtin.set_fact:
+    sd_password: "{{ seldon_random_gen_password }}"
+  when: sd_password is not defined
+
+- name: "Install Grafana instance"
+  include_role:
+    name: grafana
+  when: install_grafana | bool

--- a/ansible/roles/ecosystem/tasks/main.yaml
+++ b/ansible/roles/ecosystem/tasks/main.yaml
@@ -4,6 +4,9 @@
 - name: Install and configure Prometheus Operator
   import_tasks: prometheus.yaml
 
+- name: Install and configure Grafana
+  import_tasks: grafana.yaml
+
 - name: Install and configure Strimzi Kafka
   import_tasks: kafka.yaml
 

--- a/ansible/roles/grafana/defaults/main.yaml
+++ b/ansible/roles/grafana/defaults/main.yaml
@@ -1,0 +1,7 @@
+---
+grafana_chart_version: 7.3.9
+grafana_app_version: 10.4.2
+
+grafana_preloaded_dashboards:
+  - name: mms
+    json: "{{ lookup('file', playbook_dir + '/../../prometheus/dashboards/provisioning/seldon.json') }}"

--- a/ansible/roles/grafana/tasks/main.yaml
+++ b/ansible/roles/grafana/tasks/main.yaml
@@ -1,0 +1,26 @@
+---
+- name: Create a k8s namespace
+  kubernetes.core.k8s:
+    name: "{{ seldon_monitoring_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Install Grafana
+  kubernetes.core.helm:
+    name: grafana
+    namespace: "{{ seldon_monitoring_namespace }}"
+    chart_ref: "grafana"
+    chart_version: "{{ grafana_chart_version }}"
+    chart_repo_url: "https://grafana.github.io/helm-charts"
+    wait: true
+    values: "{{ lookup('ansible.builtin.template', '../templates/values.yaml.j2') | from_yaml }}"
+
+- name: Grafana config and login details
+  ansible.builtin.debug:
+    msg:
+      - Grafana installed in the cluster.
+      - To view the webapp, access it via the generated ingress URL, or run
+      - "kubectl port-forward -n {{ seldon_monitoring_namespace }} svc/grafana {{ seldon_monitoring_grafana_web_ui_port }}:80"
+      - in a terminal, and visit http://localhost:{{ seldon_monitoring_grafana_web_ui_port }} in your browser.
+      - Login with {{ sd_user }}/{{ sd_password }}.

--- a/ansible/roles/grafana/templates/values.yaml.j2
+++ b/ansible/roles/grafana/templates/values.yaml.j2
@@ -1,0 +1,68 @@
+---
+apiVersion: 1
+
+adminUser: "{{ sd_user }}"
+adminPassword: "{{ sd_password }}"
+
+grafana.ini:
+  paths:
+    data: /var/lib/grafana/
+    logs: /var/log/grafana
+    plugins: /var/lib/grafana/plugins
+    provisioning: /etc/grafana/provisioning
+  analytics:
+    check_for_updates: false
+  log:
+    mode: console
+  grafana_net:
+    url: https://grafana.net
+  server:
+    protocol: http
+    http_port: "{{ seldon_monitoring_grafana_web_ui_port }}"
+    domain: "''"
+    serve_from_sub_path: false
+
+persistence:
+  type: pvc
+  enabled: true
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  finalizers:
+    - kubernetes.io/pvc-protection
+  extraPvcLabels: {}
+
+datasources:
+ datasources.yaml:
+   apiVersion: 1
+   datasources:
+   - name: Prometheus
+     type: prometheus
+     url: "{{ seldon_monitoring_prometheus_url }}"
+     access: proxy
+     isDefault: true
+
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      allowUiUpdates: true
+      editable: true
+      options:
+        path: /var/lib/grafana/dashboards/default
+
+dashboards:
+  default:
+    {% for dashboard in grafana_preloaded_dashboards | default([]) -%}
+    {{ dashboard.name }}:
+      json: |-
+        {{ dashboard.json | to_nice_json(indent=2) | indent(8) }}
+      datasource:
+      - name: DS_PROMETHEUS
+        value: Prometheus
+    {% endfor -%}

--- a/prometheus/dashboards/provisioning/seldon.json
+++ b/prometheus/dashboards/provisioning/seldon.json
@@ -1,0 +1,1216 @@
+{
+   "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "3.1.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.3.0"
+    }
+  ],
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 2,
+          "values": false
+        },
+        "text": {},
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "count (seldon_loaded_model_memory_bytes_gauge{namespace=~\"^$namespace$\"} > 0 )",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "In-memory",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum (seldon_loaded_model_gauge{namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Registered",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Models",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": "",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 3,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(server) (seldon_loaded_model_gauge{namespace=~\"^$namespace$\"})",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Registered Model Replicas",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "server": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "server_replica": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": "",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 7,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "count by(server) (seldon_loaded_model_memory_bytes_gauge{namespace=~\"^$namespace$\"} > 0)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "In-Memory Model Replicas",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "server": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "server_replica": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": "",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.8
+              },
+              {
+                "color": "dark-red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 11,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 4,
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by(server) (seldon_loaded_model_memory_bytes_gauge{namespace=~\"^$namespace$\"}) / sum by(server) (seldon_server_replica_memory_capacity_overcommit_bytes_gauge{namespace=~\"^$namespace$\"})",
+          "format": "table",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "In-Memory Model Replicas (Memory Slots)",
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "Value": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "Value #A": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "Value #B": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "model_internal": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "server": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "server_replica": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value #A (sum)": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "Value #B (sum)": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "Value (lastNotNull)": {
+                "aggregations": [
+                  "lastNotNull"
+                ],
+                "operation": "aggregate"
+              },
+              "server": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "server_replica": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        }
+      ],
+      "type": "gauge"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 5
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(seldon_cache_evict_count{namespace=~\"^$namespace$\"}[1m]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Evict Rate",
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(seldon_cache_miss_count{namespace=~\"^$namespace$\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Miss Rate",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Model Evict/Miss Rate [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 5
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (server) (rate(seldon_load_model_counter{namespace=~\"^$namespace$\"}[1m]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{server}}_Load",
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (server) (rate(seldon_unload_model_counter{namespace=~\"^$namespace$\"}[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Unloa{{server}}_Loadd",
+          "refId": "B"
+        }
+      ],
+      "title": "Model Load/Unload Rate [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_server_replica_memory_capacity_bytes_gauge{server=\"triton\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Capacity",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_loaded_model_memory_bytes_gauge{server=\"triton\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Used",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_server_replica_memory_capacity_overcommit_bytes_gauge{server=\"triton\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Capacity with Over-commit",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_loaded_model_memory_bytes_gauge{server=\"triton\", namespace=~\"^$namespace$\"}) + sum(seldon_evicted_model_memory_bytes_gauge{server=\"triton\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Used with Over-commit",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Memory Slots (triton)",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 5,
+        "y": 12
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_server_replica_memory_capacity_bytes_gauge{server=\"mlserver\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Capacity",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_loaded_model_memory_bytes_gauge{server=\"mlserver\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Used",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_server_replica_memory_capacity_overcommit_bytes_gauge{server=\"mlserver\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Capacity with Over-commit",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(seldon_loaded_model_memory_bytes_gauge{server=\"mlserver\", namespace=~\"^$namespace$\"}) + sum(seldon_evicted_model_memory_bytes_gauge{server=\"mlserver\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Used with Over-commit",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Memory Slots (mlserver)",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 10,
+        "y": 12
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(container_memory_working_set_bytes{container=\"mlserver\", namespace=~\"^$namespace$\"}) ",
+          "interval": "10s",
+          "legendFormat": "mlserver",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(container_memory_working_set_bytes{container=\"triton\", namespace=~\"^$namespace$\"})",
+          "hide": false,
+          "interval": "10s",
+          "legendFormat": "triton",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 20
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "avg((rate(seldon_model_aggregate_infer_seconds_total{container=\"agent\", namespace=~\"^$namespace$\"}[1m]) / rate(seldon_model_aggregate_infer_total{container=\"agent\", namespace=~\"^$namespace$\"}[1m])) > 0 ) by (server, method_type)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{server}}_{{method_type}}_avg",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Infer Latency [1m]",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "cores",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 20
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate (container_cpu_usage_seconds_total{container=\"mlserver\", namespace=~\"^$namespace$\"}[1m])",
+          "interval": "10s",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate (container_cpu_usage_seconds_total{container=\"triton\", namespace=~\"^$namespace$\"}[1m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "CPU [1m]",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "seldon-mesh",
+          "value": "seldon-mesh"
+        },
+        "definition": "label_values(namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-10m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Seldon Core Model Mesh Monitoring",
+  "uid": "y5MkDIkVz",
+  "version": 3,
+  "weekStart": ""
+}


### PR DESCRIPTION
This PR adds an easier, automated way to deploy the MMS grafana dashboard used in various demos.

For an existing seldon core cluster, it is sufficient to run 
`ansible-playbook playbooks/setup-ecosystem.yaml -e full_install=false -e install_grafana=true`
to add the grafana install.

For new ansible installs, the grafana dashboard is deployed by default. If may be disabled by passing `install_grafana=false` to the playbook

Details:
- ansible role to add grafana to seldon cluster
- allow configuring pre-loaded dashboards connected to prometheus data-source
- add seldon MMS grafana dashboard
- generate random password for grafana install

**Which issue(s) this PR fixes**:
- INFRA-992 (internal issue) Automate grafana dashboard deployments