### PR TITLE
fix(scheduler): Do not report back draining servers for status

### DIFF
--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -390,7 +390,7 @@ func (s *Server) Subscribe(request *pb.AgentSubscribeRequest, stream pb.AgentSer
 	}
 	s.mutex.Unlock()
 
-	err := s.syncMessage(request, stream)
+	err := s.syncMessage(request)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func (s *Server) StopAgentStreams() {
 	}
 }
 
-func (s *Server) syncMessage(request *pb.AgentSubscribeRequest, stream pb.AgentService_SubscribeServer) error {
+func (s *Server) syncMessage(request *pb.AgentSubscribeRequest) error {
 	s.logger.Debugf("Add Server Replica %+v with config %+v", request, request.ReplicaConfig)
 	err := s.store.AddServerReplica(request)
 	if err != nil {

--- a/scheduler/pkg/server/server_status_test.go
+++ b/scheduler/pkg/server/server_status_test.go
@@ -173,7 +173,7 @@ func TestModelsStatusEvents(t *testing.T) {
 
 func TestServersStatusStream(t *testing.T) {
 	type serverReplicaRequest struct {
-		request        *pba.AgentSubscribeRequest
+		request  *pba.AgentSubscribeRequest
 		draining bool
 	}
 

--- a/scheduler/pkg/server/server_status_test.go
+++ b/scheduler/pkg/server/server_status_test.go
@@ -172,15 +172,15 @@ func TestModelsStatusEvents(t *testing.T) {
 }
 
 func TestServersStatusStream(t *testing.T) {
-	type req struct {
-		r        *pba.AgentSubscribeRequest
+	type serverReplicaRequest struct {
+		request        *pba.AgentSubscribeRequest
 		draining bool
 	}
 
 	g := NewGomegaWithT(t)
 	type test struct {
 		name    string
-		loadReq []req
+		loadReq []serverReplicaRequest
 		server  *SchedulerServer
 		err     bool
 	}
@@ -188,9 +188,9 @@ func TestServersStatusStream(t *testing.T) {
 	tests := []test{
 		{
 			name: "server ok - 1 empty replica",
-			loadReq: []req{
+			loadReq: []serverReplicaRequest{
 				{
-					r: &pba.AgentSubscribeRequest{
+					request: &pba.AgentSubscribeRequest{
 						ServerName: "foo",
 					},
 				},
@@ -203,9 +203,9 @@ func TestServersStatusStream(t *testing.T) {
 		},
 		{
 			name: "server ok - multiple replicas",
-			loadReq: []req{
+			loadReq: []serverReplicaRequest{
 				{
-					r: &pba.AgentSubscribeRequest{
+					request: &pba.AgentSubscribeRequest{
 						ServerName: "foo",
 						ReplicaIdx: 0,
 						LoadedModels: []*pba.ModelVersion{
@@ -218,7 +218,7 @@ func TestServersStatusStream(t *testing.T) {
 					},
 				},
 				{
-					r: &pba.AgentSubscribeRequest{
+					request: &pba.AgentSubscribeRequest{
 						ServerName: "foo",
 						ReplicaIdx: 1,
 						LoadedModels: []*pba.ModelVersion{
@@ -239,9 +239,9 @@ func TestServersStatusStream(t *testing.T) {
 		},
 		{
 			name: "server ok - multiple replicas with draining",
-			loadReq: []req{
+			loadReq: []serverReplicaRequest{
 				{
-					r: &pba.AgentSubscribeRequest{
+					request: &pba.AgentSubscribeRequest{
 						ServerName: "foo",
 						ReplicaIdx: 0,
 						LoadedModels: []*pba.ModelVersion{
@@ -254,7 +254,7 @@ func TestServersStatusStream(t *testing.T) {
 					},
 				},
 				{
-					r: &pba.AgentSubscribeRequest{
+					request: &pba.AgentSubscribeRequest{
 						ServerName: "foo",
 						ReplicaIdx: 1,
 						LoadedModels: []*pba.ModelVersion{
@@ -276,9 +276,9 @@ func TestServersStatusStream(t *testing.T) {
 		},
 		{
 			name: "timeout",
-			loadReq: []req{
+			loadReq: []serverReplicaRequest{
 				{
-					r: &pba.AgentSubscribeRequest{
+					request: &pba.AgentSubscribeRequest{
 						ServerName: "foo",
 					},
 				},
@@ -298,14 +298,14 @@ func TestServersStatusStream(t *testing.T) {
 			expectedNumLoadedModelReplicas := int32(0)
 			if test.loadReq != nil {
 				for _, r := range test.loadReq {
-					err := test.server.modelStore.AddServerReplica(r.r)
+					err := test.server.modelStore.AddServerReplica(r.request)
 					g.Expect(err).To(BeNil())
 					if !r.draining {
 						expectedReplicas++
-						expectedNumLoadedModelReplicas += int32(len(r.r.LoadedModels))
+						expectedNumLoadedModelReplicas += int32(len(r.request.LoadedModels))
 					} else {
 						server, _ := test.server.modelStore.GetServer("foo", true, false)
-						server.Replicas[int(r.r.ReplicaIdx)].SetIsDraining()
+						server.Replicas[int(r.request.ReplicaIdx)].SetIsDraining()
 					}
 				}
 			}


### PR DESCRIPTION
There is an issue with "double" counting for models in the case of draining server replicas when then are reported with server statues. While the double counting is initially correct as we are loading models onto a different server replica while having the draining server server traffic. Once the drain process has finished and the draining server removed there is no event that triggers an update to the server statuses to reflect this change. 

As eventually the draining server replica is going to get removed, we decided to just not report draining servers back on server statuses. 

Also added a test to cover this edge case.

Fixes: Infra-1080 (internal)