### PR TITLE
test(k6): Add k8s-based control plane tests 

### DIFF
--- a/tests/k6/components/k8s.js
+++ b/tests/k6/components/k8s.js
@@ -1,16 +1,26 @@
 import { Kubernetes } from "k6/x/kubernetes";
 import { getConfig } from '../components/settings.js'
 import {
-  awaitStatus,
-  awaitPipelineStatus,
   awaitExperimentStart,
   awaitExperimentStop
 } from '../components/scheduler.js';
 import { seldonObjectType } from '../components/seldon.js'
+import { sleep } from 'k6';
 
-const kubeclient = new Kubernetes();
-const namespace = getConfig().namespace;
+const seldon_target_ns = getConfig().namespace;
+var kubeclient = null;
 var schedulerClient = null;
+
+export function init() {
+    // We want to initialize/reinitialize this every time init() is called,
+    // (rather than only doing it when kubeclient is null) because if k8s
+    // operations happen within VUs, on starting a new iteration, the internal
+    // kubeclient state becomes invalid (all operations will return
+    // client-side throttling errors). This does meant each VU will need to call
+    // init() at the beginning of the iteration.
+    kubeclient = new Kubernetes();
+    return kubeclient
+}
 
 export function connectScheduler(schedulerCl) {
   schedulerClient = schedulerCl
@@ -31,52 +41,142 @@ function seldonObjExists(kind, name, ns) {
     try {
         kubeclient.get(kind.description, name, ns)
         return true
-    } catch(error) {
+    } catch(_) {
         return false
     }
 }
 
-export function loadModel(modelName, data, awaitReady=true) {
-    kubeclient.apply(data)
-    let created = kubeclient.get(seldonObjectType.MODEL.description, modelName, namespace)
-    if ('uid' in created.metadata) {
-        if (awaitReady && schedulerClient != null) {
-            awaitStatus(modelName, "ModelAvailable")
+export function getModelsWithNamePrefix(modelNamePrefix) {
+    try {
+        const modelList = kubeclient.list(seldonObjectType.MODEL.description, seldon_target_ns)
+        const modelNames = modelList.map((modelCR) => modelCR.metadata.name)
+        if(modelNamePrefix === ""){
+            return modelNames
         }
+        const filteredModels = modelNames.filter((s) => s.startsWith(modelNamePrefix))
+        return filteredModels
+    } catch (error) {
+        console.log("K8S List Models Error:" + error)
+        return []
+    }
+}
+
+export function loadModel(modelName, data, awaitReady=true) {
+    try {
+        kubeclient.apply(data)
+        let created = kubeclient.get(seldonObjectType.MODEL.description, modelName, seldon_target_ns)
+        if ('uid' in created.metadata) {
+            if (awaitReady && schedulerClient != null) {
+                awaitStatus(modelName, "ModelReady")
+            }
+        }
+        return true
+    } catch (_) {
+        // continue on error. the apply may be concurrent with a delete and fail
+        return false
+    }
+}
+
+export function getModelStatus(modelName, targetStatus) {
+    try {
+        var modelObj = kubeclient.get(seldonObjectType.MODEL.description, modelName, seldon_target_ns)
+    } catch (_) {
+        // catch the case where the model no longer exists and there is no point in waiting for it
+        return true
+    }
+    if ('status' in modelObj) {
+        let status = modelObj.status
+        if ('conditions' in status) {
+            for (let i = 0; i < status.conditions.length; i++) {
+                if(status.conditions[i].type == targetStatus) {
+                    return true
+                }
+            }
+            return false
+        } else {
+            return false
+        }
+    } else {
+        return false
+    }
+}
+
+export function awaitStatus(modelName, status) {
+    while (!getModelStatus(modelName, status)) {
+        sleep(1)
     }
 }
 
 export function unloadModel(modelName, awaitReady=true) {
-    if(seldonObjExists(seldonObjectType.MODEL, modelName, namespace)) {
-        kubeclient.delete(seldonObjectType.MODEL.description, modelName, namespace)
-        if (awaitReady && schedulerClient != null) {
-            awaitStatus(modelName, "ModelTerminated")
+    if(seldonObjExists(seldonObjectType.MODEL, modelName, seldon_target_ns)) {
+        try {
+            kubeclient.delete(seldonObjectType.MODEL.description, modelName, seldon_target_ns)
+            if (awaitReady && schedulerClient != null) {
+                while (seldonObjExists(seldonObjectType.MODEL, modelName, seldon_target_ns)) {
+                    sleep(1)
+                }
+            }
+            return true
+        } catch(_) {
+            // catch case where model was deleted concurrently by another VU
+            return false
         }
+    } else {
+        return false
     }
 }
 
 export function loadPipeline(pipelineName, data, awaitReady=true) {
     kubeclient.apply(data)
-    let created = kubeclient.get(seldonObjectType.PIPELINE.description, pipelineName, namespace)
+    let created = kubeclient.get(seldonObjectType.PIPELINE.description, pipelineName, seldon_target_ns)
     if ('uid' in created.metadata) {
         if (awaitReady && schedulerClient != null) {
-            awaitStatus(pipelineName, "PipelineReady")
+            awaitPipelineStatus(pipelineName, "PipelineReady")
         }
     }
 }
 
+export function getPipelineStatus(pipelineName, targetStatus) {
+    let pipelineObj = kubeclient.get(seldonObjectType.PIPELINE.description, pipelineName, seldon_target_ns)
+    if ('status' in pipelineObj) {
+        let status = pipelineObj.status
+        if ('conditions' in status) {
+            for (let i = 0; i < status.conditions.length; i++) {
+                // return the most recent state (true/false) of the condition
+                // type named <targetStatus>
+                if(status.conditions[i].type == targetStatus) {
+                    return status.conditions[i].status
+                }
+            }
+            return ""
+        } else {
+            return ""
+        }
+    } else {
+        return ""
+    }
+}
+
+export function awaitPipelineStatus(pipelineName, status) {
+    while (!getPipelineStatus(pipelineName, status)) {
+        sleep(1)
+    }
+}
+
 export function unloadPipeline(pipelineName, awaitReady = true) {
-    if(seldonObjExists(seldonObjectType.PIPELINE, pipelineName, namespace)) {
-        kubeclient.delete(seldonObjectType.PIPELINE.description, pipelineName, namespace)
+    if(seldonObjExists(seldonObjectType.PIPELINE, pipelineName, seldon_target_ns)) {
+        kubeclient.delete(seldonObjectType.PIPELINE.description, pipelineName, seldon_target_ns)
         if (awaitReady && schedulerClient != null) {
-            awaitStatus(pipelineName, "PipelineTerminated")
+            while (seldonObjExists(seldonObjectType.PIPELINE, pipelineName, seldon_target_ns)) {
+                sleep(1)
+            }
         }
     }
 }
 
 export function loadExperiment(experimentName, data, awaitReady=true) {
     kubeclient.apply(data)
-    let created = kubeclient.get(seldonObjectType.EXPERIMENT.description, experimentName, namespace)
+    let created = kubeclient.get(seldonObjectType.EXPERIMENT.description, experimentName, seldon_target_ns)
     if ('uid' in created.metadata) {
         if (awaitReady && schedulerClient != null) {
             awaitExperimentStart(experimentName)
@@ -85,8 +185,8 @@ export function loadExperiment(experimentName, data, awaitReady=true) {
 }
 
 export function unloadExperiment(experimentName, awaitReady=true) {
-    if(seldonObjExists(seldonObjectType.EXPERIMENT, experimentName, namespace)) {
-        kubeclient.delete(seldonObjExists.EXPERIMENT.description, experimentName, namespace)
+    if(seldonObjExists(seldonObjectType.EXPERIMENT, experimentName, seldon_target_ns)) {
+        kubeclient.delete(seldonObjExists.EXPERIMENT.description, experimentName, seldon_target_ns)
         if (awaitReady && schedulerClient != null) {
             awaitExperimentStop(experimentName)
         }

--- a/tests/k6/components/k8s.js
+++ b/tests/k6/components/k8s.js
@@ -4,7 +4,7 @@ import {
   awaitExperimentStart,
   awaitExperimentStop
 } from '../components/scheduler.js';
-import { seldonObjectType } from '../components/seldon.js'
+import { seldonObjectType, seldonOpExecStatus } from '../components/seldon.js'
 import { sleep } from 'k6';
 
 const seldon_target_ns = getConfig().namespace;
@@ -88,10 +88,10 @@ export function loadModel(modelName, data, awaitReady=true) {
                 return awaitStatus(modelName, "ModelReady")
             }
         }
-        return true
+        return seldonOpExecStatus.OK
     } catch (_) {
         // continue on error. the apply may be concurrent with a delete and fail
-        return false
+        return seldonOpExecStatus.CONCURRENT_OP_FAIL
     }
 }
 
@@ -103,13 +103,13 @@ export function awaitStatus(modelName, status) {
             retries++
             if(retries > MAX_RETRIES) {
                 console.log(`Giving up on waiting for model ${modelName} to reach status ${status}, after ${MAX_RETRIES}`)
-                return false
+                return seldonOpExecStatus.FAIL
             }
         }
-        return true
+        return seldonOpExecStatus.OK
     } catch (_) {
         // in case getModelStatus throws an exception
-        return false
+        return seldonOpExecStatus.CONCURRENT_OP_FAIL
     }
 }
 
@@ -125,7 +125,6 @@ export function getModelStatus(modelName, targetStatus) {
             }
         }
     }
-
     return false
 }
 
@@ -140,16 +139,16 @@ export function unloadModel(modelName, awaitReady=true) {
                     retries++
                     if(retries > MAX_RETRIES) {
                         console.log(`Failed to unload model ${modelName} after ${MAX_RETRIES}, giving up`)
-                        return false
+                        return seldonOpExecStatus.FAIL
                     }
                 }
             }
-            return true
+            return seldonOpExecStatus.OK
         } catch(_) {
             // catch case where model was deleted concurrently by another VU
         }
     }
-    return false
+    return seldonOpExecStatus.CONCURRENT_OP_FAIL
 }
 
 export function loadPipeline(pipelineName, data, awaitReady=true) {
@@ -161,10 +160,10 @@ export function loadPipeline(pipelineName, data, awaitReady=true) {
                 return awaitPipelineStatus(pipelineName, "PipelineReady")
             }
         }
-        return true
+        return seldonOpExecStatus.OK
     } catch (_) {
         // continue on error. the apply may be concurrent with a delete and fail
-        return false
+        return seldonOpExecStatus.CONCURRENT_OP_FAIL
     }
 }
 
