### PR TITLE
Revert "Update license.yml"

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,9 +1,6 @@
 name: V2 Generate license
 
 on:
-  schedule:
-  # * is a special character in YAML so you have to quote this string
-  - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Reverts SeldonIO/seldon-core#5715

As this is only running the schedule for the `master` branch and not triggering v2.