### PR TITLE
feat(operator): add custom printcolumns for seldon-specific CRs

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
+++ b/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
@@ -16,7 +16,29 @@ spec:
     singular: experiment
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Experiment ready status
+      jsonPath: .status.conditions[?(@.type=='ExperimentReady')].status
+      name: Experiment ready
+      type: string
+    - description: Candidates ready status
+      jsonPath: .status.conditions[?(@.type=='CandidatesReady')].status
+      name: Candidates ready
+      priority: 1
+      type: string
+    - description: Mirror ready status
+      jsonPath: .status.conditions[?(@.type=='MirrorReady')].status
+      name: Mirror ready
+      priority: 1
+      type: string
+    - description: Status message
+      jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Experiment is the Schema for the experiments API
@@ -143,7 +165,19 @@ spec:
     singular: model
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Model ready status
+      jsonPath: .status.conditions[?(@.type=="ModelReady")].status
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Model is the Schema for the models API
@@ -335,7 +369,29 @@ spec:
     singular: pipeline
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Pipeline ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Pipeline ready
+      type: string
+    - description: Models ready status
+      jsonPath: .status.conditions[?(@.type=='ModelsReady')].status
+      name: Models ready
+      priority: 1
+      type: string
+    - description: Dataflow ready status
+      jsonPath: .status.conditions[?(@.type=='PipelineReady')].status
+      name: Dataflow ready
+      priority: 1
+      type: string
+    - description: Status message
+      jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Pipeline is the Schema for the pipelines API
@@ -852,7 +908,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -908,6 +966,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -1032,7 +1137,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -1083,6 +1189,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1199,7 +1348,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1255,6 +1406,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -1380,7 +1578,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -1431,6 +1630,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1797,7 +2039,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1826,6 +2072,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -1905,7 +2164,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1934,6 +2197,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -1992,8 +2268,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -2027,7 +2302,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -2129,13 +2407,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -2209,8 +2487,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -2244,7 +2521,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -2339,10 +2619,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -2364,10 +2690,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -2503,8 +2852,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -2541,17 +2891,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -2602,8 +2947,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -2637,7 +2981,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -2914,9 +3261,7 @@ spec:
                             list cannot be specified when creating a pod, and it cannot
                             be modified by updating the pod spec. In order to add
                             an ephemeral container to an existing pod, use the pod's
-                            ephemeralcontainers subresource. This field is beta-level
-                            and available on clusters that haven't disabled the EphemeralContainers
-                            feature gate.
+                            ephemeralcontainers subresource.
                           items:
                             description: "An EphemeralContainer is a temporary container
                               that you may add to an existing Pod for user-initiated
@@ -2927,9 +3272,7 @@ spec:
                               container causes the Pod to exceed its resource allocation.
                               \n To add an ephemeral container, use the ephemeralcontainers
                               subresource of an existing Pod. Ephemeral containers
-                              may not be removed or restarted. \n This is a beta feature
-                              available on clusters that haven't disabled the EphemeralContainers
-                              feature gate."
+                              may not be removed or restarted."
                             properties:
                               args:
                                 description: 'Arguments to the entrypoint. The image''s
@@ -3194,7 +3537,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3223,6 +3570,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -3302,7 +3662,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3331,6 +3695,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -3388,8 +3765,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -3423,7 +3799,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -3596,8 +3975,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -3631,7 +4009,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -3726,11 +4107,57 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: Resources are not allowed for ephemeral
                                   containers. Ephemeral containers use spare resources
                                   already allocated to the pod.
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -3752,10 +4179,16 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: Restart policy for the container to manage
+                                  the restart behavior of each container within a
+                                  pod. This may only be set for init containers. You
+                                  cannot set this field on ephemeral containers.
+                                type: string
                               securityContext:
                                 description: 'Optional: SecurityContext defines the
                                   security options the ephemeral container should
@@ -3891,8 +4324,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -3929,17 +4363,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -3982,8 +4411,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -4017,7 +4445,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -4279,6 +4710,19 @@ spec:
                         hostPID:
                           description: 'Use the host''s pid namespace. Optional: Default
                             to false.'
+                          type: boolean
+                        hostUsers:
+                          description: 'Use the host''s user namespace. Optional:
+                            Default to true. If set to true or not present, the pod
+                            will be run in the host user namespace, useful for when
+                            the pod needs a feature only available to the host user
+                            namespace, such as loading a kernel module with CAP_SYS_MODULE.
+                            When set to false, a new userns is created for the pod.
+                            Setting false is useful for mitigating container breakout
+                            vulnerabilities even allowing users to run their containers
+                            as root without actually having root privileges on the
+                            host. This field is alpha-level and is only honored by
+                            servers that enable the UserNamespacesSupport feature.'
                           type: boolean
                         hostname:
                           description: Specifies the hostname of the Pod If not specified,
@@ -4589,7 +5033,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4618,6 +5066,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -4697,7 +5158,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4726,6 +5191,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -4784,8 +5262,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -4819,7 +5296,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -4921,13 +5401,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -5001,8 +5481,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -5036,7 +5515,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -5131,10 +5613,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -5156,10 +5684,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -5295,8 +5846,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -5333,17 +5885,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -5394,8 +5941,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -5429,7 +5975,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -5668,18 +6217,17 @@ spec:
                             is set. \n If the OS field is set to linux, the following
                             fields must be unset: -securityContext.windowsOptions
                             \n If the OS field is set to windows, following fields
-                            must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
-                            - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                            - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                            - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                            - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
-                            - spec.containers[*].securityContext.seLinuxOptions -
-                            spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities
-                            - spec.containers[*].securityContext.readOnlyRootFilesystem
+                            must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                            - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                            - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                            - spec.securityContext.sysctls - spec.shareProcessNamespace
+                            - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                            - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
+                            - spec.containers[*].securityContext.seccompProfile -
+                            spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem
                             - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
                             - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                            - spec.containers[*].securityContext.runAsGroup This is
-                            a beta field and requires the IdentifyPodOS feature"
+                            - spec.containers[*].securityContext.runAsGroup"
                           properties:
                             name:
                               description: 'Name is the name of the operating system.
@@ -5753,10 +6301,60 @@ spec:
                             - conditionType
                             type: object
                           type: array
+                        resourceClaims:
+                          description: "ResourceClaims defines which ResourceClaims
+                            must be allocated and reserved before the Pod is allowed
+                            to start. The resources will be made available to those
+                            containers which consume them by name. \n This is an alpha
+                            field and requires enabling the DynamicResourceAllocation
+                            feature gate. \n This field is immutable."
+                          items:
+                            description: PodResourceClaim references exactly one ResourceClaim
+                              through a ClaimSource. It adds a name to it that uniquely
+                              identifies the ResourceClaim inside the Pod. Containers
+                              that need access to the ResourceClaim reference it with
+                              this name.
+                            properties:
+                              name:
+                                description: Name uniquely identifies this resource
+                                  claim inside the pod. This must be a DNS_LABEL.
+                                type: string
+                              source:
+                                description: Source describes where to find the ResourceClaim.
+                                properties:
+                                  resourceClaimName:
+                                    description: ResourceClaimName is the name of
+                                      a ResourceClaim object in the same namespace
+                                      as this pod.
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    description: "ResourceClaimTemplateName is the
+                                      name of a ResourceClaimTemplate object in the
+                                      same namespace as this pod. \n The template
+                                      will be used to create a new ResourceClaim,
+                                      which will be bound to this pod. When this pod
+                                      is deleted, the ResourceClaim will also be deleted.
+                                      The pod name and resource name, along with a
+                                      generated component, will be used to form a
+                                      unique name for the ResourceClaim, which will
+                                      be recorded in pod.status.resourceClaimStatuses.
+                                      \n This field is immutable and no changes will
+                                      be made to the corresponding ResourceClaim by
+                                      the control plane after creating the ResourceClaim."
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         restartPolicy:
                           description: 'Restart policy for all containers within the
-                            pod. One of Always, OnFailure, Never. Default to Always.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                            pod. One of Always, OnFailure, Never. In some contexts,
+                            only a subset of those values may be permitted. Default
+                            to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                           type: string
                         runtimeClassName:
                           description: 'RuntimeClassName refers to a RuntimeClass
@@ -5772,6 +6370,30 @@ spec:
                             specified scheduler. If not specified, the pod will be
                             dispatched by default scheduler.
                           type: string
+                        schedulingGates:
+                          description: "SchedulingGates is an opaque list of values
+                            that if specified will block scheduling the pod. If schedulingGates
+                            is not empty, the pod will stay in the SchedulingGated
+                            state and the scheduler will not attempt to schedule the
+                            pod. \n SchedulingGates can only be set at pod creation
+                            time, and be removed only afterwards. \n This is a beta
+                            feature enabled by the PodSchedulingReadiness feature
+                            gate."
+                          items:
+                            description: PodSchedulingGate is associated to a Pod
+                              to guard its scheduling.
+                            properties:
+                              name:
+                                description: Name of the scheduling gate. Each scheduling
+                                  gate must have a unique name field.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         securityContext:
                           description: 'SecurityContext holds pod-level security attributes
                             and common container settings. Optional: Defaults to empty.  See
@@ -5867,7 +6489,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -5883,9 +6506,14 @@ spec:
                             supplementalGroups:
                               description: A list of groups applied to the first process
                                 run in each container, in addition to the container's
-                                primary GID.  If unspecified, no groups will be added
-                                to any container. Note that this field cannot be set
-                                when spec.os.name is windows.
+                                primary GID, the fsGroup (if specified), and group
+                                memberships defined in the container image for the
+                                uid of the container process. If unspecified, no additional
+                                groups are added to any container. Note that group
+                                memberships defined in the container image for the
+                                uid of the container process are still effective,
+                                even if they are not included in this list. Note that
+                                this field cannot be set when spec.os.name is windows.
                               items:
                                 format: int64
                                 type: integer
@@ -5932,15 +6560,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -6103,6 +6727,25 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: "MatchLabelKeys is a set of pod label
+                                  keys to select the pods over which spreading will
+                                  be calculated. The keys are used to lookup values
+                                  from the incoming pod labels, those key-value labels
+                                  are ANDed with labelSelector to select the group
+                                  of existing pods over which spreading will be calculated
+                                  for the incoming pod. The same key is forbidden
+                                  to exist in both MatchLabelKeys and LabelSelector.
+                                  MatchLabelKeys cannot be set when LabelSelector
+                                  isn't set. Keys that don't exist in the incoming
+                                  pod labels will be ignored. A null or empty list
+                                  means only match against labelSelector. \n This
+                                  is a beta field and requires the MatchLabelKeysInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               maxSkew:
                                 description: 'MaxSkew describes the degree to which
                                   pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -6150,10 +6793,34 @@ spec:
                                   cannot be scheduled, because computed skew will
                                   be 3(3 - 0) if new Pod is scheduled to any of the
                                   three zones, it will violate MaxSkew. \n This is
-                                  an alpha field and requires enabling MinDomainsInPodTopologySpread
-                                  feature gate."
+                                  a beta field and requires the MinDomainsInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
                                 format: int32
                                 type: integer
+                              nodeAffinityPolicy:
+                                description: "NodeAffinityPolicy indicates how we
+                                  will treat Pod's nodeAffinity/nodeSelector when
+                                  calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector
+                                  are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                  are ignored. All nodes are included in the calculations.
+                                  \n If this value is nil, the behavior is equivalent
+                                  to the Honor policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              nodeTaintsPolicy:
+                                description: "NodeTaintsPolicy indicates how we will
+                                  treat node taints when calculating pod topology
+                                  spread skew. Options are: - Honor: nodes without
+                                  taints, along with tainted nodes for which the incoming
+                                  pod has a toleration, are included. - Ignore: node
+                                  taints are ignored. All nodes are included. \n If
+                                  this value is nil, the behavior is equivalent to
+                                  the Ignore policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
                               topologyKey:
                                 description: TopologyKey is the key of node labels.
                                   Nodes that have a label with this key and identical
@@ -6162,11 +6829,12 @@ spec:
                                   try to put balanced number of pods into each bucket.
                                   We define a domain as a particular instance of a
                                   topology. Also, we define an eligible domain as
-                                  a domain whose nodes match the node selector. e.g.
-                                  If TopologyKey is "kubernetes.io/hostname", each
-                                  Node is a domain of that topology. And, if TopologyKey
-                                  is "topology.kubernetes.io/zone", each zone is a
-                                  domain of that topology. It's a required field.
+                                  a domain whose nodes meet the requirements of nodeAffinityPolicy
+                                  and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                  each Node is a domain of that topology. And, if
+                                  TopologyKey is "topology.kubernetes.io/zone", each
+                                  zone is a domain of that topology. It's a required
+                                  field.
                                 type: string
                               whenUnsatisfiable:
                                 description: 'WhenUnsatisfiable indicates how to deal
@@ -6634,7 +7302,7 @@ spec:
                                       specified here and the sum of memory limits
                                       of all containers in a pod. The default is nil
                                       which means that the limit is undefined. More
-                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
@@ -6714,10 +7382,14 @@ spec:
                                               can support the specified data source,
                                               it will create a new volume based on
                                               the contents of the specified data source.
-                                              If the AnyVolumeDataSource feature gate
-                                              is enabled, this field will always have
-                                              the same contents as the DataSourceRef
-                                              field.'
+                                              When the AnyVolumeDataSource feature
+                                              gate is enabled, dataSource contents
+                                              will be copied to dataSourceRef, and
+                                              dataSourceRef contents will be copied
+                                              to dataSource when dataSourceRef.namespace
+                                              is not specified. If the namespace is
+                                              specified, then dataSourceRef will not
+                                              be copied to dataSource.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -6744,33 +7416,41 @@ spec:
                                             description: 'dataSourceRef specifies
                                               the object from which to populate the
                                               volume with data, if a non-empty volume
-                                              is desired. This may be any local object
-                                              from a non-empty API group (non core
-                                              object) or a PersistentVolumeClaim object.
-                                              When this field is specified, volume
-                                              binding will only succeed if the type
-                                              of the specified object matches some
-                                              installed volume populator or dynamic
-                                              provisioner. This field will replace
-                                              the functionality of the DataSource
-                                              field and as such if both fields are
-                                              non-empty, they must have the same value.
-                                              For backwards compatibility, both fields
-                                              (DataSource and DataSourceRef) will
-                                              be set to the same value automatically
+                                              is desired. This may be any object from
+                                              a non-empty API group (non core object)
+                                              or a PersistentVolumeClaim object. When
+                                              this field is specified, volume binding
+                                              will only succeed if the type of the
+                                              specified object matches some installed
+                                              volume populator or dynamic provisioner.
+                                              This field will replace the functionality
+                                              of the dataSource field and as such
+                                              if both fields are non-empty, they must
+                                              have the same value. For backwards compatibility,
+                                              when namespace isn''t specified in dataSourceRef,
+                                              both fields (dataSource and dataSourceRef)
+                                              will be set to the same value automatically
                                               if one of them is empty and the other
-                                              is non-empty. There are two important
-                                              differences between DataSource and DataSourceRef:
-                                              * While DataSource only allows two specific
-                                              types of objects, DataSourceRef allows
+                                              is non-empty. When namespace is specified
+                                              in dataSourceRef, dataSource isn''t
+                                              set to the same value and must be empty.
+                                              There are three important differences
+                                              between dataSource and dataSourceRef:
+                                              * While dataSource only allows two specific
+                                              types of objects, dataSourceRef allows
                                               any non-core object, as well as PersistentVolumeClaim
-                                              objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef
+                                              objects. * While dataSource ignores
+                                              disallowed values (dropping them), dataSourceRef
                                               preserves all values, and generates
                                               an error if a disallowed value is specified.
-                                              (Beta) Using this field requires the
-                                              AnyVolumeDataSource feature gate to
-                                              be enabled.'
+                                              * While dataSource only allows local
+                                              objects, dataSourceRef allows objects
+                                              in any namespaces. (Beta) Using this
+                                              field requires the AnyVolumeDataSource
+                                              feature gate to be enabled. (Alpha)
+                                              Using the namespace field of dataSourceRef
+                                              requires the CrossNamespaceVolumeDataSource
+                                              feature gate to be enabled.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -6788,11 +7468,23 @@ spec:
                                                 description: Name is the name of resource
                                                   being referenced
                                                 type: string
+                                              namespace:
+                                                description: Namespace is the namespace
+                                                  of resource being referenced Note
+                                                  that when a namespace is specified,
+                                                  a gateway.networking.k8s.io/ReferenceGrant
+                                                  object is required in the referent
+                                                  namespace to allow that namespace's
+                                                  owner to accept the reference. See
+                                                  the ReferenceGrant documentation
+                                                  for details. (Alpha) This field
+                                                  requires the CrossNamespaceVolumeDataSource
+                                                  feature gate to be enabled.
+                                                type: string
                                             required:
                                             - kind
                                             - name
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           resources:
                                             description: 'resources represents the
                                               minimum resources the volume should
@@ -6828,7 +7520,8 @@ spec:
                                                   for a container, it defaults to
                                                   Limits if that is explicitly specified,
                                                   otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                 type: object
                                             type: object
                                           selector:
@@ -6893,6 +7586,34 @@ spec:
                                             description: 'storageClassName is the
                                               name of the StorageClass required by
                                               the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeAttributesClassName:
+                                            description: 'volumeAttributesClassName
+                                              may be used to set the VolumeAttributesClass
+                                              used by this claim. If specified, the
+                                              CSI driver will create or update the
+                                              volume with the attributes defined in
+                                              the corresponding VolumeAttributesClass.
+                                              This has a different purpose than storageClassName,
+                                              it can be changed after the claim is
+                                              created. An empty string value means
+                                              that no VolumeAttributesClass will be
+                                              applied to the claim but it''s not allowed
+                                              to reset this field to empty string
+                                              once it is set. If unspecified and the
+                                              PersistentVolumeClaim is unbound, the
+                                              default VolumeAttributesClass will be
+                                              set by the persistentvolume controller
+                                              if it exists. If the resource referred
+                                              to by volumeAttributesClass does not
+                                              exist, this PersistentVolumeClaim will
+                                              be set to a Pending state, as reflected
+                                              by the modifyVolumeStatus field, until
+                                              such as a resource exists. More info:
+                                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                              (Alpha) Using this field requires the
+                                              VolumeAttributesClass feature gate to
+                                              be enabled.'
                                             type: string
                                           volumeMode:
                                             description: volumeMode defines what type
@@ -7302,6 +8023,118 @@ spec:
                                       description: Projection that may be projected
                                         along with other supported volume types
                                       properties:
+                                        clusterTrustBundle:
+                                          description: "ClusterTrustBundle allows
+                                            a pod to access the `.spec.trustBundle`
+                                            field of ClusterTrustBundle objects in
+                                            an auto-updating file. \n Alpha, gated
+                                            by the ClusterTrustBundleProjection feature
+                                            gate. \n ClusterTrustBundle objects can
+                                            either be selected by name, or by the
+                                            combination of signer name and a label
+                                            selector. \n Kubelet performs aggressive
+                                            normalization of the PEM contents written
+                                            into the pod filesystem.  Esoteric PEM
+                                            features such as inter-block comments
+                                            and block headers are stripped.  Certificates
+                                            are deduplicated. The ordering of certificates
+                                            within the file is arbitrary, and Kubelet
+                                            may change the order over time."
+                                          properties:
+                                            labelSelector:
+                                              description: Select all ClusterTrustBundles
+                                                that match this label selector.  Only
+                                                has effect if signerName is set.  Mutually-exclusive
+                                                with name.  If unset, interpreted
+                                                as "match nothing".  If set but empty,
+                                                interpreted as "match everything".
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            name:
+                                              description: Select a single ClusterTrustBundle
+                                                by object name.  Mutually-exclusive
+                                                with signerName and labelSelector.
+                                              type: string
+                                            optional:
+                                              description: If true, don't block pod
+                                                startup if the referenced ClusterTrustBundle(s)
+                                                aren't available.  If using name,
+                                                then the named ClusterTrustBundle
+                                                is allowed not to exist.  If using
+                                                signerName, then the combination of
+                                                signerName and labelSelector is allowed
+                                                to match zero ClusterTrustBundles.
+                                              type: boolean
+                                            path:
+                                              description: Relative path from the
+                                                volume root to write the bundle.
+                                              type: string
+                                            signerName:
+                                              description: Select all ClusterTrustBundles
+                                                that match this signer name. Mutually-exclusive
+                                                with name.  The contents of all selected
+                                                ClusterTrustBundles will be unified
+                                                and deduplicated.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
                                         configMap:
                                           description: configMap information about
                                             the configMap data to project
@@ -7919,9 +8752,12 @@ spec:
                                   provisioner or an external controller can support
                                   the specified data source, it will create a new
                                   volume based on the contents of the specified data
-                                  source. If the AnyVolumeDataSource feature gate
-                                  is enabled, this field will always have the same
-                                  contents as the DataSourceRef field.'
+                                  source. When the AnyVolumeDataSource feature gate
+                                  is enabled, dataSource contents will be copied to
+                                  dataSourceRef, and dataSourceRef contents will be
+                                  copied to dataSource when dataSourceRef.namespace
+                                  is not specified. If the namespace is specified,
+                                  then dataSourceRef will not be copied to dataSource.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -7946,27 +8782,33 @@ spec:
                               dataSourceRef:
                                 description: 'dataSourceRef specifies the object from
                                   which to populate the volume with data, if a non-empty
-                                  volume is desired. This may be any local object
-                                  from a non-empty API group (non core object) or
-                                  a PersistentVolumeClaim object. When this field
-                                  is specified, volume binding will only succeed if
-                                  the type of the specified object matches some installed
-                                  volume populator or dynamic provisioner. This field
-                                  will replace the functionality of the DataSource
-                                  field and as such if both fields are non-empty,
-                                  they must have the same value. For backwards compatibility,
-                                  both fields (DataSource and DataSourceRef) will
-                                  be set to the same value automatically if one of
-                                  them is empty and the other is non-empty. There
-                                  are two important differences between DataSource
-                                  and DataSourceRef: * While DataSource only allows
-                                  two specific types of objects, DataSourceRef allows
+                                  volume is desired. This may be any object from a
+                                  non-empty API group (non core object) or a PersistentVolumeClaim
+                                  object. When this field is specified, volume binding
+                                  will only succeed if the type of the specified object
+                                  matches some installed volume populator or dynamic
+                                  provisioner. This field will replace the functionality
+                                  of the dataSource field and as such if both fields
+                                  are non-empty, they must have the same value. For
+                                  backwards compatibility, when namespace isn''t specified
+                                  in dataSourceRef, both fields (dataSource and dataSourceRef)
+                                  will be set to the same value automatically if one
+                                  of them is empty and the other is non-empty. When
+                                  namespace is specified in dataSourceRef, dataSource
+                                  isn''t set to the same value and must be empty.
+                                  There are three important differences between dataSource
+                                  and dataSourceRef: * While dataSource only allows
+                                  two specific types of objects, dataSourceRef allows
                                   any non-core object, as well as PersistentVolumeClaim
-                                  objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef preserves all values,
+                                  objects. * While dataSource ignores disallowed values
+                                  (dropping them), dataSourceRef preserves all values,
                                   and generates an error if a disallowed value is
-                                  specified. (Beta) Using this field requires the
-                                  AnyVolumeDataSource feature gate to be enabled.'
+                                  specified. * While dataSource only allows local
+                                  objects, dataSourceRef allows objects in any namespaces.
+                                  (Beta) Using this field requires the AnyVolumeDataSource
+                                  feature gate to be enabled. (Alpha) Using the namespace
+                                  field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                  feature gate to be enabled.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -7983,11 +8825,21 @@ spec:
                                     description: Name is the name of resource being
                                       referenced
                                     type: string