@@ -176,13 +175,13 @@ export function awaitPipelineStatus(pipelineName, status) {
             retries++
             if(retries > MAX_RETRIES) {
                 console.log(`Giving up on waiting for pipeline ${pipelineName} to reach status ${status}, after ${MAX_RETRIES}`)
-                return false
+                return seldonOpExecStatus.FAIL
             }
         }
-        return true
+        return seldonOpExecStatus.OK
     } catch(_) {
         // in case getPipelineStatus throws an exception
-        return false
+        return seldonOpExecStatus.CONCURRENT_OP_FAIL
     }
 }
 
@@ -214,16 +213,16 @@ export function unloadPipeline(pipelineName, awaitReady = true) {
                     retries++
                     if(retries > MAX_RETRIES) {
                         console.log(`Failed to unload pipeline ${pipelineName} after ${MAX_RETRIES}, giving up`)
-                        return false
+                        return seldonOpExecStatus.FAIL
                     }
                 }
             }
-            return true
+            return seldonOpExecStatus.OK
         } catch(_) {
             // catch case where model was deleted concurrently by another VU
         }
     }
-    return false
+    return seldonOpExecStatus.CONCURRENT_OP_FAIL
 }
 
 export function loadExperiment(experimentName, data, awaitReady=true) {

--- a/tests/k6/components/seldon.js
+++ b/tests/k6/components/seldon.js
@@ -3,3 +3,9 @@ export const seldonObjectType = {
   PIPELINE: Symbol("Pipeline.mlops.seldon.io"),
   EXPERIMENT: Symbol("Experiment.mlops.seldon.io")
 };
+
+export const seldonOpType = {
+  CREATE: Symbol("Create"),
+  UPDATE: Symbol("Update"),
+  DELETE: Symbol("Delete"),
+}

--- a/tests/k6/components/seldon.js
+++ b/tests/k6/components/seldon.js
@@ -9,3 +9,9 @@ export const seldonOpType = {
   UPDATE: Symbol("Update"),
   DELETE: Symbol("Delete"),
 }
+
+export const seldonOpExecStatus = {
+  OK: Symbol("Ok"),
+  FAIL: Symbol("Control-plane failure"),
+  CONCURRENT_OP_FAIL: Symbol("Failure because of concurrent operation in another VU")
+}

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -84,12 +84,22 @@ function unloadExperiment() {
 
 function maxNumModels() {
     if (__ENV.MAX_NUM_MODELS) {
-        return __ENV.MAX_NUM_MODELS.split(",")
+        return __ENV.MAX_NUM_MODELS.split(",").map(n => Number(n))
     } else if (__ENV.MODEL_TYPE) {
         const num =  __ENV.MODEL_TYPE.split(",").length
         return Array(num).fill(1)
     }
     return [1]
+}
+
+function maxNumModelsHeadroom() {
+    if (__ENV.MAX_NUM_MODELS_HEADROOM) {
+        return __ENV.MAX_NUM_MODELS_HEADROOM.split(",").map(n => Number(n))
+    } else if (__ENV.MODEL_TYPE) {
+        const num =  __ENV.MODEL_TYPE.split(",").length
+        return Array(num).fill(0)
+    }
+    return [0]
 }
 
 function isSchedulerProxy() {
@@ -116,6 +126,13 @@ function modelMemoryBytes() {
     return [0]
 }
 
+function maxMemUpdateFraction() {
+    if (__ENV.MAX_MEM_UPDATE_FRACTION) {
+        return Number(__ENV.MAX_MEM_UPDATE_FRACTION)
+    }
+    return 0
+}
+
 function inferBatchSize() {
     if (__ENV.INFER_BATCH_SIZE) {
         return __ENV.INFER_BATCH_SIZE.split(",").map( s => parseInt(s))
@@ -134,6 +151,23 @@ function modelReplicas() {
         return Array(num).fill(1)
     }
     return [1]
+}
+
+function modelMaxReplicas() {
+    if (__ENV.MODEL_MAX_REPLICAS) {
+        return __ENV.MODEL_MAX_REPLICAS.split(",").map( s => parseInt(s))
+    } else if (__ENV.MODEL_TYPE) {
+        const num =  __ENV.MODEL_TYPE.split(",").length
+        return Array(num).fill(1)
+    }
+    return [1]
+}
+
+function createUpdateDeleteBias() {
+    if (__ENV.MODEL_CREATE_UPDATE_DELETE_BIAS) {
+        return __ENV.MODEL_CREATE_UPDATE_DELETE_BIAS.split(",").map( s => parseInt(s)).slice(0,3)
+    }
+    return [1, 1, 1]
 }
 
 function modelStartIdx() {
@@ -223,6 +257,20 @@ function podNamespace() {
     return "seldon-mesh"
 }
 
+function maxCreateOpsPerVU() {
+    if (__ENV.MAX_CREATE_OPS_PER_VU) {
+        return Number(__ENV.MAX_CREATE_OPS_PER_VU)
+    }
+    return 10000
+}
+
+function k8sDelaySecPerVU() {
+    if (__ENV.K8S_DELAY_SECONDS_PER_VU) {
+        return Number(__ENV.K8S_DELAY_SECONDS_PER_VU)
+    }
+    return 10
+}
+
 export function getConfig() {
     return {
         "useKubeControlPlane": useKubeControlPlane(),
@@ -254,6 +302,12 @@ export function getConfig() {
         "requestRate": requestRate(),
         "constantRateDurationSeconds": constantRateDurationSeconds(),
         "modelReplicas": modelReplicas(),
+        "modelMaxReplicas": modelMaxReplicas(),
         "namespace":  podNamespace(),
+        "maxNumModelsHeadroom": maxNumModelsHeadroom(),
+        "createUpdateDeleteBias": createUpdateDeleteBias(),
+        "maxCreateOpsPerVU": maxCreateOpsPerVU(),
+        "k8sDelaySecPerVU": k8sDelaySecPerVU(),
+        "maxMemUpdateFraction": maxMemUpdateFraction(),
     }
 }

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -153,9 +153,9 @@ function modelReplicas() {
     return [1]
 }
 
-function modelMaxReplicas() {
-    if (__ENV.MODEL_MAX_REPLICAS) {
-        return __ENV.MODEL_MAX_REPLICAS.split(",").map( s => parseInt(s))
+function maxModelReplicas() {
+    if (__ENV.MAX_MODEL_REPLICAS) {
+        return __ENV.MAX_MODEL_REPLICAS.split(",").map( s => parseInt(s))
     } else if (__ENV.MODEL_TYPE) {
         const num =  __ENV.MODEL_TYPE.split(",").length
         return Array(num).fill(1)
@@ -302,7 +302,7 @@ export function getConfig() {
         "requestRate": requestRate(),
         "constantRateDurationSeconds": constantRateDurationSeconds(),
         "modelReplicas": modelReplicas(),
-        "modelMaxReplicas": modelMaxReplicas(),
+        "maxModelReplicas": maxModelReplicas(),
         "namespace":  podNamespace(),
         "maxNumModelsHeadroom": maxNumModelsHeadroom(),
         "createUpdateDeleteBias": createUpdateDeleteBias(),

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -138,6 +138,7 @@ export function connectControlPlaneOps(config) {
   const schedClient = ctl.connectSchedulerFn(config.schedulerEndpoint)
   // pass scheduler client to k8s for Model/Pipeline status queries
   if (config.useKubeControlPlane && !config.isSchedulerProxy) {
+    k8s.init()
     k8s.connectScheduler(schedClient)
   }
 

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -31,7 +31,7 @@ export function setupBase(config) {
 
                 var defs = getSeldonObjDef(config, model, seldonObjectType.MODEL)
 
-                ctl.loadModelFn(modelName, defs.model.modelDefn, false)
+                ctl.loadModelFn(modelName, defs.model.modelDefn, true)
                 if (config.isLoadPipeline) {
                     ctl.loadPipelineFn(generatePipelineName(modelName), defs.model.pipelineDefn, false)  // we use pipeline name as model name
                 }
@@ -42,17 +42,21 @@ export function setupBase(config) {
         if (!config.isLoadPipeline) {
             for (let j = 0; j < config.maxNumModels.length; j++) {
                 const n = config.maxNumModels[j] - 1
-                const modelName = config.modelNamePrefix[j] + n.toString()
-                const modelNameWithVersion = modelName + getVersionSuffix(config.isSchedulerProxy)  // first version
-                while (modelStatusHttp(config.inferHttpEndpoint, config.isEnvoy?modelName:modelNameWithVersion, config.isEnvoy) !== 200) {
-                    sleep(1)
+                if (n >= 0) {
+                  const modelName = config.modelNamePrefix[j] + n.toString()
+                  const modelNameWithVersion = modelName + getVersionSuffix(config.isSchedulerProxy)  // first version
+                  while (modelStatusHttp(config.inferHttpEndpoint, config.isEnvoy?modelName:modelNameWithVersion, config.isEnvoy) !== 200) {
+                      sleep(1)
+                  }
                 }
             }
         } else {
             for (let j = 0; j < config.maxNumModels.length; j++) {
                 const n = config.maxNumModels[j] - 1
-                const modelName = config.modelNamePrefix[j] + n.toString()
-                awaitPipelineStatus(generatePipelineName(modelName), "PipelineReady")
+                if (n >= 0) {
+                  const modelName = config.modelNamePrefix[j] + n.toString()
+                  awaitPipelineStatus(generatePipelineName(modelName), "PipelineReady")
+                }
             }
         }
 

--- a/tests/k6/configs/k8s/base/k6.yaml
+++ b/tests/k6/configs/k8s/base/k6.yaml
@@ -27,7 +27,7 @@ spec:
           "120m",
           "scenarios/infer_constant_vu.js",
           ]
-        # # infer_constant_vu
+        # # infer_constant_rate
         # args: [
         #   "--no-teardown",
         #   "--summary-export",
@@ -44,6 +44,22 @@ spec:
         #   "csv=results/base.gz",
         #   "scenarios/k8s-test-script.js",
         #   ]
+        # # core2_qa_control_plane_ops
+        # args: [
+        #   "--no-teardown",
+        #   "--verbose",
+        #   "--summary-export",
+        #   "results/base.json",
+        #   "--out",
+        #   "csv=results/base.gz",
+        #   "-u",
+        #   "5",
+        #   "-i",
+        #   "10000",
+        #   "-d",
+        #   "9h",
+        #   "scenarios/core2_qa_control_plane_ops.js",
+        #   ]
         env:
         - name: USE_KUBE_CONTROL_PLANE
           value: "true"
@@ -57,18 +73,36 @@ spec:
           value: "tfsimplea,pytorch-cifar10a,tfmnista,mlflow-winea,irisa"
         - name: MODEL_TYPE
           value: "tfsimple,pytorch_cifar10,tfmnist,mlflow_wine,iris"
-        # Specify MODEL_MEMORY_BYTES with suffixes (b, k, m, g) rather than
-        # numbers without units of measure. If supplying "naked numbers",
-        # the seldon operator will take care of converting the number for you
-        # but also take ownership of the field (as FieldManager), so the next
-        # time you run the scenario creating/updating of the model CR will fail.
+        # Specify MODEL_MEMORY_BYTES using unit-of measure suffixes (k, M, G, T)
+        # rather than numbers without units of measure. If supplying "naked
+        # numbers", the seldon operator will take care of converting the number
+        # for you but also take ownership of the field (as FieldManager), so the
+        # next time you run the scenario creating/updating of the model CR will
+        # fail.
         - name: MODEL_MEMORY_BYTES
-          value: "400k,8m,43m,200k,3m"
+          value: "400k,8M,43M,200k,3M"
+        - name: MAX_MEM_UPDATE_FRACTION
+          value: "0.1"
         - name: MAX_NUM_MODELS
           value: "800,100,25,100,100"
           # value: "0,0,25,100,100"
+        # MAX_NUM_MODELS_HEADROOM is a variable used by control-plane tests.
+        # It's the approximate number of models that can be created over
+        # MAX_NUM_MODELS over the experiment. In the worst case scenario
+        # (very unlikely) the HEADROOM values may temporarily exceed the ones
+        # specified here with the number of VUs, because each VU checks the
+        # headroom constraint independently before deciding on the available
+        # operations (no communication/sync between VUs)
+        # - name: MAX_NUM_MODELS_HEADROOM
+        #   value: "20,5,0,20,30"
         - name: INFER_BATCH_SIZE
           value: "1,1,1,1,1"
+        # MODEL_CREATE_UPDATE_DELETE_BIAS defines the probability ratios between
+        # the operations, for control-plane tests. For example, "1, 4, 3"
+        # makes an Update four times more likely then a Create, and a Delete 3
+        # times more likely than the Create.
+        # - name: MODEL_CREATE_UPDATE_DELETE_BIAS
+        #   value: "1,3,1"
         - name: WARMUP
           value: "false"
         - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/tests/k6/configs/k8s/base/k6.yaml
+++ b/tests/k6/configs/k8s/base/k6.yaml
@@ -86,6 +86,7 @@ spec:
         - name: MAX_NUM_MODELS
           value: "800,100,25,100,100"
           # value: "0,0,25,100,100"
+        #
         # MAX_NUM_MODELS_HEADROOM is a variable used by control-plane tests.
         # It's the approximate number of models that can be created over
         # MAX_NUM_MODELS over the experiment. In the worst case scenario
@@ -95,6 +96,13 @@ spec:
         # operations (no communication/sync between VUs)
         # - name: MAX_NUM_MODELS_HEADROOM
         #   value: "20,5,0,20,30"
+        #
+        # MAX_MODEL_REPLICAS is used by control-plane tests. It controls the
+        # maximum number of replicas that may be requested when
+        # creating/updating models of a given type.
+        # - name: MAX_MODEL_REPLICAS
+        #   value: "2,2,0,2,2"
+        #
         - name: INFER_BATCH_SIZE
           value: "1,1,1,1,1"
         # MODEL_CREATE_UPDATE_DELETE_BIAS defines the probability ratios between

--- a/tests/k6/configs/k8s/overlays/envoy/kustomization.yaml
+++ b/tests/k6/configs/k8s/overlays/envoy/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 
 namePrefix: envoy-
 
-bases:
-- ../../base
 
-patchesStrategicMerge:
-  - envs.yaml
+resources:
+- ../../base
+patches:
+- path: envs.yaml

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -171,7 +171,7 @@ export default function (config) {
     while (config.maxNumModels[idx] === 0) {
         idx = Math.floor(Math.random() * numModelTypes)
     }
-    let modelsOfType = k8s.getModelsWithNamePrefix(config.modelNamePrefix[idx])
+    let modelsOfType = k8s.getModels(config.modelNamePrefix[idx])
 
     // Pick random operation in CREATE/UPDATE/DELETE, amongst available ones.
     // Each operation is added multiple times in the selection array as
@@ -199,7 +199,7 @@ export default function (config) {
 }
 
 export function teardown(config) {
-    let modelNames = k8s.getModelsWithNamePrefix("")
+    let modelNames = k8s.getModels()
     for (var modelName in modelNames) {
         k8s.unloadModel(modelName, false)
     }

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -14,7 +14,7 @@
  *      - If `Update` is picked, choose one of the existing models of that type
  *        and apply some random variation to the model’s memory requirements
  *        (+/- MAX_UPDATE_MEM ratio) and/or number of replicas
- *        (+/- up to the number of config.modelMaxReplicas)
+ *        (+/- up to the number of config.maxModelReplicas)
  * 3. Apply operation to cluster
  * 4. Wait VU_OP_DELAY_SECONDS
  * 5. Repeat from 1
@@ -101,7 +101,7 @@ function handleCtlOp(config, op, modelTypeIx, existingModels) {
                 let memVariation = Math.round(Math.random() * mem * config.maxMemUpdateFraction)
                 let newMemory = String(mem + (memVariation * plusOrMinus)) + memUnit
                 // update replicas +/- with random variation
-                let replicasToMax = config.modelMaxReplicas[modelTypeIx] - model.spec.replicas
+                let replicasToMax = config.maxModelReplicas[modelTypeIx] - model.spec.replicas
                 var deltaReplicas = plusOrMinus > 0 ? replicasToMax : model.spec.replicas
                 let replicasVariation = Math.round(Math.random() * deltaReplicas)
                 let newReplicas = model.spec.replicas + (replicasVariation * plusOrMinus)

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -1,0 +1,206 @@
+/**
+ * This test aims to verify that Core 2 remains in an error-free state after
+ * numerous control-plane operations, with some of those being executed in
+ * parallel.
+ *
+ * Tests Create/Update/Delete operations; expect: consistent end-state
+ *
+ * Constant VU test;
+ * Per VU:
+ * 1. Pick arbitrary model type
+ * 2. Pick arbitrary **available** operation from the `Create/Update/Delete` set
+ *      - `Create` not available if max number of models of that type already loaded
+ *      - `Delete` not available if no models of that type remain
+ *      - If `Update` is picked, choose one of the existing models of that type
+ *        and apply some random variation to the model’s memory requirements
+ *        (+/- MAX_UPDATE_MEM ratio) and/or number of replicas
+ *        (+/- up to the number of config.modelMaxReplicas)
+ * 3. Apply operation to cluster
+ * 4. Wait VU_OP_DELAY_SECONDS
+ * 5. Repeat from 1
+ */
+
+import { dump as yamlDump } from "https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.mjs";
+import { sleep } from 'k6';
+import { vu } from 'k6/execution';
+import { Counter } from 'k6/metrics';
+import * as k8s from '../components/k8s.js';
+
+import { getConfig } from '../components/settings.js'
+import { seldonObjectType, seldonOpType } from '../components/seldon.js';
+import { setupBase } from '../components/utils.js'
+import { generateModel } from '../components/model.js';
+
+// workaround: https://community.k6.io/t/exclude-http-requests-made-in-the-setup-and-teardown-functions/1525
+export let options = {
+    thresholds: {
+        'http_req_duration{scenario:default}': [`max>=0`],
+        'http_reqs{scenario:default}': [],
+        'grpc_req_duration{scenario:default}': [`max>=0`],
+        'data_received{scenario:default}': [],
+        'data_sent{scenario:default}': [],
+    },
+    setupTimeout: '6000s',
+    duration: '30m',
+    teardownTimeout: '6000s',
+}
+
+// Each VU gets a range of Ids for the models it creates, not overlapping
+// with other VUs. The range size is controlled by MAX_CREATE_OPS_PER_VU
+var VU_maxModelId = 0
+
+const createCounter = new Counter("ctl_op_model_create")
+const updateCounter = new Counter("ctl_op_model_update")
+const deleteCounter = new Counter("ctl_op_model_delete")
+
+var kubeclient = {}
+
+export function setup() {
+    var config = getConfig()
+
+    setupBase(config)
+    console.log(config.maxNumModels)
+    let numLoadedModels = config.maxNumModels.reduce((s,a) => s + Number(a), 0)
+    console.log("Loaded models (end-of-setup):" + numLoadedModels)
+    createCounter.add(numLoadedModels)
+
+    return config
+}
+
+function handleCtlOp(config, op, modelTypeIx, existingModels) {
+    var modelName = config.modelNamePrefix[modelTypeIx]
+    var modelCRYaml = {}
+
+    // generate model CR or select one of the existing ones as the
+    // target for the control-plane operation, possibly updating its config if
+    // needed
+    switch (op) {
+        case seldonOpType.CREATE:
+            VU_maxModelId += 1
+            modelName += (vu.idInTest * config.maxCreateOpsPerVU) + VU_maxModelId
+            const i = modelTypeIx
+            let m = generateModel(config.modelType[i], modelName, 1, config.modelReplicas[i], config.isSchedulerProxy, config.modelMemoryBytes[i], config.inferBatchSize[i])
+            modelCRYaml = m.modelCRYaml
+            break;
+        case seldonOpType.UPDATE:
+        case seldonOpType.DELETE:
+            var randomModelIx = Math.floor(Math.random() * existingModels.length)
+            modelName = existingModels[randomModelIx]
+
+            if (op === seldonOpType.DELETE) {
+                break;
+            }
+
+            try {
+                let model = kubeclient.get(seldonObjectType.MODEL.description, modelName, config.namespace)
+
+                let plusOrMinus = Math.random() < 0.5 ? -1 : 1
+                // update memory +/- with random variation
+                let mem = parseInt(config.modelMemoryBytes[modelTypeIx], 10)
+                let memUnit = model.spec.memory.substring(String(mem).length)
+                let memVariation = Math.round(Math.random() * mem * config.maxMemUpdateFraction)
+                let newMemory = String(mem + (memVariation * plusOrMinus)) + memUnit
+                // update replicas +/- with random variation
+                let replicasToMax = config.modelMaxReplicas[modelTypeIx] - model.spec.replicas
+                var deltaReplicas = plusOrMinus > 0 ? replicasToMax : model.spec.replicas
+                let replicasVariation = Math.round(Math.random() * deltaReplicas)
+                let newReplicas = model.spec.replicas + (replicasVariation * plusOrMinus)
+                if (newReplicas < 1) newReplicas = 1
+
+                let newModelCR = {
+                    "apiVersion": "mlops.seldon.io/v1alpha1",
+                    "kind": "Model",
+                    "metadata": {
+                        "name": modelName,
+                        "namespace": config.namespace
+                    },
+                    "spec": {
+                        "storageUri": model.spec.storageUri,
+                        "requirements": model.spec.requirements,
+                        "memory": newMemory,
+                        "replicas": newReplicas
+                    }
+                }
+                modelCRYaml = yamlDump(newModelCR)
+            } catch (_) {
+                // just continue test, another VU might have deleted the chosen model
+                return false
+            }
+            break;
+    }
+
+    console.log(`VU ${vu.idInTest} executes ${op.description} on ${modelName}`)
+
+
+    // execute control-plane operation
+    var opOk = false
+    switch(op) {
+        case seldonOpType.CREATE:
+        case seldonOpType.UPDATE:
+            opOk = k8s.loadModel(modelName, modelCRYaml, true)
+            break;
+        case seldonOpType.DELETE:
+            opOk = k8s.unloadModel(modelName, true)
+            break;
+    }
+
+    // update k6 metrics
+    if (opOk === true) {
+        switch(op) {
+            case seldonOpType.CREATE:
+                createCounter.add(1)
+                break;
+            case seldonOpType.UPDATE:
+                updateCounter.add(1)
+                break;
+            case seldonOpType.DELETE:
+                deleteCounter.add(1)
+                break;
+        }
+    }
+
+    return opOk
+
+}
+
+export default function (config) {
+    kubeclient = k8s.init()
+    const numModelTypes = config.modelType.length
+
+    var idx = Math.floor(Math.random() * numModelTypes)
+    while (config.maxNumModels[idx] === 0) {
+        idx = Math.floor(Math.random() * numModelTypes)
+    }
+    let modelsOfType = k8s.getModelsWithNamePrefix(config.modelNamePrefix[idx])
+
+    // Pick random operation in CREATE/UPDATE/DELETE, amongst available ones.
+    // Each operation is added multiple times in the selection array as
+    // configured in the `createUpdateDeleteBias` array. This defines the
+    // probability ratios between the operations. For example, the [1,4,3]
+    // createUpdateDeleteBias array makes an Update four times more likely then
+    // a Create, and a Delete 3 times more likely than the Create.
+    //
+    // Because each VU picks the operation independently, it's possible to
+    // temporarily get more models than MAX_NUM_MODELS for a given model type.
+    let availableOps = Array(config.createUpdateDeleteBias[1]).fill(seldonOpType.UPDATE)
+    if (modelsOfType.length < config.maxNumModels[idx] + config.maxNumModelsHeadroom[idx]) {
+        let createArray = Array(config.createUpdateDeleteBias[0]).fill(seldonOpType.CREATE)
+        availableOps.push(...createArray)
+    }
+    if (modelsOfType.length > 0) {
+        let deleteArray = Array(config.createUpdateDeleteBias[2]).fill(seldonOpType.DELETE)
+        availableOps.push(...deleteArray)
+    }
+    const randomOp = availableOps[Math.floor(Math.random() * availableOps.length)]
+    handleCtlOp(config, randomOp, idx, modelsOfType)
+
+    sleep(config.k8sDelaySecPerVU + (Math.random() * 2))
+
+}
+
+export function teardown(config) {
+    let modelNames = k8s.getModelsWithNamePrefix("")
+    for (var modelName in modelNames) {
+        k8s.unloadModel(modelName, false)
+    }
+}

--- a/tests/k6/scenarios/infer_constant_rate.js
+++ b/tests/k6/scenarios/infer_constant_rate.js
@@ -33,7 +33,10 @@ export function setup() {
 
 export default function (config) {
     const numModelTypes = config.modelType.length
-    const idx = Math.floor(Math.random() * numModelTypes)
+    var idx = Math.floor(Math.random() * numModelTypes)
+    while (config.maxNumModels[idx] == 0) {
+        idx = Math.floor(Math.random() * numModelTypes)
+    }
     const modelId = Math.floor(Math.random() * config.maxNumModels[idx])
     const modelName = config.modelNamePrefix[idx] + modelId.toString()
 

--- a/tests/k6/scenarios/infer_constant_vu.js
+++ b/tests/k6/scenarios/infer_constant_vu.js
@@ -25,7 +25,10 @@ export function setup() {
 
 export default function (config) {
     const numModelTypes = config.modelType.length
-    const idx = Math.floor(Math.random() * numModelTypes)
+    var idx = Math.floor(Math.random() * numModelTypes)
+    while (config.maxNumModels[idx] == 0) {
+        idx = Math.floor(Math.random() * numModelTypes)
+    }
     const modelId = Math.floor(Math.random() * config.maxNumModels[idx])
     const modelName = config.modelNamePrefix[idx] + modelId.toString()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a k6 test that arbitrarily creates/updates/deletes models in each VU. Starting from the scenario defined in `scenarios/core2_qa_control_plane_ops.js`, we can run a variety of control plane tests to check that Core 2 responds as expected to a wide array of commands/situations, including concurrent operations.

New configuration options introduced for k6 control-plane scenarios:
- `modelMaxReplicas` (set via environment var  MODEL_MAX_REPLICAS, array)
    each model type may be updated during the test to a maximum of replicas defined here
- `maxMemUpdateFraction` (set via environment var MAX_MEM_UPDATE_FRACTION, float)
     each model type may be updated by having, in the worst case, this much memory relative to 
     its default setting either added or removed. Example: For a model being assigned 8M in 
     `MODEL_MEMORY_BYTES`, a value of 0.5 in `maxMemUpdateFraction` means that the model
    may be created, at random with a memory requirement between 4M and 12M.
- `maxNumModelsHeadroom` (set via environment var MAX_NUM_MODELS_HEADROOM, array)
    models beyond `maxNumModels` (which are all created during the setup phase) which are allowed
    during control-plane testing
- `createUpdateDeleteBias` (set via environment var  MODEL_CREATE_UPDATE_DELETE_BIAS, array)
     3 element array defining the relative frequency with which CREATE/UPDATE/DELETE operations
     happen during control-plane tests
- `maxCreateOpsPerVU` (set via environment var  MAX_CREATE_OPS_PER_VU, int)
     because each VU runs independently, we set aside a namespace of this size for model IDs created
     by that VU. For example, if maxCreateOpsPerVU is 100, preloaded models get ids [0, 99], models
     created by VU 1 get ids [100, 199], by VU 2 get ids [200, 299], etc.
- `k8sDelaySecPerVU` (set via environment var  K8S_DELAY_SECONDS_PER_VU, int)
     the following delay is observed by each VU before starting a new iteration

Minor k6 tests fixes:
- allow 0 as an element of MAX_NUM_MODELS
- check model/pipeline status via k8s rather than relying on connection to scheduler
- fix kustomize warnings

**Which issue(s) this PR fixes**:
- INFRA-1002 (internal issue) Control-plane tests

**Special notes for your reviewer**:
Tested by running control-plane tests in kind