### PR TITLE
Changes to license.yml required for v2 license check

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,9 +1,8 @@
 name: V2 Generate license
 
 on:
-  schedule:
-  # * is a special character in YAML so you have to quote this string
-  - cron: "0 0 * * *"
+  push:
+    branches: [ v2 ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is required for v2 license checks and follows the pattern from https://github.com/SeldonIO/seldon-core/blob/master/.github/workflows/security_tests_v2.yml