### PR TITLE
feat(ansible): allow local (host) mounts in kind

### DIFF
--- a/ansible/playbooks/kind-cluster.yaml
+++ b/ansible/playbooks/kind-cluster.yaml
@@ -11,3 +11,8 @@
     kind_image_version: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
 
     kind_kubectl_default_namespace: seldon-mesh
+    vars_file: vars/default.yaml
+
+  pre_tasks:
+  - name: "Load vars from {{ vars_file }}"
+    include_vars: "{{ vars_file }}"

--- a/ansible/playbooks/templates/default-kind-cluster-config.yaml.j2
+++ b/ansible/playbooks/templates/default-kind-cluster-config.yaml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+{% if kind_local_mount %}
+    extraMounts:
+      - hostPath: {{ kind_host_path }}
+        containerPath: {{ kind_container_path }}
+{% endif %}

--- a/ansible/playbooks/vars/default.yaml
+++ b/ansible/playbooks/vars/default.yaml
@@ -14,6 +14,12 @@
 seldon_admin_user: "admin"
 seldon_random_gen_password: "{{ lookup('password', '/dev/null chars=digits length=6') }}"
 
+# KinD Configuration
+kind_local_mount: false
+kind_host_path: "/tmp/kind-cluster/"
+kind_container_path: "/host-mount"
+kind_config_template: "{{ lookup('template', 'default-kind-cluster-config.yaml.j2') | from_yaml }}"
+
 # Seldon Configuration
 seldon_mesh_namespace: seldon-mesh
 

--- a/ansible/roles/kind/tasks/create_cluster.yaml
+++ b/ansible/roles/kind/tasks/create_cluster.yaml
@@ -4,7 +4,7 @@
     name: "{{ kind_cluster_name + '-control-plane' }}"
   register: cluster_check_result
 
-- name: "Start KinD Cluster: '{{ kind_cluster_name }}'"
+- name: "Start KinD Cluster with custom config: '{{ kind_cluster_name }}'"
   command:
     argv:
       - "{{ seldon_cache_directory }}/kind-{{ kind_version }}"
@@ -14,7 +14,19 @@
       - --image={{ kind_image_version }}
       - --config={{ kind_config_file }}
   register: kind_cluster_command
-  when: not cluster_check_result.exists
+  when: not cluster_check_result.exists and kind_config_file != None
+
+- name: "Start KinD Cluster: '{{ kind_cluster_name }}'"
+  shell: |
+    {{ seldon_cache_directory }}/kind-{{ kind_version }} \
+    create cluster \
+    --name={{ kind_cluster_name }} \
+    --image={{ kind_image_version }} \
+    --config - <<EOF
+    {{ kind_config_template | to_nice_yaml }}
+    EOF
+  register: kind_cluster_command
+  when: not cluster_check_result.exists and kind_config_file == None
 
 - name: Echo output of "kind create cluster ..." command
   ansible.builtin.debug:


### PR DESCRIPTION
This allows mounting local directories in a one-node kind cluster. It can be
useful (for example) for being able to load local models rather than requiring
them to be first copied to MinIO or a cloud bucket.

The changes here only add the basic support at the kind-cluster level. A
separate PR will update the helm-charts to allow for Server podSpec changes,
including adding a volume that points to the local folder now mounted in kind.

You can now set the following additional variables (overwriting with -e when
calling ansible-playbook preferred):

- kind_local_mount (bool, default false): enable kind extraMounts option when creating the cluster
- kind_host_path(string, default /tmp/kind-cluster): the local path to mount
- kind_container_path(string, default /host-mount): the "containerPath"
extraMounts setting - this (somewhat confusingly) defines the value that should be set as
the path in `volumes[i].hostPath.path` when adding a volume to the pod spec. Example:

```
kind: Pod
...
spec:
  volumes:
    - name: host-models
      hostPath:
        path: {{ kind_container_path }}
  ...
  containers
    - image: ...
      volumeMounts:
        - name: host-models
          # the actual path inside the container
          mountPath: /mnt/host-models
```

**Special notes for your reviewer**:
- No ansible docs added (yet) because using this functionality requires helm-chart updates to be added in a separate PR. The ansible docs/examples will be added together with that PR.