### PR TITLE
fix(golangci-lint): version bump and location fix

### DIFF
--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -71,8 +71,8 @@ build-jvm: build-dataflow-engine
 .PHONY: build
 build: build-go build-jvm
 
-.GOLANGCILINT_VERSION := v1.57.2
-.GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
+.GOLANGCILINT_VERSION := v1.59.1
+.GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint-versions/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \


### PR DESCRIPTION
Change location where scheduler/Makefile downloads golangci-lint. Previous
location name conflicts with any previously installed golangci-lint.

Specifically, the Makefile used to install it in
`${GOPATH}/bin/golangci-lint/[VERSION]/` however, this means that the
`${GOPATH}/bin/golangci-lint` file can not exist at the same time. The latter is
the default install path when installing via `go install`.

The new location for the seldon downloaded golangci-lint is
`${GOPATH}/bin/golangci-lint-versions/[VERSION]/`