### PR TITLE
feat(scheduler): Add max elapsed duration for model load/unload

### DIFF
--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -47,6 +47,8 @@ const (
 	maxElapsedTimeReadySubServiceBeforeStart = 15 * time.Minute // 15 mins is the default MaxElapsedTime
 	// period for subservice ready "cron"
 	periodReadySubService = 60 * time.Second
+	// max time to wait for a model server to load a model, including retrues
+	maxLoadElapsedTime = 120 * time.Minute
 	// number of retries for loading a model onto a server
 	maxLoadRetryCount = 10
 	// number of retries for unloading a model onto a server
@@ -275,6 +277,7 @@ func main() {
 			periodReadySubService,
 			maxElapsedTimeReadySubServiceBeforeStart,
 			maxElapsedTimeReadySubServiceAfterStart,
+			maxLoadElapsedTime,
 			maxLoadRetryCount,
 			maxUnloadRetryCount,
 		),

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -49,6 +49,8 @@ const (
 	periodReadySubService = 60 * time.Second
 	// max time to wait for a model server to load a model, including retrues
 	maxLoadElapsedTime = 120 * time.Minute
+	// max time to wait for a model server to unload a model, including retrues
+	maxUnloadElapsedTime = 15 * time.Minute // 15 mins is the default MaxElapsedTime
 	// number of retries for loading a model onto a server
 	maxLoadRetryCount = 10
 	// number of retries for unloading a model onto a server
@@ -278,6 +280,7 @@ func main() {
 			maxElapsedTimeReadySubServiceBeforeStart,
 			maxElapsedTimeReadySubServiceAfterStart,
 			maxLoadElapsedTime,
+			maxUnloadElapsedTime,
 			maxLoadRetryCount,
 			maxUnloadRetryCount,
 		),

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -52,7 +52,7 @@ const (
 	// max time to wait for a model server to unload a model, including retries
 	maxUnloadElapsedTime = 15 * time.Minute // 15 mins is the default MaxElapsedTime
 	// number of retries for loading a model onto a server
-	maxLoadRetryCount = 10
+	maxLoadRetryCount = 5
 	// number of retries for unloading a model onto a server
 	maxUnloadRetryCount = 1
 )

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -47,9 +47,9 @@ const (
 	maxElapsedTimeReadySubServiceBeforeStart = 15 * time.Minute // 15 mins is the default MaxElapsedTime
 	// period for subservice ready "cron"
 	periodReadySubService = 60 * time.Second
-	// max time to wait for a model server to load a model, including retrues
+	// max time to wait for a model server to load a model, including retries
 	maxLoadElapsedTime = 120 * time.Minute
-	// max time to wait for a model server to unload a model, including retrues
+	// max time to wait for a model server to unload a model, including retries
 	maxUnloadElapsedTime = 15 * time.Minute // 15 mins is the default MaxElapsedTime
 	// number of retries for loading a model onto a server
 	maxLoadRetryCount = 10

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -88,6 +88,7 @@ type ClientSettings struct {
 	periodReadySubService                    time.Duration
 	maxElapsedTimeReadySubServiceBeforeStart time.Duration
 	maxElapsedTimeReadySubServiceAfterStart  time.Duration
+	maxLoadElapsedTime                       time.Duration
 	maxLoadRetryCount                        uint8
 	maxUnloadRetryCount                      uint8
 }
@@ -100,7 +101,8 @@ func NewClientSettings(
 	schedulerTlsPort int,
 	periodReadySubService,
 	maxElapsedTimeReadySubServiceBeforeStart,
-	maxElapsedTimeReadySubServiceAfterStart time.Duration,
+	maxElapsedTimeReadySubServiceAfterStart,
+	maxLoadElapsedTime time.Duration,
 	maxLoadRetryCount,
 	maxUnloadRetryCount uint8,
 ) *ClientSettings {
@@ -113,6 +115,7 @@ func NewClientSettings(
 		periodReadySubService:                    periodReadySubService,
 		maxElapsedTimeReadySubServiceBeforeStart: maxElapsedTimeReadySubServiceBeforeStart,
 		maxElapsedTimeReadySubServiceAfterStart:  maxElapsedTimeReadySubServiceAfterStart,
+		maxLoadElapsedTime:                       maxLoadElapsedTime,
 		maxLoadRetryCount:                        maxLoadRetryCount,
 		maxUnloadRetryCount:                      maxUnloadRetryCount,
 	}

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -89,6 +89,7 @@ type ClientSettings struct {
 	maxElapsedTimeReadySubServiceBeforeStart time.Duration
 	maxElapsedTimeReadySubServiceAfterStart  time.Duration
 	maxLoadElapsedTime                       time.Duration
+	maxUnloadElapsedTime                     time.Duration
 	maxLoadRetryCount                        uint8
 	maxUnloadRetryCount                      uint8
 }
@@ -102,7 +103,8 @@ func NewClientSettings(
 	periodReadySubService,
 	maxElapsedTimeReadySubServiceBeforeStart,
 	maxElapsedTimeReadySubServiceAfterStart,
-	maxLoadElapsedTime time.Duration,
+	maxLoadElapsedTime,
+	maxUnloadElapsedTime time.Duration,
 	maxLoadRetryCount,
 	maxUnloadRetryCount uint8,
 ) *ClientSettings {
@@ -116,6 +118,7 @@ func NewClientSettings(
 		maxElapsedTimeReadySubServiceBeforeStart: maxElapsedTimeReadySubServiceBeforeStart,
 		maxElapsedTimeReadySubServiceAfterStart:  maxElapsedTimeReadySubServiceAfterStart,
 		maxLoadElapsedTime:                       maxLoadElapsedTime,
+		maxUnloadElapsedTime:                     maxUnloadElapsedTime,
 		maxLoadRetryCount:                        maxLoadRetryCount,
 		maxUnloadRetryCount:                      maxUnloadRetryCount,
 	}
@@ -601,7 +604,7 @@ func (c *Client) LoadModel(request *agent.ModelOperationMessage) error {
 	loaderFn := func() error {
 		return c.stateManager.LoadModelVersion(modifiedModelVersionRequest)
 	}
-	if err := backoffWithMaxNumRetry(loaderFn, c.settings.maxLoadRetryCount, logger); err != nil {
+	if err := backoffWithMaxNumRetry(loaderFn, c.settings.maxLoadRetryCount, c.settings.maxLoadElapsedTime, logger); err != nil {
 		c.sendModelEventError(modelName, modelVersion, agent.ModelEventMessage_LOAD_FAILED, err)
 		return err
 	}
@@ -643,7 +646,7 @@ func (c *Client) UnloadModel(request *agent.ModelOperationMessage) error {
 	unloaderFn := func() error {
 		return c.stateManager.UnloadModelVersion(modifiedModelVersionRequest)
 	}
-	if err := backoffWithMaxNumRetry(unloaderFn, c.settings.maxUnloadRetryCount, logger); err != nil {
+	if err := backoffWithMaxNumRetry(unloaderFn, c.settings.maxUnloadRetryCount, c.settings.maxUnloadElapsedTime, logger); err != nil {
 		c.sendModelEventError(modelName, modelVersion, agent.ModelEventMessage_UNLOAD_FAILED, err)
 		return err
 	}

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -206,7 +206,7 @@ func TestClientCreate(t *testing.T) {
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client,
 				test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -366,7 +366,7 @@ func TestLoadModel(t *testing.T) {
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 
@@ -515,7 +515,7 @@ parameters:
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository,
 				v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService,
@@ -657,7 +657,7 @@ func TestUnloadModel(t *testing.T) {
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 			mockAgentV2Server := &mockAgentV2Server{models: []string{}}
@@ -715,7 +715,7 @@ func TestClientClose(t *testing.T) {
 	drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 	drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 	client := NewClient(
-		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 		logger, modelRepository, v2Client,
 		&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 		rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -815,7 +815,7 @@ func TestAgentStopOnSubServicesFailure(t *testing.T) {
 				_ = drainerService.Start()
 			}()
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client,
 				&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -206,7 +206,7 @@ func TestClientCreate(t *testing.T) {
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client,
 				test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -366,7 +366,7 @@ func TestLoadModel(t *testing.T) {
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 
@@ -515,7 +515,7 @@ parameters:
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository,
 				v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService,
@@ -657,7 +657,7 @@ func TestUnloadModel(t *testing.T) {
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 			mockAgentV2Server := &mockAgentV2Server{models: []string{}}
@@ -715,7 +715,7 @@ func TestClientClose(t *testing.T) {
 	drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 	drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 	client := NewClient(
-		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
 		logger, modelRepository, v2Client,
 		&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 		rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -815,7 +815,7 @@ func TestAgentStopOnSubServicesFailure(t *testing.T) {
 				_ = drainerService.Start()
 			}()
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart, 1*time.Minute, 1*time.Minute, 1, 1),
 				logger, modelRepository, v2Client,
 				&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -111,7 +111,7 @@ func (b *backOffWithMaxCount) Reset() {
 }
 
 func (b *backOffWithMaxCount) NextBackOff() time.Duration {
-	if b.currentCount >= b.maxCount {
+	if b.currentCount >= b.maxCount - 1 {
 		return backoff.Stop
 	} else {
 		b.currentCount++

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -83,7 +83,6 @@ func isReadyChecker(
 
 func backoffWithMaxNumRetry(fn func() error, count uint8, logger log.FieldLogger) error {
 	backoffWithMax := backoff.NewExponentialBackOff()
-	// Wait for model repo to be ready
 	i := 0
 	logFailure := func(err error, delay time.Duration) {
 		logger.WithError(err).Errorf("Retry op #%d", i)

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -81,8 +81,8 @@ func isReadyChecker(
 	return nil
 }
 
-func backoffWithMaxNumRetry(fn func() error, count uint8, logger log.FieldLogger) error {
-	backoffWithMax := backoff.NewExponentialBackOff()
+func backoffWithMaxNumRetry(fn func() error, count uint8, maxElapsedTime time.Duration, logger log.FieldLogger) error {
+	backoffWithMax := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(maxElapsedTime))
 	i := 0
 	logFailure := func(err error, delay time.Duration) {
 		logger.WithError(err).Errorf("Retry op #%d", i)

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -111,7 +111,7 @@ func (b *backOffWithMaxCount) Reset() {
 }
 
 func (b *backOffWithMaxCount) NextBackOff() time.Duration {
-	if b.currentCount >= b.maxCount - 1 {
+	if b.currentCount >= b.maxCount-1 {
 		return backoff.Stop
 	} else {
 		b.currentCount++

--- a/scheduler/pkg/agent/client_utils_test.go
+++ b/scheduler/pkg/agent/client_utils_test.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func TestBackOffPolicyWithMax(t *testing.T) {
+func TestBackOffPolicyWithMaxCount(t *testing.T) {
 	t.Logf("Started")
 	logger := log.New()
 	log.SetLevel(log.DebugLevel)

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -27,7 +27,7 @@ const (
 	GRPCRetryMaxCount            = 5 // around 3.2s in total wait duration
 	GRPCMaxMsgSizeBytes          = 1000 * 1024 * 1024
 	EnvoyUpdateDefaultBatchWait  = 250 * time.Millisecond
-	GRPCModelServerLoadTimeout   = 30 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
+	GRPCModelServerLoadTimeout   = 60 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
 	GRPCModelServerUnloadTimeout = 2 * time.Minute
 	GRPCControlPlaneTimeout      = 1 * time.Minute // For control plane operations except load/unload
 )


### PR DESCRIPTION
Previously we had a fixed elapsed duration defaulting to 15 minutes for model load retries. For loading large llms (e.g. llama3 70b), this fixed max elapsed time didnt allow for any retries consequently as the size of the model will take the duration of the load towards this limit. 

This change then introduces the following:
- Allowing to define a max elapsed duration for model load (defaults to 2 hours) and unload (defaults to 15 minutes)
- Increase an individual load timeout call to 1 hour.
- Reduced the number of retries to 5 from 10.

In the case of retries, hf can resume downloads in the case one download has not finished completely with a single call.

Note that this change doesnt make these values configurable yet for the user to specify.

Fixes: INFRA-1114 (internal).