### PR TITLE
fix: Add experiments pipeline tests for envoy processor

### DIFF
--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -358,7 +358,7 @@ func createTestModel(modelName string,
 	return f
 }
 
-func remoteTestModel(
+func removeTestModel(
 	modelName string,
 	version uint32,
 	serverName string,
@@ -512,7 +512,7 @@ func TestEnvoySettings(t *testing.T) {
 				createTestModel("model1", "server", 1, []int{0}, 1, []store.ModelReplicaState{store.Available}),
 				createTestModel("model2", "server", 1, []int{1}, 1, []store.ModelReplicaState{store.Available}),
 				createTestExperiment("exp", []string{"model1", "model2"}, getStrPtr("model1"), nil),
-				remoteTestModel("model2", 1, "server", 1),
+				removeTestModel("model2", 1, "server", 1),
 			},
 			numExpectedClusters: 4,
 			numExpectedRoutes:   2, // model2 should be removed from the routes
@@ -553,7 +553,7 @@ func TestEnvoySettings(t *testing.T) {
 				createTestModel("model1", "server", 1, []int{0}, 1, []store.ModelReplicaState{store.Available}),
 				createTestModel("model2", "server", 1, []int{1}, 1, []store.ModelReplicaState{store.Available}),
 				createTestExperiment("exp", []string{"model1"}, getStrPtr("model1"), getStrPtr("model2")),
-				remoteTestModel("model2", 1, "server", 1),
+				removeTestModel("model2", 1, "server", 1),
 			},
 			numExpectedClusters: 4,
 			numExpectedRoutes:   2, // model2 should be removed from the routes
@@ -595,7 +595,7 @@ func TestEnvoySettings(t *testing.T) {
 				createTestModel("model2", "server", 1, []int{1}, 1, []store.ModelReplicaState{store.Available}),
 				createTestModel("model3", "server", 1, []int{1}, 1, []store.ModelReplicaState{store.Available}),
 				createTestPipeline("pipe", []string{"model1", "model2", "model3"}, 1),
-				remoteTestModel("model2", 1, "server", 1),
+				removeTestModel("model2", 1, "server", 1),
 			},
 			numExpectedClusters:  4,
 			numExpectedRoutes:    2, // model2 should be removed from the routes

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -493,6 +493,19 @@ func TestEnvoySettings(t *testing.T) {
 			experimentExists:    true,
 		},
 		{
+			name: "experiment - no default",
+			ops: []func(inc *IncrementalProcessor, g *WithT){
+				createTestServer("server", 2),
+				createTestModel("model1", "server", 1, []int{0}, 1, []store.ModelReplicaState{store.Available}),
+				createTestModel("model2", "server", 1, []int{1}, 1, []store.ModelReplicaState{store.Available}),
+				createTestExperiment("exp", []string{"model1", "model2"}, nil, nil),
+			},
+			numExpectedClusters: 4,
+			numExpectedRoutes:   3,
+			experimentActive:    true,
+			experimentExists:    true,
+		},
+		{
 			name: "experiment with deleted model",
 			ops: []func(inc *IncrementalProcessor, g *WithT){
 				createTestServer("server", 2),

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -365,8 +365,9 @@ func remoteTestModel(
 	serverIdx int,
 ) func(inc *IncrementalProcessor, g *WithT) {
 	f := func(inc *IncrementalProcessor, g *WithT) {
-		inc.modelStore.RemoveModel(&scheduler.UnloadModelRequest{Model: &scheduler.ModelReference{Name: "model1", Version: &version}})
-		err := inc.modelStore.UpdateModelState(modelName, version, serverName, serverIdx, nil, store.Available, store.Unloaded, "")
+		err := inc.modelStore.RemoveModel(&scheduler.UnloadModelRequest{Model: &scheduler.ModelReference{Name: "model1", Version: &version}})
+		g.Expect(err).To(BeNil())
+		err = inc.modelStore.UpdateModelState(modelName, version, serverName, serverIdx, nil, store.Available, store.Unloaded, "")
 		g.Expect(err).To(BeNil())
 	}
 	return f
@@ -574,7 +575,7 @@ func TestEnvoySettings(t *testing.T) {
 			numExpectedPipelines: 1,
 		},
 		{
-			name: "pipeline wih removed model",
+			name: "pipeline with removed model",
 			ops: []func(inc *IncrementalProcessor, g *WithT){
 				createTestServer("server", 2),
 				createTestModel("model1", "server", 1, []int{0}, 1, []store.ModelReplicaState{store.Available}),

--- a/scheduler/pkg/store/experiment/store_test.go
+++ b/scheduler/pkg/store/experiment/store_test.go
@@ -204,7 +204,7 @@ func TestStartExperiment(t *testing.T) {
 					// check db
 					experimentFromDB, _ := server.db.get(ea.experiment.Name)
 					g.Expect(experimentFromDB.Deleted).To(BeFalse())
-					g.Expect(experimentFromDB.Active).To(BeFalse())  // by default experiments are not active
+					g.Expect(experimentFromDB.Active).To(BeFalse()) // by default experiments are not active
 				}
 			}
 			g.Expect(len(server.experiments)).To(Equal(test.expectedNumExp))

--- a/scheduler/pkg/store/experiment/store_test.go
+++ b/scheduler/pkg/store/experiment/store_test.go
@@ -204,7 +204,7 @@ func TestStartExperiment(t *testing.T) {
 					// check db
 					experimentFromDB, _ := server.db.get(ea.experiment.Name)
 					g.Expect(experimentFromDB.Deleted).To(BeFalse())
-					g.Expect(experimentFromDB.Active).To(BeFalse())
+					g.Expect(experimentFromDB.Active).To(BeFalse())  // by default experiments are not active
 				}
 			}
 			g.Expect(len(server.experiments)).To(Equal(test.expectedNumExp))


### PR DESCRIPTION
This PR increases tests coverage to understand the behaviour of envoy when different resources change state.