### PR TITLE
fix(scheduler): Pipeline terminating fix on rebalance

### DIFF
--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -655,7 +655,7 @@ func (s *stubChainerServer) Send(r *chainer.PipelineUpdateMessage) error {
 // TODO: this function is defined elsewhere, refactor to avoid duplication
 func createTestScheduler(t *testing.T, serverName string) (*ChainerServer, *coordinator.EventHub) {
 	logger := log.New()
-	logger.SetLevel(log.WarnLevel)
+	logger.SetLevel(log.DebugLevel)
 
 	eventHub, _ := coordinator.NewEventHub(logger)
 


### PR DESCRIPTION
This PR fixes a bug when a pipeline is in a terminating state gets recreated in the case of a dataflow subscription causing a rebalance. In this case we keep marking the pipeline as terminating and issue a delete operation to `dataflow-engine`.

Also added testing coverage for this part of the code base.

Fixes INFRA-1023 (internal)