### PR TITLE
fix(ansible): allow multiple custom secrets without namespaces

### DIFF
--- a/ansible/roles/seldon/tasks/custom_secrets.yaml
+++ b/ansible/roles/seldon/tasks/custom_secrets.yaml
@@ -3,7 +3,7 @@
 - name: Add the mesh namespace to custom secrets without an explicit namespace
   ansible.builtin.set_fact:
     seldon_custom_secrets: >-
-      {{  custom_secrets |
+      {{  seldon_custom_secrets | default(custom_secrets) |
            rejectattr('name', 'equalto', secrdef.name) | list +
            [ secrdef | combine({
              'namespaces': [seldon_mesh_namespace]


### PR DESCRIPTION
Fix a bug where defining multiple custom secrets in an extra-vars file without explicit namespaces would add the default namespace only to the last one, and fail the playbook.

**Special notes for your reviewer**:

Previously, each iteration of the modified set_fact would overwrite the `seldon_custom_secrets` variable entirely rather than updating it (appending the default namespace to each secret defined in `custom_secrets`).