### PR TITLE
feat(helm-charts): allow pod spec overrides via values

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-runtime/templates/seldon-runtime.yaml
+++ b/k8s/helm-charts/seldon-core-v2-runtime/templates/seldon-runtime.yaml
@@ -10,22 +10,28 @@ spec:
   - name: hodometer
     disable: {{ .Values.hodometer.disable }}
     replicas: {{ .Values.hodometer.replicas }}
+    podSpec: {{ toJson .Values.hodometer.podSpec }}
   - name: seldon-scheduler
     disable: {{ .Values.scheduler.disable }}
     serviceType: {{ .Values.scheduler.serviceType }}
+    podSpec: {{ toJson .Values.scheduler.podSpec }}
   - name: seldon-envoy
     disable: {{ .Values.envoy.disable }}
     replicas: {{ .Values.envoy.replicas }}
     serviceType: {{ .Values.envoy.serviceType }}
+    podSpec: {{ toJson .Values.envoy.podSpec }}
   - name: seldon-dataflow-engine
     disable: {{ .Values.dataflow.disable }}
     replicas: {{ .Values.dataflow.replicas }}
+    podSpec: {{ toJson .Values.dataflow.podSpec }}
   - name: seldon-modelgateway
     disable: {{ .Values.modelgateway.disable }}
     replicas: {{ .Values.modelgateway.replicas }}
+    podSpec: {{ toJson .Values.modelgateway.podSpec }}
   - name: seldon-pipelinegateway
     disable: {{ .Values.pipelinegateway.disable }}
     replicas: {{ .Values.pipelinegateway.replicas }}
+    podSpec: {{ toJson .Values.pipelinegateway.podSpec }}
   config:
     agentConfig:
       rclone:

--- a/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
+++ b/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mlserver
   namespace: '{{ .Release.Namespace }}'
 spec:
+  podSpec: {{ toJson .Values.mlserver.podSpec }}
   replicas: {{ .Values.mlserver.replicas }}
   serverConfig: mlserver
 ---
@@ -13,5 +14,6 @@ metadata:
   name: triton
   namespace: '{{ .Release.Namespace }}'
 spec:
+  podSpec: {{ toJson .Values.triton.podSpec }}
   replicas: {{ .Values.triton.replicas }}
   serverConfig: triton

--- a/k8s/kustomize/helm-servers/patch_mlserver.yaml
+++ b/k8s/kustomize/helm-servers/patch_mlserver.yaml
@@ -4,3 +4,4 @@ metadata:
   name: mlserver
 spec:
   replicas: HACK_REMOVE_ME{{ .Values.mlserver.replicas }}
+  podSpec: HACK_REMOVE_ME{{ toJson .Values.mlserver.podSpec }}

--- a/k8s/kustomize/helm-servers/patch_triton.yaml
+++ b/k8s/kustomize/helm-servers/patch_triton.yaml
@@ -4,3 +4,4 @@ metadata:
   name: triton
 spec:
   replicas: HACK_REMOVE_ME{{ .Values.triton.replicas }}
+  podSpec: HACK_REMOVE_ME{{ toJson .Values.triton.podSpec }}


### PR DESCRIPTION
Updates the helm charts to allow passing dictionary values that update the
podSpec for:

- hodometer
- seldon-scheduler
- seldon-envoy
- seldon-dataflow-engine
- seldon-modelgateway
- seldon-pipelinegateway
- default mlserver & triton Server CRs

The podSpec value can be used to override any of the k8s pod spec configs,
including:
- tolerations
- nodeSelector/nodeAffinity
- volumes

The current operator behaviour when providing list values as part of the podSpec
setting is to append the elements of those lists to already existing elements.

The one exception is the list under podSpec.containers, where the settings for
items (containers) with the same name are *merged*.

**TODO**
- [x] add ansible dev docs showing how to mount local paths in the rclone container

**Which issue(s) this PR fixes**:
- Related to #4976

**Special notes for your reviewer**:
- server helm chart generated via the makefile (kustomize)
- merge after #5770