### PR TITLE
fix(envoy): upgrade models in experiment

### DIFF
--- a/samples/models/iris2.yaml
+++ b/samples/models/iris2.yaml
@@ -1,0 +1,8 @@
+apiVersion: mlops.seldon.io/v1alpha1
+kind: Model
+metadata:
+  name: iris2
+spec:
+  storageUri: "gs://seldon-models/scv2/samples/rolling/iris/v2"
+  requirements:
+  - sklearn

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -435,6 +435,13 @@ func (p *IncrementalProcessor) addExperiment(exp *experiment.Experiment) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	routeName := fmt.Sprintf("%s.experiment", exp.Name)
+
+	// first clear any existing routes
+	if err := p.removeRouteForServerInEnvoyCache(routeName); err != nil {
+		logger.WithError(err).Errorf("Failed to remove traffic for experiment %s", routeName)
+		return err
+	}
+
 	if err := p.addTrafficForExperiment(routeName, exp); err != nil {
 		logger.WithError(err).Errorf("Failed to add traffic for experiment %s", routeName)
 		return err
@@ -640,6 +647,7 @@ func (p *IncrementalProcessor) modelUpdate(modelName string) error {
 func (p *IncrementalProcessor) callVersionCleanupIfNeeded(modelName string) {
 	logger := p.logger.WithField("func", "callVersionCleanupIfNeeded")
 	if routes, ok := p.xdsCache.Routes[modelName]; ok {
+		logger.Debugf("routes for model %s %v", modelName, routes)
 		activeRoutes := len(routes.Clusters)
 		if activeRoutes == 1 && p.versionCleaner != nil {
 			logger.Debugf("Calling cleanup for model %s", modelName)

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -648,8 +648,7 @@ func (p *IncrementalProcessor) callVersionCleanupIfNeeded(modelName string) {
 	logger := p.logger.WithField("func", "callVersionCleanupIfNeeded")
 	if routes, ok := p.xdsCache.Routes[modelName]; ok {
 		logger.Debugf("routes for model %s %v", modelName, routes)
-		activeRoutes := len(routes.Clusters)
-		if activeRoutes == 1 && p.versionCleaner != nil {
+		if p.versionCleaner != nil {
 			logger.Debugf("Calling cleanup for model %s", modelName)
 			p.versionCleaner.RunCleanup(modelName)
 		}

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -531,6 +531,10 @@ func TestEnvoySettings(t *testing.T) {
 			numExpectedRoutes:   3,
 			experimentActive:    true,
 			experimentExists:    true,
+			expectedVersionsInRoutes: map[string]uint32{
+				"model1": 1,
+				"model2": 1,
+			},
 		},
 		{
 			name: "experiment - new model version",
@@ -561,7 +565,7 @@ func TestEnvoySettings(t *testing.T) {
 				createTestExperiment("exp", []string{"model1", "model2"}, getStrPtr("model1"), nil),
 				removeTestModel("model2", 1, "server", 1),
 			},
-			numExpectedClusters: 4,
+			numExpectedClusters: 2,  // model2 should be removed from the clusters (server 1)
 			numExpectedRoutes:   2, // model2 should be removed from the routes
 			experimentActive:    false,
 			experimentExists:    true,
@@ -602,7 +606,7 @@ func TestEnvoySettings(t *testing.T) {
 				createTestExperiment("exp", []string{"model1"}, getStrPtr("model1"), getStrPtr("model2")),
 				removeTestModel("model2", 1, "server", 1),
 			},
-			numExpectedClusters: 4,
+			numExpectedClusters: 2, // model2 should be removed from the clusters (server 1)
 			numExpectedRoutes:   2, // model2 should be removed from the routes
 			experimentActive:    false,
 			experimentExists:    true,

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -705,7 +705,7 @@ func TestEnvoySettings(t *testing.T) {
 					for _, cluster := range route.Clusters {
 						if cluster.ModelName == modelName {
 							g.Expect(cluster.ModelVersion).To(Equal(version))
-						}	
+						}
 					}
 				}
 			}

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -400,6 +400,32 @@ func createTestExperiment(experimentName string, modelNames []string, defaultMod
 	return f
 }
 
+func refreshTestExperiment(experimentName string, modelNames []string, defaultModel *string, mirrorName *string) func(inc *IncrementalProcessor, g *WithT) {
+	f := func(inc *IncrementalProcessor, g *WithT) {
+		var candidates []*experiment.Candidate
+		var mirror *experiment.Mirror
+		for _, modelName := range modelNames {
+			candidates = append(candidates, &experiment.Candidate{Name: modelName, Weight: 1})
+		}
+		if mirrorName != nil {
+			mirror = &experiment.Mirror{
+				Name:    *mirrorName,
+				Percent: 100,
+			}
+		}
+		exp := &experiment.Experiment{
+			Name:       experimentName,
+			Default:    defaultModel,
+			Candidates: candidates,
+			Mirror:     mirror,
+		}
+
+		err := inc.experimentUpdate(exp)
+		g.Expect(err).To(BeNil())
+	}
+	return f
+}
+
 func deleteTestExperiment(experimentName string) func(inc *IncrementalProcessor, g *WithT) {
 	f := func(inc *IncrementalProcessor, g *WithT) {
 		err := inc.experimentServer.StopExperiment(experimentName)
@@ -499,6 +525,22 @@ func TestEnvoySettings(t *testing.T) {
 				createTestModel("model1", "server", 1, []int{0}, 1, []store.ModelReplicaState{store.Available}),
 				createTestModel("model2", "server", 1, []int{1}, 1, []store.ModelReplicaState{store.Available}),
 				createTestExperiment("exp", []string{"model1", "model2"}, nil, nil),
+			},
+			numExpectedClusters: 4,
+			numExpectedRoutes:   3,
+			experimentActive:    true,
+			experimentExists:    true,
+		},
+		{
+			name: "experiment - new model version",
+			ops: []func(inc *IncrementalProcessor, g *WithT){
+				createTestServer("server", 2),
+				createTestModel("model1", "server", 1, []int{0}, 1, []store.ModelReplicaState{store.Available}),
+				createTestModel("model2", "server", 1, []int{1}, 1, []store.ModelReplicaState{store.Available}),
+				createTestExperiment("exp", []string{"model1", "model2"}, nil, nil),
+				// update model2 to version 2
+				createTestModel("model2", "server", 1, []int{1}, 2, []store.ModelReplicaState{store.Available}),
+				refreshTestExperiment("exp", []string{"model1", "model2"}, nil, nil),
 			},
 			numExpectedClusters: 4,
 			numExpectedRoutes:   3,

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -565,7 +565,7 @@ func TestEnvoySettings(t *testing.T) {
 				createTestExperiment("exp", []string{"model1", "model2"}, getStrPtr("model1"), nil),
 				removeTestModel("model2", 1, "server", 1),
 			},
-			numExpectedClusters: 2,  // model2 should be removed from the clusters (server 1)
+			numExpectedClusters: 2, // model2 should be removed from the clusters (server 1)
 			numExpectedRoutes:   2, // model2 should be removed from the routes
 			experimentActive:    false,
 			experimentExists:    true,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This change addresses 2 issues related to `Experiments`:
- When upgrading to a new version of a model, an experiment route in envoy containing this model would still point to the old (and the new version). This is problematic as we unload the old versions after a new version in made available. 
- When upgrading to a new version of model and in an experiment that has a `Default` route pointing to this model, the old versions of the model  are not unloaded. This is incorrect behaviour.

The changes are respectively:

- When we process events to update an experiment due to a model change, we first remove an existing state (which had the old route) before creating the routes for the experiment which updated models etc.
- We always clean old versions of models regardless of how many routes existed for it. This was introduced initially to guard against 404s which is not true anymore as we have a first remove the routes from envoy (`UnloadEnvoyRequested`) before unloading a model (`UnloadRequested`).

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # INFRA-1001 (internal)

**Special notes for your reviewer**:
