### PR TITLE
feat(k6): add automated state consistency checking

### DIFF
--- a/tests/k6/Dockerfile.k6
+++ b/tests/k6/Dockerfile.k6
@@ -1,3 +1,5 @@
+ARG K6_VERSION=0.51.0
+
 FROM alpine:3.19.1 AS builder
 
 RUN apk add --update \
@@ -8,8 +10,9 @@ RUN apk add --update \
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
 
-FROM grafana/k6
 
+FROM grafana/k6:${K6_VERSION}
+ARG K6_VERSION
 USER root
 
 RUN apk add --update python3 uuidgen sed go
@@ -29,17 +32,17 @@ ADD apis /home/apis/
 WORKDIR k6
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest
-RUN ~/go/bin/xk6 build --with github.com/grafana/xk6-kubernetes
+RUN ~/go/bin/xk6 build v${K6_VERSION} --with github.com/grafana/xk6-kubernetes
 
 RUN mkdir results
 
 RUN chmod +x k6wrapper.sh
 ENTRYPOINT ["./k6wrapper.sh", "run"]
 
-ARG GIT_COMMIT $GIT_COMMIT}
-ARG GIT_BRANCH ${GIT_COMMIT}
-ENV GIT_COMMIT ${GIT_COMMIT}
-ENV GIT_BRANCH ${GIT_BRANCH}
+ARG GIT_COMMIT=${GIT_COMMIT}
+ARG GIT_BRANCH=${GIT_COMMIT}
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV GIT_BRANCH=${GIT_BRANCH}
 
-# should be overriden in practice 
+# should be overriden in practice
 CMD ["-u", "5", "scenarios/infer_constant_vu.js"]

--- a/tests/k6/Makefile
+++ b/tests/k6/Makefile
@@ -1,6 +1,5 @@
 CUSTOM_IMAGE_TAG ?= latest
-# DOCKERHUB_USERNAME ?= seldonio
-DOCKERHUB_USERNAME ?= sakoushseldon
+DOCKERHUB_USERNAME ?= seldonio
 NAMESPACE ?= seldon-mesh
 K6_VERSION ?= 0.51.0
 

--- a/tests/k6/Makefile
+++ b/tests/k6/Makefile
@@ -1,6 +1,8 @@
 CUSTOM_IMAGE_TAG ?= latest
-DOCKERHUB_USERNAME ?= seldonio
+# DOCKERHUB_USERNAME ?= seldonio
+DOCKERHUB_USERNAME ?= sakoushseldon
 NAMESPACE ?= seldon-mesh
+K6_VERSION ?= 0.51.0
 
 IMG ?= ${DOCKERHUB_USERNAME}/seldon-k6:${CUSTOM_IMAGE_TAG}
 GIT_COMMIT := $(shell git rev-parse HEAD)
@@ -27,12 +29,17 @@ SERVICE_ACCOUNT_NAME ?= scv2-k6-tests
 GCS_BUCKET_NAME ?= seldon-tmp
 PROJECT_ID ?= seldon-pub
 
-docker-push: 
+docker-push:
 	docker push ${IMG}
 
 docker-build:
 	tar -czvf ../../k6.tar.gz .
-	cd ../../ && docker build --build-arg GIT_COMMIT=${GIT_COMMIT} --build-arg GIT_BRANCH=${GIT_BRANCH}  -t ${IMG} -f tests/k6/Dockerfile.k6 .
+	cd ../../ && docker build \
+		--build-arg GIT_COMMIT=${GIT_COMMIT} \
+		--build-arg GIT_BRANCH=${GIT_BRANCH} \
+		--build-arg K6_VERSION=${K6_VERSION} \
+		-t ${IMG} \
+		-f tests/k6/Dockerfile.k6 .
 	rm ../../k6.tar.gz
 
 docker-run:
@@ -58,25 +65,25 @@ deploy-rproxy-mlserver-test:
 undeploy-rproxy-test:
 	kustomize build configs/k8s/overlays/rproxy | kubectl delete -f -
 
-deploy-server-test: 
+deploy-server-test:
 	cd configs/k8s/base && kustomize edit set image k6=${IMG} && kustomize edit set namespace ${NAMESPACE}
 	kustomize build configs/k8s/overlays/server | SCHEDULER_ENDPOINT="${SCHEDULER_ENDPOINT}" RPROXY_ENDPOINT="${RPROXY_TRITON_ENDPOINT}" envsubst | kubectl apply -f -
 
-deploy-server-mlserver-test: 
+deploy-server-mlserver-test:
 	cd configs/k8s/base && kustomize edit set image k6=${IMG} && kustomize edit set namespace ${NAMESPACE}
 	kustomize build configs/k8s/overlays/server | SCHEDULER_ENDPOINT="${SCHEDULER_ENDPOINT}" RPROXY_ENDPOINT="${RPROXY_MLSERVER_ENDPOINT}" envsubst | kubectl apply -f -
 
 undeploy-server-test:
 	kustomize build configs/k8s/overlays/server | kubectl delete -f -
 
