### PR TITLE
fix(deps): major version updates in /scheduler/data-flow

### DIFF
--- a/scheduler/data-flow/build.gradle.kts
+++ b/scheduler/data-flow/build.gradle.kts
@@ -5,8 +5,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("com.github.hierynomus.license-report") version "0.16.1"
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    kotlin("jvm") version "1.8.20" // the kotlin version
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
+    kotlin("jvm") version "1.9.21" // the kotlin version
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     java
     application
 }
@@ -33,12 +33,12 @@ dependencies {
 
     // gRPC
     implementation("io.grpc:grpc-kotlin-stub:1.4.1")
-    implementation("io.grpc:grpc-stub:1.63.0")
-    implementation("io.grpc:grpc-protobuf:1.63.0")
-    runtimeOnly("io.grpc:grpc-netty-shaded:1.63.0")
+    implementation("io.grpc:grpc-stub:1.64.0")
+    implementation("io.grpc:grpc-protobuf:1.64.0")
+    runtimeOnly("io.grpc:grpc-netty-shaded:1.64.0")
     implementation("com.google.protobuf:protobuf-java:3.25.3")
     implementation("com.google.protobuf:protobuf-kotlin:3.25.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
     implementation("com.michael-bull.kotlin-retry:kotlin-retry:2.0.1")
 
     // k8s

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/TypeExtensions.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/TypeExtensions.kt
@@ -10,6 +10,7 @@ the Change License after the Change Date as each is defined in accordance with t
 package io.seldon.dataflow
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.DEFAULT_CONCURRENCY
@@ -17,7 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 
-@OptIn(FlowPreview::class)
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 suspend fun <T, R> Flow<T>.parallel(
     scope: CoroutineScope,
     concurrency: Int = DEFAULT_CONCURRENCY,

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/PipelineSubscriberTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/PipelineSubscriberTest.kt
@@ -9,6 +9,7 @@ the Change License after the Change Date as each is defined in accordance with t
 
 package io.seldon.dataflow
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.asFlow
@@ -37,6 +38,7 @@ internal class PipelineSubscriberTest {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `should run ops concurrently`() {
         val xs = (1..10).asFlow()
@@ -58,7 +60,7 @@ internal class PipelineSubscriberTest {
     }
 
     @Test
-    fun `should run ops in parallel`() {
+    fun `should run ops concurrently using custom Flow type extension`() {
         suspend fun waitAndPrint(i: Int) {
             kotlinx.coroutines.delay(1000)
             println("${LocalDateTime.now()} - $i")


### PR DESCRIPTION
- bump kotlin language version 1.8.20 -> 1.9.21
- bump kotlinx-coroutines-core 1.7.3 -> 1.8.1
- bump io.grpc:grpc-* 1.63.0 -> 1.64.0

The only remaining update that we would like to make to dataflow is bumping JDK 17 -> JDK 21. However, that update is currently blocked by the requirements of kafka-streams; The confluent platform libraries that we're using (kafka-streams:7.6.1-ccs) have only been tested up to JDK 17 according to: https://docs.confluent.io/platform/current/installation/versions-interoperability.html#java

**Which issue(s) this PR fixes**:
- INFRA-721 (Internal): Bump dataflow dependency versions

**Special notes for your reviewer**:
- Tested in kind (pipelines smoke test). Same behaviour as before the updates.
- The unrelated code updates just touch the code used by a test, in order to eliminate some compilation warnings