### PR TITLE
feat: Add pipelines to core2 qa control plane tests

### DIFF
--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -33,7 +33,7 @@ export function setupBase(config) {
 
                 ctl.loadModelFn(modelName, defs.model.modelDefn, true)
                 if (config.isLoadPipeline) {
-                    ctl.loadPipelineFn(generatePipelineName(modelName), defs.model.pipelineDefn, false)  // we use pipeline name as model name
+                    ctl.loadPipelineFn(generatePipelineName(modelName), defs.model.pipelineDefn, false)  // we use pipeline name as model name + "-pipeline"
                 }
             }
         }

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -178,19 +178,19 @@ function handleCtlOp(config, op, modelTypeIx, existingModels) {
         case seldonOpType.CREATE:
         case seldonOpType.UPDATE:
             opOk = k8s.loadModel(modelName, modelCRYaml, true)
-            if (config.isLoadPipeline) {
-                opOk = k8s.loadPipeline(generatePipelineName(modelName), pipelineCRYaml, true) && opOk
+            if (opOk === seldonOpExecStatus.OK && config.isLoadPipeline) {
+                opOk = k8s.loadPipeline(generatePipelineName(modelName), pipelineCRYaml, true)
             }
             break;
         case seldonOpType.DELETE:
             opOk = k8s.unloadModel(modelName, true)
-            if (config.isLoadPipeline) {
+            if (opOk === seldonOpExecStatus.OK && config.isLoadPipeline) {
                 // a model can go away while a pipeline is still loaded, we then simulate this behavior
                 // by not unloading the pipeline in 50% of the cases
                 // TODO: make it an environment variable?
                 let unloadPipeline = Math.random() < 0.5 ? 0 : 1
                 if (unloadPipeline) {
-                    opOk = k8s.unloadPipeline(generatePipelineName(modelName), true) && opOk
+                    opOk = k8s.unloadPipeline(generatePipelineName(modelName), true)
                 }
             }
             break;

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -18,6 +18,16 @@
  * 3. Apply operation to cluster
  * 4. Wait VU_OP_DELAY_SECONDS
  * 5. Repeat from 1
+ * 
+ * When testing with pipelines (i.e running `make deploy-kpipeline-test`) we are also
+ * testing pipeline creation/deletion. The pipeline operation follows the same pattern 
+ * for the model operation, with the following differences:
+ * There assumptions to note with the current change:
+ * - The test that we currently have is for a single model pipelines
+ * - To update a pipeline we induce a change to the pipeline CR that has no real effect 
+ *   (by setting `batch` to a random value)
+ * - We delete pipelines 50% of the time when a delete of a model is required, 
+ *   to simulate a pipeline that is not available due to issues with models.
  */
 
 import { dump as yamlDump } from "https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.mjs";

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -175,6 +175,9 @@ function handleCtlOp(config, op, modelTypeIx, existingModels) {
         case seldonOpType.DELETE:
             opOk = k8s.unloadModel(modelName, true)
             if (config.isLoadPipeline) {
+                // a model can go away while a pipeline is still loaded, we then simulate this behavior
+                // by not unloading the pipeline in 50% of the cases
+                // TODO: make it an environment variable?
                 let unloadPipeline = Math.random() < 0.5 ? 0 : 1
                 if (unloadPipeline) {
                     opOk = k8s.unloadPipeline(generatePipelineName(modelName), true) && opOk


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR updates k6 scenario `tests/k6/scenarios/core2_qa_control_plane_ops.js` with pipelines. This scenario is then usable with tests such as the one triggered by `make deploy-kpipeline-test`.

There are assumptions to note with the current change:
- The test that we currently have is for a single model pipelines
- To update a pipeline we induce a change to the pipeline CR that has no real effect (by setting `batch` to a random value)
- We delete pipelines 50% of the time when a delete of a model is required, to simulate a pipeline that is not available due to issues with models.