-deploy-kmodel-test: 
+deploy-kmodel-test:
 	cd configs/k8s/base && kustomize edit set image k6=${IMG} && kustomize edit set namespace ${NAMESPACE}
 	kustomize build configs/k8s/overlays/kmodel | SCHEDULER_ENDPOINT="${SCHEDULER_ENDPOINT}" PIPELINE_ENDPOINT="${PIPELINE_ENDPOINT}" envsubst | kubectl apply -f -
 
 undeploy-kmodel-test:
 	kustomize build configs/k8s/overlays/kmodel | kubectl delete -f -
 
-deploy-kpipeline-test: 
+deploy-kpipeline-test:
 	cd configs/k8s/base && kustomize edit set image k6=${IMG} && kustomize edit set namespace ${NAMESPACE}
 	kustomize build configs/k8s/overlays/kpipeline | SCHEDULER_ENDPOINT="${SCHEDULER_ENDPOINT}" PIPELINE_ENDPOINT="${PIPELINE_ENDPOINT}" envsubst | kubectl apply -f -
 
@@ -95,4 +102,4 @@ create-secret:
 xk6-install:
 	# Install xk6
 	go install go.k6.io/xk6/cmd/xk6@latest
-	xk6 build --with github.com/grafana/xk6-kubernetes
+	xk6 build v${K6_VERSION} --with github.com/grafana/xk6-kubernetes

--- a/tests/k6/components/scheduler.js
+++ b/tests/k6/components/scheduler.js
@@ -39,6 +39,36 @@ export function getModelStatus(modelName) {
     }
 }
 
+export async function getAllObjects(grpcStatusEndpointName){
+    let objStatusResponse = new Promise((resolve, reject) => {
+        let objStatusStream = new grpc.Stream(schedulerClient, grpcStatusEndpointName, null)
+        var objs = []
+        objStatusStream.on('data', function(objStatus) {
+            objs.push(objStatus)
+        })
+        objStatusStream.on('end', function() {
+            resolve(objs)
+        })
+        objStatusStream.on('error', function(err) {
+            console.log('error: ' + err)
+            reject(err)
+        })
+
+        objStatusStream.write({ "subscriberName": "seldon-k6", "allVersions": false })
+        objStatusStream.end()
+    })
+
+    return await objStatusResponse
+}
+
+export async function getAllModels() {
+    return await getAllObjects("seldon.mlops.scheduler.Scheduler/ModelStatus")
+}
+
+export async function getAllPipelines() {
+    return await getAllObjects("seldon.mlops.scheduler.Scheduler/PipelineStatus")
+}
+
 export function awaitStatus(modelName, status) {
     while (getModelStatus(modelName) !== status) {
         sleep(1)

--- a/tests/k6/components/scheduler.js
+++ b/tests/k6/components/scheduler.js
@@ -65,10 +65,6 @@ export async function getAllModels() {
     return await getAllObjects("seldon.mlops.scheduler.Scheduler/ModelStatus")
 }
 
-export async function getAllPipelines() {
-    return await getAllObjects("seldon.mlops.scheduler.Scheduler/PipelineStatus")
-}
-
 export function awaitStatus(modelName, status) {
     while (getModelStatus(modelName) !== status) {
         sleep(1)
@@ -83,6 +79,10 @@ export function unloadModel(modelName, awaitReady = true) {
             awaitStatus(modelName, "ModelTerminated")
         }
     }
+}
+
+export async function getAllPipelines() {
+    return await getAllObjects("seldon.mlops.scheduler.Scheduler/PipelineStatus")
 }
 
 export function loadPipeline(pipelineName, data, awaitReady=true) {
@@ -120,6 +120,10 @@ export function unloadPipeline(pipelineName, awaitReady = true) {
             awaitPipelineStatus(pipelineName, "PipelineTerminated")
         }
     }
+}
+
+export async function getAllExperiments() {
+    return await getAllObjects("seldon.mlops.scheduler.Scheduler/ExperimentStatus")
 }
 
 export function isExperimentActive(experimentName) {

--- a/tests/k6/components/scheduler.js
+++ b/tests/k6/components/scheduler.js
@@ -54,7 +54,13 @@ export async function getAllObjects(grpcStatusEndpointName){
             reject(err)
         })
 
-        objStatusStream.write({ "subscriberName": "seldon-k6", "allVersions": false })
+        let req = null
+        if (grpcStatusEndpointName.endsWith("ExperimentStatus")) {
+            req = { "subscriberName": "seldon-k6" }
+        } else {
+            req = { "subscriberName": "seldon-k6", "allVersions": false }
+        }
+        objStatusStream.write(req)
         objStatusStream.end()
     })
 

--- a/tests/k6/components/seldon.js
+++ b/tests/k6/components/seldon.js
@@ -15,3 +15,11 @@ export const seldonOpExecStatus = {
   FAIL: Symbol("Control-plane failure"),
   CONCURRENT_OP_FAIL: Symbol("Failure because of concurrent operation in another VU")
 }
+
+export function getSeldonObjectCommonName(objType) {
+  let objName = objType.description.split(".")[0]
+  return {
+    one: objName,
+    many: objName + "s"
+  }
+}

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -299,6 +299,13 @@ function stopOnCheckFailure() {
     return true
 }
 