+                                  namespace:
+                                    description: Namespace is the namespace of resource
+                                      being referenced Note that when a namespace
+                                      is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                      object is required in the referent namespace
+                                      to allow that namespace's owner to accept the
+                                      reference. See the ReferenceGrant documentation
+                                      for details. (Alpha) This field requires the
+                                      CrossNamespaceVolumeDataSource feature gate
+                                      to be enabled.
+                                    type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
-                                x-kubernetes-map-type: atomic
                               resources:
                                 description: 'resources represents the minimum resources
                                   the volume should have. If RecoverVolumeExpansionFailure
@@ -8017,8 +8869,8 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
                               selector:
@@ -8073,6 +8925,27 @@ spec:
                               storageClassName:
                                 description: 'storageClassName is the name of the
                                   StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeAttributesClassName:
+                                description: 'volumeAttributesClassName may be used
+                                  to set the VolumeAttributesClass used by this claim.
+                                  If specified, the CSI driver will create or update
+                                  the volume with the attributes defined in the corresponding
+                                  VolumeAttributesClass. This has a different purpose
+                                  than storageClassName, it can be changed after the
+                                  claim is created. An empty string value means that
+                                  no VolumeAttributesClass will be applied to the
+                                  claim but it''s not allowed to reset this field
+                                  to empty string once it is set. If unspecified and
+                                  the PersistentVolumeClaim is unbound, the default
+                                  VolumeAttributesClass will be set by the persistentvolume
+                                  controller if it exists. If the resource referred
+                                  to by volumeAttributesClass does not exist, this
+                                  PersistentVolumeClaim will be set to a Pending state,
+                                  as reflected by the modifyVolumeStatus field, until
+                                  such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                  (Alpha) Using this field requires the VolumeAttributesClass
+                                  feature gate to be enabled.'
                                 type: string
                               volumeMode:
                                 description: volumeMode defines what type of volume
@@ -8560,7 +9433,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -8616,6 +9491,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -8740,7 +9662,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -8791,6 +9714,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -8907,7 +9873,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -8963,6 +9931,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -9088,7 +10103,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -9139,6 +10155,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -9505,7 +10564,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -9534,6 +10597,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -9613,7 +10689,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -9642,6 +10722,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -9700,8 +10793,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -9735,7 +10827,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -9837,13 +10932,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -9917,8 +11012,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -9952,7 +11046,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -10047,10 +11144,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -10072,10 +11215,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -10211,8 +11377,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -10249,17 +11416,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -10310,8 +11472,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -10345,7 +11506,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -10958,7 +12122,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -10987,6 +12155,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -11066,7 +12247,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -11095,6 +12280,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -11153,8 +12351,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -11188,7 +12385,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -11290,13 +12490,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -11370,8 +12570,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -11405,7 +12604,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -11500,10 +12702,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -11525,10 +12773,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -11664,8 +12935,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -11702,17 +12974,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -11763,8 +13030,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -11798,7 +13064,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -12209,7 +13478,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -12225,9 +13495,14 @@ spec:
                             supplementalGroups:
                               description: A list of groups applied to the first process
                                 run in each container, in addition to the container's
-                                primary GID.  If unspecified, no groups will be added
-                                to any container. Note that this field cannot be set
-                                when spec.os.name is windows.
+                                primary GID, the fsGroup (if specified), and group
+                                memberships defined in the container image for the
+                                uid of the container process. If unspecified, no additional
+                                groups are added to any container. Note that group
+                                memberships defined in the container image for the
+                                uid of the container process are still effective,
+                                even if they are not included in this list. Note that
+                                this field cannot be set when spec.os.name is windows.
                               items:
                                 format: int64
                                 type: integer
@@ -12274,15 +13549,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -12439,6 +13710,25 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: "MatchLabelKeys is a set of pod label
+                                  keys to select the pods over which spreading will
+                                  be calculated. The keys are used to lookup values
+                                  from the incoming pod labels, those key-value labels
+                                  are ANDed with labelSelector to select the group
+                                  of existing pods over which spreading will be calculated
+                                  for the incoming pod. The same key is forbidden
+                                  to exist in both MatchLabelKeys and LabelSelector.
+                                  MatchLabelKeys cannot be set when LabelSelector
+                                  isn't set. Keys that don't exist in the incoming
+                                  pod labels will be ignored. A null or empty list
+                                  means only match against labelSelector. \n This
+                                  is a beta field and requires the MatchLabelKeysInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               maxSkew:
                                 description: 'MaxSkew describes the degree to which
                                   pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -12486,10 +13776,34 @@ spec:
                                   cannot be scheduled, because computed skew will
                                   be 3(3 - 0) if new Pod is scheduled to any of the
                                   three zones, it will violate MaxSkew. \n This is
-                                  an alpha field and requires enabling MinDomainsInPodTopologySpread
-                                  feature gate."
+                                  a beta field and requires the MinDomainsInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
                                 format: int32
                                 type: integer
+                              nodeAffinityPolicy:
+                                description: "NodeAffinityPolicy indicates how we
+                                  will treat Pod's nodeAffinity/nodeSelector when
+                                  calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector
+                                  are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                  are ignored. All nodes are included in the calculations.
+                                  \n If this value is nil, the behavior is equivalent
+                                  to the Honor policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              nodeTaintsPolicy:
+                                description: "NodeTaintsPolicy indicates how we will
+                                  treat node taints when calculating pod topology
+                                  spread skew. Options are: - Honor: nodes without
+                                  taints, along with tainted nodes for which the incoming
+                                  pod has a toleration, are included. - Ignore: node
+                                  taints are ignored. All nodes are included. \n If
+                                  this value is nil, the behavior is equivalent to
+                                  the Ignore policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
                               topologyKey:
                                 description: TopologyKey is the key of node labels.
                                   Nodes that have a label with this key and identical
@@ -12498,11 +13812,12 @@ spec:
                                   try to put balanced number of pods into each bucket.
                                   We define a domain as a particular instance of a
                                   topology. Also, we define an eligible domain as
-                                  a domain whose nodes match the node selector. e.g.
-                                  If TopologyKey is "kubernetes.io/hostname", each
-                                  Node is a domain of that topology. And, if TopologyKey
-                                  is "topology.kubernetes.io/zone", each zone is a
-                                  domain of that topology. It's a required field.
+                                  a domain whose nodes meet the requirements of nodeAffinityPolicy
+                                  and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                  each Node is a domain of that topology. And, if
+                                  TopologyKey is "topology.kubernetes.io/zone", each
+                                  zone is a domain of that topology. It's a required
+                                  field.
                                 type: string
                               whenUnsatisfiable:
                                 description: 'WhenUnsatisfiable indicates how to deal
@@ -12970,7 +14285,7 @@ spec:
                                       specified here and the sum of memory limits
                                       of all containers in a pod. The default is nil
                                       which means that the limit is undefined. More
-                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
@@ -13050,10 +14365,14 @@ spec:
                                               can support the specified data source,
                                               it will create a new volume based on
                                               the contents of the specified data source.
-                                              If the AnyVolumeDataSource feature gate
-                                              is enabled, this field will always have
-                                              the same contents as the DataSourceRef
-                                              field.'
+                                              When the AnyVolumeDataSource feature
+                                              gate is enabled, dataSource contents
+                                              will be copied to dataSourceRef, and
+                                              dataSourceRef contents will be copied
+                                              to dataSource when dataSourceRef.namespace
+                                              is not specified. If the namespace is
+                                              specified, then dataSourceRef will not
+                                              be copied to dataSource.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -13080,33 +14399,41 @@ spec:
                                             description: 'dataSourceRef specifies
                                               the object from which to populate the
                                               volume with data, if a non-empty volume
-                                              is desired. This may be any local object
-                                              from a non-empty API group (non core
-                                              object) or a PersistentVolumeClaim object.
-                                              When this field is specified, volume
-                                              binding will only succeed if the type
-                                              of the specified object matches some
-                                              installed volume populator or dynamic
-                                              provisioner. This field will replace
-                                              the functionality of the DataSource
-                                              field and as such if both fields are
-                                              non-empty, they must have the same value.
-                                              For backwards compatibility, both fields
-                                              (DataSource and DataSourceRef) will
-                                              be set to the same value automatically
+                                              is desired. This may be any object from
+                                              a non-empty API group (non core object)
+                                              or a PersistentVolumeClaim object. When
+                                              this field is specified, volume binding
+                                              will only succeed if the type of the
+                                              specified object matches some installed
+                                              volume populator or dynamic provisioner.
+                                              This field will replace the functionality
+                                              of the dataSource field and as such
+                                              if both fields are non-empty, they must
+                                              have the same value. For backwards compatibility,
+                                              when namespace isn''t specified in dataSourceRef,
+                                              both fields (dataSource and dataSourceRef)
+                                              will be set to the same value automatically
                                               if one of them is empty and the other
-                                              is non-empty. There are two important
-                                              differences between DataSource and DataSourceRef:
-                                              * While DataSource only allows two specific
-                                              types of objects, DataSourceRef allows
+                                              is non-empty. When namespace is specified
+                                              in dataSourceRef, dataSource isn''t
+                                              set to the same value and must be empty.
+                                              There are three important differences
+                                              between dataSource and dataSourceRef:
+                                              * While dataSource only allows two specific
+                                              types of objects, dataSourceRef allows
                                               any non-core object, as well as PersistentVolumeClaim
-                                              objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef
+                                              objects. * While dataSource ignores
+                                              disallowed values (dropping them), dataSourceRef
                                               preserves all values, and generates
                                               an error if a disallowed value is specified.
-                                              (Beta) Using this field requires the
-                                              AnyVolumeDataSource feature gate to
-                                              be enabled.'
+                                              * While dataSource only allows local
+                                              objects, dataSourceRef allows objects
+                                              in any namespaces. (Beta) Using this
+                                              field requires the AnyVolumeDataSource
+                                              feature gate to be enabled. (Alpha)
+                                              Using the namespace field of dataSourceRef
+                                              requires the CrossNamespaceVolumeDataSource
+                                              feature gate to be enabled.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -13124,11 +14451,23 @@ spec:
                                                 description: Name is the name of resource
                                                   being referenced
                                                 type: string
+                                              namespace:
+                                                description: Namespace is the namespace
+                                                  of resource being referenced Note
+                                                  that when a namespace is specified,
+                                                  a gateway.networking.k8s.io/ReferenceGrant
+                                                  object is required in the referent
+                                                  namespace to allow that namespace's
+                                                  owner to accept the reference. See
+                                                  the ReferenceGrant documentation
+                                                  for details. (Alpha) This field
+                                                  requires the CrossNamespaceVolumeDataSource
+                                                  feature gate to be enabled.
+                                                type: string
                                             required:
                                             - kind
                                             - name
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           resources:
                                             description: 'resources represents the
                                               minimum resources the volume should
@@ -13164,7 +14503,8 @@ spec:
                                                   for a container, it defaults to
                                                   Limits if that is explicitly specified,
                                                   otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                 type: object
                                             type: object
                                           selector:
@@ -13229,6 +14569,34 @@ spec:
                                             description: 'storageClassName is the
                                               name of the StorageClass required by
                                               the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeAttributesClassName:
+                                            description: 'volumeAttributesClassName
+                                              may be used to set the VolumeAttributesClass
+                                              used by this claim. If specified, the
+                                              CSI driver will create or update the
+                                              volume with the attributes defined in
+                                              the corresponding VolumeAttributesClass.
+                                              This has a different purpose than storageClassName,
+                                              it can be changed after the claim is
+                                              created. An empty string value means
+                                              that no VolumeAttributesClass will be
+                                              applied to the claim but it''s not allowed
+                                              to reset this field to empty string
+                                              once it is set. If unspecified and the
+                                              PersistentVolumeClaim is unbound, the
+                                              default VolumeAttributesClass will be
+                                              set by the persistentvolume controller
+                                              if it exists. If the resource referred
+                                              to by volumeAttributesClass does not
+                                              exist, this PersistentVolumeClaim will
+                                              be set to a Pending state, as reflected
+                                              by the modifyVolumeStatus field, until
+                                              such as a resource exists. More info:
+                                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                              (Alpha) Using this field requires the
+                                              VolumeAttributesClass feature gate to
+                                              be enabled.'
                                             type: string
                                           volumeMode:
                                             description: volumeMode defines what type
@@ -13638,6 +15006,118 @@ spec:
                                       description: Projection that may be projected
                                         along with other supported volume types
                                       properties:
+                                        clusterTrustBundle:
+                                          description: "ClusterTrustBundle allows
+                                            a pod to access the `.spec.trustBundle`
+                                            field of ClusterTrustBundle objects in
+                                            an auto-updating file. \n Alpha, gated
+                                            by the ClusterTrustBundleProjection feature
+                                            gate. \n ClusterTrustBundle objects can
+                                            either be selected by name, or by the
+                                            combination of signer name and a label
+                                            selector. \n Kubelet performs aggressive
+                                            normalization of the PEM contents written
+                                            into the pod filesystem.  Esoteric PEM
+                                            features such as inter-block comments
+                                            and block headers are stripped.  Certificates
+                                            are deduplicated. The ordering of certificates
+                                            within the file is arbitrary, and Kubelet
+                                            may change the order over time."
+                                          properties:
+                                            labelSelector:
+                                              description: Select all ClusterTrustBundles
+                                                that match this label selector.  Only
+                                                has effect if signerName is set.  Mutually-exclusive
+                                                with name.  If unset, interpreted
+                                                as "match nothing".  If set but empty,
+                                                interpreted as "match everything".
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            name:
+                                              description: Select a single ClusterTrustBundle
+                                                by object name.  Mutually-exclusive
+                                                with signerName and labelSelector.
+                                              type: string
+                                            optional:
+                                              description: If true, don't block pod
+                                                startup if the referenced ClusterTrustBundle(s)
+                                                aren't available.  If using name,
+                                                then the named ClusterTrustBundle
+                                                is allowed not to exist.  If using
+                                                signerName, then the combination of
+                                                signerName and labelSelector is allowed
+                                                to match zero ClusterTrustBundles.
+                                              type: boolean
+                                            path:
+                                              description: Relative path from the
+                                                volume root to write the bundle.
+                                              type: string
+                                            signerName:
+                                              description: Select all ClusterTrustBundles
+                                                that match this signer name. Mutually-exclusive
+                                                with name.  The contents of all selected
+                                                ClusterTrustBundles will be unified
+                                                and deduplicated.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
                                         configMap:
                                           description: configMap information about
                                             the configMap data to project
@@ -14595,7 +16075,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -14646,6 +16127,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -14759,7 +16282,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -14809,6 +16333,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -14919,7 +16481,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -14970,6 +16533,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -15083,7 +16688,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -15133,6 +16739,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -15480,7 +17124,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -15507,6 +17154,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -15579,7 +17238,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -15606,6 +17268,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -15661,8 +17335,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -15694,7 +17367,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -15791,13 +17466,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -15869,8 +17544,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -15902,7 +17576,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -15992,10 +17668,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -16017,9 +17737,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -16144,7 +17885,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -16177,15 +17919,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -16234,8 +17972,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -16267,7 +18004,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -16527,9 +18266,7 @@ spec:
                       actions such as debugging. This list cannot be specified when
                       creating a pod, and it cannot be modified by updating the pod
                       spec. In order to add an ephemeral container to an existing
-                      pod, use the pod's ephemeralcontainers subresource. This field
-                      is beta-level and available on clusters that haven't disabled
-                      the EphemeralContainers feature gate.
+                      pod, use the pod's ephemeralcontainers subresource.
                     items:
                       description: "An EphemeralContainer is a temporary container
                         that you may add to an existing Pod for user-initiated activities
@@ -16539,9 +18276,7 @@ spec:
                         may evict a Pod if an ephemeral container causes the Pod to
                         exceed its resource allocation. \n To add an ephemeral container,
                         use the ephemeralcontainers subresource of an existing Pod.
-                        Ephemeral containers may not be removed or restarted. \n This
-                        is a beta feature available on clusters that haven't disabled
-                        the EphemeralContainers feature gate."
+                        Ephemeral containers may not be removed or restarted."
                       properties:
                         args:
                           description: 'Arguments to the entrypoint. The image''s
@@ -16791,7 +18526,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -16818,6 +18556,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -16890,7 +18640,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -16917,6 +18670,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -16970,8 +18735,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -17003,7 +18767,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -17169,8 +18935,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -17202,7 +18967,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -17292,11 +19059,55 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: Resources are not allowed for ephemeral containers.
                             Ephemeral containers use spare resources already allocated
                             to the pod.
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -17318,9 +19129,15 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: Restart policy for the container to manage
+                            the restart behavior of each container within a pod. This
+                            may only be set for init containers. You cannot set this
+                            field on ephemeral containers.
+                          type: string
                         securityContext:
                           description: 'Optional: SecurityContext defines the security
                             options the ephemeral container should be run with. If
@@ -17445,7 +19262,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -17478,15 +19296,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -17527,8 +19341,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -17560,7 +19373,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -17806,6 +19621,18 @@ spec:
                   hostPID:
                     description: 'Use the host''s pid namespace. Optional: Default
                       to false.'
+                    type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
                     type: boolean
                   hostname:
                     description: Specifies the hostname of the Pod If not specified,
@@ -18099,7 +19926,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -18126,6 +19956,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -18198,7 +20040,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -18225,6 +20070,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -18280,8 +20137,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -18313,7 +20169,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -18410,13 +20268,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -18488,8 +20346,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -18521,7 +20378,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -18611,10 +20470,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -18636,9 +20539,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -18763,7 +20687,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -18796,15 +20721,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -18853,8 +20774,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -18886,7 +20806,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -19111,7 +21033,7 @@ spec:
                       the OS field is set to linux, the following fields must be unset:
                       -securityContext.windowsOptions \n If the OS field is set to
                       windows, following fields must be unset: - spec.hostPID - spec.hostIPC
-                      - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                      - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
                       - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
                       - spec.securityContext.sysctls - spec.shareProcessNamespace
                       - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
@@ -19120,8 +21042,7 @@ spec:
                       - spec.containers[*].securityContext.readOnlyRootFilesystem
                       - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
                       - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                      - spec.containers[*].securityContext.runAsGroup This is a beta
-                      field and requires the IdentifyPodOS feature"
+                      - spec.containers[*].securityContext.runAsGroup"
                     properties:
                       name:
                         description: 'Name is the name of the operating system. The
@@ -19189,9 +21110,56 @@ spec:
                       - conditionType
                       type: object
                     type: array
+                  resourceClaims:
+                    description: "ResourceClaims defines which ResourceClaims must
+                      be allocated and reserved before the Pod is allowed to start.
+                      The resources will be made available to those containers which
+                      consume them by name. \n This is an alpha field and requires
+                      enabling the DynamicResourceAllocation feature gate. \n This
+                      field is immutable."
+                    items:
+                      description: PodResourceClaim references exactly one ResourceClaim
+                        through a ClaimSource. It adds a name to it that uniquely
+                        identifies the ResourceClaim inside the Pod. Containers that
+                        need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: Name uniquely identifies this resource claim
+                            inside the pod. This must be a DNS_LABEL.
+                          type: string
+                        source:
+                          description: Source describes where to find the ResourceClaim.
+                          properties:
+                            resourceClaimName:
+                              description: ResourceClaimName is the name of a ResourceClaim
+                                object in the same namespace as this pod.
+                              type: string
+                            resourceClaimTemplateName:
+                              description: "ResourceClaimTemplateName is the name
+                                of a ResourceClaimTemplate object in the same namespace
+                                as this pod. \n The template will be used to create
+                                a new ResourceClaim, which will be bound to this pod.
+                                When this pod is deleted, the ResourceClaim will also
+                                be deleted. The pod name and resource name, along
+                                with a generated component, will be used to form a
+                                unique name for the ResourceClaim, which will be recorded
+                                in pod.status.resourceClaimStatuses. \n This field
+                                is immutable and no changes will be made to the corresponding
+                                ResourceClaim by the control plane after creating
+                                the ResourceClaim."
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   restartPolicy:
                     description: 'Restart policy for all containers within the pod.
-                      One of Always, OnFailure, Never. Default to Always. More info:
+                      One of Always, OnFailure, Never. In some contexts, only a subset
+                      of those values may be permitted. Default to Always. More info:
                       https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                     type: string
                   runtimeClassName:
@@ -19207,6 +21175,29 @@ spec:
                       scheduler. If not specified, the pod will be dispatched by default
                       scheduler.
                     type: string
+                  schedulingGates:
+                    description: "SchedulingGates is an opaque list of values that
+                      if specified will block scheduling the pod. If schedulingGates
+                      is not empty, the pod will stay in the SchedulingGated state
+                      and the scheduler will not attempt to schedule the pod. \n SchedulingGates
+                      can only be set at pod creation time, and be removed only afterwards.
+                      \n This is a beta feature enabled by the PodSchedulingReadiness
+                      feature gate."
+                    items:
+                      description: PodSchedulingGate is associated to a Pod to guard
+                        its scheduling.
+                      properties:
+                        name:
+                          description: Name of the scheduling gate. Each scheduling
+                            gate must have a unique name field.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   securityContext:
                     description: 'SecurityContext holds pod-level security attributes
                       and common container settings. Optional: Defaults to empty.  See
@@ -19298,7 +21289,8 @@ spec:
                               in a file on the node should be used. The profile must
                               be preconfigured on the node to work. Must be a descending
                               path, relative to the kubelet's configured seccomp profile
-                              location. Must only be set if type is "Localhost".
+                              location. Must be set if type is "Localhost". Must NOT
+                              be set for any other type.
                             type: string
                           type:
                             description: "type indicates which kind of seccomp profile
@@ -19313,9 +21305,13 @@ spec:
                       supplementalGroups:
                         description: A list of groups applied to the first process
                           run in each container, in addition to the container's primary
-                          GID.  If unspecified, no groups will be added to any container.
-                          Note that this field cannot be set when spec.os.name is
-                          windows.
+                          GID, the fsGroup (if specified), and group memberships defined
+                          in the container image for the uid of the container process.
+                          If unspecified, no additional groups are added to any container.
+                          Note that group memberships defined in the container image
+                          for the uid of the container process are still effective,
+                          even if they are not included in this list. Note that this
+                          field cannot be set when spec.os.name is windows.
                         items:
                           format: int64
                           type: integer
@@ -19359,15 +21355,12 @@ spec:
                             type: string
                           hostProcess:
                             description: HostProcess determines if a container should
-                              be run as a 'Host Process' container. This field is
-                              alpha-level and will only be honored by components that
-                              enable the WindowsHostProcessContainers feature flag.
-                              Setting this field without the feature flag will result
-                              in errors when validating the Pod. All of a Pod's containers
-                              must have the same effective HostProcess value (it is
-                              not allowed to have a mix of HostProcess containers
-                              and non-HostProcess containers).  In addition, if HostProcess
-                              is true then HostNetwork must also be set to true.
+                              be run as a 'Host Process' container. All of a Pod's
+                              containers must have the same effective HostProcess
+                              value (it is not allowed to have a mix of HostProcess
+                              containers and non-HostProcess containers). In addition,
+                              if HostProcess is true then HostNetwork must also be
+                              set to true.
                             type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
@@ -19521,6 +21514,24 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: "MatchLabelKeys is a set of pod label keys
+                            to select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. The same key
+                            is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't
+                            set. Keys that don't exist in the incoming pod labels
+                            will be ignored. A null or empty list means only match
+                            against labelSelector. \n This is a beta field and requires
+                            the MatchLabelKeysInPodTopologySpread feature gate to
+                            be enabled (enabled by default)."
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         maxSkew:
                           description: 'MaxSkew describes the degree to which pods
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -19563,11 +21574,33 @@ spec:
                             as 0. In this situation, new pod with the same labelSelector
                             cannot be scheduled, because computed skew will be 3(3
                             - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
                           format: int32
                           type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a beta-level
+                            feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
@@ -19575,11 +21608,11 @@ spec:
                             <key, value> as a "bucket", and try to put balanced number
                             of pods into each bucket. We define a domain as a particular
                             instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -20013,7 +22046,7 @@ spec:
                                 value between the SizeLimit specified here and the
                                 sum of memory limits of all containers in a pod. The
                                 default is nil which means that the limit is undefined.
-                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
@@ -20088,10 +22121,13 @@ spec:
                                         If the provisioner or an external controller
                                         can support the specified data source, it
                                         will create a new volume based on the contents
-                                        of the specified data source. If the AnyVolumeDataSource
-                                        feature gate is enabled, this field will always
-                                        have the same contents as the DataSourceRef
-                                        field.'
+                                        of the specified data source. When the AnyVolumeDataSource
+                                        feature gate is enabled, dataSource contents
+                                        will be copied to dataSourceRef, and dataSourceRef
+                                        contents will be copied to dataSource when
+                                        dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef
+                                        will not be copied to dataSource.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -20117,29 +22153,37 @@ spec:
                                       description: 'dataSourceRef specifies the object
                                         from which to populate the volume with data,
                                         if a non-empty volume is desired. This may
-                                        be any local object from a non-empty API group
-                                        (non core object) or a PersistentVolumeClaim
-                                        object. When this field is specified, volume
-                                        binding will only succeed if the type of the
-                                        specified object matches some installed volume
-                                        populator or dynamic provisioner. This field
-                                        will replace the functionality of the DataSource
-                                        field and as such if both fields are non-empty,
+                                        be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding
+                                        will only succeed if the type of the specified
+                                        object matches some installed volume populator
+                                        or dynamic provisioner. This field will replace
+                                        the functionality of the dataSource field
+                                        and as such if both fields are non-empty,
                                         they must have the same value. For backwards
-                                        compatibility, both fields (DataSource and
-                                        DataSourceRef) will be set to the same value
-                                        automatically if one of them is empty and
-                                        the other is non-empty. There are two important
-                                        differences between DataSource and DataSourceRef:
-                                        * While DataSource only allows two specific
-                                        types of objects, DataSourceRef allows any
-                                        non-core object, as well as PersistentVolumeClaim
-                                        objects. * While DataSource ignores disallowed
-                                        values (dropping them), DataSourceRef preserves
-                                        all values, and generates an error if a disallowed
-                                        value is specified. (Beta) Using this field
-                                        requires the AnyVolumeDataSource feature gate
-                                        to be enabled.'
+                                        compatibility, when namespace isn''t specified
+                                        in dataSourceRef, both fields (dataSource
+                                        and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty
+                                        and the other is non-empty. When namespace
+                                        is specified in dataSourceRef, dataSource
+                                        isn''t set to the same value and must be empty.
+                                        There are three important differences between
+                                        dataSource and dataSourceRef: * While dataSource
+                                        only allows two specific types of objects,
+                                        dataSourceRef allows any non-core object,
+                                        as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values
+                                        (dropping them), dataSourceRef preserves all
+                                        values, and generates an error if a disallowed
+                                        value is specified. * While dataSource only
+                                        allows local objects, dataSourceRef allows
+                                        objects in any namespaces. (Beta) Using this
+                                        field requires the AnyVolumeDataSource feature
+                                        gate to be enabled. (Alpha) Using the namespace
+                                        field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                        feature gate to be enabled.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -20156,11 +22200,21 @@ spec:
                                           description: Name is the name of resource
                                             being referenced
                                           type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of resource being referenced Note that
+                                            when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. (Alpha) This
+                                            field requires the CrossNamespaceVolumeDataSource
+                                            feature gate to be enabled.
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
@@ -20193,7 +22247,8 @@ spec:
                                             If Requests is omitted for a container,
                                             it defaults to Limits if that is explicitly
                                             specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     selector:
@@ -20253,6 +22308,29 @@ spec:
                                       description: 'storageClassName is the name of
                                         the StorageClass required by the claim. More
                                         info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: 'volumeAttributesClassName may
+                                        be used to set the VolumeAttributesClass used
+                                        by this claim. If specified, the CSI driver
+                                        will create or update the volume with the
+                                        attributes defined in the corresponding VolumeAttributesClass.
+                                        This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created.
+                                        An empty string value means that no VolumeAttributesClass
+                                        will be applied to the claim but it''s not
+                                        allowed to reset this field to empty string
+                                        once it is set. If unspecified and the PersistentVolumeClaim
+                                        is unbound, the default VolumeAttributesClass
+                                        will be set by the persistentvolume controller
+                                        if it exists. If the resource referred to
+                                        by volumeAttributesClass does not exist, this
+                                        PersistentVolumeClaim will be set to a Pending
+                                        state, as reflected by the modifyVolumeStatus
+                                        field, until such as a resource exists. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                        (Alpha) Using this field requires the VolumeAttributesClass
+                                        feature gate to be enabled.'
                                       type: string
                                     volumeMode:
                                       description: volumeMode defines what type of
@@ -20642,6 +22720,107 @@ spec:
                                 description: Projection that may be projected along
                                   with other supported volume types
                                 properties:
+                                  clusterTrustBundle:
+                                    description: "ClusterTrustBundle allows a pod
+                                      to access the `.spec.trustBundle` field of ClusterTrustBundle
+                                      objects in an auto-updating file. \n Alpha,
+                                      gated by the ClusterTrustBundleProjection feature
+                                      gate. \n ClusterTrustBundle objects can either
+                                      be selected by name, or by the combination of
+                                      signer name and a label selector. \n Kubelet
+                                      performs aggressive normalization of the PEM
+                                      contents written into the pod filesystem.  Esoteric
+                                      PEM features such as inter-block comments and
+                                      block headers are stripped.  Certificates are
+                                      deduplicated. The ordering of certificates within
+                                      the file is arbitrary, and Kubelet may change
+                                      the order over time."
+                                    properties:
+                                      labelSelector:
+                                        description: Select all ClusterTrustBundles
+                                          that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive
+                                          with name.  If unset, interpreted as "match
+                                          nothing".  If set but empty, interpreted
+                                          as "match everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: Select a single ClusterTrustBundle
+                                          by object name.  Mutually-exclusive with
+                                          signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: If true, don't block pod startup
+                                          if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the
+                                          named ClusterTrustBundle is allowed not
+                                          to exist.  If using signerName, then the
+                                          combination of signerName and labelSelector
+                                          is allowed to match zero ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: Select all ClusterTrustBundles
+                                          that match this signer name. Mutually-exclusive
+                                          with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and
+                                          deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
                                   configMap:
                                     description: configMap information about the configMap
                                       data to project
@@ -21211,9 +23390,12 @@ spec:
                             * An existing PVC (PersistentVolumeClaim) If the provisioner
                             or an external controller can support the specified data
                             source, it will create a new volume based on the contents
-                            of the specified data source. If the AnyVolumeDataSource
-                            feature gate is enabled, this field will always have the
-                            same contents as the DataSourceRef field.'
+                            of the specified data source. When the AnyVolumeDataSource
+                            feature gate is enabled, dataSource contents will be copied
+                            to dataSourceRef, and dataSourceRef contents will be copied
+                            to dataSource when dataSourceRef.namespace is not specified.
+                            If the namespace is specified, then dataSourceRef will
+                            not be copied to dataSource.'
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource
@@ -21235,25 +23417,31 @@ spec:
                         dataSourceRef:
                           description: 'dataSourceRef specifies the object from which
                             to populate the volume with data, if a non-empty volume
-                            is desired. This may be any local object from a non-empty
-                            API group (non core object) or a PersistentVolumeClaim
-                            object. When this field is specified, volume binding will
-                            only succeed if the type of the specified object matches
-                            some installed volume populator or dynamic provisioner.
-                            This field will replace the functionality of the DataSource
+                            is desired. This may be any object from a non-empty API
+                            group (non core object) or a PersistentVolumeClaim object.
+                            When this field is specified, volume binding will only
+                            succeed if the type of the specified object matches some
+                            installed volume populator or dynamic provisioner. This
+                            field will replace the functionality of the dataSource
                             field and as such if both fields are non-empty, they must
-                            have the same value. For backwards compatibility, both
-                            fields (DataSource and DataSourceRef) will be set to the
-                            same value automatically if one of them is empty and the
-                            other is non-empty. There are two important differences
-                            between DataSource and DataSourceRef: * While DataSource
-                            only allows two specific types of objects, DataSourceRef
-                            allows any non-core object, as well as PersistentVolumeClaim
-                            objects. * While DataSource ignores disallowed values
-                            (dropping them), DataSourceRef preserves all values, and
-                            generates an error if a disallowed value is specified.
-                            (Beta) Using this field requires the AnyVolumeDataSource
-                            feature gate to be enabled.'
+                            have the same value. For backwards compatibility, when
+                            namespace isn''t specified in dataSourceRef, both fields
+                            (dataSource and dataSourceRef) will be set to the same
+                            value automatically if one of them is empty and the other
+                            is non-empty. When namespace is specified in dataSourceRef,
+                            dataSource isn''t set to the same value and must be empty.
+                            There are three important differences between dataSource
+                            and dataSourceRef: * While dataSource only allows two
+                            specific types of objects, dataSourceRef allows any non-core
+                            object, as well as PersistentVolumeClaim objects. * While
+                            dataSource ignores disallowed values (dropping them),
+                            dataSourceRef preserves all values, and generates an error
+                            if a disallowed value is specified. * While dataSource
+                            only allows local objects, dataSourceRef allows objects
+                            in any namespaces. (Beta) Using this field requires the
+                            AnyVolumeDataSource feature gate to be enabled. (Alpha)
+                            Using the namespace field of dataSourceRef requires the
+                            CrossNamespaceVolumeDataSource feature gate to be enabled.'
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource
@@ -21267,11 +23455,20 @@ spec:
                             name:
                               description: Name is the name of resource being referenced
                               type: string
+                            namespace:
+                              description: Namespace is the namespace of resource
+                                being referenced Note that when a namespace is specified,
+                                a gateway.networking.k8s.io/ReferenceGrant object
+                                is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the
+                                ReferenceGrant documentation for details. (Alpha)
+                                This field requires the CrossNamespaceVolumeDataSource
+                                feature gate to be enabled.
+                              type: string
                           required:
                           - kind
                           - name
                           type: object
-                          x-kubernetes-map-type: atomic
                         resources:
                           description: 'resources represents the minimum resources
                             the volume should have. If RecoverVolumeExpansionFailure
@@ -21301,7 +23498,7 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         selector:
@@ -21355,6 +23552,25 @@ spec:
                           description: 'storageClassName is the name of the StorageClass
                             required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                           type: string
+                        volumeAttributesClassName:
+                          description: 'volumeAttributesClassName may be used to set
+                            the VolumeAttributesClass used by this claim. If specified,
+                            the CSI driver will create or update the volume with the
+                            attributes defined in the corresponding VolumeAttributesClass.
+                            This has a different purpose than storageClassName, it
+                            can be changed after the claim is created. An empty string
+                            value means that no VolumeAttributesClass will be applied
+                            to the claim but it''s not allowed to reset this field
+                            to empty string once it is set. If unspecified and the
+                            PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                            will be set by the persistentvolume controller if it exists.
+                            If the resource referred to by volumeAttributesClass does
+                            not exist, this PersistentVolumeClaim will be set to a
+                            Pending state, as reflected by the modifyVolumeStatus
+                            field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                            (Alpha) Using this field requires the VolumeAttributesClass
+                            feature gate to be enabled.'
+                          type: string
                         volumeMode:
                           description: volumeMode defines what type of volume is required
                             by the claim. Value of Filesystem is implied when not
@@ -21401,7 +23617,23 @@ spec:
     singular: server
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Server ready status
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Number of loaded models
+      jsonPath: .status.loadedModels
+      name: Loaded Models
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Server is the Schema for the servers API
@@ -21693,7 +23925,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -21720,6 +23955,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -21792,7 +24039,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -21819,6 +24069,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -21873,8 +24135,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -21906,7 +24167,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -22002,13 +24265,13 @@ spec:
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will
-                          be accessible from the network. Cannot be updated.
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in
                             a single container.
@@ -22078,8 +24341,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -22111,7 +24373,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -22201,10 +24465,53 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        description: Resources resize policy for the container.
+                        items:
+                          description: ContainerResizePolicy represents resource resize
+                            policy for the container.
+                          properties:
+                            resourceName:
+                              description: 'Name of the resource to which this resource
+                                resize policy applies. Supported values: cpu, memory.'
+                              type: string
+                            restartPolicy:
+                              description: Restart policy to apply when specified
+                                resource is resized. If not specified, it defaults
+                                to NotRequired.
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         description: 'Compute Resources required by this container.
                           Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -22226,9 +24533,29 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
+                      restartPolicy:
+                        description: 'RestartPolicy defines the restart behavior of
+                          individual containers in a pod. This field may only be set
+                          for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod''s restart policy
+                          and the container type. Setting the RestartPolicy as "Always"
+                          for the init container will have the following effect: this
+                          init container will be continually restarted on exit until
+                          all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy
+                          "Always" will be shut down. This lifecycle differs from
+                          normal init containers and is often referred to as a "sidecar"
+                          container. Although this init container still starts in
+                          the init container sequence, it does not wait for the container
+                          to complete before proceeding to the next init container.
+                          Instead, the next init container starts immediately after
+                          this init container is started, or after any startupProbe
+                          has successfully completed.'
+                        type: string
                       securityContext:
                         description: 'SecurityContext defines the security options
                           the container should be run with. If set, the fields of
@@ -22351,8 +24678,9 @@ spec:
                                   defined in a file on the node should be used. The
                                   profile must be preconfigured on the node to work.
                                   Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must only be
-                                  set if type is "Localhost".
+                                  configured seccomp profile location. Must be set
+                                  if type is "Localhost". Must NOT be set for any
+                                  other type.
                                 type: string
                               type:
                                 description: "type indicates which kind of seccomp
@@ -22385,15 +24713,11 @@ spec:
                                 type: string
                               hostProcess:
                                 description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. This
-                                  field is alpha-level and will only be honored by
-                                  components that enable the WindowsHostProcessContainers
-                                  feature flag. Setting this field without the feature
-                                  flag will result in errors when validating the Pod.
-                                  All of a Pod's containers must have the same effective
+                                  should be run as a 'Host Process' container. All
+                                  of a Pod's containers must have the same effective
                                   HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).  In
-                                  addition, if HostProcess is true then HostNetwork
+                                  of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork
                                   must also be set to true.
                                 type: boolean
                               runAsUserName:
@@ -22440,8 +24764,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -22473,7 +24796,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -22927,7 +25252,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -22954,6 +25282,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -23026,7 +25366,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -23053,6 +25396,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -23107,8 +25462,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -23140,7 +25494,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -23236,13 +25592,13 @@ spec:
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will
-                          be accessible from the network. Cannot be updated.
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in
                             a single container.
@@ -23312,8 +25668,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -23345,7 +25700,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -23435,10 +25792,53 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        description: Resources resize policy for the container.
+                        items:
+                          description: ContainerResizePolicy represents resource resize
+                            policy for the container.
+                          properties:
+                            resourceName:
+                              description: 'Name of the resource to which this resource
+                                resize policy applies. Supported values: cpu, memory.'
+                              type: string
+                            restartPolicy:
+                              description: Restart policy to apply when specified
+                                resource is resized. If not specified, it defaults
+                                to NotRequired.
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         description: 'Compute Resources required by this container.
                           Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -23460,9 +25860,29 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
+                      restartPolicy:
+                        description: 'RestartPolicy defines the restart behavior of
+                          individual containers in a pod. This field may only be set
+                          for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod''s restart policy
+                          and the container type. Setting the RestartPolicy as "Always"
+                          for the init container will have the following effect: this
+                          init container will be continually restarted on exit until
+                          all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy
+                          "Always" will be shut down. This lifecycle differs from
+                          normal init containers and is often referred to as a "sidecar"
+                          container. Although this init container still starts in
+                          the init container sequence, it does not wait for the container
+                          to complete before proceeding to the next init container.
+                          Instead, the next init container starts immediately after
+                          this init container is started, or after any startupProbe
+                          has successfully completed.'
+                        type: string
                       securityContext:
                         description: 'SecurityContext defines the security options
                           the container should be run with. If set, the fields of
@@ -23585,8 +26005,9 @@ spec:
                                   defined in a file on the node should be used. The
                                   profile must be preconfigured on the node to work.
                                   Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must only be
-                                  set if type is "Localhost".
+                                  configured seccomp profile location. Must be set
+                                  if type is "Localhost". Must NOT be set for any
+                                  other type.
                                 type: string
                               type:
                                 description: "type indicates which kind of seccomp
@@ -23619,15 +26040,11 @@ spec:
                                 type: string
                               hostProcess:
                                 description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. This
-                                  field is alpha-level and will only be honored by
-                                  components that enable the WindowsHostProcessContainers
-                                  feature flag. Setting this field without the feature
-                                  flag will result in errors when validating the Pod.
-                                  All of a Pod's containers must have the same effective
+                                  should be run as a 'Host Process' container. All
+                                  of a Pod's containers must have the same effective
                                   HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).  In
-                                  addition, if HostProcess is true then HostNetwork
+                                  of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork
                                   must also be set to true.
                                 type: boolean
                               runAsUserName:
@@ -23674,8 +26091,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -23707,7 +26123,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -24177,7 +26595,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -24228,6 +26647,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -24341,7 +26802,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -24391,6 +26853,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -24501,7 +27001,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -24552,6 +27053,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -24665,7 +27208,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -24715,6 +27259,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -25062,7 +27644,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -25089,6 +27674,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -25161,7 +27758,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -25188,6 +27788,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -25243,8 +27855,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -25276,7 +27887,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -25373,13 +27986,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -25451,8 +28064,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -25484,7 +28096,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -25574,10 +28188,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -25599,9 +28257,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -25726,7 +28405,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -25759,15 +28439,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -25816,8 +28492,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -25849,7 +28524,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -26427,7 +29104,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -26454,6 +29134,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -26526,7 +29218,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -26553,6 +29248,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -26608,8 +29315,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -26641,7 +29347,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -26738,13 +29446,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -26816,8 +29524,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -26849,7 +29556,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -26939,10 +29648,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -26964,9 +29717,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -27091,7 +29865,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -27124,15 +29899,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -27181,8 +29952,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -27214,7 +29984,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -27601,7 +30373,8 @@ spec:
                               in a file on the node should be used. The profile must
                               be preconfigured on the node to work. Must be a descending
                               path, relative to the kubelet's configured seccomp profile
-                              location. Must only be set if type is "Localhost".
+                              location. Must be set if type is "Localhost". Must NOT
+                              be set for any other type.
                             type: string
                           type:
                             description: "type indicates which kind of seccomp profile
@@ -27616,9 +30389,13 @@ spec:
                       supplementalGroups:
                         description: A list of groups applied to the first process
                           run in each container, in addition to the container's primary
-                          GID.  If unspecified, no groups will be added to any container.
-                          Note that this field cannot be set when spec.os.name is
-                          windows.
+                          GID, the fsGroup (if specified), and group memberships defined
+                          in the container image for the uid of the container process.
+                          If unspecified, no additional groups are added to any container.
+                          Note that group memberships defined in the container image
+                          for the uid of the container process are still effective,
+                          even if they are not included in this list. Note that this
+                          field cannot be set when spec.os.name is windows.
                         items:
                           format: int64
                           type: integer
@@ -27662,15 +30439,12 @@ spec:
                             type: string
                           hostProcess:
                             description: HostProcess determines if a container should
-                              be run as a 'Host Process' container. This field is
-                              alpha-level and will only be honored by components that
-                              enable the WindowsHostProcessContainers feature flag.
-                              Setting this field without the feature flag will result
-                              in errors when validating the Pod. All of a Pod's containers
-                              must have the same effective HostProcess value (it is
-                              not allowed to have a mix of HostProcess containers
-                              and non-HostProcess containers).  In addition, if HostProcess
-                              is true then HostNetwork must also be set to true.
+                              be run as a 'Host Process' container. All of a Pod's
+                              containers must have the same effective HostProcess
+                              value (it is not allowed to have a mix of HostProcess
+                              containers and non-HostProcess containers). In addition,
+                              if HostProcess is true then HostNetwork must also be
+                              set to true.
                             type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
@@ -27819,6 +30593,24 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: "MatchLabelKeys is a set of pod label keys
+                            to select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. The same key
+                            is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't
+                            set. Keys that don't exist in the incoming pod labels
+                            will be ignored. A null or empty list means only match
+                            against labelSelector. \n This is a beta field and requires
+                            the MatchLabelKeysInPodTopologySpread feature gate to
+                            be enabled (enabled by default)."
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         maxSkew:
                           description: 'MaxSkew describes the degree to which pods
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -27861,11 +30653,33 @@ spec:
                             as 0. In this situation, new pod with the same labelSelector
                             cannot be scheduled, because computed skew will be 3(3
                             - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
                           format: int32
                           type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a beta-level
+                            feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
@@ -27873,11 +30687,11 @@ spec:
                             <key, value> as a "bucket", and try to put balanced number
                             of pods into each bucket. We define a domain as a particular
                             instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -28311,7 +31125,7 @@ spec:
                                 value between the SizeLimit specified here and the
                                 sum of memory limits of all containers in a pod. The
                                 default is nil which means that the limit is undefined.
-                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
@@ -28386,10 +31200,13 @@ spec:
                                         If the provisioner or an external controller
                                         can support the specified data source, it
                                         will create a new volume based on the contents
-                                        of the specified data source. If the AnyVolumeDataSource
-                                        feature gate is enabled, this field will always
-                                        have the same contents as the DataSourceRef
-                                        field.'
+                                        of the specified data source. When the AnyVolumeDataSource
+                                        feature gate is enabled, dataSource contents
+                                        will be copied to dataSourceRef, and dataSourceRef
+                                        contents will be copied to dataSource when
+                                        dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef
+                                        will not be copied to dataSource.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -28415,29 +31232,37 @@ spec:
                                       description: 'dataSourceRef specifies the object
                                         from which to populate the volume with data,
                                         if a non-empty volume is desired. This may
-                                        be any local object from a non-empty API group
-                                        (non core object) or a PersistentVolumeClaim
-                                        object. When this field is specified, volume
-                                        binding will only succeed if the type of the
-                                        specified object matches some installed volume
-                                        populator or dynamic provisioner. This field
-                                        will replace the functionality of the DataSource
-                                        field and as such if both fields are non-empty,
+                                        be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding
+                                        will only succeed if the type of the specified
+                                        object matches some installed volume populator
+                                        or dynamic provisioner. This field will replace
+                                        the functionality of the dataSource field
+                                        and as such if both fields are non-empty,
                                         they must have the same value. For backwards
-                                        compatibility, both fields (DataSource and
-                                        DataSourceRef) will be set to the same value
-                                        automatically if one of them is empty and
-                                        the other is non-empty. There are two important
-                                        differences between DataSource and DataSourceRef:
-                                        * While DataSource only allows two specific
-                                        types of objects, DataSourceRef allows any
-                                        non-core object, as well as PersistentVolumeClaim
-                                        objects. * While DataSource ignores disallowed
-                                        values (dropping them), DataSourceRef preserves
-                                        all values, and generates an error if a disallowed
-                                        value is specified. (Beta) Using this field
-                                        requires the AnyVolumeDataSource feature gate
-                                        to be enabled.'
+                                        compatibility, when namespace isn''t specified
+                                        in dataSourceRef, both fields (dataSource
+                                        and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty
+                                        and the other is non-empty. When namespace
+                                        is specified in dataSourceRef, dataSource
+                                        isn''t set to the same value and must be empty.
+                                        There are three important differences between
+                                        dataSource and dataSourceRef: * While dataSource
+                                        only allows two specific types of objects,
+                                        dataSourceRef allows any non-core object,
+                                        as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values
+                                        (dropping them), dataSourceRef preserves all
+                                        values, and generates an error if a disallowed
+                                        value is specified. * While dataSource only
+                                        allows local objects, dataSourceRef allows
+                                        objects in any namespaces. (Beta) Using this
+                                        field requires the AnyVolumeDataSource feature
+                                        gate to be enabled. (Alpha) Using the namespace
+                                        field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                        feature gate to be enabled.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -28454,11 +31279,21 @@ spec:
                                           description: Name is the name of resource
                                             being referenced
                                           type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of resource being referenced Note that
+                                            when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. (Alpha) This
+                                            field requires the CrossNamespaceVolumeDataSource
+                                            feature gate to be enabled.
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
@@ -28491,7 +31326,8 @@ spec:
                                             If Requests is omitted for a container,
                                             it defaults to Limits if that is explicitly
                                             specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     selector:
@@ -28551,6 +31387,29 @@ spec:
                                       description: 'storageClassName is the name of
                                         the StorageClass required by the claim. More
                                         info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: 'volumeAttributesClassName may
+                                        be used to set the VolumeAttributesClass used
+                                        by this claim. If specified, the CSI driver
+                                        will create or update the volume with the
+                                        attributes defined in the corresponding VolumeAttributesClass.
+                                        This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created.
+                                        An empty string value means that no VolumeAttributesClass
+                                        will be applied to the claim but it''s not
+                                        allowed to reset this field to empty string
+                                        once it is set. If unspecified and the PersistentVolumeClaim
+                                        is unbound, the default VolumeAttributesClass
+                                        will be set by the persistentvolume controller
+                                        if it exists. If the resource referred to
+                                        by volumeAttributesClass does not exist, this
+                                        PersistentVolumeClaim will be set to a Pending
+                                        state, as reflected by the modifyVolumeStatus
+                                        field, until such as a resource exists. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                        (Alpha) Using this field requires the VolumeAttributesClass
+                                        feature gate to be enabled.'
                                       type: string
                                     volumeMode:
                                       description: volumeMode defines what type of
@@ -28940,6 +31799,107 @@ spec:
                                 description: Projection that may be projected along
                                   with other supported volume types
                                 properties:
+                                  clusterTrustBundle:
+                                    description: "ClusterTrustBundle allows a pod
+                                      to access the `.spec.trustBundle` field of ClusterTrustBundle
+                                      objects in an auto-updating file. \n Alpha,
+                                      gated by the ClusterTrustBundleProjection feature
+                                      gate. \n ClusterTrustBundle objects can either
+                                      be selected by name, or by the combination of
+                                      signer name and a label selector. \n Kubelet
+                                      performs aggressive normalization of the PEM
+                                      contents written into the pod filesystem.  Esoteric
+                                      PEM features such as inter-block comments and
+                                      block headers are stripped.  Certificates are
+                                      deduplicated. The ordering of certificates within
+                                      the file is arbitrary, and Kubelet may change
+                                      the order over time."
+                                    properties:
+                                      labelSelector:
+                                        description: Select all ClusterTrustBundles
+                                          that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive
+                                          with name.  If unset, interpreted as "match
+                                          nothing".  If set but empty, interpreted
+                                          as "match everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: Select a single ClusterTrustBundle
+                                          by object name.  Mutually-exclusive with
+                                          signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: If true, don't block pod startup
+                                          if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the
+                                          named ClusterTrustBundle is allowed not
+                                          to exist.  If using signerName, then the
+                                          combination of signerName and labelSelector
+                                          is allowed to match zero ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: Select all ClusterTrustBundles
+                                          that match this signer name. Mutually-exclusive
+                                          with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and
+                                          deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
                                   configMap:
                                     description: configMap information about the configMap
                                       data to project

--- a/k8s/yaml/crds.yaml
+++ b/k8s/yaml/crds.yaml
@@ -18,7 +18,29 @@ spec:
     singular: experiment
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Experiment ready status
+      jsonPath: .status.conditions[?(@.type=='ExperimentReady')].status
+      name: Experiment ready
+      type: string
+    - description: Candidates ready status
+      jsonPath: .status.conditions[?(@.type=='CandidatesReady')].status
+      name: Candidates ready
+      priority: 1
+      type: string
+    - description: Mirror ready status
+      jsonPath: .status.conditions[?(@.type=='MirrorReady')].status
+      name: Mirror ready
+      priority: 1
+      type: string
+    - description: Status message
+      jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Experiment is the Schema for the experiments API
@@ -146,7 +168,19 @@ spec:
     singular: model
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Model ready status
+      jsonPath: .status.conditions[?(@.type=="ModelReady")].status
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Model is the Schema for the models API
@@ -339,7 +373,29 @@ spec:
     singular: pipeline
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Pipeline ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Pipeline ready
+      type: string
+    - description: Models ready status
+      jsonPath: .status.conditions[?(@.type=='ModelsReady')].status
+      name: Models ready
+      priority: 1
+      type: string
+    - description: Dataflow ready status
+      jsonPath: .status.conditions[?(@.type=='PipelineReady')].status
+      name: Dataflow ready
+      priority: 1
+      type: string
+    - description: Status message
+      jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Pipeline is the Schema for the pipelines API
@@ -857,7 +913,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -913,6 +971,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -1037,7 +1142,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -1088,6 +1194,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1204,7 +1353,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1260,6 +1411,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -1385,7 +1583,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -1436,6 +1635,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -1802,7 +2044,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1831,6 +2077,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -1910,7 +2169,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1939,6 +2202,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -1997,8 +2273,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -2032,7 +2307,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -2134,13 +2412,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -2214,8 +2492,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -2249,7 +2526,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -2344,10 +2624,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -2369,10 +2695,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -2508,8 +2857,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -2546,17 +2896,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -2607,8 +2952,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -2642,7 +2986,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -2919,9 +3266,7 @@ spec:
                             list cannot be specified when creating a pod, and it cannot
                             be modified by updating the pod spec. In order to add
                             an ephemeral container to an existing pod, use the pod's
-                            ephemeralcontainers subresource. This field is beta-level
-                            and available on clusters that haven't disabled the EphemeralContainers
-                            feature gate.
+                            ephemeralcontainers subresource.
                           items:
                             description: "An EphemeralContainer is a temporary container
                               that you may add to an existing Pod for user-initiated
@@ -2932,9 +3277,7 @@ spec:
                               container causes the Pod to exceed its resource allocation.
                               \n To add an ephemeral container, use the ephemeralcontainers
                               subresource of an existing Pod. Ephemeral containers
-                              may not be removed or restarted. \n This is a beta feature
-                              available on clusters that haven't disabled the EphemeralContainers
-                              feature gate."
+                              may not be removed or restarted."
                             properties:
                               args:
                                 description: 'Arguments to the entrypoint. The image''s
@@ -3199,7 +3542,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3228,6 +3575,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -3307,7 +3667,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3336,6 +3700,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -3393,8 +3770,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -3428,7 +3804,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -3601,8 +3980,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -3636,7 +4014,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -3731,11 +4112,57 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: Resources are not allowed for ephemeral
                                   containers. Ephemeral containers use spare resources
                                   already allocated to the pod.
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -3757,10 +4184,16 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: Restart policy for the container to manage
+                                  the restart behavior of each container within a
+                                  pod. This may only be set for init containers. You
+                                  cannot set this field on ephemeral containers.
+                                type: string
                               securityContext:
                                 description: 'Optional: SecurityContext defines the
                                   security options the ephemeral container should
@@ -3896,8 +4329,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -3934,17 +4368,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -3987,8 +4416,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -4022,7 +4450,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -4284,6 +4715,19 @@ spec:
                         hostPID:
                           description: 'Use the host''s pid namespace. Optional: Default
                             to false.'
+                          type: boolean
+                        hostUsers:
+                          description: 'Use the host''s user namespace. Optional:
+                            Default to true. If set to true or not present, the pod
+                            will be run in the host user namespace, useful for when
+                            the pod needs a feature only available to the host user
+                            namespace, such as loading a kernel module with CAP_SYS_MODULE.
+                            When set to false, a new userns is created for the pod.
+                            Setting false is useful for mitigating container breakout
+                            vulnerabilities even allowing users to run their containers
+                            as root without actually having root privileges on the
+                            host. This field is alpha-level and is only honored by
+                            servers that enable the UserNamespacesSupport feature.'
                           type: boolean
                         hostname:
                           description: Specifies the hostname of the Pod If not specified,
@@ -4594,7 +5038,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4623,6 +5071,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -4702,7 +5163,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4731,6 +5196,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -4789,8 +5267,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -4824,7 +5301,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -4926,13 +5406,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -5006,8 +5486,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -5041,7 +5520,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -5136,10 +5618,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -5161,10 +5689,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -5300,8 +5851,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -5338,17 +5890,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -5399,8 +5946,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -5434,7 +5980,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -5673,18 +6222,17 @@ spec:
                             is set. \n If the OS field is set to linux, the following
                             fields must be unset: -securityContext.windowsOptions
                             \n If the OS field is set to windows, following fields
-                            must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
-                            - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                            - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                            - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                            - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
-                            - spec.containers[*].securityContext.seLinuxOptions -
-                            spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities
-                            - spec.containers[*].securityContext.readOnlyRootFilesystem
+                            must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                            - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                            - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                            - spec.securityContext.sysctls - spec.shareProcessNamespace
+                            - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                            - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
+                            - spec.containers[*].securityContext.seccompProfile -
+                            spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem
                             - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
                             - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                            - spec.containers[*].securityContext.runAsGroup This is
-                            a beta field and requires the IdentifyPodOS feature"
+                            - spec.containers[*].securityContext.runAsGroup"
                           properties:
                             name:
                               description: 'Name is the name of the operating system.
@@ -5758,10 +6306,60 @@ spec:
                             - conditionType
                             type: object
                           type: array
+                        resourceClaims:
+                          description: "ResourceClaims defines which ResourceClaims
+                            must be allocated and reserved before the Pod is allowed
+                            to start. The resources will be made available to those
+                            containers which consume them by name. \n This is an alpha
+                            field and requires enabling the DynamicResourceAllocation
+                            feature gate. \n This field is immutable."
+                          items:
+                            description: PodResourceClaim references exactly one ResourceClaim
+                              through a ClaimSource. It adds a name to it that uniquely
+                              identifies the ResourceClaim inside the Pod. Containers
+                              that need access to the ResourceClaim reference it with
+                              this name.
+                            properties:
+                              name:
+                                description: Name uniquely identifies this resource
+                                  claim inside the pod. This must be a DNS_LABEL.
+                                type: string
+                              source:
+                                description: Source describes where to find the ResourceClaim.
+                                properties:
+                                  resourceClaimName:
+                                    description: ResourceClaimName is the name of
+                                      a ResourceClaim object in the same namespace
+                                      as this pod.
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    description: "ResourceClaimTemplateName is the
+                                      name of a ResourceClaimTemplate object in the
+                                      same namespace as this pod. \n The template
+                                      will be used to create a new ResourceClaim,
+                                      which will be bound to this pod. When this pod
+                                      is deleted, the ResourceClaim will also be deleted.
+                                      The pod name and resource name, along with a
+                                      generated component, will be used to form a
+                                      unique name for the ResourceClaim, which will
+                                      be recorded in pod.status.resourceClaimStatuses.
+                                      \n This field is immutable and no changes will
+                                      be made to the corresponding ResourceClaim by
+                                      the control plane after creating the ResourceClaim."
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         restartPolicy:
                           description: 'Restart policy for all containers within the
-                            pod. One of Always, OnFailure, Never. Default to Always.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                            pod. One of Always, OnFailure, Never. In some contexts,
+                            only a subset of those values may be permitted. Default
+                            to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                           type: string
                         runtimeClassName:
                           description: 'RuntimeClassName refers to a RuntimeClass
@@ -5777,6 +6375,30 @@ spec:
                             specified scheduler. If not specified, the pod will be
                             dispatched by default scheduler.
                           type: string
+                        schedulingGates:
+                          description: "SchedulingGates is an opaque list of values
+                            that if specified will block scheduling the pod. If schedulingGates
+                            is not empty, the pod will stay in the SchedulingGated
+                            state and the scheduler will not attempt to schedule the
+                            pod. \n SchedulingGates can only be set at pod creation
+                            time, and be removed only afterwards. \n This is a beta
+                            feature enabled by the PodSchedulingReadiness feature
+                            gate."
+                          items:
+                            description: PodSchedulingGate is associated to a Pod
+                              to guard its scheduling.
+                            properties:
+                              name:
+                                description: Name of the scheduling gate. Each scheduling
+                                  gate must have a unique name field.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         securityContext:
                           description: 'SecurityContext holds pod-level security attributes
                             and common container settings. Optional: Defaults to empty.  See
@@ -5872,7 +6494,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -5888,9 +6511,14 @@ spec:
                             supplementalGroups:
                               description: A list of groups applied to the first process
                                 run in each container, in addition to the container's
-                                primary GID.  If unspecified, no groups will be added
-                                to any container. Note that this field cannot be set
-                                when spec.os.name is windows.
+                                primary GID, the fsGroup (if specified), and group
+                                memberships defined in the container image for the
+                                uid of the container process. If unspecified, no additional
+                                groups are added to any container. Note that group
+                                memberships defined in the container image for the
+                                uid of the container process are still effective,
+                                even if they are not included in this list. Note that
+                                this field cannot be set when spec.os.name is windows.
                               items:
                                 format: int64
                                 type: integer
@@ -5937,15 +6565,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -6108,6 +6732,25 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: "MatchLabelKeys is a set of pod label
+                                  keys to select the pods over which spreading will
+                                  be calculated. The keys are used to lookup values
+                                  from the incoming pod labels, those key-value labels
+                                  are ANDed with labelSelector to select the group
+                                  of existing pods over which spreading will be calculated
+                                  for the incoming pod. The same key is forbidden
+                                  to exist in both MatchLabelKeys and LabelSelector.
+                                  MatchLabelKeys cannot be set when LabelSelector
+                                  isn't set. Keys that don't exist in the incoming
+                                  pod labels will be ignored. A null or empty list
+                                  means only match against labelSelector. \n This
+                                  is a beta field and requires the MatchLabelKeysInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               maxSkew:
                                 description: 'MaxSkew describes the degree to which
                                   pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -6155,10 +6798,34 @@ spec:
                                   cannot be scheduled, because computed skew will
                                   be 3(3 - 0) if new Pod is scheduled to any of the
                                   three zones, it will violate MaxSkew. \n This is
-                                  an alpha field and requires enabling MinDomainsInPodTopologySpread
-                                  feature gate."
+                                  a beta field and requires the MinDomainsInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
                                 format: int32
                                 type: integer
+                              nodeAffinityPolicy:
+                                description: "NodeAffinityPolicy indicates how we
+                                  will treat Pod's nodeAffinity/nodeSelector when
+                                  calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector
+                                  are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                  are ignored. All nodes are included in the calculations.
+                                  \n If this value is nil, the behavior is equivalent
+                                  to the Honor policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              nodeTaintsPolicy:
+                                description: "NodeTaintsPolicy indicates how we will
+                                  treat node taints when calculating pod topology
+                                  spread skew. Options are: - Honor: nodes without
+                                  taints, along with tainted nodes for which the incoming
+                                  pod has a toleration, are included. - Ignore: node
+                                  taints are ignored. All nodes are included. \n If
+                                  this value is nil, the behavior is equivalent to
+                                  the Ignore policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
                               topologyKey:
                                 description: TopologyKey is the key of node labels.
                                   Nodes that have a label with this key and identical
@@ -6167,11 +6834,12 @@ spec:
                                   try to put balanced number of pods into each bucket.
                                   We define a domain as a particular instance of a
                                   topology. Also, we define an eligible domain as
-                                  a domain whose nodes match the node selector. e.g.
-                                  If TopologyKey is "kubernetes.io/hostname", each
-                                  Node is a domain of that topology. And, if TopologyKey
-                                  is "topology.kubernetes.io/zone", each zone is a
-                                  domain of that topology. It's a required field.
+                                  a domain whose nodes meet the requirements of nodeAffinityPolicy
+                                  and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                  each Node is a domain of that topology. And, if
+                                  TopologyKey is "topology.kubernetes.io/zone", each
+                                  zone is a domain of that topology. It's a required
+                                  field.
                                 type: string
                               whenUnsatisfiable:
                                 description: 'WhenUnsatisfiable indicates how to deal
@@ -6639,7 +7307,7 @@ spec:
                                       specified here and the sum of memory limits
                                       of all containers in a pod. The default is nil
                                       which means that the limit is undefined. More
-                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
@@ -6719,10 +7387,14 @@ spec:
                                               can support the specified data source,
                                               it will create a new volume based on
                                               the contents of the specified data source.
-                                              If the AnyVolumeDataSource feature gate
-                                              is enabled, this field will always have
-                                              the same contents as the DataSourceRef
-                                              field.'
+                                              When the AnyVolumeDataSource feature
+                                              gate is enabled, dataSource contents
+                                              will be copied to dataSourceRef, and
+                                              dataSourceRef contents will be copied
+                                              to dataSource when dataSourceRef.namespace
+                                              is not specified. If the namespace is
+                                              specified, then dataSourceRef will not
+                                              be copied to dataSource.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -6749,33 +7421,41 @@ spec:
                                             description: 'dataSourceRef specifies
                                               the object from which to populate the
                                               volume with data, if a non-empty volume
-                                              is desired. This may be any local object
-                                              from a non-empty API group (non core
-                                              object) or a PersistentVolumeClaim object.
-                                              When this field is specified, volume
-                                              binding will only succeed if the type
-                                              of the specified object matches some
-                                              installed volume populator or dynamic
-                                              provisioner. This field will replace
-                                              the functionality of the DataSource
-                                              field and as such if both fields are
-                                              non-empty, they must have the same value.
-                                              For backwards compatibility, both fields
-                                              (DataSource and DataSourceRef) will
-                                              be set to the same value automatically
+                                              is desired. This may be any object from
+                                              a non-empty API group (non core object)
+                                              or a PersistentVolumeClaim object. When
+                                              this field is specified, volume binding
+                                              will only succeed if the type of the
+                                              specified object matches some installed
+                                              volume populator or dynamic provisioner.
+                                              This field will replace the functionality
+                                              of the dataSource field and as such
+                                              if both fields are non-empty, they must
+                                              have the same value. For backwards compatibility,
+                                              when namespace isn''t specified in dataSourceRef,
+                                              both fields (dataSource and dataSourceRef)
+                                              will be set to the same value automatically
                                               if one of them is empty and the other
-                                              is non-empty. There are two important
-                                              differences between DataSource and DataSourceRef:
-                                              * While DataSource only allows two specific
-                                              types of objects, DataSourceRef allows
+                                              is non-empty. When namespace is specified
+                                              in dataSourceRef, dataSource isn''t
+                                              set to the same value and must be empty.
+                                              There are three important differences
+                                              between dataSource and dataSourceRef:
+                                              * While dataSource only allows two specific
+                                              types of objects, dataSourceRef allows
                                               any non-core object, as well as PersistentVolumeClaim
-                                              objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef
+                                              objects. * While dataSource ignores
+                                              disallowed values (dropping them), dataSourceRef
                                               preserves all values, and generates
                                               an error if a disallowed value is specified.
-                                              (Beta) Using this field requires the
-                                              AnyVolumeDataSource feature gate to
-                                              be enabled.'
+                                              * While dataSource only allows local
+                                              objects, dataSourceRef allows objects
+                                              in any namespaces. (Beta) Using this
+                                              field requires the AnyVolumeDataSource
+                                              feature gate to be enabled. (Alpha)
+                                              Using the namespace field of dataSourceRef
+                                              requires the CrossNamespaceVolumeDataSource
+                                              feature gate to be enabled.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -6793,11 +7473,23 @@ spec:
                                                 description: Name is the name of resource
                                                   being referenced
                                                 type: string
+                                              namespace:
+                                                description: Namespace is the namespace
+                                                  of resource being referenced Note
+                                                  that when a namespace is specified,
+                                                  a gateway.networking.k8s.io/ReferenceGrant
+                                                  object is required in the referent
+                                                  namespace to allow that namespace's
+                                                  owner to accept the reference. See
+                                                  the ReferenceGrant documentation
+                                                  for details. (Alpha) This field
+                                                  requires the CrossNamespaceVolumeDataSource
+                                                  feature gate to be enabled.
+                                                type: string
                                             required:
                                             - kind
                                             - name
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           resources:
                                             description: 'resources represents the
                                               minimum resources the volume should
@@ -6833,7 +7525,8 @@ spec:
                                                   for a container, it defaults to
                                                   Limits if that is explicitly specified,
                                                   otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                 type: object
                                             type: object
                                           selector:
@@ -6898,6 +7591,34 @@ spec:
                                             description: 'storageClassName is the
                                               name of the StorageClass required by
                                               the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeAttributesClassName:
+                                            description: 'volumeAttributesClassName
+                                              may be used to set the VolumeAttributesClass
+                                              used by this claim. If specified, the
+                                              CSI driver will create or update the
+                                              volume with the attributes defined in
+                                              the corresponding VolumeAttributesClass.
+                                              This has a different purpose than storageClassName,
+                                              it can be changed after the claim is
+                                              created. An empty string value means
+                                              that no VolumeAttributesClass will be
+                                              applied to the claim but it''s not allowed
+                                              to reset this field to empty string
+                                              once it is set. If unspecified and the
+                                              PersistentVolumeClaim is unbound, the
+                                              default VolumeAttributesClass will be
+                                              set by the persistentvolume controller
+                                              if it exists. If the resource referred
+                                              to by volumeAttributesClass does not
+                                              exist, this PersistentVolumeClaim will
+                                              be set to a Pending state, as reflected
+                                              by the modifyVolumeStatus field, until
+                                              such as a resource exists. More info:
+                                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                              (Alpha) Using this field requires the
+                                              VolumeAttributesClass feature gate to
+                                              be enabled.'
                                             type: string
                                           volumeMode:
                                             description: volumeMode defines what type
@@ -7307,6 +8028,118 @@ spec:
                                       description: Projection that may be projected
                                         along with other supported volume types
                                       properties:
+                                        clusterTrustBundle:
+                                          description: "ClusterTrustBundle allows
+                                            a pod to access the `.spec.trustBundle`
+                                            field of ClusterTrustBundle objects in
+                                            an auto-updating file. \n Alpha, gated
+                                            by the ClusterTrustBundleProjection feature
+                                            gate. \n ClusterTrustBundle objects can
+                                            either be selected by name, or by the
+                                            combination of signer name and a label
+                                            selector. \n Kubelet performs aggressive
+                                            normalization of the PEM contents written
+                                            into the pod filesystem.  Esoteric PEM
+                                            features such as inter-block comments
+                                            and block headers are stripped.  Certificates
+                                            are deduplicated. The ordering of certificates
+                                            within the file is arbitrary, and Kubelet
+                                            may change the order over time."
+                                          properties:
+                                            labelSelector:
+                                              description: Select all ClusterTrustBundles
+                                                that match this label selector.  Only
+                                                has effect if signerName is set.  Mutually-exclusive
+                                                with name.  If unset, interpreted
+                                                as "match nothing".  If set but empty,
+                                                interpreted as "match everything".
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            name:
+                                              description: Select a single ClusterTrustBundle
+                                                by object name.  Mutually-exclusive
+                                                with signerName and labelSelector.
+                                              type: string
+                                            optional:
+                                              description: If true, don't block pod
+                                                startup if the referenced ClusterTrustBundle(s)
+                                                aren't available.  If using name,
+                                                then the named ClusterTrustBundle
+                                                is allowed not to exist.  If using
+                                                signerName, then the combination of
+                                                signerName and labelSelector is allowed
+                                                to match zero ClusterTrustBundles.
+                                              type: boolean
+                                            path:
+                                              description: Relative path from the
+                                                volume root to write the bundle.
+                                              type: string
+                                            signerName:
+                                              description: Select all ClusterTrustBundles
+                                                that match this signer name. Mutually-exclusive
+                                                with name.  The contents of all selected
+                                                ClusterTrustBundles will be unified
+                                                and deduplicated.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
                                         configMap:
                                           description: configMap information about
                                             the configMap data to project
@@ -7924,9 +8757,12 @@ spec:
                                   provisioner or an external controller can support
                                   the specified data source, it will create a new
                                   volume based on the contents of the specified data
-                                  source. If the AnyVolumeDataSource feature gate
-                                  is enabled, this field will always have the same
-                                  contents as the DataSourceRef field.'
+                                  source. When the AnyVolumeDataSource feature gate
+                                  is enabled, dataSource contents will be copied to
+                                  dataSourceRef, and dataSourceRef contents will be
+                                  copied to dataSource when dataSourceRef.namespace
+                                  is not specified. If the namespace is specified,
+                                  then dataSourceRef will not be copied to dataSource.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -7951,27 +8787,33 @@ spec:
                               dataSourceRef:
                                 description: 'dataSourceRef specifies the object from
                                   which to populate the volume with data, if a non-empty
-                                  volume is desired. This may be any local object
-                                  from a non-empty API group (non core object) or
-                                  a PersistentVolumeClaim object. When this field
-                                  is specified, volume binding will only succeed if
-                                  the type of the specified object matches some installed
-                                  volume populator or dynamic provisioner. This field
-                                  will replace the functionality of the DataSource
-                                  field and as such if both fields are non-empty,
-                                  they must have the same value. For backwards compatibility,
-                                  both fields (DataSource and DataSourceRef) will
-                                  be set to the same value automatically if one of
-                                  them is empty and the other is non-empty. There
-                                  are two important differences between DataSource
-                                  and DataSourceRef: * While DataSource only allows
-                                  two specific types of objects, DataSourceRef allows
+                                  volume is desired. This may be any object from a
+                                  non-empty API group (non core object) or a PersistentVolumeClaim
+                                  object. When this field is specified, volume binding
+                                  will only succeed if the type of the specified object
+                                  matches some installed volume populator or dynamic
+                                  provisioner. This field will replace the functionality
+                                  of the dataSource field and as such if both fields
+                                  are non-empty, they must have the same value. For
+                                  backwards compatibility, when namespace isn''t specified
+                                  in dataSourceRef, both fields (dataSource and dataSourceRef)
+                                  will be set to the same value automatically if one
+                                  of them is empty and the other is non-empty. When
+                                  namespace is specified in dataSourceRef, dataSource
+                                  isn''t set to the same value and must be empty.
+                                  There are three important differences between dataSource
+                                  and dataSourceRef: * While dataSource only allows
+                                  two specific types of objects, dataSourceRef allows
                                   any non-core object, as well as PersistentVolumeClaim
-                                  objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef preserves all values,
+                                  objects. * While dataSource ignores disallowed values
+                                  (dropping them), dataSourceRef preserves all values,
                                   and generates an error if a disallowed value is
-                                  specified. (Beta) Using this field requires the
-                                  AnyVolumeDataSource feature gate to be enabled.'
+                                  specified. * While dataSource only allows local
+                                  objects, dataSourceRef allows objects in any namespaces.
+                                  (Beta) Using this field requires the AnyVolumeDataSource
+                                  feature gate to be enabled. (Alpha) Using the namespace
+                                  field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                  feature gate to be enabled.'
                                 properties:
                                   apiGroup:
                                     description: APIGroup is the group for the resource
@@ -7988,11 +8830,21 @@ spec:
                                     description: Name is the name of resource being
                                       referenced
                                     type: string
+                                  namespace:
+                                    description: Namespace is the namespace of resource
+                                      being referenced Note that when a namespace
+                                      is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                      object is required in the referent namespace
+                                      to allow that namespace's owner to accept the
+                                      reference. See the ReferenceGrant documentation
+                                      for details. (Alpha) This field requires the
+                                      CrossNamespaceVolumeDataSource feature gate
+                                      to be enabled.
+                                    type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
-                                x-kubernetes-map-type: atomic
                               resources:
                                 description: 'resources represents the minimum resources
                                   the volume should have. If RecoverVolumeExpansionFailure
@@ -8022,8 +8874,8 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
                               selector:
@@ -8078,6 +8930,27 @@ spec:
                               storageClassName:
                                 description: 'storageClassName is the name of the
                                   StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeAttributesClassName:
+                                description: 'volumeAttributesClassName may be used
+                                  to set the VolumeAttributesClass used by this claim.
+                                  If specified, the CSI driver will create or update
+                                  the volume with the attributes defined in the corresponding
+                                  VolumeAttributesClass. This has a different purpose
+                                  than storageClassName, it can be changed after the
+                                  claim is created. An empty string value means that
+                                  no VolumeAttributesClass will be applied to the
+                                  claim but it''s not allowed to reset this field
+                                  to empty string once it is set. If unspecified and
+                                  the PersistentVolumeClaim is unbound, the default
+                                  VolumeAttributesClass will be set by the persistentvolume
+                                  controller if it exists. If the resource referred
+                                  to by volumeAttributesClass does not exist, this
+                                  PersistentVolumeClaim will be set to a Pending state,
+                                  as reflected by the modifyVolumeStatus field, until
+                                  such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                  (Alpha) Using this field requires the VolumeAttributesClass
+                                  feature gate to be enabled.'
                                 type: string
                               volumeMode:
                                 description: volumeMode defines what type of volume
@@ -8566,7 +9439,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -8622,6 +9497,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -8746,7 +9668,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -8797,6 +9720,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -8913,7 +9879,9 @@ spec:
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
-                                              of resources, in this case pods.
+                                              of resources, in this case pods. If
+                                              it's null, this PodAffinityTerm matches
+                                              with no Pods.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -8969,6 +9937,53 @@ spec:
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: MatchLabelKeys is a set of
+                                              pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key in (value)` to select the group
+                                              of existing pods which pods will be
+                                              taken into consideration for the incoming
+                                              pod's pod (anti) affinity. Keys that
+                                              don't exist in the incoming pod labels
+                                              will be ignored. The default value is
+                                              empty. The same key is forbidden to
+                                              exist in both MatchLabelKeys and LabelSelector.
+                                              Also, MatchLabelKeys cannot be set when
+                                              LabelSelector isn't set. This is an
+                                              alpha field and requires enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: MismatchLabelKeys is a set
+                                              of pod label keys to select which pods
+                                              will be taken into consideration. The
+                                              keys are used to lookup values from
+                                              the incoming pod labels, those key-value
+                                              labels are merged with `LabelSelector`
+                                              as `key notin (value)` to select the
+                                              group of existing pods which pods will
+                                              be taken into consideration for the
+                                              incoming pod's pod (anti) affinity.
+                                              Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default
+                                              value is empty. The same key is forbidden
+                                              to exist in both MismatchLabelKeys and
+                                              LabelSelector. Also, MismatchLabelKeys
+                                              cannot be set when LabelSelector isn't
+                                              set. This is an alpha field and requires
+                                              enabling MatchLabelKeysInPodAffinity
+                                              feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -9094,7 +10109,8 @@ spec:
                                     properties:
                                       labelSelector:
                                         description: A label query over a set of resources,
-                                          in this case pods.
+                                          in this case pods. If it's null, this PodAffinityTerm
+                                          matches with no Pods.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
@@ -9145,6 +10161,49 @@ spec:
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select which pods will be
+                                          taken into consideration. The keys are used
+                                          to lookup values from the incoming pod labels,
+                                          those key-value labels are merged with `LabelSelector`
+                                          as `key in (value)` to select the group
+                                          of existing pods which pods will be taken
+                                          into consideration for the incoming pod's
+                                          pod (anti) affinity. Keys that don't exist
+                                          in the incoming pod labels will be ignored.
+                                          The default value is empty. The same key
+                                          is forbidden to exist in both MatchLabelKeys
+                                          and LabelSelector. Also, MatchLabelKeys
+                                          cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling
+                                          MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: MismatchLabelKeys is a set of
+                                          pod label keys to select which pods will
+                                          be taken into consideration. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are merged
+                                          with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which
+                                          pods will be taken into consideration for
+                                          the incoming pod's pod (anti) affinity.
+                                          Keys that don't exist in the incoming pod
+                                          labels will be ignored. The default value
+                                          is empty. The same key is forbidden to exist
+                                          in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when
+                                          LabelSelector isn't set. This is an alpha
+                                          field and requires enabling MatchLabelKeysInPodAffinity
+                                          feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       namespaceSelector:
                                         description: A label query over the set of
                                           namespaces that the term applies to. The
@@ -9511,7 +10570,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -9540,6 +10603,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -9619,7 +10695,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -9648,6 +10728,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -9706,8 +10799,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -9741,7 +10833,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -9843,13 +10938,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -9923,8 +11018,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -9958,7 +11052,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -10053,10 +11150,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -10078,10 +11221,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -10217,8 +11383,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -10255,17 +11422,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -10316,8 +11478,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -10351,7 +11512,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -10964,7 +12128,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -10993,6 +12161,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -11072,7 +12253,11 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -11101,6 +12286,19 @@ spec:
                                             type: string
                                         required:
                                         - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents the duration
+                                          that the container should sleep before being
+                                          terminated.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of
+                                              seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                        - seconds
                                         type: object
                                       tcpSocket:
                                         description: Deprecated. TCPSocket is NOT
@@ -11159,8 +12357,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -11194,7 +12391,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -11296,13 +12496,13 @@ spec:
                                 type: string
                               ports:
                                 description: List of ports to expose from the container.
-                                  Exposing a port here gives the system additional
-                                  information about the network connections a container
-                                  uses, but is primarily informational. Not specifying
-                                  a port here DOES NOT prevent that port from being
-                                  exposed. Any port which is listening on the default
-                                  "0.0.0.0" address inside a container will be accessible
-                                  from the network. Cannot be updated.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
                                 items:
                                   description: ContainerPort represents a network
                                     port in a single container.
@@ -11376,8 +12576,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -11411,7 +12610,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -11506,10 +12708,56 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource
+                                    resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: 'Name of the resource to which
+                                        this resource resize policy applies. Supported
+                                        values: cpu, memory.'
+                                      type: string
+                                    restartPolicy:
+                                      description: Restart policy to apply when specified
+                                        resource is resized. If not specified, it
+                                        defaults to NotRequired.
+                                      type: string
+                                  required:
+                                  - resourceName
+                                  - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
                               resources:
                                 description: 'Compute Resources required by this container.
                                   Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:
@@ -11531,10 +12779,33 @@ spec:
                                       of compute resources required. If Requests is
                                       omitted for a container, it defaults to Limits
                                       if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
+                              restartPolicy:
+                                description: 'RestartPolicy defines the restart behavior
+                                  of individual containers in a pod. This field may
+                                  only be set for init containers, and the only allowed
+                                  value is "Always". For non-init containers or when
+                                  this field is not specified, the restart behavior
+                                  is defined by the Pod''s restart policy and the
+                                  container type. Setting the RestartPolicy as "Always"
+                                  for the init container will have the following effect:
+                                  this init container will be continually restarted
+                                  on exit until all regular containers have terminated.
+                                  Once all regular containers have completed, all
+                                  init containers with restartPolicy "Always" will
+                                  be shut down. This lifecycle differs from normal
+                                  init containers and is often referred to as a "sidecar"
+                                  container. Although this init container still starts
+                                  in the init container sequence, it does not wait
+                                  for the container to complete before proceeding
+                                  to the next init container. Instead, the next init
+                                  container starts immediately after this init container
+                                  is started, or after any startupProbe has successfully
+                                  completed.'
+                                type: string
                               securityContext:
                                 description: 'SecurityContext defines the security
                                   options the container should be run with. If set,
@@ -11670,8 +12941,9 @@ spec:
                                           be used. The profile must be preconfigured
                                           on the node to work. Must be a descending
                                           path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                          seccomp profile location. Must be set if
+                                          type is "Localhost". Must NOT be set for
+                                          any other type.
                                         type: string
                                       type:
                                         description: "type indicates which kind of
@@ -11708,17 +12980,12 @@ spec:
                                       hostProcess:
                                         description: HostProcess determines if a container
                                           should be run as a 'Host Process' container.
-                                          This field is alpha-level and will only
-                                          be honored by components that enable the
-                                          WindowsHostProcessContainers feature flag.
-                                          Setting this field without the feature flag
-                                          will result in errors when validating the
-                                          Pod. All of a Pod's containers must have
-                                          the same effective HostProcess value (it
-                                          is not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).  In
-                                          addition, if HostProcess is true then HostNetwork
-                                          must also be set to true.
+                                          All of a Pod's containers must have the
+                                          same effective HostProcess value (it is
+                                          not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then
+                                          HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
                                         description: The UserName in Windows to run
@@ -11769,8 +13036,7 @@ spec:
                                     type: integer
                                   grpc:
                                     description: GRPC specifies an action involving
-                                      a GRPC port. This is a beta field and requires
-                                      enabling GRPCContainerProbe feature gate.
+                                      a GRPC port.
                                     properties:
                                       port:
                                         description: Port number of the gRPC service.
@@ -11804,7 +13070,10 @@ spec:
                                             header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
+                                              description: The header field name.
+                                                This will be canonicalized upon output,
+                                                so case-variant names will be understood
+                                                as the same header.
                                               type: string
                                             value:
                                               description: The header field value
@@ -12215,7 +13484,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -12231,9 +13501,14 @@ spec:
                             supplementalGroups:
                               description: A list of groups applied to the first process
                                 run in each container, in addition to the container's
-                                primary GID.  If unspecified, no groups will be added
-                                to any container. Note that this field cannot be set
-                                when spec.os.name is windows.
+                                primary GID, the fsGroup (if specified), and group
+                                memberships defined in the container image for the
+                                uid of the container process. If unspecified, no additional
+                                groups are added to any container. Note that group
+                                memberships defined in the container image for the
+                                uid of the container process are still effective,
+                                even if they are not included in this list. Note that
+                                this field cannot be set when spec.os.name is windows.
                               items:
                                 format: int64
                                 type: integer
@@ -12280,15 +13555,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -12445,6 +13716,25 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: "MatchLabelKeys is a set of pod label
+                                  keys to select the pods over which spreading will
+                                  be calculated. The keys are used to lookup values
+                                  from the incoming pod labels, those key-value labels
+                                  are ANDed with labelSelector to select the group
+                                  of existing pods over which spreading will be calculated
+                                  for the incoming pod. The same key is forbidden
+                                  to exist in both MatchLabelKeys and LabelSelector.
+                                  MatchLabelKeys cannot be set when LabelSelector
+                                  isn't set. Keys that don't exist in the incoming
+                                  pod labels will be ignored. A null or empty list
+                                  means only match against labelSelector. \n This
+                                  is a beta field and requires the MatchLabelKeysInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               maxSkew:
                                 description: 'MaxSkew describes the degree to which
                                   pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -12492,10 +13782,34 @@ spec:
                                   cannot be scheduled, because computed skew will
                                   be 3(3 - 0) if new Pod is scheduled to any of the
                                   three zones, it will violate MaxSkew. \n This is
-                                  an alpha field and requires enabling MinDomainsInPodTopologySpread
-                                  feature gate."
+                                  a beta field and requires the MinDomainsInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
                                 format: int32
                                 type: integer
+                              nodeAffinityPolicy:
+                                description: "NodeAffinityPolicy indicates how we
+                                  will treat Pod's nodeAffinity/nodeSelector when
+                                  calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector
+                                  are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                  are ignored. All nodes are included in the calculations.
+                                  \n If this value is nil, the behavior is equivalent
+                                  to the Honor policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              nodeTaintsPolicy:
+                                description: "NodeTaintsPolicy indicates how we will
+                                  treat node taints when calculating pod topology
+                                  spread skew. Options are: - Honor: nodes without
+                                  taints, along with tainted nodes for which the incoming
+                                  pod has a toleration, are included. - Ignore: node
+                                  taints are ignored. All nodes are included. \n If
+                                  this value is nil, the behavior is equivalent to
+                                  the Ignore policy. This is a beta-level feature
+                                  default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
                               topologyKey:
                                 description: TopologyKey is the key of node labels.
                                   Nodes that have a label with this key and identical
@@ -12504,11 +13818,12 @@ spec:
                                   try to put balanced number of pods into each bucket.
                                   We define a domain as a particular instance of a
                                   topology. Also, we define an eligible domain as
-                                  a domain whose nodes match the node selector. e.g.
-                                  If TopologyKey is "kubernetes.io/hostname", each
-                                  Node is a domain of that topology. And, if TopologyKey
-                                  is "topology.kubernetes.io/zone", each zone is a
-                                  domain of that topology. It's a required field.
+                                  a domain whose nodes meet the requirements of nodeAffinityPolicy
+                                  and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                  each Node is a domain of that topology. And, if
+                                  TopologyKey is "topology.kubernetes.io/zone", each
+                                  zone is a domain of that topology. It's a required
+                                  field.
                                 type: string
                               whenUnsatisfiable:
                                 description: 'WhenUnsatisfiable indicates how to deal
@@ -12976,7 +14291,7 @@ spec:
                                       specified here and the sum of memory limits
                                       of all containers in a pod. The default is nil
                                       which means that the limit is undefined. More
-                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
@@ -13056,10 +14371,14 @@ spec:
                                               can support the specified data source,
                                               it will create a new volume based on
                                               the contents of the specified data source.
-                                              If the AnyVolumeDataSource feature gate
-                                              is enabled, this field will always have
-                                              the same contents as the DataSourceRef
-                                              field.'
+                                              When the AnyVolumeDataSource feature
+                                              gate is enabled, dataSource contents
+                                              will be copied to dataSourceRef, and
+                                              dataSourceRef contents will be copied
+                                              to dataSource when dataSourceRef.namespace
+                                              is not specified. If the namespace is
+                                              specified, then dataSourceRef will not
+                                              be copied to dataSource.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -13086,33 +14405,41 @@ spec:
                                             description: 'dataSourceRef specifies
                                               the object from which to populate the
                                               volume with data, if a non-empty volume
-                                              is desired. This may be any local object
-                                              from a non-empty API group (non core
-                                              object) or a PersistentVolumeClaim object.
-                                              When this field is specified, volume
-                                              binding will only succeed if the type
-                                              of the specified object matches some
-                                              installed volume populator or dynamic
-                                              provisioner. This field will replace
-                                              the functionality of the DataSource
-                                              field and as such if both fields are
-                                              non-empty, they must have the same value.
-                                              For backwards compatibility, both fields
-                                              (DataSource and DataSourceRef) will
-                                              be set to the same value automatically
+                                              is desired. This may be any object from
+                                              a non-empty API group (non core object)
+                                              or a PersistentVolumeClaim object. When
+                                              this field is specified, volume binding
+                                              will only succeed if the type of the
+                                              specified object matches some installed
+                                              volume populator or dynamic provisioner.
+                                              This field will replace the functionality
+                                              of the dataSource field and as such
+                                              if both fields are non-empty, they must
+                                              have the same value. For backwards compatibility,
+                                              when namespace isn''t specified in dataSourceRef,
+                                              both fields (dataSource and dataSourceRef)
+                                              will be set to the same value automatically
                                               if one of them is empty and the other
-                                              is non-empty. There are two important
-                                              differences between DataSource and DataSourceRef:
-                                              * While DataSource only allows two specific
-                                              types of objects, DataSourceRef allows
+                                              is non-empty. When namespace is specified
+                                              in dataSourceRef, dataSource isn''t
+                                              set to the same value and must be empty.
+                                              There are three important differences
+                                              between dataSource and dataSourceRef:
+                                              * While dataSource only allows two specific
+                                              types of objects, dataSourceRef allows
                                               any non-core object, as well as PersistentVolumeClaim
-                                              objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef
+                                              objects. * While dataSource ignores
+                                              disallowed values (dropping them), dataSourceRef
                                               preserves all values, and generates
                                               an error if a disallowed value is specified.
-                                              (Beta) Using this field requires the
-                                              AnyVolumeDataSource feature gate to
-                                              be enabled.'
+                                              * While dataSource only allows local
+                                              objects, dataSourceRef allows objects
+                                              in any namespaces. (Beta) Using this
+                                              field requires the AnyVolumeDataSource
+                                              feature gate to be enabled. (Alpha)
+                                              Using the namespace field of dataSourceRef
+                                              requires the CrossNamespaceVolumeDataSource
+                                              feature gate to be enabled.'
                                             properties:
                                               apiGroup:
                                                 description: APIGroup is the group
@@ -13130,11 +14457,23 @@ spec:
                                                 description: Name is the name of resource
                                                   being referenced
                                                 type: string
+                                              namespace:
+                                                description: Namespace is the namespace
+                                                  of resource being referenced Note
+                                                  that when a namespace is specified,
+                                                  a gateway.networking.k8s.io/ReferenceGrant
+                                                  object is required in the referent
+                                                  namespace to allow that namespace's
+                                                  owner to accept the reference. See
+                                                  the ReferenceGrant documentation
+                                                  for details. (Alpha) This field
+                                                  requires the CrossNamespaceVolumeDataSource
+                                                  feature gate to be enabled.
+                                                type: string
                                             required:
                                             - kind
                                             - name
                                             type: object
-                                            x-kubernetes-map-type: atomic
                                           resources:
                                             description: 'resources represents the
                                               minimum resources the volume should
@@ -13170,7 +14509,8 @@ spec:
                                                   for a container, it defaults to
                                                   Limits if that is explicitly specified,
                                                   otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                  value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                 type: object
                                             type: object
                                           selector:
@@ -13235,6 +14575,34 @@ spec:
                                             description: 'storageClassName is the
                                               name of the StorageClass required by
                                               the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            type: string
+                                          volumeAttributesClassName:
+                                            description: 'volumeAttributesClassName
+                                              may be used to set the VolumeAttributesClass
+                                              used by this claim. If specified, the
+                                              CSI driver will create or update the
+                                              volume with the attributes defined in
+                                              the corresponding VolumeAttributesClass.
+                                              This has a different purpose than storageClassName,
+                                              it can be changed after the claim is
+                                              created. An empty string value means
+                                              that no VolumeAttributesClass will be
+                                              applied to the claim but it''s not allowed
+                                              to reset this field to empty string
+                                              once it is set. If unspecified and the
+                                              PersistentVolumeClaim is unbound, the
+                                              default VolumeAttributesClass will be
+                                              set by the persistentvolume controller
+                                              if it exists. If the resource referred
+                                              to by volumeAttributesClass does not
+                                              exist, this PersistentVolumeClaim will
+                                              be set to a Pending state, as reflected
+                                              by the modifyVolumeStatus field, until
+                                              such as a resource exists. More info:
+                                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                              (Alpha) Using this field requires the
+                                              VolumeAttributesClass feature gate to
+                                              be enabled.'
                                             type: string
                                           volumeMode:
                                             description: volumeMode defines what type
@@ -13644,6 +15012,118 @@ spec:
                                       description: Projection that may be projected
                                         along with other supported volume types
                                       properties:
+                                        clusterTrustBundle:
+                                          description: "ClusterTrustBundle allows
+                                            a pod to access the `.spec.trustBundle`
+                                            field of ClusterTrustBundle objects in
+                                            an auto-updating file. \n Alpha, gated
+                                            by the ClusterTrustBundleProjection feature
+                                            gate. \n ClusterTrustBundle objects can
+                                            either be selected by name, or by the
+                                            combination of signer name and a label
+                                            selector. \n Kubelet performs aggressive
+                                            normalization of the PEM contents written
+                                            into the pod filesystem.  Esoteric PEM
+                                            features such as inter-block comments
+                                            and block headers are stripped.  Certificates
+                                            are deduplicated. The ordering of certificates
+                                            within the file is arbitrary, and Kubelet
+                                            may change the order over time."
+                                          properties:
+                                            labelSelector:
+                                              description: Select all ClusterTrustBundles
+                                                that match this label selector.  Only
+                                                has effect if signerName is set.  Mutually-exclusive
+                                                with name.  If unset, interpreted
+                                                as "match nothing".  If set but empty,
+                                                interpreted as "match everything".
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            name:
+                                              description: Select a single ClusterTrustBundle
+                                                by object name.  Mutually-exclusive
+                                                with signerName and labelSelector.
+                                              type: string
+                                            optional:
+                                              description: If true, don't block pod
+                                                startup if the referenced ClusterTrustBundle(s)
+                                                aren't available.  If using name,
+                                                then the named ClusterTrustBundle
+                                                is allowed not to exist.  If using
+                                                signerName, then the combination of
+                                                signerName and labelSelector is allowed
+                                                to match zero ClusterTrustBundles.
+                                              type: boolean
+                                            path:
+                                              description: Relative path from the
+                                                volume root to write the bundle.
+                                              type: string
+                                            signerName:
+                                              description: Select all ClusterTrustBundles
+                                                that match this signer name. Mutually-exclusive
+                                                with name.  The contents of all selected
+                                                ClusterTrustBundles will be unified
+                                                and deduplicated.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
                                         configMap:
                                           description: configMap information about
                                             the configMap data to project
@@ -14602,7 +16082,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -14653,6 +16134,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -14766,7 +16289,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -14816,6 +16340,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -14926,7 +16488,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -14977,6 +16540,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -15090,7 +16695,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -15140,6 +16746,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -15487,7 +17131,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -15514,6 +17161,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -15586,7 +17245,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -15613,6 +17275,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -15668,8 +17342,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -15701,7 +17374,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -15798,13 +17473,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -15876,8 +17551,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -15909,7 +17583,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -15999,10 +17675,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -16024,9 +17744,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -16151,7 +17892,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -16184,15 +17926,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -16241,8 +17979,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -16274,7 +18011,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -16534,9 +18273,7 @@ spec:
                       actions such as debugging. This list cannot be specified when
                       creating a pod, and it cannot be modified by updating the pod
                       spec. In order to add an ephemeral container to an existing
-                      pod, use the pod's ephemeralcontainers subresource. This field
-                      is beta-level and available on clusters that haven't disabled
-                      the EphemeralContainers feature gate.
+                      pod, use the pod's ephemeralcontainers subresource.
                     items:
                       description: "An EphemeralContainer is a temporary container
                         that you may add to an existing Pod for user-initiated activities
@@ -16546,9 +18283,7 @@ spec:
                         may evict a Pod if an ephemeral container causes the Pod to
                         exceed its resource allocation. \n To add an ephemeral container,
                         use the ephemeralcontainers subresource of an existing Pod.
-                        Ephemeral containers may not be removed or restarted. \n This
-                        is a beta feature available on clusters that haven't disabled
-                        the EphemeralContainers feature gate."
+                        Ephemeral containers may not be removed or restarted."
                       properties:
                         args:
                           description: 'Arguments to the entrypoint. The image''s
@@ -16798,7 +18533,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -16825,6 +18563,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -16897,7 +18647,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -16924,6 +18677,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -16977,8 +18742,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -17010,7 +18774,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -17176,8 +18942,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -17209,7 +18974,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -17299,11 +19066,55 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: Resources are not allowed for ephemeral containers.
                             Ephemeral containers use spare resources already allocated
                             to the pod.
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -17325,9 +19136,15 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: Restart policy for the container to manage
+                            the restart behavior of each container within a pod. This
+                            may only be set for init containers. You cannot set this
+                            field on ephemeral containers.
+                          type: string
                         securityContext:
                           description: 'Optional: SecurityContext defines the security
                             options the ephemeral container should be run with. If
@@ -17452,7 +19269,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -17485,15 +19303,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -17534,8 +19348,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -17567,7 +19380,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -17813,6 +19628,18 @@ spec:
                   hostPID:
                     description: 'Use the host''s pid namespace. Optional: Default
                       to false.'
+                    type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
                     type: boolean
                   hostname:
                     description: Specifies the hostname of the Pod If not specified,
@@ -18106,7 +19933,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -18133,6 +19963,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -18205,7 +20047,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -18232,6 +20077,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -18287,8 +20144,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -18320,7 +20176,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -18417,13 +20275,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -18495,8 +20353,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -18528,7 +20385,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -18618,10 +20477,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -18643,9 +20546,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -18770,7 +20694,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -18803,15 +20728,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -18860,8 +20781,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -18893,7 +20813,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -19118,7 +21040,7 @@ spec:
                       the OS field is set to linux, the following fields must be unset:
                       -securityContext.windowsOptions \n If the OS field is set to
                       windows, following fields must be unset: - spec.hostPID - spec.hostIPC
-                      - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                      - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
                       - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
                       - spec.securityContext.sysctls - spec.shareProcessNamespace
                       - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
@@ -19127,8 +21049,7 @@ spec:
                       - spec.containers[*].securityContext.readOnlyRootFilesystem
                       - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
                       - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                      - spec.containers[*].securityContext.runAsGroup This is a beta
-                      field and requires the IdentifyPodOS feature"
+                      - spec.containers[*].securityContext.runAsGroup"
                     properties:
                       name:
                         description: 'Name is the name of the operating system. The
@@ -19196,9 +21117,56 @@ spec:
                       - conditionType
                       type: object
                     type: array
+                  resourceClaims:
+                    description: "ResourceClaims defines which ResourceClaims must
+                      be allocated and reserved before the Pod is allowed to start.
+                      The resources will be made available to those containers which
+                      consume them by name. \n This is an alpha field and requires
+                      enabling the DynamicResourceAllocation feature gate. \n This
+                      field is immutable."
+                    items:
+                      description: PodResourceClaim references exactly one ResourceClaim
+                        through a ClaimSource. It adds a name to it that uniquely
+                        identifies the ResourceClaim inside the Pod. Containers that
+                        need access to the ResourceClaim reference it with this name.
+                      properties:
+                        name:
+                          description: Name uniquely identifies this resource claim
+                            inside the pod. This must be a DNS_LABEL.
+                          type: string
+                        source:
+                          description: Source describes where to find the ResourceClaim.
+                          properties:
+                            resourceClaimName:
+                              description: ResourceClaimName is the name of a ResourceClaim
+                                object in the same namespace as this pod.
+                              type: string
+                            resourceClaimTemplateName:
+                              description: "ResourceClaimTemplateName is the name
+                                of a ResourceClaimTemplate object in the same namespace
+                                as this pod. \n The template will be used to create
+                                a new ResourceClaim, which will be bound to this pod.
+                                When this pod is deleted, the ResourceClaim will also
+                                be deleted. The pod name and resource name, along
+                                with a generated component, will be used to form a
+                                unique name for the ResourceClaim, which will be recorded
+                                in pod.status.resourceClaimStatuses. \n This field
+                                is immutable and no changes will be made to the corresponding
+                                ResourceClaim by the control plane after creating
+                                the ResourceClaim."
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   restartPolicy:
                     description: 'Restart policy for all containers within the pod.
-                      One of Always, OnFailure, Never. Default to Always. More info:
+                      One of Always, OnFailure, Never. In some contexts, only a subset
+                      of those values may be permitted. Default to Always. More info:
                       https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                     type: string
                   runtimeClassName:
@@ -19214,6 +21182,29 @@ spec:
                       scheduler. If not specified, the pod will be dispatched by default
                       scheduler.
                     type: string
+                  schedulingGates:
+                    description: "SchedulingGates is an opaque list of values that
+                      if specified will block scheduling the pod. If schedulingGates
+                      is not empty, the pod will stay in the SchedulingGated state
+                      and the scheduler will not attempt to schedule the pod. \n SchedulingGates
+                      can only be set at pod creation time, and be removed only afterwards.
+                      \n This is a beta feature enabled by the PodSchedulingReadiness
+                      feature gate."
+                    items:
+                      description: PodSchedulingGate is associated to a Pod to guard
+                        its scheduling.
+                      properties:
+                        name:
+                          description: Name of the scheduling gate. Each scheduling
+                            gate must have a unique name field.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   securityContext:
                     description: 'SecurityContext holds pod-level security attributes
                       and common container settings. Optional: Defaults to empty.  See
@@ -19305,7 +21296,8 @@ spec:
                               in a file on the node should be used. The profile must
                               be preconfigured on the node to work. Must be a descending
                               path, relative to the kubelet's configured seccomp profile
-                              location. Must only be set if type is "Localhost".
+                              location. Must be set if type is "Localhost". Must NOT
+                              be set for any other type.
                             type: string
                           type:
                             description: "type indicates which kind of seccomp profile
@@ -19320,9 +21312,13 @@ spec:
                       supplementalGroups:
                         description: A list of groups applied to the first process
                           run in each container, in addition to the container's primary
-                          GID.  If unspecified, no groups will be added to any container.
-                          Note that this field cannot be set when spec.os.name is
-                          windows.
+                          GID, the fsGroup (if specified), and group memberships defined
+                          in the container image for the uid of the container process.
+                          If unspecified, no additional groups are added to any container.
+                          Note that group memberships defined in the container image
+                          for the uid of the container process are still effective,
+                          even if they are not included in this list. Note that this
+                          field cannot be set when spec.os.name is windows.
                         items:
                           format: int64
                           type: integer
@@ -19366,15 +21362,12 @@ spec:
                             type: string
                           hostProcess:
                             description: HostProcess determines if a container should
-                              be run as a 'Host Process' container. This field is
-                              alpha-level and will only be honored by components that
-                              enable the WindowsHostProcessContainers feature flag.
-                              Setting this field without the feature flag will result
-                              in errors when validating the Pod. All of a Pod's containers
-                              must have the same effective HostProcess value (it is
-                              not allowed to have a mix of HostProcess containers
-                              and non-HostProcess containers).  In addition, if HostProcess
-                              is true then HostNetwork must also be set to true.
+                              be run as a 'Host Process' container. All of a Pod's
+                              containers must have the same effective HostProcess
+                              value (it is not allowed to have a mix of HostProcess
+                              containers and non-HostProcess containers). In addition,
+                              if HostProcess is true then HostNetwork must also be
+                              set to true.
                             type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
@@ -19528,6 +21521,24 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: "MatchLabelKeys is a set of pod label keys
+                            to select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. The same key
+                            is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't
+                            set. Keys that don't exist in the incoming pod labels
+                            will be ignored. A null or empty list means only match
+                            against labelSelector. \n This is a beta field and requires
+                            the MatchLabelKeysInPodTopologySpread feature gate to
+                            be enabled (enabled by default)."
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         maxSkew:
                           description: 'MaxSkew describes the degree to which pods
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -19570,11 +21581,33 @@ spec:
                             as 0. In this situation, new pod with the same labelSelector
                             cannot be scheduled, because computed skew will be 3(3
                             - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
                           format: int32
                           type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a beta-level
+                            feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
@@ -19582,11 +21615,11 @@ spec:
                             <key, value> as a "bucket", and try to put balanced number
                             of pods into each bucket. We define a domain as a particular
                             instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -20020,7 +22053,7 @@ spec:
                                 value between the SizeLimit specified here and the
                                 sum of memory limits of all containers in a pod. The
                                 default is nil which means that the limit is undefined.
-                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
@@ -20095,10 +22128,13 @@ spec:
                                         If the provisioner or an external controller
                                         can support the specified data source, it
                                         will create a new volume based on the contents
-                                        of the specified data source. If the AnyVolumeDataSource
-                                        feature gate is enabled, this field will always
-                                        have the same contents as the DataSourceRef
-                                        field.'
+                                        of the specified data source. When the AnyVolumeDataSource
+                                        feature gate is enabled, dataSource contents
+                                        will be copied to dataSourceRef, and dataSourceRef
+                                        contents will be copied to dataSource when
+                                        dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef
+                                        will not be copied to dataSource.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -20124,29 +22160,37 @@ spec:
                                       description: 'dataSourceRef specifies the object
                                         from which to populate the volume with data,
                                         if a non-empty volume is desired. This may
-                                        be any local object from a non-empty API group
-                                        (non core object) or a PersistentVolumeClaim
-                                        object. When this field is specified, volume
-                                        binding will only succeed if the type of the
-                                        specified object matches some installed volume
-                                        populator or dynamic provisioner. This field
-                                        will replace the functionality of the DataSource
-                                        field and as such if both fields are non-empty,
+                                        be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding
+                                        will only succeed if the type of the specified
+                                        object matches some installed volume populator
+                                        or dynamic provisioner. This field will replace
+                                        the functionality of the dataSource field
+                                        and as such if both fields are non-empty,
                                         they must have the same value. For backwards
-                                        compatibility, both fields (DataSource and
-                                        DataSourceRef) will be set to the same value
-                                        automatically if one of them is empty and
-                                        the other is non-empty. There are two important
-                                        differences between DataSource and DataSourceRef:
-                                        * While DataSource only allows two specific
-                                        types of objects, DataSourceRef allows any
-                                        non-core object, as well as PersistentVolumeClaim
-                                        objects. * While DataSource ignores disallowed
-                                        values (dropping them), DataSourceRef preserves
-                                        all values, and generates an error if a disallowed
-                                        value is specified. (Beta) Using this field
-                                        requires the AnyVolumeDataSource feature gate
-                                        to be enabled.'
+                                        compatibility, when namespace isn''t specified
+                                        in dataSourceRef, both fields (dataSource
+                                        and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty
+                                        and the other is non-empty. When namespace
+                                        is specified in dataSourceRef, dataSource
+                                        isn''t set to the same value and must be empty.
+                                        There are three important differences between
+                                        dataSource and dataSourceRef: * While dataSource
+                                        only allows two specific types of objects,
+                                        dataSourceRef allows any non-core object,
+                                        as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values
+                                        (dropping them), dataSourceRef preserves all
+                                        values, and generates an error if a disallowed
+                                        value is specified. * While dataSource only
+                                        allows local objects, dataSourceRef allows
+                                        objects in any namespaces. (Beta) Using this
+                                        field requires the AnyVolumeDataSource feature
+                                        gate to be enabled. (Alpha) Using the namespace
+                                        field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                        feature gate to be enabled.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -20163,11 +22207,21 @@ spec:
                                           description: Name is the name of resource
                                             being referenced
                                           type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of resource being referenced Note that
+                                            when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. (Alpha) This
+                                            field requires the CrossNamespaceVolumeDataSource
+                                            feature gate to be enabled.
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
@@ -20200,7 +22254,8 @@ spec:
                                             If Requests is omitted for a container,
                                             it defaults to Limits if that is explicitly
                                             specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     selector:
@@ -20260,6 +22315,29 @@ spec:
                                       description: 'storageClassName is the name of
                                         the StorageClass required by the claim. More
                                         info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: 'volumeAttributesClassName may
+                                        be used to set the VolumeAttributesClass used
+                                        by this claim. If specified, the CSI driver
+                                        will create or update the volume with the
+                                        attributes defined in the corresponding VolumeAttributesClass.
+                                        This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created.
+                                        An empty string value means that no VolumeAttributesClass
+                                        will be applied to the claim but it''s not
+                                        allowed to reset this field to empty string
+                                        once it is set. If unspecified and the PersistentVolumeClaim
+                                        is unbound, the default VolumeAttributesClass
+                                        will be set by the persistentvolume controller
+                                        if it exists. If the resource referred to
+                                        by volumeAttributesClass does not exist, this
+                                        PersistentVolumeClaim will be set to a Pending
+                                        state, as reflected by the modifyVolumeStatus
+                                        field, until such as a resource exists. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                        (Alpha) Using this field requires the VolumeAttributesClass
+                                        feature gate to be enabled.'
                                       type: string
                                     volumeMode:
                                       description: volumeMode defines what type of
@@ -20649,6 +22727,107 @@ spec:
                                 description: Projection that may be projected along
                                   with other supported volume types
                                 properties:
+                                  clusterTrustBundle:
+                                    description: "ClusterTrustBundle allows a pod
+                                      to access the `.spec.trustBundle` field of ClusterTrustBundle
+                                      objects in an auto-updating file. \n Alpha,
+                                      gated by the ClusterTrustBundleProjection feature
+                                      gate. \n ClusterTrustBundle objects can either
+                                      be selected by name, or by the combination of
+                                      signer name and a label selector. \n Kubelet
+                                      performs aggressive normalization of the PEM
+                                      contents written into the pod filesystem.  Esoteric
+                                      PEM features such as inter-block comments and
+                                      block headers are stripped.  Certificates are
+                                      deduplicated. The ordering of certificates within
+                                      the file is arbitrary, and Kubelet may change
+                                      the order over time."
+                                    properties:
+                                      labelSelector:
+                                        description: Select all ClusterTrustBundles
+                                          that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive
+                                          with name.  If unset, interpreted as "match
+                                          nothing".  If set but empty, interpreted
+                                          as "match everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: Select a single ClusterTrustBundle
+                                          by object name.  Mutually-exclusive with
+                                          signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: If true, don't block pod startup
+                                          if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the
+                                          named ClusterTrustBundle is allowed not
+                                          to exist.  If using signerName, then the
+                                          combination of signerName and labelSelector
+                                          is allowed to match zero ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: Select all ClusterTrustBundles
+                                          that match this signer name. Mutually-exclusive
+                                          with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and
+                                          deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
                                   configMap:
                                     description: configMap information about the configMap
                                       data to project
@@ -21218,9 +23397,12 @@ spec:
                             * An existing PVC (PersistentVolumeClaim) If the provisioner
                             or an external controller can support the specified data
                             source, it will create a new volume based on the contents
-                            of the specified data source. If the AnyVolumeDataSource
-                            feature gate is enabled, this field will always have the
-                            same contents as the DataSourceRef field.'
+                            of the specified data source. When the AnyVolumeDataSource
+                            feature gate is enabled, dataSource contents will be copied
+                            to dataSourceRef, and dataSourceRef contents will be copied
+                            to dataSource when dataSourceRef.namespace is not specified.
+                            If the namespace is specified, then dataSourceRef will
+                            not be copied to dataSource.'
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource
@@ -21242,25 +23424,31 @@ spec:
                         dataSourceRef:
                           description: 'dataSourceRef specifies the object from which
                             to populate the volume with data, if a non-empty volume
-                            is desired. This may be any local object from a non-empty
-                            API group (non core object) or a PersistentVolumeClaim
-                            object. When this field is specified, volume binding will
-                            only succeed if the type of the specified object matches
-                            some installed volume populator or dynamic provisioner.
-                            This field will replace the functionality of the DataSource
+                            is desired. This may be any object from a non-empty API
+                            group (non core object) or a PersistentVolumeClaim object.
+                            When this field is specified, volume binding will only
+                            succeed if the type of the specified object matches some
+                            installed volume populator or dynamic provisioner. This
+                            field will replace the functionality of the dataSource
                             field and as such if both fields are non-empty, they must
-                            have the same value. For backwards compatibility, both
-                            fields (DataSource and DataSourceRef) will be set to the
-                            same value automatically if one of them is empty and the
-                            other is non-empty. There are two important differences
-                            between DataSource and DataSourceRef: * While DataSource
-                            only allows two specific types of objects, DataSourceRef
-                            allows any non-core object, as well as PersistentVolumeClaim
-                            objects. * While DataSource ignores disallowed values
-                            (dropping them), DataSourceRef preserves all values, and
-                            generates an error if a disallowed value is specified.
-                            (Beta) Using this field requires the AnyVolumeDataSource
-                            feature gate to be enabled.'
+                            have the same value. For backwards compatibility, when
+                            namespace isn''t specified in dataSourceRef, both fields
+                            (dataSource and dataSourceRef) will be set to the same
+                            value automatically if one of them is empty and the other
+                            is non-empty. When namespace is specified in dataSourceRef,
+                            dataSource isn''t set to the same value and must be empty.
+                            There are three important differences between dataSource
+                            and dataSourceRef: * While dataSource only allows two
+                            specific types of objects, dataSourceRef allows any non-core
+                            object, as well as PersistentVolumeClaim objects. * While
+                            dataSource ignores disallowed values (dropping them),
+                            dataSourceRef preserves all values, and generates an error
+                            if a disallowed value is specified. * While dataSource
+                            only allows local objects, dataSourceRef allows objects
+                            in any namespaces. (Beta) Using this field requires the
+                            AnyVolumeDataSource feature gate to be enabled. (Alpha)
+                            Using the namespace field of dataSourceRef requires the
+                            CrossNamespaceVolumeDataSource feature gate to be enabled.'
                           properties:
                             apiGroup:
                               description: APIGroup is the group for the resource
@@ -21274,11 +23462,20 @@ spec:
                             name:
                               description: Name is the name of resource being referenced
                               type: string
+                            namespace:
+                              description: Namespace is the namespace of resource
+                                being referenced Note that when a namespace is specified,
+                                a gateway.networking.k8s.io/ReferenceGrant object
+                                is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the
+                                ReferenceGrant documentation for details. (Alpha)
+                                This field requires the CrossNamespaceVolumeDataSource
+                                feature gate to be enabled.
+                              type: string
                           required:
                           - kind
                           - name
                           type: object
-                          x-kubernetes-map-type: atomic
                         resources:
                           description: 'resources represents the minimum resources
                             the volume should have. If RecoverVolumeExpansionFailure
@@ -21308,7 +23505,7 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         selector:
@@ -21362,6 +23559,25 @@ spec:
                           description: 'storageClassName is the name of the StorageClass
                             required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                           type: string
+                        volumeAttributesClassName:
+                          description: 'volumeAttributesClassName may be used to set
+                            the VolumeAttributesClass used by this claim. If specified,
+                            the CSI driver will create or update the volume with the
+                            attributes defined in the corresponding VolumeAttributesClass.
+                            This has a different purpose than storageClassName, it
+                            can be changed after the claim is created. An empty string
+                            value means that no VolumeAttributesClass will be applied
+                            to the claim but it''s not allowed to reset this field
+                            to empty string once it is set. If unspecified and the
+                            PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                            will be set by the persistentvolume controller if it exists.
+                            If the resource referred to by volumeAttributesClass does
+                            not exist, this PersistentVolumeClaim will be set to a
+                            Pending state, as reflected by the modifyVolumeStatus
+                            field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                            (Alpha) Using this field requires the VolumeAttributesClass
+                            feature gate to be enabled.'
+                          type: string
                         volumeMode:
                           description: volumeMode defines what type of volume is required
                             by the claim. Value of Filesystem is implied when not
@@ -21409,7 +23625,23 @@ spec:
     singular: server
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Server ready status
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Number of loaded models
+      jsonPath: .status.loadedModels
+      name: Loaded Models
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Server is the Schema for the servers API
@@ -21701,7 +23933,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -21728,6 +23963,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -21800,7 +24047,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -21827,6 +24077,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -21881,8 +24143,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -21914,7 +24175,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -22010,13 +24273,13 @@ spec:
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will
-                          be accessible from the network. Cannot be updated.
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in
                             a single container.
@@ -22086,8 +24349,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -22119,7 +24381,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -22209,10 +24473,53 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        description: Resources resize policy for the container.
+                        items:
+                          description: ContainerResizePolicy represents resource resize
+                            policy for the container.
+                          properties:
+                            resourceName:
+                              description: 'Name of the resource to which this resource
+                                resize policy applies. Supported values: cpu, memory.'
+                              type: string
+                            restartPolicy:
+                              description: Restart policy to apply when specified
+                                resource is resized. If not specified, it defaults
+                                to NotRequired.
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         description: 'Compute Resources required by this container.
                           Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -22234,9 +24541,29 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
+                      restartPolicy:
+                        description: 'RestartPolicy defines the restart behavior of
+                          individual containers in a pod. This field may only be set
+                          for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod''s restart policy
+                          and the container type. Setting the RestartPolicy as "Always"
+                          for the init container will have the following effect: this
+                          init container will be continually restarted on exit until
+                          all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy
+                          "Always" will be shut down. This lifecycle differs from
+                          normal init containers and is often referred to as a "sidecar"
+                          container. Although this init container still starts in
+                          the init container sequence, it does not wait for the container
+                          to complete before proceeding to the next init container.
+                          Instead, the next init container starts immediately after
+                          this init container is started, or after any startupProbe
+                          has successfully completed.'
+                        type: string
                       securityContext:
                         description: 'SecurityContext defines the security options
                           the container should be run with. If set, the fields of
@@ -22359,8 +24686,9 @@ spec:
                                   defined in a file on the node should be used. The
                                   profile must be preconfigured on the node to work.
                                   Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must only be
-                                  set if type is "Localhost".
+                                  configured seccomp profile location. Must be set
+                                  if type is "Localhost". Must NOT be set for any
+                                  other type.
                                 type: string
                               type:
                                 description: "type indicates which kind of seccomp
@@ -22393,15 +24721,11 @@ spec:
                                 type: string
                               hostProcess:
                                 description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. This
-                                  field is alpha-level and will only be honored by
-                                  components that enable the WindowsHostProcessContainers
-                                  feature flag. Setting this field without the feature
-                                  flag will result in errors when validating the Pod.
-                                  All of a Pod's containers must have the same effective
+                                  should be run as a 'Host Process' container. All
+                                  of a Pod's containers must have the same effective
                                   HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).  In
-                                  addition, if HostProcess is true then HostNetwork
+                                  of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork
                                   must also be set to true.
                                 type: boolean
                               runAsUserName:
@@ -22448,8 +24772,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -22481,7 +24804,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -22935,7 +25260,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -22962,6 +25290,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -23034,7 +25374,10 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: The header field name. This
+                                            will be canonicalized upon output, so
+                                            case-variant names will be understood
+                                            as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -23061,6 +25404,18 @@ spec:
                                     type: string
                                 required:
                                 - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds
+                                      to sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - seconds
                                 type: object
                               tcpSocket:
                                 description: Deprecated. TCPSocket is NOT supported
@@ -23115,8 +25470,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -23148,7 +25502,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -23244,13 +25600,13 @@ spec:
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Exposing
-                          a port here gives the system additional information about
-                          the network connections a container uses, but is primarily
-                          informational. Not specifying a port here DOES NOT prevent
-                          that port from being exposed. Any port which is listening
-                          on the default "0.0.0.0" address inside a container will
-                          be accessible from the network. Cannot be updated.
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in
                             a single container.
@@ -23320,8 +25676,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -23353,7 +25708,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -23443,10 +25800,53 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        description: Resources resize policy for the container.
+                        items:
+                          description: ContainerResizePolicy represents resource resize
+                            policy for the container.
+                          properties:
+                            resourceName:
+                              description: 'Name of the resource to which this resource
+                                resize policy applies. Supported values: cpu, memory.'
+                              type: string
+                            restartPolicy:
+                              description: Restart policy to apply when specified
+                                resource is resized. If not specified, it defaults
+                                to NotRequired.
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         description: 'Compute Resources required by this container.
                           Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -23468,9 +25868,29 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
+                      restartPolicy:
+                        description: 'RestartPolicy defines the restart behavior of
+                          individual containers in a pod. This field may only be set
+                          for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod''s restart policy
+                          and the container type. Setting the RestartPolicy as "Always"
+                          for the init container will have the following effect: this
+                          init container will be continually restarted on exit until
+                          all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy
+                          "Always" will be shut down. This lifecycle differs from
+                          normal init containers and is often referred to as a "sidecar"
+                          container. Although this init container still starts in
+                          the init container sequence, it does not wait for the container
+                          to complete before proceeding to the next init container.
+                          Instead, the next init container starts immediately after
+                          this init container is started, or after any startupProbe
+                          has successfully completed.'
+                        type: string
                       securityContext:
                         description: 'SecurityContext defines the security options
                           the container should be run with. If set, the fields of
@@ -23593,8 +26013,9 @@ spec:
                                   defined in a file on the node should be used. The
                                   profile must be preconfigured on the node to work.
                                   Must be a descending path, relative to the kubelet's
-                                  configured seccomp profile location. Must only be
-                                  set if type is "Localhost".
+                                  configured seccomp profile location. Must be set
+                                  if type is "Localhost". Must NOT be set for any
+                                  other type.
                                 type: string
                               type:
                                 description: "type indicates which kind of seccomp
@@ -23627,15 +26048,11 @@ spec:
                                 type: string
                               hostProcess:
                                 description: HostProcess determines if a container
-                                  should be run as a 'Host Process' container. This
-                                  field is alpha-level and will only be honored by
-                                  components that enable the WindowsHostProcessContainers
-                                  feature flag. Setting this field without the feature
-                                  flag will result in errors when validating the Pod.
-                                  All of a Pod's containers must have the same effective
+                                  should be run as a 'Host Process' container. All
+                                  of a Pod's containers must have the same effective
                                   HostProcess value (it is not allowed to have a mix
-                                  of HostProcess containers and non-HostProcess containers).  In
-                                  addition, if HostProcess is true then HostNetwork
+                                  of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork
                                   must also be set to true.
                                 type: boolean
                               runAsUserName:
@@ -23682,8 +26099,7 @@ spec:
                             type: integer
                           grpc:
                             description: GRPC specifies an action involving a GRPC
-                              port. This is a beta field and requires enabling GRPCContainerProbe
-                              feature gate.
+                              port.
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number
@@ -23715,7 +26131,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -24185,7 +26603,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -24236,6 +26655,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -24349,7 +26810,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -24399,6 +26861,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -24509,7 +27009,8 @@ spec:
                                   properties:
                                     labelSelector:
                                       description: A label query over a set of resources,
-                                        in this case pods.
+                                        in this case pods. If it's null, this PodAffinityTerm
+                                        matches with no Pods.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -24560,6 +27061,48 @@ spec:
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key in (value)` to select the group of
+                                        existing pods which pods will be taken into
+                                        consideration for the incoming pod's pod (anti)
+                                        affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value
+                                        is empty. The same key is forbidden to exist
+                                        in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector
+                                        isn't set. This is an alpha field and requires
+                                        enabling MatchLabelKeysInPodAffinity feature
+                                        gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: MismatchLabelKeys is a set of pod
+                                        label keys to select which pods will be taken
+                                        into consideration. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are merged with `LabelSelector`
+                                        as `key notin (value)` to select the group
+                                        of existing pods which pods will be taken
+                                        into consideration for the incoming pod's
+                                        pod (anti) affinity. Keys that don't exist
+                                        in the incoming pod labels will be ignored.
+                                        The default value is empty. The same key is
+                                        forbidden to exist in both MismatchLabelKeys
+                                        and LabelSelector. Also, MismatchLabelKeys
+                                        cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling
+                                        MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     namespaceSelector:
                                       description: A label query over the set of namespaces
                                         that the term applies to. The term is applied
@@ -24673,7 +27216,8 @@ spec:
                               properties:
                                 labelSelector:
                                   description: A label query over a set of resources,
-                                    in this case pods.
+                                    in this case pods. If it's null, this PodAffinityTerm
+                                    matches with no Pods.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -24723,6 +27267,44 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key in (value)` to select
+                                    the group of existing pods which pods will be
+                                    taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MatchLabelKeys and LabelSelector. Also,
+                                    MatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: MismatchLabelKeys is a set of pod label
+                                    keys to select which pods will be taken into consideration.
+                                    The keys are used to lookup values from the incoming
+                                    pod labels, those key-value labels are merged
+                                    with `LabelSelector` as `key notin (value)` to
+                                    select the group of existing pods which pods will
+                                    be taken into consideration for the incoming pod's
+                                    pod (anti) affinity. Keys that don't exist in
+                                    the incoming pod labels will be ignored. The default
+                                    value is empty. The same key is forbidden to exist
+                                    in both MismatchLabelKeys and LabelSelector. Also,
+                                    MismatchLabelKeys cannot be set when LabelSelector
+                                    isn't set. This is an alpha field and requires
+                                    enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 namespaceSelector:
                                   description: A label query over the set of namespaces
                                     that the term applies to. The term is applied
@@ -25070,7 +27652,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -25097,6 +27682,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -25169,7 +27766,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -25196,6 +27796,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -25251,8 +27863,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -25284,7 +27895,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -25381,13 +27994,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -25459,8 +28072,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -25492,7 +28104,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -25582,10 +28196,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -25607,9 +28265,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -25734,7 +28413,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -25767,15 +28447,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -25824,8 +28500,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -25857,7 +28532,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -26435,7 +29112,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -26462,6 +29142,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -26534,7 +29226,10 @@ spec:
                                           header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
+                                            description: The header field name. This
+                                              will be canonicalized upon output, so
+                                              case-variant names will be understood
+                                              as the same header.
                                             type: string
                                           value:
                                             description: The header field value
@@ -26561,6 +29256,18 @@ spec:
                                       type: string
                                   required:
                                   - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents the duration that
+                                    the container should sleep before being terminated.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds
+                                        to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
                                   type: object
                                 tcpSocket:
                                   description: Deprecated. TCPSocket is NOT supported
@@ -26616,8 +29323,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -26649,7 +29355,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -26746,13 +29454,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -26824,8 +29532,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -26857,7 +29564,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -26947,10 +29656,54 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource
+                              resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource
+                                  resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified
+                                  resource is resized. If not specified, it defaults
+                                  to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           description: 'Compute Resources required by this container.
                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -26972,9 +29725,30 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior
+                            of individual containers in a pod. This field may only
+                            be set for init containers, and the only allowed value
+                            is "Always". For non-init containers or when this field
+                            is not specified, the restart behavior is defined by the
+                            Pod''s restart policy and the container type. Setting
+                            the RestartPolicy as "Always" for the init container will
+                            have the following effect: this init container will be
+                            continually restarted on exit until all regular containers
+                            have terminated. Once all regular containers have completed,
+                            all init containers with restartPolicy "Always" will be
+                            shut down. This lifecycle differs from normal init containers
+                            and is often referred to as a "sidecar" container. Although
+                            this init container still starts in the init container
+                            sequence, it does not wait for the container to complete
+                            before proceeding to the next init container. Instead,
+                            the next init container starts immediately after this
+                            init container is started, or after any startupProbe has
+                            successfully completed.'
+                          type: string
                         securityContext:
                           description: 'SecurityContext defines the security options
                             the container should be run with. If set, the fields of
@@ -27099,7 +29873,8 @@ spec:
                                     The profile must be preconfigured on the node
                                     to work. Must be a descending path, relative to
                                     the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
+                                    Must be set if type is "Localhost". Must NOT be
+                                    set for any other type.
                                   type: string
                                 type:
                                   description: "type indicates which kind of seccomp
@@ -27132,15 +29907,11 @@ spec:
                                   type: string
                                 hostProcess:
                                   description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
+                                    should be run as a 'Host Process' container. All
+                                    of a Pod's containers must have the same effective
+                                    HostProcess value (it is not allowed to have a
+                                    mix of HostProcess containers and non-HostProcess
+                                    containers). In addition, if HostProcess is true
                                     then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
@@ -27189,8 +29960,7 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is a beta field and requires enabling GRPCContainerProbe
-                                feature gate.
+                                port.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -27222,7 +29992,9 @@ spec:
                                       to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
+                                        description: The header field name. This will
+                                          be canonicalized upon output, so case-variant
+                                          names will be understood as the same header.
                                         type: string
                                       value:
                                         description: The header field value
@@ -27609,7 +30381,8 @@ spec:
                               in a file on the node should be used. The profile must
                               be preconfigured on the node to work. Must be a descending
                               path, relative to the kubelet's configured seccomp profile
-                              location. Must only be set if type is "Localhost".
+                              location. Must be set if type is "Localhost". Must NOT
+                              be set for any other type.
                             type: string
                           type:
                             description: "type indicates which kind of seccomp profile
@@ -27624,9 +30397,13 @@ spec:
                       supplementalGroups:
                         description: A list of groups applied to the first process
                           run in each container, in addition to the container's primary
-                          GID.  If unspecified, no groups will be added to any container.
-                          Note that this field cannot be set when spec.os.name is
-                          windows.
+                          GID, the fsGroup (if specified), and group memberships defined
+                          in the container image for the uid of the container process.
+                          If unspecified, no additional groups are added to any container.
+                          Note that group memberships defined in the container image
+                          for the uid of the container process are still effective,
+                          even if they are not included in this list. Note that this
+                          field cannot be set when spec.os.name is windows.
                         items:
                           format: int64
                           type: integer
@@ -27670,15 +30447,12 @@ spec:
                             type: string
                           hostProcess:
                             description: HostProcess determines if a container should
-                              be run as a 'Host Process' container. This field is
-                              alpha-level and will only be honored by components that
-                              enable the WindowsHostProcessContainers feature flag.
-                              Setting this field without the feature flag will result
-                              in errors when validating the Pod. All of a Pod's containers
-                              must have the same effective HostProcess value (it is
-                              not allowed to have a mix of HostProcess containers
-                              and non-HostProcess containers).  In addition, if HostProcess
-                              is true then HostNetwork must also be set to true.
+                              be run as a 'Host Process' container. All of a Pod's
+                              containers must have the same effective HostProcess
+                              value (it is not allowed to have a mix of HostProcess
+                              containers and non-HostProcess containers). In addition,
+                              if HostProcess is true then HostNetwork must also be
+                              set to true.
                             type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
@@ -27827,6 +30601,24 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: "MatchLabelKeys is a set of pod label keys
+                            to select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. The same key
+                            is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't
+                            set. Keys that don't exist in the incoming pod labels
+                            will be ignored. A null or empty list means only match
+                            against labelSelector. \n This is a beta field and requires
+                            the MatchLabelKeysInPodTopologySpread feature gate to
+                            be enabled (enabled by default)."
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         maxSkew:
                           description: 'MaxSkew describes the degree to which pods
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -27869,11 +30661,33 @@ spec:
                             as 0. In this situation, new pod with the same labelSelector
                             cannot be scheduled, because computed skew will be 3(3
                             - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
                           format: int32
                           type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a beta-level
+                            feature default enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
@@ -27881,11 +30695,11 @@ spec:
                             <key, value> as a "bucket", and try to put balanced number
                             of pods into each bucket. We define a domain as a particular
                             instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -28319,7 +31133,7 @@ spec:
                                 value between the SizeLimit specified here and the
                                 sum of memory limits of all containers in a pod. The
                                 default is nil which means that the limit is undefined.
-                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
@@ -28394,10 +31208,13 @@ spec:
                                         If the provisioner or an external controller
                                         can support the specified data source, it
                                         will create a new volume based on the contents
-                                        of the specified data source. If the AnyVolumeDataSource
-                                        feature gate is enabled, this field will always
-                                        have the same contents as the DataSourceRef
-                                        field.'
+                                        of the specified data source. When the AnyVolumeDataSource
+                                        feature gate is enabled, dataSource contents
+                                        will be copied to dataSourceRef, and dataSourceRef
+                                        contents will be copied to dataSource when
+                                        dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef
+                                        will not be copied to dataSource.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -28423,29 +31240,37 @@ spec:
                                       description: 'dataSourceRef specifies the object
                                         from which to populate the volume with data,
                                         if a non-empty volume is desired. This may
-                                        be any local object from a non-empty API group
-                                        (non core object) or a PersistentVolumeClaim
-                                        object. When this field is specified, volume
-                                        binding will only succeed if the type of the
-                                        specified object matches some installed volume
-                                        populator or dynamic provisioner. This field
-                                        will replace the functionality of the DataSource
-                                        field and as such if both fields are non-empty,
+                                        be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding
+                                        will only succeed if the type of the specified
+                                        object matches some installed volume populator
+                                        or dynamic provisioner. This field will replace
+                                        the functionality of the dataSource field
+                                        and as such if both fields are non-empty,
                                         they must have the same value. For backwards
-                                        compatibility, both fields (DataSource and
-                                        DataSourceRef) will be set to the same value
-                                        automatically if one of them is empty and
-                                        the other is non-empty. There are two important
-                                        differences between DataSource and DataSourceRef:
-                                        * While DataSource only allows two specific
-                                        types of objects, DataSourceRef allows any
-                                        non-core object, as well as PersistentVolumeClaim
-                                        objects. * While DataSource ignores disallowed
-                                        values (dropping them), DataSourceRef preserves
-                                        all values, and generates an error if a disallowed
-                                        value is specified. (Beta) Using this field
-                                        requires the AnyVolumeDataSource feature gate
-                                        to be enabled.'
+                                        compatibility, when namespace isn''t specified
+                                        in dataSourceRef, both fields (dataSource
+                                        and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty
+                                        and the other is non-empty. When namespace
+                                        is specified in dataSourceRef, dataSource
+                                        isn''t set to the same value and must be empty.
+                                        There are three important differences between
+                                        dataSource and dataSourceRef: * While dataSource
+                                        only allows two specific types of objects,
+                                        dataSourceRef allows any non-core object,
+                                        as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values
+                                        (dropping them), dataSourceRef preserves all
+                                        values, and generates an error if a disallowed
+                                        value is specified. * While dataSource only
+                                        allows local objects, dataSourceRef allows
+                                        objects in any namespaces. (Beta) Using this
+                                        field requires the AnyVolumeDataSource feature
+                                        gate to be enabled. (Alpha) Using the namespace
+                                        field of dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                        feature gate to be enabled.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -28462,11 +31287,21 @@ spec:
                                           description: Name is the name of resource
                                             being referenced
                                           type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of resource being referenced Note that
+                                            when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. (Alpha) This
+                                            field requires the CrossNamespaceVolumeDataSource
+                                            feature gate to be enabled.
+                                          type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
@@ -28499,7 +31334,8 @@ spec:
                                             If Requests is omitted for a container,
                                             it defaults to Limits if that is explicitly
                                             specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     selector:
@@ -28559,6 +31395,29 @@ spec:
                                       description: 'storageClassName is the name of
                                         the StorageClass required by the claim. More
                                         info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: 'volumeAttributesClassName may
+                                        be used to set the VolumeAttributesClass used
+                                        by this claim. If specified, the CSI driver
+                                        will create or update the volume with the
+                                        attributes defined in the corresponding VolumeAttributesClass.
+                                        This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created.
+                                        An empty string value means that no VolumeAttributesClass
+                                        will be applied to the claim but it''s not
+                                        allowed to reset this field to empty string
+                                        once it is set. If unspecified and the PersistentVolumeClaim
+                                        is unbound, the default VolumeAttributesClass
+                                        will be set by the persistentvolume controller
+                                        if it exists. If the resource referred to
+                                        by volumeAttributesClass does not exist, this
+                                        PersistentVolumeClaim will be set to a Pending
+                                        state, as reflected by the modifyVolumeStatus
+                                        field, until such as a resource exists. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                        (Alpha) Using this field requires the VolumeAttributesClass
+                                        feature gate to be enabled.'
                                       type: string
                                     volumeMode:
                                       description: volumeMode defines what type of
@@ -28948,6 +31807,107 @@ spec:
                                 description: Projection that may be projected along
                                   with other supported volume types
                                 properties:
+                                  clusterTrustBundle:
+                                    description: "ClusterTrustBundle allows a pod
+                                      to access the `.spec.trustBundle` field of ClusterTrustBundle
+                                      objects in an auto-updating file. \n Alpha,
+                                      gated by the ClusterTrustBundleProjection feature
+                                      gate. \n ClusterTrustBundle objects can either
+                                      be selected by name, or by the combination of
+                                      signer name and a label selector. \n Kubelet
+                                      performs aggressive normalization of the PEM
+                                      contents written into the pod filesystem.  Esoteric
+                                      PEM features such as inter-block comments and
+                                      block headers are stripped.  Certificates are
+                                      deduplicated. The ordering of certificates within
+                                      the file is arbitrary, and Kubelet may change
+                                      the order over time."
+                                    properties:
+                                      labelSelector:
+                                        description: Select all ClusterTrustBundles
+                                          that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive
+                                          with name.  If unset, interpreted as "match
+                                          nothing".  If set but empty, interpreted
+                                          as "match everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: Select a single ClusterTrustBundle
+                                          by object name.  Mutually-exclusive with
+                                          signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: If true, don't block pod startup
+                                          if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the
+                                          named ClusterTrustBundle is allowed not
+                                          to exist.  If using signerName, then the
+                                          combination of signerName and labelSelector
+                                          is allowed to match zero ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: Select all ClusterTrustBundles
+                                          that match this signer name. Mutually-exclusive
+                                          with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and
+                                          deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
                                   configMap:
                                     description: configMap information about the configMap
                                       data to project

--- a/operator/apis/mlops/v1alpha1/experiment_types.go
+++ b/operator/apis/mlops/v1alpha1/experiment_types.go
@@ -54,6 +54,11 @@ type ExperimentStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=mlx
+//+kubebuilder:printcolumn:name="Experiment ready",type=string,JSONPath=`.status.conditions[?(@.type=='ExperimentReady')].status`,description="Experiment ready status"
+//+kubebuilder:printcolumn:name="Candidates ready",type=string,JSONPath=`.status.conditions[?(@.type=='CandidatesReady')].status`,description="Candidates ready status",priority=1
+//+kubebuilder:printcolumn:name="Mirror ready",type=string,JSONPath=`.status.conditions[?(@.type=='MirrorReady')].status`,description="Mirror ready status",priority=1
+//+kubebuilder:printcolumn:name="Message",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].message`,description="Status message"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Experiment is the Schema for the experiments API
 type Experiment struct {

--- a/operator/apis/mlops/v1alpha1/experiment_types_test.go
+++ b/operator/apis/mlops/v1alpha1/experiment_types_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 )
@@ -154,16 +154,16 @@ func TestAsSchedulerExperimentRequest(t *testing.T) {
 * Rather than fixing the test directly, FIRST UPDATE the kubebuilder:printcolumn comments,
 * THEN update the test to also match the new values.
 *
-*/
+ */
 func TestExperimentStatusPrintColumns(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
-		name			string
-		experiment	*Experiment
+		name       string
+		experiment *Experiment
 	}
 	fail_reason := "Experiment.Status.Conditions[].Type string changed in CRD from \"%s\" to \"%[2]s\" without updating kubebuilder:printcolumn comment for type Experiment. " +
-								 "Update kubebuilder:printcolumn comment in experiment_types.go to match \"%[2]s\"."
+		"Update kubebuilder:printcolumn comment in experiment_types.go to match \"%[2]s\"."
 
 	// !! When the test fails, update the string values here ONLY after updating the kubebuilder:
 	// printcolumn comments in experiment_types.go to match the new values
@@ -171,12 +171,11 @@ func TestExperimentStatusPrintColumns(t *testing.T) {
 	// The key represents the condition used by the CR, the value is the string currently used in
 	// the kubebuilder:printcolumn comments.
 	expectedPrintColumnString := map[apis.ConditionType]string{
-		ExperimentReady: "ExperimentReady",
-		CandidatesReady: "CandidatesReady",
-		MirrorReady:     "MirrorReady",
+		ExperimentReady:     "ExperimentReady",
+		CandidatesReady:     "CandidatesReady",
+		MirrorReady:         "MirrorReady",
 		apis.ConditionReady: "Ready",
 	}
-
 
 	tests := []test{
 		{
@@ -186,10 +185,10 @@ func TestExperimentStatusPrintColumns(t *testing.T) {
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{
 							// pass the strings used in kubebuilder:printcolumn comments as the ConditionType
-							{ Type: apis.ConditionType(expectedPrintColumnString[ExperimentReady]), Status: v1.ConditionTrue },
-							{ Type: apis.ConditionType(expectedPrintColumnString[CandidatesReady]), Status: v1.ConditionTrue },
-							{ Type: apis.ConditionType(expectedPrintColumnString[MirrorReady]), Status: v1.ConditionTrue },
-							{ Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue },
+							{Type: apis.ConditionType(expectedPrintColumnString[ExperimentReady]), Status: v1.ConditionTrue},
+							{Type: apis.ConditionType(expectedPrintColumnString[CandidatesReady]), Status: v1.ConditionTrue},
+							{Type: apis.ConditionType(expectedPrintColumnString[MirrorReady]), Status: v1.ConditionTrue},
+							{Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue},
 						},
 					},
 				},
@@ -199,7 +198,7 @@ func TestExperimentStatusPrintColumns(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.experiment.Status.Conditions != nil {
-				searchMap := make (map[string]v1.ConditionStatus)
+				searchMap := make(map[string]v1.ConditionStatus)
 				for _, cond := range test.experiment.Status.Conditions {
 					searchMap[string(cond.Type)] = cond.Status
 				}

--- a/operator/apis/mlops/v1alpha1/experiment_types_test.go
+++ b/operator/apis/mlops/v1alpha1/experiment_types_test.go
@@ -14,6 +14,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
 
 	"github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 )
@@ -135,6 +138,76 @@ func TestAsSchedulerExperimentRequest(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			proto := test.experiment.AsSchedulerExperimentRequest()
 			g.Expect(proto).To(Equal(test.proto))
+		})
+	}
+}
+
+/* WARNING: Read this first if test below fails (either at compile-time or while running the
+* test):
+*
+* The test below aims to ensure that the fields used in kubebuilder:printcolumn comments in
+* experiment_types.go match the structure and condition types in the Experiment CRD.
+*
+* If the test fails, it means that the CRD was updated without updating the kubebuilder:
+* printcolumn comments.
+*
+* Rather than fixing the test directly, FIRST UPDATE the kubebuilder:printcolumn comments,
+* THEN update the test to also match the new values.
+*
+*/
+func TestExperimentStatusPrintColumns(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name			string
+		experiment	*Experiment
+	}
+	fail_reason := "Experiment.Status.Conditions[].Type string changed in CRD from \"%s\" to \"%[2]s\" without updating kubebuilder:printcolumn comment for type Experiment. " +
+								 "Update kubebuilder:printcolumn comment in experiment_types.go to match \"%[2]s\"."
+
+	// !! When the test fails, update the string values here ONLY after updating the kubebuilder:
+	// printcolumn comments in experiment_types.go to match the new values
+	//
+	// The key represents the condition used by the CR, the value is the string currently used in
+	// the kubebuilder:printcolumn comments.
+	expectedPrintColumnString := map[apis.ConditionType]string{
+		ExperimentReady: "ExperimentReady",
+		CandidatesReady: "CandidatesReady",
+		MirrorReady:     "MirrorReady",
+		apis.ConditionReady: "Ready",
+	}
+
+
+	tests := []test{
+		{
+			name: "experiment ready conditions",
+			experiment: &Experiment{
+				Status: ExperimentStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							// pass the strings used in kubebuilder:printcolumn comments as the ConditionType
+							{ Type: apis.ConditionType(expectedPrintColumnString[ExperimentReady]), Status: v1.ConditionTrue },
+							{ Type: apis.ConditionType(expectedPrintColumnString[CandidatesReady]), Status: v1.ConditionTrue },
+							{ Type: apis.ConditionType(expectedPrintColumnString[MirrorReady]), Status: v1.ConditionTrue },
+							{ Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue },
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.experiment.Status.Conditions != nil {
+				searchMap := make (map[string]v1.ConditionStatus)
+				for _, cond := range test.experiment.Status.Conditions {
+					searchMap[string(cond.Type)] = cond.Status
+				}
+				for conditionKey, printColumnString := range expectedPrintColumnString {
+					_, found := searchMap[string(conditionKey)]
+					g.Expect(found).To(BeTrueBecause(fail_reason, printColumnString, string(conditionKey)))
+				}
+			}
 		})
 	}
 }

--- a/operator/apis/mlops/v1alpha1/model_types.go
+++ b/operator/apis/mlops/v1alpha1/model_types.go
@@ -113,7 +113,10 @@ type ModelStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=mlm
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+//+kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="ModelReady")].status`,description="Model ready status"
+//+kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`, description="Number of replicas"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Model is the Schema for the models API
 type Model struct {

--- a/operator/apis/mlops/v1alpha1/model_types_test.go
+++ b/operator/apis/mlops/v1alpha1/model_types_test.go
@@ -11,10 +11,15 @@ package v1alpha1
 
 import (
 	"testing"
+	"encoding/json"
 
+	"github.com/tidwall/gjson"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
 
 	scheduler "github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 )
@@ -320,6 +325,91 @@ func TestAsModelDetails(t *testing.T) {
 				g.Expect(md).To(Equal(test.modelpb))
 			} else {
 				g.Expect(err).ToNot(BeNil())
+			}
+		})
+	}
+}
+
+
+/* WARNING: Read this first if test below fails (either at compile-time or while running the
+* test):
+*
+* The test below aims to ensure that the fields used in kubebuilder:printcolumn comments in
+* model_types.go match the structure and condition types in the Model CRD.
+*
+* If the test fails, it means that the CRD was updated without updating the kubebuilder:
+* printcolumn comments.
+*
+* Rather than fixing the test directly, FIRST UPDATE the kubebuilder:printcolumn comments,
+* THEN update the test to also match the new values.
+*
+*/
+func TestModelStatusPrintColumns(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name    string
+		model   *Model
+		expectedJsonSerializationKeys []string
+	}
+	condition_fail_reason := "Model.Status.Conditions[].Type string changed in CRD from \"%s\" to \"%[2]s\" without updating kubebuilder:printcolumn comment for type Model. " +
+								 "Update kubebuilder:printcolumn comment in model_types.go to match \"%[2]s\"."
+	json_fail_reason := "Json serialization of Model.Status does not contain path \"%s\", used in kubebuilder.printcolum comments. " +
+								"Update kubebuilder:printcolumn comments to match the new serialization keys."
+
+	// !! When the test fails, update the string values here ONLY after updating the kubebuilder:
+	// printcolumn comments in model_types.go to match the new values
+	//
+	// The key represents the condition used by the CR, the value is the string currently used in
+	// the kubebuilder:printcolumn comments.
+	expectedPrintColumnString := map[apis.ConditionType]string{
+		ModelReady: "ModelReady",
+		apis.ConditionReady: "Ready",
+	}
+
+
+	tests := []test{
+		{
+			name: "model ready conditions",
+			model: &Model{
+				Status: ModelStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							// pass the strings used in kubebuilder:printcolumn comments as the ConditionType
+							{ Type: apis.ConditionType(expectedPrintColumnString[ModelReady]), Status: v1.ConditionTrue },
+							{ Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue },
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "model replicas",
+			model: &Model{
+				Status: ModelStatus{
+					Replicas: 1,
+				},
+			},
+			expectedJsonSerializationKeys: []string{"status.replicas"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.model.Status.Conditions != nil {
+				searchMap := make (map[string]v1.ConditionStatus)
+				for _, cond := range test.model.Status.Conditions {
+					searchMap[string(cond.Type)] = cond.Status
+				}
+				for conditionKey, printColumnString := range expectedPrintColumnString {
+					_, found := searchMap[string(conditionKey)]
+					g.Expect(found).To(BeTrueBecause(condition_fail_reason, printColumnString, string(conditionKey)))
+				}
+			} else {
+				jsonBytes, err := json.Marshal(test.model)
+				g.Expect(err).To(BeNil())
+				for _, key := range test.expectedJsonSerializationKeys {
+					g.Expect(gjson.GetBytes(jsonBytes, key).Exists()).To(BeTrueBecause(json_fail_reason, key))
+				}
 			}
 		})
 	}

--- a/operator/apis/mlops/v1alpha1/model_types_test.go
+++ b/operator/apis/mlops/v1alpha1/model_types_test.go
@@ -10,16 +10,16 @@ the Change License after the Change Date as each is defined in accordance with t
 package v1alpha1
 
 import (
-	"testing"
 	"encoding/json"
+	"testing"
 
-	"github.com/tidwall/gjson"
 	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	scheduler "github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 )
@@ -330,7 +330,6 @@ func TestAsModelDetails(t *testing.T) {
 	}
 }
 
-
 /* WARNING: Read this first if test below fails (either at compile-time or while running the
 * test):
 *
@@ -343,19 +342,19 @@ func TestAsModelDetails(t *testing.T) {
 * Rather than fixing the test directly, FIRST UPDATE the kubebuilder:printcolumn comments,
 * THEN update the test to also match the new values.
 *
-*/
+ */
 func TestModelStatusPrintColumns(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
-		name    string
-		model   *Model
+		name                          string
+		model                         *Model
 		expectedJsonSerializationKeys []string
 	}
 	condition_fail_reason := "Model.Status.Conditions[].Type string changed in CRD from \"%s\" to \"%[2]s\" without updating kubebuilder:printcolumn comment for type Model. " +
-								 "Update kubebuilder:printcolumn comment in model_types.go to match \"%[2]s\"."
+		"Update kubebuilder:printcolumn comment in model_types.go to match \"%[2]s\"."
 	json_fail_reason := "Json serialization of Model.Status does not contain path \"%s\", used in kubebuilder.printcolum comments. " +
-								"Update kubebuilder:printcolumn comments to match the new serialization keys."
+		"Update kubebuilder:printcolumn comments to match the new serialization keys."
 
 	// !! When the test fails, update the string values here ONLY after updating the kubebuilder:
 	// printcolumn comments in model_types.go to match the new values
@@ -363,10 +362,9 @@ func TestModelStatusPrintColumns(t *testing.T) {
 	// The key represents the condition used by the CR, the value is the string currently used in
 	// the kubebuilder:printcolumn comments.
 	expectedPrintColumnString := map[apis.ConditionType]string{
-		ModelReady: "ModelReady",
+		ModelReady:          "ModelReady",
 		apis.ConditionReady: "Ready",
 	}
-
 
 	tests := []test{
 		{
@@ -376,8 +374,8 @@ func TestModelStatusPrintColumns(t *testing.T) {
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{
 							// pass the strings used in kubebuilder:printcolumn comments as the ConditionType
-							{ Type: apis.ConditionType(expectedPrintColumnString[ModelReady]), Status: v1.ConditionTrue },
-							{ Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue },
+							{Type: apis.ConditionType(expectedPrintColumnString[ModelReady]), Status: v1.ConditionTrue},
+							{Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue},
 						},
 					},
 				},
@@ -396,7 +394,7 @@ func TestModelStatusPrintColumns(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.model.Status.Conditions != nil {
-				searchMap := make (map[string]v1.ConditionStatus)
+				searchMap := make(map[string]v1.ConditionStatus)
 				for _, cond := range test.model.Status.Conditions {
 					searchMap[string(cond.Type)] = cond.Status
 				}

--- a/operator/apis/mlops/v1alpha1/pipeline_types.go
+++ b/operator/apis/mlops/v1alpha1/pipeline_types.go
@@ -21,6 +21,11 @@ import (
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=mlp
+//+kubebuilder:printcolumn:name="Pipeline ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`,description="Pipeline ready status"
+//+kubebuilder:printcolumn:name="Models ready",type=string,JSONPath=`.status.conditions[?(@.type=='ModelsReady')].status`,description="Models ready status",priority=1
+//+kubebuilder:printcolumn:name="Dataflow ready",type=string,JSONPath=`.status.conditions[?(@.type=='PipelineReady')].status`,description="Dataflow ready status",priority=1
+//+kubebuilder:printcolumn:name="Message",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].message`,description="Status message"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Pipeline is the Schema for the pipelines API
 type Pipeline struct {

--- a/operator/apis/mlops/v1alpha1/pipeline_types_test.go
+++ b/operator/apis/mlops/v1alpha1/pipeline_types_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	scheduler "github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 )
@@ -122,16 +122,16 @@ func TestAsPipelineDetails(t *testing.T) {
 * Rather than fixing the test directly, FIRST UPDATE the kubebuilder:printcolumn comments,
 * THEN update the test to also match the new values.
 *
-*/
+ */
 func TestPipelineStatusPrintColumns(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
-		name			string
-		pipeline	*Pipeline
+		name     string
+		pipeline *Pipeline
 	}
 	fail_reason := "Pipeline.Status.Conditions[].Type string changed in CRD from \"%s\" to \"%[2]s\" without updating kubebuilder:printcolumn comment for type Model. " +
-								 "Update kubebuilder:printcolumn comment in pipeline_types.go to match \"%[2]s\"."
+		"Update kubebuilder:printcolumn comment in pipeline_types.go to match \"%[2]s\"."
 
 	// !! When the test fails, update the string values here ONLY after updating the kubebuilder:
 	// printcolumn comments in pipeline_types.go to match the new values
@@ -139,11 +139,10 @@ func TestPipelineStatusPrintColumns(t *testing.T) {
 	// The key represents the condition used by the CR, the value is the string currently used in
 	// the kubebuilder:printcolumn comments.
 	expectedPrintColumnString := map[apis.ConditionType]string{
-		ModelsReady: "ModelsReady",
-		PipelineReady: "PipelineReady",
+		ModelsReady:         "ModelsReady",
+		PipelineReady:       "PipelineReady",
 		apis.ConditionReady: "Ready",
 	}
-
 
 	tests := []test{
 		{
@@ -153,9 +152,9 @@ func TestPipelineStatusPrintColumns(t *testing.T) {
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{
 							// pass the strings used in kubebuilder:printcolumn comments as the ConditionType
-							{ Type: apis.ConditionType(expectedPrintColumnString[ModelsReady]), Status: v1.ConditionTrue },
-							{ Type: apis.ConditionType(expectedPrintColumnString[PipelineReady]), Status: v1.ConditionTrue },
-							{ Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue },
+							{Type: apis.ConditionType(expectedPrintColumnString[ModelsReady]), Status: v1.ConditionTrue},
+							{Type: apis.ConditionType(expectedPrintColumnString[PipelineReady]), Status: v1.ConditionTrue},
+							{Type: apis.ConditionType(expectedPrintColumnString[apis.ConditionReady]), Status: v1.ConditionTrue},
 						},
 					},
 				},
@@ -165,7 +164,7 @@ func TestPipelineStatusPrintColumns(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.pipeline.Status.Conditions != nil {
-				searchMap := make (map[string]v1.ConditionStatus)
+				searchMap := make(map[string]v1.ConditionStatus)
 				for _, cond := range test.pipeline.Status.Conditions {
 					searchMap[string(cond.Type)] = cond.Status
 				}

--- a/operator/apis/mlops/v1alpha1/server_types.go
+++ b/operator/apis/mlops/v1alpha1/server_types.go
@@ -73,6 +73,10 @@ type ServerStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 //+kubebuilder:resource:shortName=mls
+//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Server ready status"
+//+kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`,description="Number of replicas"
+//+kubebuilder:printcolumn:name="Loaded Models",type=integer,JSONPath=`.status.loadedModels`,description="Number of loaded models"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Server is the Schema for the servers API
 type Server struct {

--- a/operator/apis/mlops/v1alpha1/server_types_test.go
+++ b/operator/apis/mlops/v1alpha1/server_types_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed by
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+	"encoding/json"
+
+	"github.com/tidwall/gjson"
+	. "github.com/onsi/gomega"
+)
+
+/* WARNING: Read this first if test below fails (either at compile-time or while running the
+* test):
+*
+* The test below aims to ensure that the fields used in kubebuilder:printcolumn comments in
+* server_types.go match the structure and condition types in the Server CRD.
+*
+* If the test fails, it means that the CRD was updated without updating the kubebuilder:
+* printcolumn comments.
+*
+* Rather than fixing the test directly, FIRST UPDATE the kubebuilder:printcolumn comments,
+* THEN update the test to also match the new values.
+*
+*/
+func TestServerStatusPrintColumns(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name    string
+		server   *Server
+		expectedJsonSerializationKeys []string
+	}
+	json_fail_reason := "Json serialization of Server.Status does not contain path \"%s\", used in kubebuilder.printcolumn comments. " +
+								"Update kubebuilder:printcolumn comments to match the new serialization keys."
+
+	tests := []test{
+		{
+			name: "server replicas",
+			server: &Server{
+				Status: ServerStatus{
+					Replicas: 1,
+				},
+			},
+			expectedJsonSerializationKeys: []string{"status.replicas"},
+		},
+		{
+			name: "server loaded models",
+			server: &Server{
+				Status: ServerStatus{
+					LoadedModelReplicas: 1,
+				},
+			},
+			expectedJsonSerializationKeys: []string{"status.loadedModels"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			jsonBytes, err := json.Marshal(test.server)
+			g.Expect(err).To(BeNil())
+			for _, key := range test.expectedJsonSerializationKeys {
+				g.Expect(gjson.GetBytes(jsonBytes, key).Exists()).To(BeTrueBecause(json_fail_reason, key))
+			}
+		})
+	}
+}

--- a/operator/apis/mlops/v1alpha1/server_types_test.go
+++ b/operator/apis/mlops/v1alpha1/server_types_test.go
@@ -10,11 +10,11 @@ the Change License after the Change Date as each is defined in accordance with t
 package v1alpha1
 
 import (
-	"testing"
 	"encoding/json"
+	"testing"
 
-	"github.com/tidwall/gjson"
 	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
 )
 
 /* WARNING: Read this first if test below fails (either at compile-time or while running the
@@ -29,17 +29,17 @@ import (
 * Rather than fixing the test directly, FIRST UPDATE the kubebuilder:printcolumn comments,
 * THEN update the test to also match the new values.
 *
-*/
+ */
 func TestServerStatusPrintColumns(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
-		name    string
-		server   *Server
+		name                          string
+		server                        *Server
 		expectedJsonSerializationKeys []string
 	}
 	json_fail_reason := "Json serialization of Server.Status does not contain path \"%s\", used in kubebuilder.printcolumn comments. " +
-								"Update kubebuilder:printcolumn comments to match the new serialization keys."
+		"Update kubebuilder:printcolumn comments to match the new serialization keys."
 
 	tests := []test{
 		{

--- a/operator/config/crd/bases/mlops.seldon.io_experiments.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_experiments.yaml
@@ -17,7 +17,29 @@ spec:
     singular: experiment
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Experiment ready status
+      jsonPath: .status.conditions[?(@.type=='ExperimentReady')].status
+      name: Experiment ready
+      type: string
+    - description: Candidates ready status
+      jsonPath: .status.conditions[?(@.type=='CandidatesReady')].status
+      name: Candidates ready
+      priority: 1
+      type: string
+    - description: Mirror ready status
+      jsonPath: .status.conditions[?(@.type=='MirrorReady')].status
+      name: Mirror ready
+      priority: 1
+      type: string
+    - description: Status message
+      jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Experiment is the Schema for the experiments API

--- a/operator/config/crd/bases/mlops.seldon.io_models.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_models.yaml
@@ -17,7 +17,19 @@ spec:
     singular: model
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Model ready status
+      jsonPath: .status.conditions[?(@.type=="ModelReady")].status
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Model is the Schema for the models API

--- a/operator/config/crd/bases/mlops.seldon.io_pipelines.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_pipelines.yaml
@@ -17,7 +17,29 @@ spec:
     singular: pipeline
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Pipeline ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Pipeline ready
+      type: string
+    - description: Models ready status
+      jsonPath: .status.conditions[?(@.type=='ModelsReady')].status
+      name: Models ready
+      priority: 1
+      type: string
+    - description: Dataflow ready status
+      jsonPath: .status.conditions[?(@.type=='PipelineReady')].status
+      name: Dataflow ready
+      priority: 1
+      type: string
+    - description: Status message
+      jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Pipeline is the Schema for the pipelines API

--- a/operator/config/crd/bases/mlops.seldon.io_servers.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_servers.yaml
@@ -17,7 +17,23 @@ spec:
     singular: server
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Server ready status
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Number of replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Number of loaded models
+      jsonPath: .status.loadedModels
+      name: Loaded Models
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Server is the Schema for the servers API

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/seldonio/seldon-core/components/tls/v2 v2.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
+	github.com/tidwall/gjson v1.17.1
 	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.34.1
 	k8s.io/api v0.29.2
@@ -31,6 +32,8 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 )
 

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -788,6 +788,12 @@ github.com/testcontainers/testcontainers-go/modules/compose v0.29.1 h1:47ipPM+s+
 github.com/testcontainers/testcontainers-go/modules/compose v0.29.1/go.mod h1:Sqh+Ef2ESdbJQjTJl57UOkEHkOc7gXvQLg1b5xh6f1Y=
 github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4DzbAiAiEL3c=
 github.com/theupdateframework/notary v0.7.0/go.mod h1:c9DRxcmhHmVLDay4/2fUYdISnHqbFDGRSlXPO0AhYWw=
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 h1:QB54BJwA6x8QU9nHY3xJSZR2kX9bgpZekRKGkLTmEXA=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375/go.mod h1:xRroudyp5iVtxKqZCrA6n2TLFRBf8bmnjr1UD4x+z7g=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=


### PR DESCRIPTION
Additional printcolumns for CRs covered in this change:
 - Models: ModelReady, Replicas, Age
![CR-printfields-models](https://github.com/SeldonIO/seldon-core/assets/19005/2a1426ee-8c73-4308-8e3c-5f26d340841c)

 - Pipelines: Ready, ModelsReady*, PipelineReady*, Message, Age
![CR-printfields-pipelines](https://github.com/SeldonIO/seldon-core/assets/19005/b9abbb90-532b-476e-8308-c83cd8be9832)

 - Servers: Ready, Replicas, Loaded Models, Age
 ![CR-printfields-servers](https://github.com/SeldonIO/seldon-core/assets/19005/fe57d640-05e2-4d8c-b17a-d915f4f083a7)

 - Experiments: ExperimentReady, CandidatesReady*, MirrorReady*, Message, Age
 ![CR-printfields-experiments](https://github.com/SeldonIO/seldon-core/assets/19005/e482756e-9dc4-4124-97c4-9a34b01d38c0)


The additional columns show up when getting the list of objects of a given type via `kubectl get`, and subsequently also show up in k9s.

Printcolumns marked with * above only show up when running `kubectl get ... -o wide`

**Which issue(s) this PR fixes**:
Fixes #INFRA-1058 (internal): Print additional fields for seldon-specific CRDs

**Special notes for your reviewer**:
PR contains automatically-generated files, will mark those with a comment