### PR TITLE
fix(golang-lint): update lint config file to remove deprecated settings

### DIFF
--- a/scheduler/.errcheck_excludes.txt
+++ b/scheduler/.errcheck_excludes.txt
@@ -1,2 +1,0 @@
-fmt.Fprintln
-fmt.Fprint

--- a/scheduler/.golangci.yml
+++ b/scheduler/.golangci.yml
@@ -6,17 +6,12 @@ run:
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1
 
-  # which dirs to skip: they won't be analyzed;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but next dirs are always skipped independently
-  # from this option's value:
-  #     vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs: vendor
-
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
+      path: stdout
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -36,13 +31,14 @@ linters:
     - govet
     - misspell
     - staticcheck
-    - structcheck
     - typecheck
-    - varcheck
+    - unused
 
 linters-settings:
   errcheck:
-    exclude: ./.errcheck_excludes.txt
+    exclude-functions:
+      - fmt.Fprintln
+      - fmt.Fprint
   gci:
     sections:
       - standard
@@ -51,3 +47,12 @@ linters-settings:
       - prefix(github.com/seldonio/seldon-core/scheduler)
   goconst:
     min-occurrences: 5
+
+issues:
+  # which dirs to skip: they won't be analyzed;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but next dirs are always skipped independently
+  # from this option's value:
+  #     vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  exclude-dirs:
+    - vendor

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -74,7 +74,7 @@ build: build-go build-jvm
 .GOLANGCILINT_VERSION := v1.57.2
 .GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
 
-${.GOLANGCILINT_PATH}/golangci-lint: 
+${.GOLANGCILINT_PATH}/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 			| sh -s -- -b ${.GOLANGCILINT_PATH} ${.GOLANGCILINT_VERSION}
 
@@ -597,8 +597,8 @@ start-scheduler-local-mtls: export AGENT_SECURITY_PROTOCOL=SSL
 start-scheduler-local-mtls: export AGENT_TLS_CRT_LOCATION=${PWD}/testing/certs/server/tls.crt
 start-scheduler-local-mtls: export AGENT_TLS_KEY_LOCATION=${PWD}/testing/certs/server/tls.key
 start-scheduler-local-mtls: export AGENT_TLS_CA_LOCATION=${PWD}/testing/certs/server/ca.crt
-start-scheduler-local-mtls: 
-	./bin/scheduler --log-level debug --db-path "${DB_PATH_LOCAL}" 
+start-scheduler-local-mtls:
+	./bin/scheduler --log-level debug --db-path "${DB_PATH_LOCAL}"
 
 .PHONY: clear-scheduler-state
 clear-scheduler-state:
@@ -618,7 +618,7 @@ start-agent-local-mlserver-mtls: export AGENT_SECURITY_PROTOCOL=SSL
 start-agent-local-mlserver-mtls: export AGENT_TLS_CRT_LOCATION=${PWD}/testing/certs/client/tls.crt
 start-agent-local-mlserver-mtls: export AGENT_TLS_KEY_LOCATION=${PWD}/testing/certs/client/tls.key
 start-agent-local-mlserver-mtls: export AGENT_TLS_CA_LOCATION=${PWD}/testing/certs/client/ca.crt
-start-agent-local-mlserver-mtls: 
+start-agent-local-mlserver-mtls:
 	./bin/agent --agent-folder ${PWD}/mnt/mlserver --inference-http-port 8080 --inference-grpc-port 8081 --scheduler-host "0.0.0.0" --scheduler-port 9005 --reverse-proxy-http-port 9999 --reverse-proxy-grpc-port 9998 --debug-grpc-port 7777 --metrics-port 9006 \
 		--server-type mlserver \
 		--log-level debug \


### PR DESCRIPTION
This removes a number of warnings when running recent golangci-lint versions