### PR TITLE
adding pipeline and model name validation

### DIFF
--- a/scheduler/pkg/store/pipeline/errors.go
+++ b/scheduler/pkg/store/pipeline/errors.go
@@ -195,3 +195,11 @@ type PipelineInputErr struct {
 func (pie *PipelineInputErr) Error() string {
 	return fmt.Sprintf("pipeline %s input %s is invalid. %s", pie.pipeline, pie.input, pie.reason)
 }
+
+type PipelineNameValidationErr struct {
+	pipeline string
+}
+
+func (pnve *PipelineNameValidationErr) Error() string {
+	return fmt.Sprintf("pipeline %s does not have a valid name - it must be alphanmumeric and can contain underscores and dashes", pnve.pipeline)
+}

--- a/scheduler/pkg/store/pipeline/validate.go
+++ b/scheduler/pkg/store/pipeline/validate.go
@@ -10,6 +10,7 @@ the Change License after the Change Date as each is defined in accordance with t
 package pipeline
 
 import (
+	"regexp"
 	"strings"
 )
 
@@ -27,6 +28,9 @@ const (
 )
 
 func validate(pv *PipelineVersion) error {
+	if err := checkName(pv); err != nil {
+		return err
+	}
 	if err := checkStepsExist(pv); err != nil {
 		return err
 	}
@@ -53,6 +57,14 @@ func validate(pv *PipelineVersion) error {
 	}
 	if err := checkPipelineInput(pv); err != nil {
 		return err
+	}
+	return nil
+}
+
+func checkName(pv *PipelineVersion) error {
+	ok, err := regexp.Match("^[a-zA-Z0-9-_]*$", []byte(pv.Name))
+	if !ok || err != nil {
+		return &PipelineNameValidationErr{pipeline: pv.Name}
 	}
 	return nil
 }

--- a/scheduler/pkg/store/pipeline/validate_test.go
+++ b/scheduler/pkg/store/pipeline/validate_test.go
@@ -845,3 +845,58 @@ func TestCheckStepOutputs(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckName(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tests := []validateTest{
+		{
+			name: "a valid name",
+			pipelineVersion: &PipelineVersion{
+				Name: "1-name_that-isVa1id0",
+				Steps: map[string]*PipelineStep{
+					"a": {
+						Name: "a",
+					},
+					"b": {
+						Name:   "b",
+						Inputs: []string{"a.outputs.t1", "a.inputs", "a.outputs"},
+					},
+					"c": {
+						Name:   "c",
+						Inputs: []string{"a.outputs.t1"},
+					},
+				},
+			},
+		},
+		{
+			name: "a invalid name with dots",
+			pipelineVersion: &PipelineVersion{
+				Name: "a-name_that-is-not-Valid.10.1",
+			},
+			err: &PipelineNameValidationErr{pipeline: "a-name_that-is-not-Valid.10.1"},
+		},
+		{
+			name: "a invalid name with a special character",
+			pipelineVersion: &PipelineVersion{
+				Name: "aNameThatIs%notValid",
+			},
+			err: &PipelineNameValidationErr{pipeline: "aNameThatIs%notValid"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkName(test.pipelineVersion)
+			if test.err == nil {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err.Error()).To(Equal(test.err.Error()))
+			}
+			err = validate(test.pipelineVersion)
+			if test.err == nil {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err.Error()).To(Equal(test.err.Error()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding some validation to model and pipeline names. Only alphanumeric names with underscores and dashes are valid.

TODO : 
 - [ ] add model name validation check
