### PR TITLE
fix(model-gateway): Create consumer if model can serve traffic

### DIFF
--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -154,7 +154,8 @@ func (kc *KafkaSchedulerClient) SubscribeModelEvents() error {
 		logger.Infof("Received event name %s version %d state %s", event.ModelName, latestVersionStatus.Version, latestVersionStatus.State.State.String())
 
 		// if there are available replicas then we add the consumer for the model
-		// note that this will also get triggered if the model is already added and in this case it is a no-op
+		// note that this will also get triggered if the model is already added but there is a status change (e.g. due to scale up)
+		// and in the case then it is a no-op
 		if latestVersionStatus.State.GetAvailableReplicas() > 0 {
 			if kc.consumerManager.Exists(event.ModelName) {
 				logger.Debugf("Model consumer %s already exists", event.ModelName)

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -157,7 +157,7 @@ func (kc *KafkaSchedulerClient) SubscribeModelEvents() error {
 		// note that this will also get triggered if the model is already added and in this case it is a no-op
 		if latestVersionStatus.State.GetAvailableReplicas() > 0 {
 			if kc.consumerManager.Exists(event.ModelName) {
-				logger.Infof("Model consumer %s already exists", event.ModelName)
+				logger.Debugf("Model consumer %s already exists", event.ModelName)
 				continue
 			}
 			logger.Infof("Adding model %s", event.ModelName)

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -157,7 +157,10 @@ func (kc *KafkaSchedulerClient) SubscribeModelEvents() error {
 		// note that this will also get triggered if the model is already added but there is a status change (e.g. due to scale up)
 		// and in the case then it is a no-op
 		// note in the future we might want to check that available replicas > min replicas
-		if latestVersionStatus.State.GetAvailableReplicas() > 0 {
+		if latestVersionStatus.GetState().GetAvailableReplicas() > 0 {
+			if latestVersionStatus.GetState().GetState() != scheduler.ModelStatus_ModelAvailable {
+				logger.Warnf("Model %s state is: %s", event.ModelName, latestVersionStatus.GetState().GetState().String())
+			}
 			if kc.consumerManager.Exists(event.ModelName) {
 				logger.Debugf("Model consumer %s already exists", event.ModelName)
 				continue

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -156,6 +156,7 @@ func (kc *KafkaSchedulerClient) SubscribeModelEvents() error {
 		// if there are available replicas then we add the consumer for the model
 		// note that this will also get triggered if the model is already added but there is a status change (e.g. due to scale up)
 		// and in the case then it is a no-op
+		// note in the future we might want to check that available replicas > min replicas
 		if latestVersionStatus.State.GetAvailableReplicas() > 0 {
 			if kc.consumerManager.Exists(event.ModelName) {
 				logger.Debugf("Model consumer %s already exists", event.ModelName)

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -310,6 +310,13 @@ func (kc *InferKafkaHandler) RemoveModel(modelName string) error {
 	return nil
 }
 
+func (kc *InferKafkaHandler) Exists(modelName string) bool {
+	kc.mu.RLock()
+	defer kc.mu.RUnlock()
+	_, ok := kc.loadedModels[modelName]
+	return ok
+}	
+
 func (kc *InferKafkaHandler) Serve() {
 	logger := kc.logger.WithField("func", "Serve").WithField("consumerName", kc.consumerName)
 	run := true
@@ -349,7 +356,7 @@ func (kc *InferKafkaHandler) Serve() {
 					continue
 				}
 
-				kc.mu.Lock()
+				kc.mu.RLock()
 				if _, ok := kc.loadedModels[modelName]; !ok {
 					kc.mu.Unlock()
 					logger.Infof("Failed to find model %s in loaded models", modelName)

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -356,13 +356,11 @@ func (kc *InferKafkaHandler) Serve() {
 					continue
 				}
 
-				kc.mu.RLock()
-				if _, ok := kc.loadedModels[modelName]; !ok {
-					kc.mu.Unlock()
+				exists := kc.Exists(modelName)
+				if !exists {
 					logger.Infof("Failed to find model %s in loaded models", modelName)
 					continue
 				}
-				kc.mu.Unlock()
 
 				// Add tracing span
 				ctx := context.Background()

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -356,8 +356,7 @@ func (kc *InferKafkaHandler) Serve() {
 					continue
 				}
 
-				exists := kc.Exists(modelName)
-				if !exists {
+				if !kc.Exists(modelName) {
 					logger.Infof("Failed to find model %s in loaded models", modelName)
 					continue
 				}

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -315,7 +315,7 @@ func (kc *InferKafkaHandler) Exists(modelName string) bool {
 	defer kc.mu.RUnlock()
 	_, ok := kc.loadedModels[modelName]
 	return ok
-}	
+}
 
 func (kc *InferKafkaHandler) Serve() {
 	logger := kc.logger.WithField("func", "Serve").WithField("consumerName", kc.consumerName)

--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -197,6 +197,18 @@ func (cm *ConsumerManager) GetNumModels() int {
 	return tot
 }
 
+func (cm *ConsumerManager) Exists(modelName string) bool {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	ic, err := cm.getInferKafkaConsumer(modelName, false)
+	if err != nil {
+		return false
+	}
+
+	return ic != nil && ic.Exists(modelName)
+}
+
 func (cm *ConsumerManager) Stop() {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()

--- a/scheduler/pkg/kafka/gateway/manager_test.go
+++ b/scheduler/pkg/kafka/gateway/manager_test.go
@@ -85,6 +85,59 @@ func TestAddRemoveModel(t *testing.T) {
 	}
 }
 
+func TestExists(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name           string
+		modelsConsumed []string
+		model          string
+		exists         bool
+	}
+	tests := []test{
+		{
+			name:           "exists",
+			modelsConsumed: []string{"foo", "bar"},
+			model:          "foo",
+			exists:         true,
+		},
+		{
+			name:           "doesnt Exist",
+			modelsConsumed: []string{"foo"},
+			model:          "bar",
+			exists:         false,
+		},
+		{
+			name:           "empty",
+			modelsConsumed: []string{},
+			model:          "bar",
+			exists:         false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := log.New()
+			t.Log("Start test", test.name)
+			kafkaServerConfig := InferenceServerConfig{
+				Host:     "0.0.0.0",
+				HttpPort: 1234,
+				GrpcPort: 1235,
+			}
+			tp, err := seldontracer.NewTraceProvider("test", nil, logger)
+			g.Expect(err).To(BeNil())
+			c := &ManagerConfig{SeldonKafkaConfig: &config.KafkaConfig{}, Namespace: "default", InferenceServerConfig: &kafkaServerConfig, TraceProvider: tp, NumWorkers: 0}
+			cm, err := NewConsumerManager(logger, c, 5)
+			g.Expect(err).To(BeNil())
+			for _, model := range test.modelsConsumed {
+				err := cm.AddModel(model)
+				g.Expect(err).To(BeNil())
+			}
+			g.Expect(cm.Exists(test.model)).To(Equal(test.exists))
+		})
+	}
+}
+
 func TestConsistentModelToConsumer(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Currently we only  create then model gateway consumer when the model is explicitly set as Available. This is ok but it doesnt cover edge cases whether the model is partially available (e.g. during scale up when there is no extra server replica).

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes INFRA-1149 (internal)

**Special notes for your reviewer**:
