### PR TITLE
fix(agent): cleanup rclone directory on errors

### DIFF
--- a/scheduler/pkg/agent/repository/model_repository.go
+++ b/scheduler/pkg/agent/repository/model_repository.go
@@ -86,7 +86,7 @@ func (r *V2ModelRepository) DownloadModelVersion(
 	defer func() {
 		// Once the model artifact has been downloaded via rclone, ensure that we clean it up,
 		// even in the presence of errors (e.g. if the PVC doesn't have enough space to copy the
-	  // artifact into the inference server's model repository path).
+		// artifact into the inference server's model repository path).
 		err_purge := r.rcloneClient.PurgeLocal(rclonePath)
 		if err_purge != nil {
 			err = errors.Join(err, err_purge)


### PR DESCRIPTION
Previously, any error occurring after the downloading of the model artifact but
before the model was properly registered in the agent's model repository would
result in the rclone path not being cleaned-up. This leads to the PVC filling up
and requiring end-user manual intervention.

This change fixes this, by cleaning the rclone path even when errors occur.

**Which issue(s) this PR fixes**:
- Fixes #INFRA-1126 (internal): rclone directory is not cleaned-up