### PR TITLE
fix(build): Trigger license check on changes to v2 branch

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,9 +1,8 @@
 name: V2 Licenses
 
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "0 0 * * *"
+  push:
+    branches: [ v2 ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR triggers 3rd party license check on changes to the v2 branch.

This replaces the cron schedule (as for some reason it was not working as expected). 