### PR TITLE
fix(ci): add additional licenses for transitive dependencies

### DIFF
--- a/licenses/additional_license_info.csv
+++ b/licenses/additional_license_info.csv
@@ -68,6 +68,8 @@ https://github.com/golangci/go-misc/blob/master/LICENSE,BSD 3-Clause "New" or "R
 https://github.com/google/licenseclassifier/blob/master/LICENSE,Apache License 2.0
 https://github.com/gotestyourself/gotest.tools/blob/main/LICENSE,Apache License 2.0
 https://github.com/hashicorp/go.net/blob/master/LICENSE,BSD 3-Clause "New" or "Revised" License
+https://github.com/hashicorp/vault/blob/main/LICENSE,BSL-1.1
+https://github.com/shopspring/decimal/blob/master/LICENSE,MIT License
 https://github.com/jenkins-x/go-scm/blob/main/LICENSE,BSD 3-Clause "New" or "Revised" License
 https://github.com/jmespath/go-jmespath/blob/master/LICENSE,Apache License 2.0
 https://github.com/kevinburke/ssh_config/blob/master/LICENSE,MIT License


### PR DESCRIPTION
License exceptions added for transitive dependencies whose license could not be automatically determined:
- hasicorp/vault (BSL-1.1)
- shopspring/decimal (MIT)