+function enableStateCheck() {
+    if (__ENV.ENABLE_STATE_CHECK) {
+        return (__ENV.ENABLE_STATE_CHECK === "true")
+    }
+    return true
+}
+
 export function getConfig() {
     return {
         "useKubeControlPlane": useKubeControlPlane(),
@@ -337,6 +344,7 @@ export function getConfig() {
         "maxCreateOpsPerVU": maxCreateOpsPerVU(),
         "k8sDelaySecPerVU": k8sDelaySecPerVU(),
         "maxMemUpdateFraction": maxMemUpdateFraction(),
+        "enableStateCheck": enableStateCheck(),
         "checkStateEverySec": checkStateEverySec(),
         "maxCheckTimeSec": maxCheckTimeSec(),
         "stopOnCheckFailure": stopOnCheckFailure(),

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -271,6 +271,34 @@ function k8sDelaySecPerVU() {
     return 10
 }
 
+// How often to do state consistency checks (in seconds)
+function checkStateEverySec() {
+    if (__ENV.CHECK_STATE_EVERY_SECONDS) {
+        return Number(__ENV.CHECK_STATE_EVERY_SECONDS)
+    }
+    return 4 * 60
+}
+
+// Maximum time to wait for a state consistency check to complete (in seconds).
+// This MUST be fulfilled under all circumstances, otherwise concurrency issues
+// will appear. This is because other VUs will start control-plane operations
+// after maxCheckTimeSec in the current checkPeriod, irrespective of whether
+// the state check is done or not.
+function maxCheckTimeSec() {
+    if (__ENV.MAX_CHECK_TIME_SECONDS) {
+        return Number(__ENV.MAX_CHECK_TIME_SECONDS)
+    }
+    return 10
+}
+
+// Whether to abort the k6 test if a state consistency check fails
+function stopOnCheckFailure() {
+    if (__ENV.STOP_ON_CHECK_FAILURE) {
+        return (__ENV.STOP_ON_CHECK_FAILURE === "true")
+    }
+    return true
+}
+
 export function getConfig() {
     return {
         "useKubeControlPlane": useKubeControlPlane(),
@@ -309,5 +337,8 @@ export function getConfig() {
         "maxCreateOpsPerVU": maxCreateOpsPerVU(),
         "k8sDelaySecPerVU": k8sDelaySecPerVU(),
         "maxMemUpdateFraction": maxMemUpdateFraction(),
+        "checkStateEverySec": checkStateEverySec(),
+        "maxCheckTimeSec": maxCheckTimeSec(),
+        "stopOnCheckFailure": stopOnCheckFailure(),
     }
 }

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -484,19 +484,19 @@ export function checkModelsStateIsConsistent(k8sModels, schedModels) {
       let k8sModelName = k8sModel.metadata.name
       let isConsistent = true
 
-      // check same status
-      let k8sModelStatus = k8s.getModelCRStatus(k8sModel)
-      if (k8sModelStatus !== schedModel.state.state) {
+      // check same status & state
+      const {value: k8sModelState, met: modelIsReady} = k8s.getModelReadyCondition(k8sModel)
+      if (k8sModelState !== schedModel.state.state) {
           isConsistent = false
           let inconsistency = {
-              type: "ModelStatus",
-              message: `Model ${k8sModelName} has status ${k8sModelStatus} in K8S and ${schedModel.state.state} in Scheduler`
+              type: "ModelState",
+              message: `Model ${k8sModelName} has state ${k8sModelState} in K8S and ${schedModel.state.state} in Scheduler`
           }
           inconsArr.push(inconsistency)
       }
 
       // if status is "Ready" check same number of replicas
-      if (k8sModelStatus == "ModelReady" && k8sModel.status.replicas !== schedModel.state.availableReplicas) {
+      if (modelIsReady && k8sModel.status.replicas !== schedModel.state.availableReplicas) {
         isConsistent = false
         let inconsistency = {
             type: `ModelReplicas`,
@@ -507,7 +507,7 @@ export function checkModelsStateIsConsistent(k8sModels, schedModels) {
 
       // if status is "Ready" check if on the same version
       let schedVersion = schedModel.version
-      if (k8sModelStatus == "ModelReady" && k8sModel.metadata.generation !== schedVersion) {
+      if (modelIsReady && k8sModel.metadata.generation !== schedVersion) {
           isConsistent = false
           let inconsistency = {
           type: `ModelVersion`,
@@ -560,19 +560,19 @@ export function checkPipelinesStateIsConsistent(k8sPipelines, schedPipelines) {
       let isConsistent = true
 
       // check same status
-      let k8sPipelineStatus = k8s.getPipelineCRStatus(k8sPipeline)
-      if (k8sPipelineStatus !== schedPipeline.state.status) {
+      const {value: k8sPipelineState, met: pipelineIsReady} = k8s.getPipelineReadyCondition(k8sPipeline)
+      if (k8sPipelineState !== schedPipeline.state.status) {
           isConsistent = false
           let inconsistency = {
-              type: "PipelineStatus",
-              message: `Pipeline ${k8sPipelineName} has status ${k8sPipelineStatus} in K8S and ${schedPipeline.state.status} in Scheduler`
+              type: "PipelineState",
+              message: `Pipeline ${k8sPipelineName} has status ${k8sPipelineState} in K8S and ${schedPipeline.state.status} in Scheduler`
           }
           inconsArr.push(inconsistency)
       }
 
       // check same version
       let schedVersion = schedPipeline.pipeline.version
-      if (k8sPipelineStatus === "PipelineReady" && k8sPipeline.metadata.generation == schedVersion) {
+      if (pipelineIsReady && k8sPipeline.metadata.generation == schedVersion) {
           isConsistent = false
           let inconsistency = {
               type: `PipelineVersion`,
@@ -600,4 +600,8 @@ export function checkPipelinesStateIsConsistent(k8sPipelines, schedPipelines) {
   }
 
   return statesConsistent
+}
+
+export function checkExperimentsStateIsConsistent(k8sExperiments, schedExperiments) {
+  return true // to implement
 }

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -507,8 +507,8 @@ export function checkModelsStateIsConsistent(k8sModels, schedModels) {
 
       // if status is "Ready" check if on the same version
       let schedVersion = schedModel.version
-      if (k8sModelStatus == "ModelReady" && Number(k8sModel.metadata.generation) !== schedVersion) {
-          statesConsistent = false
+      if (k8sModelStatus == "ModelReady" && k8sModel.metadata.generation !== schedVersion) {
+          isConsistent = false
           let inconsistency = {
           type: `ModelVersion`,
           message: `Model ${k8sModelName} has version ${k8sModel.metadata.generation} in K8S and ${schedVersion} in Scheduler`
@@ -572,8 +572,8 @@ export function checkPipelinesStateIsConsistent(k8sPipelines, schedPipelines) {
 
       // check same version
       let schedVersion = schedPipeline.pipeline.version
-      if (k8sPipelineStatus === "PipelineReady" && Number(k8sPipeline.metadata.generation) == schedVersion) {
-          statesConsistent = false
+      if (k8sPipelineStatus === "PipelineReady" && k8sPipeline.metadata.generation == schedVersion) {
+          isConsistent = false
           let inconsistency = {
               type: `PipelineVersion`,
               message: `Pipeline ${k8sPipelineName} has version ${k8sPipeline.metadata.generation} in K8S and ${schedVersion} in Scheduler`

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -572,7 +572,7 @@ export function checkPipelinesStateIsConsistent(k8sPipelines, schedPipelines) {
 
       // check same version
       let schedVersion = schedPipeline.pipeline.version
-      if (pipelineIsReady && k8sPipeline.metadata.generation == schedVersion) {
+      if (pipelineIsReady && k8sPipeline.metadata.generation !== schedVersion) {
           isConsistent = false
           let inconsistency = {
               type: `PipelineVersion`,

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -1,4 +1,5 @@
 import { sleep } from 'k6';
+import { scenario, vu } from 'k6/execution';
 import { generateModel, generatePipelineName } from '../components/model.js';
 import { connectScheduler,
   disconnectScheduler,
@@ -16,7 +17,7 @@ import {
     loadModel as loadModelProxy,
     unloadModel as unloadModelProxy
 } from '../components/scheduler_proxy.js';
-import { seldonObjectType } from '../components/seldon.js'
+import { seldonObjectType, getSeldonObjectCommonName } from '../components/seldon.js'
 import { inferGrpcLoop, inferHttpLoop, modelStatusHttp } from '../components/v2.js';
 import * as k8s from '../components/k8s.js';
 
@@ -33,7 +34,7 @@ export function setupBase(config) {
 
                 ctl.loadModelFn(modelName, defs.model.modelDefn, true)
                 if (config.isLoadPipeline) {
-                    ctl.loadPipelineFn(generatePipelineName(modelName), defs.model.pipelineDefn, false)  // we use pipeline name as model name + "-pipeline"
+                    ctl.loadPipelineFn(generatePipelineName(modelName), defs.model.pipelineDefn, true)  // we use pipeline name as model name + "-pipeline"
                 }
             }
         }
@@ -220,4 +221,383 @@ export function getVersionSuffix(isSchedulerProxy) {
         versionSuffix = "_0"
     }
     return versionSuffix
+}
+
+/**
+ * periodicExclusiveRun(...) allows setting up k6 iteration code such that,
+ * periodically and for a fixed period, a single VU (VU 1) executes while other
+ * VUs wait. This is not a great synchronization primitive because the
+ * implementation relies on timestamps and sleeping. However, we choose this
+ * strategy as there is no implicit communication between VUs and we don't want
+ * to introduce external mechanisms or setup requirements (additional http
+ * endpoints to call in order to sync, a database, etc).
+ *
+ * However, for avoiding concurrency issues under the chosen design we need
+ * fairly large margins (say, 0.5 to 1s) for the following parameters:
+ *  - maxIterDuration, the max duration of an iteration (including any waits)
+ *  - maxRuntimeSec, the max duration of the function running exclusively
+ * In particular, the guarantees of exclusive execution might not hold towards
+ * the end of the intervals defined by those durations.
+ *
+ * @param {Number} exclusiveEverySec - The period where VU 1 runs exclusively
+ * starts every exclusiveEverySec seconds.
+ * @param {Number} maxRuntimeSec - The maximum time that the exclusive run might
+ * take. It's important for the exclusive code to complete well within this time;
+ * other VUs will only wait for this long before continuing, so after
+ * maxRuntimeSec VU1 looses execution exclusivity even if it hasn't finished
+ * running its "exclusive" code.
+ * @param {Number} maxIterDuration - The maximum time that a normal
+ * (non-exclusive) iteration might take. This is used to determine if there is
+ * enough time left before the next exclusive interval for another iteration to
+ * run. If any iterations run longer than this duration, we can no longer
+ * guarantee that the VU1 code run when periodicExclusiveRun(...) returns true
+ * will run exclusively.
+ * @param {object} status - The status object for the exclusive run. During the
+ * first call, this should be status = { isDue: true }. VU 1 needs to pass
+ * the same object here across iterations (a global) to keep track of whether
+ * the periodic exclusive run is due and to avoid running it twice in the same
+ * period.
+ * @returns {boolean} - Returns true only for VU 1, at the point where it is in
+ * the right time slot for running the exclusive check.
+ *
+ * Every VU should call periodicExclusiveRun(...) at the beginning of each
+ * iteration. The same configuration arguments need to be passed on each call
+ * (there's no support to modify the exclusive run frequency or max runtime).
+ *
+ * - If there is sufficient time for the VU to execute another iteration,
+ * periodicExclusiveRun simply returns false, and the iteration of the VU
+ * calling periodicExclusiveRun should continue as normal.
+ * - If not, VU1 waits until the time when the next exclusive run is scheduled
+ * and returns true. Other VUs wait until the time of the next exclusive run +
+ * the maximum time that the exclusive run might take, then return false.
+ *
+ * Example usage:
+ *
+ *   // globals
+ *   const status = { isDue: true }
+ *   const exclusiveEverySec = 30
+ *   const maxRuntimeSec = 5
+ *   const maxIterDuration = 10
+ *   ....
+ *   export default function (data) { // iteration code
+ *      if (periodicExclusiveRun(exclusiveEverySec, maxRuntimeSec, maxIterDuration, status)) {
+ *         // Code exclusively run on VU 1 every exclusiveEverySec seconds
+ *         // while other VUs wait
+ *
+ *         // return recommended if the exclusive run code sets any async
+ *         // operations; this will allow those to execute on the event loop
+ *         // before the next iteration starts
+ *         return
+ *      }
+ *
+ *      // Normal iteration code (parallel, on all VUs)
+ *   }
+ *
+ * The following diagram (not to scale) shows periods when iterations may run
+ * (marked with I) vs times when all VUs except the first one wait for the check
+ * on VU 1 to complete. It also shows, for an arbitrary iteration,
+ * the timeToNextRun as used in the implementation to determine if enough time
+ * exists to run another iteration:
+ *
+ * |<------------------exclusiveEverySec------------------>|<----exclusiveEverySec-----..
+ * |<---maxRuntimeSec--->|           |<--maxIterDuration-->|<---maxRuntimeSec--->|     ..
+ * |  VU 1 runs check    | I I I I I I                     |  VU 1 runs check    | I I ..
+ * |  other VUs wait     |       ^-----timeToNextRun------>|  other VUs wait     |
+ */
+export function periodicExclusiveRun(exclusiveEverySec, maxRuntimeSec, maxIterDuration, status) {
+  let timeSoFar = new Date().getTime() - scenario.startTime
+  const exclusiveEveryMs = exclusiveEverySec * 1000
+  const timeToNextRun = (exclusiveEveryMs - (timeSoFar % exclusiveEveryMs)) / 1000.0
+
+  // The case when a VU ends up calling periodicExclusiveRun during the time
+  // reserved for the exclusive run. It will occur on test startup (first
+  // exclusive run), and defend against iterations starting too soon in other
+  // cases.
+  const deltaFromPeriodStart = exclusiveEverySec - timeToNextRun
+  if (deltaFromPeriodStart < maxRuntimeSec) {
+      if (vu.idInTest == 1) {
+          if(status.isDue === true) {
+              status.isDue = false
+              return true
+          }
+      } else {
+          sleep(maxRuntimeSec - deltaFromPeriodStart)
+      }
+      return false
+  }
+
+  // We've passed beyond maxExclusiveRuntimeSec within the current period.
+  // Reset checkStatus for VU1, preparing for the next period
+  if (vu.idInTest == 1) {
+      status.isDue = true
+  }
+  // Do we have time to run another iteration (operation)?
+  if (timeToNextRun < maxIterDuration) {
+      // no time for another iteration; VU 1 will wait for the exclusive run
+      // time slot, others will wait until the exclusive run interval ends.
+      if (vu.idInTest == 1) {
+          console.log("VU 1 now waiting for the exclusive run time slot")
+          sleep(timeToNextRun)
+          status.isDue = false
+          return true
+      } else {
+          console.log(`VU ${vu.idInTest} now waiting for the exclusive run interval to end`)
+          sleep(timeToNextRun + maxRuntimeSec)
+      }
+  }
+  return false
+}
+
+/**
+ * Basic state consistency checks that apply to all seldon objects (Models,
+ * Pipelines, Experiments).
+ *
+ * There are 3 high-level checks implemented by this function:
+ *
+ * 1. The number of objects of the given type is the same in K8S and the scheduler
+ * 2. All objects in K8S are in the scheduler
+ * 3. There are no additional models present as non-terminated in the scheduler
+ * compared to the ones reported by K8S
+ *
+ * Custom checks when comparing two objects with the same name can be added by
+ * providing a perMatchCheckFn function. Other custom checks should be implemented
+ * separately.
+ *
+ * @param {*} k8sObjects - the array of objects (CRs) from Kubernetes.
+ * @param {*} schedObjects - the array of status objects as returned by the scheduler
+ * @param {*} objType - one of the seldon.seldonObjectType values
+ * @param {*} perMatchCheckFn - user-provided function running for each matched
+ * object pair (K8S, Scheduler). It should return true if the object states are
+ * consistent, and false if they are not. The function should accept three
+ * arguments: the K8S object, the Scheduler object, and an array to which it can
+ * append any inconsistencies found: function perMatchCheckFn(k8sObject,
+ * schedObject, inconsistencies)
+ * @returns {object} - Returns an object with the following properties:
+ * - schedObjIndex: the scheduler objects of the given type, indexed by name
+ * - stateIsConsistent: true if the state is consistent, false otherwise
+ * - inconsistencies: an array of inconsistencies found
+ *
+ */
+function checkSeldonObjectStateIsConsistent(k8sObjects, schedObjects, objType, perMatchCheckFn = null) {
+  let statesConsistent = true
+  let inconsistencies = []
+  let objName = getSeldonObjectCommonName(objType)
+
+  // Filter-out scheduler state objects that have been terminated, as those
+  // will never appear on the k8s side
+  let activeSchedObjs = schedObjects.filter(obj => {
+    switch (objType) {
+      case seldonObjectType.MODEL:
+        return obj.versions[0].state.state !== "ModelTerminated"
+      case seldonObjectType.PIPELINE:
+        return obj.versions[0].state.status !== "PipelineTerminated"
+      case seldonObjectType.EXPERIMENT:
+        return !obj.active
+    }
+  });
+
+  // Build index for objects currently active in the scheduler
+  let schedObjsIndex = {}
+  for (let i = 0; i < activeSchedObjs.length; i++) {
+      let propName = objName.one.charAt(0).toLowerCase() + objName.one.slice(1) + "Name"
+      let objInstanceName = activeSchedObjs[i][propName]
+      schedObjsIndex[objInstanceName] = activeSchedObjs[i].versions[0]
+      schedObjsIndex[objInstanceName].found = false
+  }
+
+  // CHECK 1: Number of objects in K8S and Scheduler are the same
+  if (k8sObjects.length !== activeSchedObjs.length) {
+      statesConsistent = false
+      let inconsistency = {
+          type: `NumberOf${objName.many}`,
+          message: `K8S has ${k8sObjects.length} ${objName.many}, Scheduler has ${activeSchedObjs.length} ${objName.many}`
+      }
+      inconsistencies.push(inconsistency)
+  } else {
+      console.log(`State consistency check: number of ${objName.many} = ${k8sObjects.length}`)
+  }
+
+  // CHECK 2: All objects in K8S are in the Scheduler, delegate per-object
+  // state checks to the perMatchCheckFn function, if provided
+  for (let i = 0; i < k8sObjects.length; i++) {
+      let k8sObject = k8sObjects[i]
+      let k8sObjectName = k8sObject.metadata.name
+      if (k8sObjectName in schedObjsIndex) {
+          let schedObject = schedObjsIndex[k8sObjectName]
+          schedObjsIndex[k8sObjectName].found = true
+
+          // More checks applicable for any two seldon objects with the same
+          // name can be added here
+
+          if (perMatchCheckFn != null) {
+            statesConsistent &= perMatchCheckFn(k8sObject, schedObject, inconsistencies)
+          }
+      } else {
+          statesConsistent = false
+          let inconsistency = {
+              type: `${objName.one}NotFound`,
+              message: `${objName.one} ${k8sObjectName} not found in scheduler`
+          }
+          inconsistencies.push(inconsistency)
+      }
+  }
+
+  // CHECK 3: The only models present as non-terminated in the scheduler are
+  // the ones we've just checked based on the K8S list
+  Object.keys(schedObjsIndex).forEach((objIxName) => {
+    if (!schedObjsIndex[objIxName].found) {
+        statesConsistent = false
+        let inconsistency = {
+            type: `${objName.one}NotFound`,
+            message: `${objName.one} ${objIxName} not found in K8S but present in scheduler`
+        }
+        inconsistencies.push(inconsistency)
+    }
+  })
+
+  return {
+    "schedObjIndex": schedObjsIndex,
+    "stateIsConsistent": statesConsistent,
+    "inconsistencies": inconsistencies,
+  }
+}
+
+/**
+ * Checks if the models' state is consistent between Kubernetes (K8S) and the scheduler.
+ *
+ * @param {Array} k8sModels - The array of model (CRs) from Kubernetes. This is typically
+ * fetched first, via k8sModels = k8s.getAllModels().
+ * @param {Array} schedModels - The array of models from the scheduler. This is typically
+ * fetched via scheduler.getAllModels().then((schedModels) => {
+ *    // call checkModelsStateIsConsistent(k8sModels, schedModels) here
+ * }).
+ * @returns {boolean} - Returns true if the models' state is consistent, false otherwise.
+ */
+export function checkModelsStateIsConsistent(k8sModels, schedModels) {
+  let statesConsistent = true
+  let inconsistencies = []
+
+  // Common checks for all seldon objects plus a number of model-specific checks
+  let commonChecks = checkSeldonObjectStateIsConsistent(k8sModels,
+    schedModels, seldonObjectType.MODEL,
+    (k8sModel, schedModel, inconsArr) => {
+      let k8sModelName = k8sModel.metadata.name
+      let isConsistent = true
+
+      // check same status
+      let k8sModelStatus = k8s.getModelCRStatus(k8sModel)
+      if (k8sModelStatus !== schedModel.state.state) {
+          isConsistent = false
+          let inconsistency = {
+              type: "ModelStatus",
+              message: `Model ${k8sModelName} has status ${k8sModelStatus} in K8S and ${schedModel.state.state} in Scheduler`
+          }
+          inconsArr.push(inconsistency)
+      }
+
+      // if status is "Ready" check same number of replicas
+      if (k8sModelStatus == "ModelReady" && k8sModel.status.replicas !== schedModel.state.availableReplicas) {
+        isConsistent = false
+        let inconsistency = {
+            type: `ModelReplicas`,
+            message: `Model ${k8sModelName} has ${k8sModel.status.replicas} replicas in K8S and ${schedModel.state.availableReplicas} in Scheduler`
+        }
+        inconsArr.push(inconsistency)
+      }
+
+      // if status is "Ready" check if on the same version
+      let schedVersion = schedModel.version
+      if (k8sModelStatus == "ModelReady" && Number(k8sModel.metadata.generation) !== schedVersion) {
+          statesConsistent = false
+          let inconsistency = {
+          type: `ModelVersion`,
+          message: `Model ${k8sModelName} has version ${k8sModel.metadata.generation} in K8S and ${schedVersion} in Scheduler`
+          }
+          inconsistencies.push(inconsistency)
+      }
+
+      return isConsistent
+    })
+
+  statesConsistent = commonChecks.stateIsConsistent
+  inconsistencies.push(...commonChecks.inconsistencies)
+
+  // Any further checks go here
+  // ...
+
+  if (!statesConsistent) {
+      console.log("[MODELS] State consistency check: FAIL; inconsistencies:")
+      for (let i = 0; i < inconsistencies.length; i++) {
+          console.log(inconsistencies[i].message)
+      }
+  } else {
+      console.log("[MODELS] State consistency check: OK")
+  }
+
+  return statesConsistent
+}
+
+/**
+ * Checks if the pipelines' state is consistent between Kubernetes (K8S) and the scheduler.
+ *
+ * @param {Array} k8sPipelines - The array of pipeline (CRs) from Kubernetes. This is typically
+ * fetched first, via k8sPipelines = k8s.getAllPipelines().
+ * @param {Array} schedPipelines - The array of pipelines from the scheduler. This is typically
+ * fetched via scheduler.getAllPipelines().then((schedPipelines) => {
+ *   // call checkPipelinesStateIsConsistent(k8sPipelines, schedPipelines) here
+ * }).
+ * @returns {boolean} - Returns true if the pipelines' state is consistent, false otherwise.
+ */
+export function checkPipelinesStateIsConsistent(k8sPipelines, schedPipelines) {
+  let statesConsistent = true
+  let inconsistencies = []
+
+  // Common checks for all seldon objects
+  let commonChecks = checkSeldonObjectStateIsConsistent(
+    k8sPipelines, schedPipelines, seldonObjectType.PIPELINE,
+    (k8sPipeline, schedPipeline, inconsArr) => {
+      let k8sPipelineName = k8sPipeline.metadata.name
+      let isConsistent = true
+
+      // check same status
+      let k8sPipelineStatus = k8s.getPipelineCRStatus(k8sPipeline)
+      if (k8sPipelineStatus !== schedPipeline.state.status) {
+          isConsistent = false
+          let inconsistency = {
+              type: "PipelineStatus",
+              message: `Pipeline ${k8sPipelineName} has status ${k8sPipelineStatus} in K8S and ${schedPipeline.state.status} in Scheduler`
+          }
+          inconsArr.push(inconsistency)
+      }
+
+      // check same version
+      let schedVersion = schedPipeline.pipeline.version
+      if (k8sPipelineStatus === "PipelineReady" && Number(k8sPipeline.metadata.generation) == schedVersion) {
+          statesConsistent = false
+          let inconsistency = {
+              type: `PipelineVersion`,
+              message: `Pipeline ${k8sPipelineName} has version ${k8sPipeline.metadata.generation} in K8S and ${schedVersion} in Scheduler`
+          }
+          inconsistencies.push(inconsistency)
+      }
+
+      return isConsistent
+    })
+
+  statesConsistent = commonChecks.stateIsConsistent
+  inconsistencies.push(...commonChecks.inconsistencies)
+
+  // Any further checks go here
+  // ...
+
+  if (!statesConsistent) {
+    console.log("[PIPELINES] State consistency check: FAIL; inconsistencies:")
+    for (let i = 0; i < inconsistencies.length; i++) {
+        console.log(inconsistencies[i].message)
+    }
+  } else {
+      console.log("[PIPELINES] State consistency check: OK")
+  }
+
+  return statesConsistent
 }

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -211,7 +211,7 @@ function handleCtlOp(config, op, modelTypeIx, existingModels, existingPipelines)
                     // This is because when deleting a model, we don't always delete
                     // its associated pipeline (to test the case when the pipeline remains
                     // and the model disappears) but instead pick another pipeline.
-                    targetPipelineName = pipelineName in existingPipelines ? pipelineName : altPipelineName
+                    targetPipelineName = existingPipelines.includes(pipelineName) ? pipelineName : altPipelineName
                     let pipeline = kubeClient.get(seldonObjectType.PIPELINE.description, targetPipelineName, config.namespace)
                     let steps = pipeline.spec.steps
                     steps[0]["batch"] = {"size": Math.round(Math.random() * 100)}  // to induce a change in pipeline

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -139,6 +139,7 @@ function handleCtlOp(config, op, modelTypeIx, existingModels, existingPipelines)
         case seldonOpType.DELETE:
             var randomModelIx = Math.floor(Math.random() * existingModels.length)
             modelName = existingModels[randomModelIx]
+            pipelineName = generatePipelineName(modelName)
 
             var randomPipelineIx = Math.floor(Math.random() * existingPipelines.length)
             altPipelineName = existingPipelines[randomPipelineIx]

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -163,10 +163,11 @@ function handleCtlOp(config, op, modelTypeIx, existingModels, existingPipelines)
                     // the model, we still want to delete a pipeline, because
                     // otherwise the number of pipelines will grow indefinitely.
                     // We have picked this altPipeline at random from the existing
-                    // ones. In practice, this means that the probability to delete
-                    // the pipeline associated with the model is slightly larger than
-                    // 0.5
-                    let unloadAltPipeline = Math.random() < 0.5 ? 0 : 1
+                    // ones (including the one associated with the model). This
+                    // means that the probability to delete the pipeline
+                    // associated with the deleted model is slightly larger than
+                    // 0.8
+                    let unloadAltPipeline = Math.random() > 0.8 ? 0 : 1
                     if (unloadAltPipeline) {
                         targetPipelineName = altPipelineName
                     }

--- a/tests/k6/scenarios/core2_qa_control_plane_ops.js
+++ b/tests/k6/scenarios/core2_qa_control_plane_ops.js
@@ -45,7 +45,7 @@ import { getConfig } from '../components/settings.js'
 import { seldonObjectType, seldonOpExecStatus, seldonOpType } from '../components/seldon.js';
 import {
     setupBase,
-    periodicExclusiveRun,
+    checkOrWaitForExclusiveRun,
     checkModelsStateIsConsistent,
     checkPipelinesStateIsConsistent,
     checkExperimentsStateIsConsistent,
@@ -76,7 +76,7 @@ const maxOpDuration = k8s.MAX_RETRIES + 2
 const maxIterDuration = maxOpDuration + getConfig().k8sDelaySecPerVU + maxRandomDelay
 
 // Variable only used by VU 1, to avoid running the check twice in the same
-// period; Pass object to periodicExclusiveRun(), as the status argument.
+// period; Pass object to checkOrWaitForExclusiveRun(), as the status argument.
 var checkStatus = {
     isDue: true
 }
@@ -154,7 +154,7 @@ function handleCtlOp(config, op, modelTypeIx, existingModels, existingPipelines)
 
             if (op === seldonOpType.DELETE) {
                 if (config.isLoadPipeline) {
-                    // We don't want to always delete the pipeline corrsponding to
+                    // We don't want to always delete the pipeline corresponding to
                     // the deleted model, because we also want to test the case
                     // where the pipeline remains without some of the component
                     // models.
@@ -310,7 +310,7 @@ function handleCtlOp(config, op, modelTypeIx, existingModels, existingPipelines)
 export default function (config) {
     kubeClient = k8s.init()
     if(config.enableStateCheck) {
-        if (periodicExclusiveRun(config.checkStateEverySec,
+        if (checkOrWaitForExclusiveRun(config.checkStateEverySec,
                                 config.maxCheckTimeSec,
                                 maxIterDuration, checkStatus)) {
             console.log(`VU ${vu.idInTest} starts a state consistency check...`)


### PR DESCRIPTION
Adds a number of reusable features to the k6 scenarios, so that we may periodically check that the state of objects (models, pipelines) on the seldon scheduler matches their state as viewed from the operator (k8s) side.

- k6 periodic randezvous implementation, with time slots where VU 1 executes code exclusively and other VUs wait. This is needed because we need other VUs to stop making changes to the state while we check consistency
- fetching object status from scheduler via k6 grpc streaming
- use of async operations during VU iteration code
- adds detailed state consistency checks for Models and Pipelines

**Which issue(s) this PR fixes:**
- INFRA-1026 (Internal): Add automated state consistency checks to k6