### PR TITLE
fix(agent): cleaning up models that fail to load

### DIFF
--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -557,7 +557,7 @@ func (c *Client) getArtifactConfig(request *agent.ModelOperationMessage) ([]byte
 	return nil, nil
 }
 
-func (c *Client) LoadModel(request *agent.ModelOperationMessage) (err error) {
+func (c *Client) LoadModel(request *agent.ModelOperationMessage) error {
 	if request == nil || request.ModelVersion == nil {
 		return fmt.Errorf("empty request received for load model")
 	}

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -54,14 +54,18 @@ type mockAgentV2Server struct {
 }
 
 type FakeModelRepository struct {
-	err error
+	err            error
+	modelRemovals  int
+	modelDownloads int
 }
 
-func (f FakeModelRepository) RemoveModelVersion(modelName string) error {
+func (f *FakeModelRepository) RemoveModelVersion(modelName string) error {
+	f.modelRemovals++
 	return nil
 }
 
-func (f FakeModelRepository) DownloadModelVersion(modelName string, version uint32, modelSpec *pbs.ModelSpec, config []byte) (*string, error) {
+func (f *FakeModelRepository) DownloadModelVersion(modelName string, version uint32, modelSpec *pbs.ModelSpec, config []byte) (*string, error) {
+	f.modelDownloads++
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -69,7 +73,7 @@ func (f FakeModelRepository) DownloadModelVersion(modelName string, version uint
 	return &path, nil
 }
 
-func (f FakeModelRepository) Ready() error {
+func (f *FakeModelRepository) Ready() error {
 	return f.err
 }
 
@@ -197,7 +201,7 @@ func TestClientCreate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			v2Client := createTestV2Client(addVerionToModels(test.models, 0), test.v2Status)
 			httpmock.ActivateNonDefault(v2Client.(*testing_utils.V2RestClientForTest).HttpClient)
-			modelRepository := FakeModelRepository{err: test.modelRepoErr}
+			modelRepository := &FakeModelRepository{err: test.modelRepoErr}
 			rpHTTP := FakeDependencyService{err: nil}
 			rpGRPC := FakeDependencyService{err: nil}
 			agentDebug := FakeDependencyService{err: nil}
@@ -271,7 +275,8 @@ func TestLoadModel(t *testing.T) {
 			replicaConfig:           &pb.ReplicaConfig{MemoryBytes: 1000},
 			expectedAvailableMemory: 500,
 			v2Status:                200,
-			success:                 true}, // Success
+			success:                 true,
+		}, // Success
 		{
 			name:   "simple - autoscaling enabled",
 			models: []string{"iris"},
@@ -291,7 +296,8 @@ func TestLoadModel(t *testing.T) {
 			expectedAvailableMemory: 500,
 			v2Status:                200,
 			success:                 true,
-			autoscalingEnabled:      true}, // Success
+			autoscalingEnabled:      true,
+		}, // Success
 		{
 			name:   "V2Fail",
 			models: []string{"iris"},
@@ -309,7 +315,8 @@ func TestLoadModel(t *testing.T) {
 			replicaConfig:           &pb.ReplicaConfig{MemoryBytes: 1000},
 			expectedAvailableMemory: 1000,
 			v2Status:                400,
-			success:                 false}, // Fail as V2 fail
+			success:                 false,
+		}, // Fail as V2 fail
 		{
 			name:   "MemoryAvailableFail",
 			models: []string{"iris"},
@@ -327,7 +334,8 @@ func TestLoadModel(t *testing.T) {
 			replicaConfig:           &pb.ReplicaConfig{MemoryBytes: 1000},
 			expectedAvailableMemory: 1000,
 			v2Status:                200,
-			success:                 false}, // Fail due to too much memory required
+			success:                 false,
+		}, // Fail due to too much memory required
 	}
 
 	for tidx, test := range tests {
@@ -337,7 +345,7 @@ func TestLoadModel(t *testing.T) {
 			// Set up dependencies
 			v2Client := createTestV2Client(addVerionToModels(test.models, 0), test.v2Status)
 			httpmock.ActivateNonDefault(v2Client.(*testing_utils.V2RestClientForTest).HttpClient)
-			modelRepository := FakeModelRepository{err: test.modelRepoErr}
+			modelRepository := &FakeModelRepository{err: test.modelRepoErr}
 			rpHTTP := FakeDependencyService{err: nil}
 			rpGRPC := FakeDependencyService{err: nil}
 			agentDebug := FakeDependencyService{err: nil}
@@ -392,6 +400,7 @@ func TestLoadModel(t *testing.T) {
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(1))
 				g.Expect(mockAgentV2Server.loadFailedEvents).To(Equal(0))
 				g.Expect(client.stateManager.GetAvailableMemoryBytes()).To(Equal(test.expectedAvailableMemory))
+				g.Expect(modelRepository.modelRemovals).To(Equal(0))
 				loadedVersions := client.stateManager.modelVersions.getVersionsForAllModels()
 				// we have only one version in the test
 				g.Expect(proto.Clone(loadedVersions[0])).To(Equal(proto.Clone(test.op.ModelVersion)))
@@ -414,6 +423,7 @@ func TestLoadModel(t *testing.T) {
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(0))
 				g.Expect(mockAgentV2Server.loadFailedEvents).To(Equal(1))
 				g.Expect(client.stateManager.GetAvailableMemoryBytes()).To(Equal(test.expectedAvailableMemory))
+				g.Expect(modelRepository.modelRemovals).To(Equal(1))
 			}
 			client.Stop()
 			httpmock.DeactivateAndReset()
@@ -505,7 +515,7 @@ parameters:
 			t.Logf("Test #%d", tidx)
 			v2Client := createTestV2Client(addVerionToModels(test.models, 0), test.v2Status)
 			httpmock.ActivateNonDefault(v2Client.(*testing_utils.V2RestClientForTest).HttpClient)
-			modelRepository := FakeModelRepository{}
+			modelRepository := &FakeModelRepository{}
 			rpHTTP := FakeDependencyService{err: nil}
 			rpGRPC := FakeDependencyService{err: nil}
 			agentDebug := FakeDependencyService{err: nil}
@@ -540,9 +550,11 @@ parameters:
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(1))
 				g.Expect(mockAgentV2Server.loadFailedEvents).To(Equal(0))
 				g.Expect(client.stateManager.GetAvailableMemoryBytes()).To(Equal(test.expectedAvailableMemory))
+				g.Expect(modelRepository.modelRemovals).To(Equal(0))
 			} else {
 				g.Expect(err).ToNot(BeNil())
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(0))
+				g.Expect(modelRepository.modelRemovals).To(Equal(1))
 			}
 			client.Stop()
 			httpmock.DeactivateAndReset()
@@ -596,7 +608,8 @@ func TestUnloadModel(t *testing.T) {
 			replicaConfig:           &pb.ReplicaConfig{MemoryBytes: 1000},
 			expectedAvailableMemory: 1000,
 			v2Status:                200,
-			success:                 true}, // Success
+			success:                 true,
+		}, // Success
 		{
 			name:   "UnknownModel - unload ok",
 			models: []string{"iris"},
@@ -625,7 +638,8 @@ func TestUnloadModel(t *testing.T) {
 			replicaConfig:           &pb.ReplicaConfig{MemoryBytes: 1000},
 			expectedAvailableMemory: 500,
 			v2Status:                200,
-			success:                 true},
+			success:                 true,
+		},
 	}
 
 	for tidx, test := range tests {
@@ -633,7 +647,7 @@ func TestUnloadModel(t *testing.T) {
 			t.Logf("Test #%d", tidx)
 			v2Client := createTestV2Client(addVerionToModels(test.models, 0), test.v2Status)
 			httpmock.ActivateNonDefault(v2Client.(*testing_utils.V2RestClientForTest).HttpClient)
-			modelRepository := FakeModelRepository{}
+			modelRepository := &FakeModelRepository{}
 			rpHTTP := FakeDependencyService{err: nil}
 			rpGRPC := FakeDependencyService{err: nil}
 			agentDebug := FakeDependencyService{err: nil}
@@ -705,7 +719,7 @@ func TestClientClose(t *testing.T) {
 	v2Client := createTestV2Client(nil, 200)
 	httpmock.ActivateNonDefault(v2Client.(*testing_utils.V2RestClientForTest).HttpClient)
 	defer httpmock.DeactivateAndReset()
-	modelRepository := FakeModelRepository{}
+	modelRepository := &FakeModelRepository{}
 	rpHTTP := FakeDependencyService{err: nil}
 	rpGRPC := FakeDependencyService{err: nil}
 	agentDebug := FakeDependencyService{err: nil}
@@ -782,7 +796,6 @@ func TestAgentStopOnSubServicesFailure(t *testing.T) {
 	maxTimeAfterStart := 1 * time.Millisecond
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			mockMLServer := &testing_utils.MockGRPCMLServer{}
 			backEndGRPCPort, err := testing_utils2.GetFreePortForTest()
 			if err != nil {
@@ -798,7 +811,7 @@ func TestAgentStopOnSubServicesFailure(t *testing.T) {
 			v2Client := oip.NewV2Client(
 				oip.GetV2ConfigWithDefaults("", backEndGRPCPort), log.New())
 
-			modelRepository := FakeModelRepository{}
+			modelRepository := &FakeModelRepository{}
 			rpHTTP := FakeDependencyService{err: nil}
 			rpGRPC := FakeDependencyService{err: nil}
 			agentDebug := FakeDependencyService{err: nil}


### PR DESCRIPTION
If an error occurred whenever a model was loading, the artefacts belonging to the model would remain on disk in the `model` directory, potentially causing the disk to fill up unnecessarily. 

This PR adds a `cleanup` function, which is executed whenever an error that leads to a `LOAD_FAILED` event occurs. 