### PR TITLE
feat(env): parameters exposed as env variables

### DIFF
--- a/scheduler/cmd/agent/cli/cli.go
+++ b/scheduler/cmd/agent/cli/cli.go
@@ -20,106 +20,134 @@ import (
 )
 
 const (
-	envServerHttpPort                = "SELDON_SERVER_HTTP_PORT"
-	envServerGrpcPort                = "SELDON_SERVER_GRPC_PORT"
-	envReverseProxyHttpPort          = "SELDON_REVERSE_PROXY_HTTP_PORT"
-	envReverseProxyGrpcPort          = "SELDON_REVERSE_PROXY_GRPC_PORT"
-	envDebugGrpcPort                 = "SELDON_DEBUG_GRPC_PORT"
-	envMetricsPort                   = "SELDON_METRICS_PORT"
-	envPodName                       = "POD_NAME"
-	envSchedulerHost                 = "SELDON_SCHEDULER_HOST"
-	envSchedulerPort                 = "SELDON_SCHEDULER_PORT"
-	envSchedulerTlsPort              = "SELDON_SCHEDULER_TLS_PORT"
-	envReplicaConfig                 = "SELDON_REPLICA_CONFIG"
-	envLogLevel                      = "SELDON_LOG_LEVEL"
-	envServerType                    = "SELDON_SERVER_TYPE"
-	envMemoryRequest                 = "MEMORY_REQUEST"
-	envCapabilities                  = "SELDON_SERVER_CAPABILITIES"
-	envOverCommitPercentage          = "SELDON_OVERCOMMIT_PERCENTAGE"
-	envEnvoyHost                     = "SELDON_ENVOY_HOST"
-	envEnvoyPort                     = "SELDON_ENVOY_PORT"
-	envDrainerServicePort            = "SELDON_DRAINER_PORT"
-	envModelInferenceLagThreshold    = "SELDON_MODEL_INFERENCE_LAG_THRESHOLD"
-	envModelInactiveSecondsThreshold = "SELDON_MODEL_INACTIVE_SECONDS_THRESHOLD"
-	envScalingStatsPeriodSeconds     = "SELDON_SCALING_STATS_PERIOD_SECONDS"
+	envServerHttpPort                                  = "SELDON_SERVER_HTTP_PORT"
+	envServerGrpcPort                                  = "SELDON_SERVER_GRPC_PORT"
+	envReverseProxyHttpPort                            = "SELDON_REVERSE_PROXY_HTTP_PORT"
+	envReverseProxyGrpcPort                            = "SELDON_REVERSE_PROXY_GRPC_PORT"
+	envDebugGrpcPort                                   = "SELDON_DEBUG_GRPC_PORT"
+	envMetricsPort                                     = "SELDON_METRICS_PORT"
+	envPodName                                         = "POD_NAME"
+	envSchedulerHost                                   = "SELDON_SCHEDULER_HOST"
+	envSchedulerPort                                   = "SELDON_SCHEDULER_PORT"
+	envSchedulerTlsPort                                = "SELDON_SCHEDULER_TLS_PORT"
+	envReplicaConfig                                   = "SELDON_REPLICA_CONFIG"
+	envLogLevel                                        = "SELDON_LOG_LEVEL"
+	envServerType                                      = "SELDON_SERVER_TYPE"
+	envMemoryRequest                                   = "MEMORY_REQUEST"
+	envCapabilities                                    = "SELDON_SERVER_CAPABILITIES"
+	envOverCommitPercentage                            = "SELDON_OVERCOMMIT_PERCENTAGE"
+	envEnvoyHost                                       = "SELDON_ENVOY_HOST"
+	envEnvoyPort                                       = "SELDON_ENVOY_PORT"
+	envDrainerServicePort                              = "SELDON_DRAINER_PORT"
+	envModelInferenceLagThreshold                      = "SELDON_MODEL_INFERENCE_LAG_THRESHOLD"
+	envModelInactiveSecondsThreshold                   = "SELDON_MODEL_INACTIVE_SECONDS_THRESHOLD"
+	envScalingStatsPeriodSeconds                       = "SELDON_SCALING_STATS_PERIOD_SECONDS"
+	envMaxElapsedTimeReadySubServiceAfterStartSeconds  = "SELDON_MAX_TIME_READY_SUB_SERVICE_AFTER_START_SECONDS"
+	envMaxElapsedTimeReadySubServiceBeforeStartMinutes = "SELDON_MAX_ELAPSED_TIME_READY_SUB_SERVICE_BEFORE_START_MINUTES"
+	envPeriodReadySubServiceSeconds                    = "SELDON_PERIOD_READY_SUB_SERVICE_SECONDS"
+	envMaxLoadElapsedTimeMinutes                       = "SELDON_MAX_LOAD_ELAPSED_TIME_MINUTES"
+	envMaxUnloadElapsedTimeMinutes                     = "SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES"
+	envMaxLoadRetryCount                               = "SELDON_MAX_LOAD_RETRY_COUNT"
+	envMaxUnloadRetryCount                             = "SELDON_MAX_UNLOAD_RETRY_COUNT"
 
-	flagSchedulerHost                 = "scheduler-host"
-	flagSchedulerPlaintxtPort         = "scheduler-port"
-	flagSchedulerTlsPort              = "scheduler-tls-port"
-	flagServerName                    = "server-name"
-	flagServerIdx                     = "server-idx"
-	flagInferenceHttpPort             = "inference-http-port"
-	flagInferenceGrpcPort             = "inference-grpc-port"
-	flagReverseProxyHttpPort          = "reverse-proxy-http-port"
-	flagReverseProxyGrpcPort          = "reverse-proxy-grpc-port"
-	flagDebugGrpcPort                 = "debug-grpc-port"
-	flagMetricsPort                   = "metrics-port"
-	flagReplicaConfig                 = "replica-config"
-	flagLogLevel                      = "log-level"
-	flagServerType                    = "server-type"
-	flagMemoryBytes                   = "memory-bytes"
-	flagCapabilities                  = "capabilities"
-	flagOverCommitPercentage          = "over-commit-percentage"
-	flagTracingConfigPath             = "tracing-config-path"
-	flagEnvoyHost                     = "envoy-host"
-	flagEnvoyPort                     = "envoy-port"
-	flagDrainerServicePort            = "drainer-port"
-	flagModelInferenceLagThreshold    = "model-inference-lag-threshold"
-	flagModelInactiveSecondsThreshold = "model-inactive-seconds-threshold"
-	flagScalingStatsPeriodSeconds     = "scaling-stats-period-seconds"
+	flagSchedulerHost                                   = "scheduler-host"
+	flagSchedulerPlaintxtPort                           = "scheduler-port"
+	flagSchedulerTlsPort                                = "scheduler-tls-port"
+	flagServerName                                      = "server-name"
+	flagServerIdx                                       = "server-idx"
+	flagInferenceHttpPort                               = "inference-http-port"
+	flagInferenceGrpcPort                               = "inference-grpc-port"
+	flagReverseProxyHttpPort                            = "reverse-proxy-http-port"
+	flagReverseProxyGrpcPort                            = "reverse-proxy-grpc-port"
+	flagDebugGrpcPort                                   = "debug-grpc-port"
+	flagMetricsPort                                     = "metrics-port"
+	flagReplicaConfig                                   = "replica-config"
+	flagLogLevel                                        = "log-level"
+	flagServerType                                      = "server-type"
+	flagMemoryBytes                                     = "memory-bytes"
+	flagCapabilities                                    = "capabilities"
+	flagOverCommitPercentage                            = "over-commit-percentage"
+	flagTracingConfigPath                               = "tracing-config-path"
+	flagEnvoyHost                                       = "envoy-host"
+	flagEnvoyPort                                       = "envoy-port"
+	flagDrainerServicePort                              = "drainer-port"
+	flagModelInferenceLagThreshold                      = "model-inference-lag-threshold"
+	flagModelInactiveSecondsThreshold                   = "model-inactive-seconds-threshold"
+	flagScalingStatsPeriodSeconds                       = "scaling-stats-period-seconds"
+	flagMaxElapsedTimeReadySubServiceAfterStartSeconds  = "max-elapsed-time-ready-sub-service-after-start-seconds"
+	flagMaxElapsedTimeReadySubServiceBeforeStartMinutes = "max-elapsed-time-ready-sub-service-before-start-minutes"
+	flagPeriodReadySubServiceSeconds                    = "period-ready-sub-service-seconds"
+	flagMaxLoadElapsedTimeMinutes                       = "max-load-elapsed-time-minutes"
+	flagMaxUnloadElapsedTimeMinutes                     = "max-unload-elapsed-time-minutes"
+	flagMaxLoadRetryCount                               = "max-load-retry-count"
+	flagMaxUnloadRetryCount                             = "max-unload-retry-count"
 )
 
 const (
-	defaultInferenceHttpPort        = 8080
-	defaultInferenceGrpcPort        = 9500
-	defaultRclonePort               = 5572
-	defaultSchedulerPort            = 9005
-	defaultSchedulerTlsPort         = 9055
-	defaultMetricsPort              = 9006
-	defaultEnvoyHost                = "0.0.0.0"
-	defaultEnvoyPort                = 9000
-	defaultDrainerServicePort       = 9007
-	statsPeriodSecondsDefault       = 5
-	lagThresholdDefault             = 30
-	lastUsedThresholdSecondsDefault = 30
+	defaultInferenceHttpPort                               = 8080
+	defaultInferenceGrpcPort                               = 9500
+	defaultRclonePort                                      = 5572
+	defaultSchedulerPort                                   = 9005
+	defaultSchedulerTlsPort                                = 9055
+	defaultMetricsPort                                     = 9006
+	defaultEnvoyHost                                       = "0.0.0.0"
+	defaultEnvoyPort                                       = 9000
+	defaultDrainerServicePort                              = 9007
+	statsPeriodSecondsDefault                              = 5
+	lagThresholdDefault                                    = 30
+	lastUsedThresholdSecondsDefault                        = 30
+	defaultMaxElapsedTimeReadySubServiceAfterStartSeconds  = 30
+	defaultMaxElapsedTimeReadySubServiceBeforeStartMinutes = 15
+	defaultPeriodReadySubServiceSeconds                    = 60
+	defaultMaxLoadElapsedTimeMinute                        = 120
+	defaultMaxUnloadElapsedTimeMinute                      = 15
+	defaultMaxLoadRetryCount                               = 5
+	defaultMaxUnloadRetryCount                             = 1
 )
 
 var (
-	agentHost                     string
-	ServerName                    string
-	ReplicaIdx                    uint
-	SchedulerHost                 string
-	SchedulerPort                 int
-	SchedulerTlsPort              int
-	RcloneHost                    string
-	RclonePort                    int
-	InferenceHost                 string
-	InferenceHttpPort             int
-	InferenceGrpcPort             int
-	ReverseProxyHttpPort          int
-	ReverseProxyGrpcPort          int
-	DebugGrpcPort                 int
-	MetricsPort                   int
-	AgentFolder                   string
-	Namespace                     string
-	ReplicaConfigStr              string
-	InferenceSvcName              string
-	ConfigPath                    string
-	LogLevel                      string
-	ServerType                    string
-	memoryBytes                   int
-	MemoryBytes64                 uint64
-	capabilitiesList              string
-	Capabilities                  []string
-	OverCommitPercentage          int
-	serverTypes                   = [...]string{"mlserver", "triton"}
-	TracingConfigPath             string
-	EnvoyHost                     string
-	EnvoyPort                     int
-	DrainerServicePort            int
-	ModelInferenceLagThreshold    int
-	ModelInactiveSecondsThreshold int
-	ScalingStatsPeriodSeconds     int
+	agentHost                                       string
+	ServerName                                      string
+	ReplicaIdx                                      uint
+	SchedulerHost                                   string
+	SchedulerPort                                   int
+	SchedulerTlsPort                                int
+	RcloneHost                                      string
+	RclonePort                                      int
+	InferenceHost                                   string
+	InferenceHttpPort                               int
+	InferenceGrpcPort                               int
+	ReverseProxyHttpPort                            int
+	ReverseProxyGrpcPort                            int
+	DebugGrpcPort                                   int
+	MetricsPort                                     int
+	AgentFolder                                     string
+	Namespace                                       string
+	ReplicaConfigStr                                string
+	InferenceSvcName                                string
+	ConfigPath                                      string
+	LogLevel                                        string
+	ServerType                                      string
+	memoryBytes                                     int
+	MemoryBytes64                                   uint64
+	capabilitiesList                                string
+	Capabilities                                    []string
+	OverCommitPercentage                            int
+	serverTypes                                     = [...]string{"mlserver", "triton"}
+	TracingConfigPath                               string
+	EnvoyHost                                       string
+	EnvoyPort                                       int
+	DrainerServicePort                              int
+	ModelInferenceLagThreshold                      int
+	ModelInactiveSecondsThreshold                   int
+	ScalingStatsPeriodSeconds                       int
+	MaxElapsedTimeReadySubServiceAfterStartSeconds  int
+	MaxElapsedTimeReadySubServiceBeforeStartMinutes int
+	PeriodReadySubServiceSeconds                    int
+	MaxLoadElapsedTimeMinute                        int
+	MaxUnloadElapsedTimeMinute                      int
+	MaxLoadRetryCount                               int
+	MaxUnloadRetryCount                             int
 )
 
 func init() {
@@ -156,6 +184,13 @@ func updateFlagsFromEnv() {
 	maybeUpdateModelInferenceLagThreshold()
 	maybeUpdateModelInactiveSecondsThreshold()
 	maybeUpdateScalingStatsPeriodSeconds()
+	maybeMaxElapsedTimeReadySubServiceAfterStartSeconds()
+	maybeMaxElapsedTimeReadySubServiceBeforeStartMinutes()
+	maybePeriodReadySubServiceSeconds()
+	maybeMaxLoadElapsedTimeMinute()
+	maybeMaxUnloadElapsedTimeMinute()
+	maybeMaxLoadRetryCount()
+	maybeMaxUnloadRetryCount()
 }
 
 func maybeUpdateModelInferenceLagThreshold() {
@@ -336,6 +371,69 @@ func maybeUpdateSchedulerTlsPort() {
 
 func maybeUpdateMetricsPort() {
 	maybeUpdatePort(flagMetricsPort, envMetricsPort, &MetricsPort)
+}
+
+func maybeMaxElapsedTimeReadySubServiceAfterStartSeconds() {
+	maybeUpdateFromIntEnv(
+		flagMaxElapsedTimeReadySubServiceAfterStartSeconds,
+		envMaxElapsedTimeReadySubServiceAfterStartSeconds,
+		&MaxElapsedTimeReadySubServiceAfterStartSeconds,
+		"sub service after start seconds",
+	)
+}
+
+func maybeMaxElapsedTimeReadySubServiceBeforeStartMinutes() {
+	maybeUpdateFromIntEnv(
+		flagMaxElapsedTimeReadySubServiceBeforeStartMinutes,
+		envMaxElapsedTimeReadySubServiceBeforeStartMinutes,
+		&MaxElapsedTimeReadySubServiceBeforeStartMinutes,
+		"sub service before start minutes",
+	)
+}
+
+func maybePeriodReadySubServiceSeconds() {
+	maybeUpdateFromIntEnv(
+		flagPeriodReadySubServiceSeconds,
+		envPeriodReadySubServiceSeconds,
+		&PeriodReadySubServiceSeconds,
+		"period ready sub service seconds",
+	)
+}
+
+func maybeMaxLoadElapsedTimeMinute() {
+	maybeUpdateFromIntEnv(
+		flagMaxLoadElapsedTimeMinutes,
+		envMaxLoadElapsedTimeMinutes,
+		&MaxLoadElapsedTimeMinute,
+		"max load elapsed time minutes",
+	)
+}
+
+func maybeMaxUnloadElapsedTimeMinute() {
+	maybeUpdateFromIntEnv(
+		flagMaxUnloadElapsedTimeMinutes,
+		envMaxUnloadElapsedTimeMinutes,
+		&MaxUnloadElapsedTimeMinute,
+		"max unload elapsed time minutes",
+	)
+}
+
+func maybeMaxLoadRetryCount() {
+	maybeUpdateFromIntEnv(
+		flagMaxLoadRetryCount,
+		envMaxLoadRetryCount,
+		&MaxLoadRetryCount,
+		"max load retry count",
+	)
+}
+
+func maybeMaxUnloadRetryCount() {
+	maybeUpdateFromIntEnv(
+		flagMaxUnloadRetryCount,
+		envMaxUnloadRetryCount,
+		&MaxUnloadRetryCount,
+		"max unload retry count",
+	)
 }
 
 func maybeUpdateSchedulerHost() {

--- a/scheduler/cmd/agent/cli/flags.go
+++ b/scheduler/cmd/agent/cli/flags.go
@@ -53,11 +53,11 @@ func makeArgs() {
 	flag.IntVar(&ScalingStatsPeriodSeconds, flagScalingStatsPeriodSeconds, statsPeriodSecondsDefault, "Scaling stats period seconds")
 	flag.IntVar(&MaxElapsedTimeReadySubServiceAfterStartSeconds, flagMaxElapsedTimeReadySubServiceAfterStartSeconds, defaultMaxElapsedTimeReadySubServiceAfterStartSeconds, "Ready sub service after start seconds")
 	flag.IntVar(&MaxElapsedTimeReadySubServiceBeforeStartMinutes, flagMaxElapsedTimeReadySubServiceBeforeStartMinutes, defaultMaxElapsedTimeReadySubServiceBeforeStartMinutes, "Max elapsed time sub service before start minutes")
-	flag.IntVar(&PeriodReadySubServiceSeconds, flagPeriodReadySubServiceSeconds, defaultPeriodReadySubServiceSeconds, "period in seconds for subservice ready \"cron\"")
-	flag.IntVar(&MaxLoadElapsedTimeMinute, flagMaxLoadElapsedTimeMinutes, defaultMaxLoadElapsedTimeMinute, "max time in minutes to wait for a model server to load a model, including retries")
-	flag.IntVar(&MaxUnloadElapsedTimeMinute, flagMaxUnloadElapsedTimeMinutes, defaultMaxUnloadElapsedTimeMinute, "max time in minutes to wait for a model server to unload a model, including retries")
-	flag.IntVar(&MaxLoadRetryCount, flagMaxLoadRetryCount, defaultMaxLoadRetryCount, "number of retries for loading a model onto a server")
-	flag.IntVar(&MaxUnloadRetryCount, flagMaxUnloadRetryCount, defaultMaxUnloadRetryCount, "number of retries for unloading a model onto a server")
+	flag.IntVar(&PeriodReadySubServiceSeconds, flagPeriodReadySubServiceSeconds, defaultPeriodReadySubServiceSeconds, "Period in seconds for subservice ready \"cron\"")
+	flag.IntVar(&MaxLoadElapsedTimeMinute, flagMaxLoadElapsedTimeMinutes, defaultMaxLoadElapsedTimeMinute, "Max time in minutes to wait for a model server to load a model, including retries")
+	flag.IntVar(&MaxUnloadElapsedTimeMinute, flagMaxUnloadElapsedTimeMinutes, defaultMaxUnloadElapsedTimeMinute, "Max time in minutes to wait for a model server to unload a model, including retries")
+	flag.IntVar(&MaxLoadRetryCount, flagMaxLoadRetryCount, defaultMaxLoadRetryCount, "Number of retries for loading a model onto a server")
+	flag.IntVar(&MaxUnloadRetryCount, flagMaxUnloadRetryCount, defaultMaxUnloadRetryCount, "Number of retries for unloading a model onto a server")
 }
 
 func parseFlags() {

--- a/scheduler/cmd/agent/cli/flags.go
+++ b/scheduler/cmd/agent/cli/flags.go
@@ -51,6 +51,13 @@ func makeArgs() {
 	flag.IntVar(&ModelInferenceLagThreshold, flagModelInferenceLagThreshold, lagThresholdDefault, "Model inference lag threshold")
 	flag.IntVar(&ModelInactiveSecondsThreshold, flagModelInactiveSecondsThreshold, lastUsedThresholdSecondsDefault, "Model inactive seconds threshold")
 	flag.IntVar(&ScalingStatsPeriodSeconds, flagScalingStatsPeriodSeconds, statsPeriodSecondsDefault, "Scaling stats period seconds")
+	flag.IntVar(&MaxElapsedTimeReadySubServiceAfterStartSeconds, flagMaxElapsedTimeReadySubServiceAfterStartSeconds, defaultMaxElapsedTimeReadySubServiceAfterStartSeconds, "Ready sub service after start seconds")
+	flag.IntVar(&MaxElapsedTimeReadySubServiceBeforeStartMinutes, flagMaxElapsedTimeReadySubServiceBeforeStartMinutes, defaultMaxElapsedTimeReadySubServiceBeforeStartMinutes, "Max elapsed time sub service before start minutes")
+	flag.IntVar(&PeriodReadySubServiceSeconds, flagPeriodReadySubServiceSeconds, defaultPeriodReadySubServiceSeconds, "period in seconds for subservice ready \"cron\"")
+	flag.IntVar(&MaxLoadElapsedTimeMinute, flagMaxLoadElapsedTimeMinutes, defaultMaxLoadElapsedTimeMinute, "max time in minutes to wait for a model server to load a model, including retries")
+	flag.IntVar(&MaxUnloadElapsedTimeMinute, flagMaxUnloadElapsedTimeMinutes, defaultMaxUnloadElapsedTimeMinute, "max time in minutes to wait for a model server to unload a model, including retries")
+	flag.IntVar(&MaxLoadRetryCount, flagMaxLoadRetryCount, defaultMaxLoadRetryCount, "number of retries for loading a model onto a server")
+	flag.IntVar(&MaxUnloadRetryCount, flagMaxUnloadRetryCount, defaultMaxUnloadRetryCount, "number of retries for unloading a model onto a server")
 }
 
 func parseFlags() {

--- a/scheduler/cmd/agent/cli/flags_test.go
+++ b/scheduler/cmd/agent/cli/flags_test.go
@@ -24,39 +24,46 @@ func TestAgentCliArgsDefault(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
-		name                                  string
-		args                                  []string
-		envs                                  []string
-		expectedAgentHost                     string
-		expectedServerName                    string
-		expectedReplicaIdx                    uint
-		expectedSchedulerHost                 string
-		expectedSchedulerPort                 int
-		expectedSchedulerTlsPort              int
-		expectedRcloneHost                    string
-		expectedRclonePort                    int
-		expectedInferenceHost                 string
-		expectedInferenceHttpPort             int
-		expectedInferenceGrpcPort             int
-		expectedReverseProxyHttpPort          int
-		expectedReverseProxyGrpcPort          int
-		expectedDebugGrpcPort                 int
-		expectedMetricsPort                   int
-		expectedAgentFolder                   string
-		expectedReplicaConfigStr              string
-		expectedNamespace                     string
-		expectedConfigPath                    string
-		expectedLogLevel                      string
-		expectedServerType                    string
-		expectedMemoryRequest                 uint64
-		expectedCapabilities                  []string
-		expectedOverCommitPercentage          int
-		expectedEnvoyHost                     string
-		expectedEnvoyPort                     int
-		expectedDrainerPort                   int
-		expectedModelInferenceLagThreshold    int
-		expectedModelInactiveSecondsThreshold int
-		expectedScalingStatsPeriodSeconds     int
+		name                                                    string
+		args                                                    []string
+		envs                                                    []string
+		expectedAgentHost                                       string
+		expectedServerName                                      string
+		expectedReplicaIdx                                      uint
+		expectedSchedulerHost                                   string
+		expectedSchedulerPort                                   int
+		expectedSchedulerTlsPort                                int
+		expectedRcloneHost                                      string
+		expectedRclonePort                                      int
+		expectedInferenceHost                                   string
+		expectedInferenceHttpPort                               int
+		expectedInferenceGrpcPort                               int
+		expectedReverseProxyHttpPort                            int
+		expectedReverseProxyGrpcPort                            int
+		expectedDebugGrpcPort                                   int
+		expectedMetricsPort                                     int
+		expectedAgentFolder                                     string
+		expectedReplicaConfigStr                                string
+		expectedNamespace                                       string
+		expectedConfigPath                                      string
+		expectedLogLevel                                        string
+		expectedServerType                                      string
+		expectedMemoryRequest                                   uint64
+		expectedCapabilities                                    []string
+		expectedOverCommitPercentage                            int
+		expectedEnvoyHost                                       string
+		expectedEnvoyPort                                       int
+		expectedDrainerPort                                     int
+		expectedModelInferenceLagThreshold                      int
+		expectedModelInactiveSecondsThreshold                   int
+		expectedScalingStatsPeriodSeconds                       int
+		expectedMaxElapsedTimeReadySubServiceAfterStartSeconds  int
+		expectedMaxElapsedTimeReadySubServiceBeforeStartMinutes int
+		expectedPeriodReadySubServiceSeconds                    int
+		expectedMaxLoadElapsedTimeMinute                        int
+		expectedMaxUnloadElapsedTimeMinute                      int
+		expectedMaxLoadRetryCount                               int
+		expectedMaxUnloadRetryCount                             int
 	}
 	tests := []test{
 		{
@@ -93,6 +100,13 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			expectedModelInferenceLagThreshold:    lagThresholdDefault,
 			expectedModelInactiveSecondsThreshold: lastUsedThresholdSecondsDefault,
 			expectedScalingStatsPeriodSeconds:     statsPeriodSecondsDefault,
+			expectedMaxElapsedTimeReadySubServiceAfterStartSeconds:  defaultMaxElapsedTimeReadySubServiceAfterStartSeconds,
+			expectedMaxElapsedTimeReadySubServiceBeforeStartMinutes: defaultMaxElapsedTimeReadySubServiceBeforeStartMinutes,
+			expectedPeriodReadySubServiceSeconds:                    defaultPeriodReadySubServiceSeconds,
+			expectedMaxLoadElapsedTimeMinute:                        defaultMaxLoadElapsedTimeMinute,
+			expectedMaxUnloadElapsedTimeMinute:                      defaultMaxUnloadElapsedTimeMinute,
+			expectedMaxLoadRetryCount:                               defaultMaxLoadRetryCount,
+			expectedMaxUnloadRetryCount:                             defaultMaxUnloadRetryCount,
 		},
 		{
 			name: "good args",
@@ -127,6 +141,13 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"--model-inference-lag-threshold=20",
 				"--model-inactive-seconds-threshold=30",
 				"--scaling-stats-period-seconds=40",
+				"--max-elapsed-time-ready-sub-service-after-start-seconds=30",
+				"--max-elapsed-time-ready-sub-service-before-start-minutes=15",
+				"--period-ready-sub-service-seconds=60",
+				"--max-load-elapsed-time-minutes=120",
+				"--max-unload-elapsed-time-minutes=15",
+				"--max-load-retry-count=5",
+				"--max-unload-retry-count=1",
 			},
 			envs:                                  []string{},
 			expectedAgentHost:                     "1.1.1.1",
@@ -159,6 +180,13 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			expectedModelInferenceLagThreshold:    20,
 			expectedModelInactiveSecondsThreshold: 30,
 			expectedScalingStatsPeriodSeconds:     40,
+			expectedMaxElapsedTimeReadySubServiceAfterStartSeconds:  30,
+			expectedMaxElapsedTimeReadySubServiceBeforeStartMinutes: 15,
+			expectedPeriodReadySubServiceSeconds:                    60,
+			expectedMaxLoadElapsedTimeMinute:                        120,
+			expectedMaxUnloadElapsedTimeMinute:                      15,
+			expectedMaxLoadRetryCount:                               5,
+			expectedMaxUnloadRetryCount:                             1,
 		},
 		{
 			name: "good envs",
@@ -185,6 +213,13 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"SELDON_MODEL_INFERENCE_LAG_THRESHOLD=50",
 				"SELDON_MODEL_INACTIVE_SECONDS_THRESHOLD=60",
 				"SELDON_SCALING_STATS_PERIOD_SECONDS=70",
+				"SELDON_MAX_TIME_READY_SUB_SERVICE_AFTER_START_SECONDS=30",
+				"SELDON_MAX_ELAPSED_TIME_READY_SUB_SERVICE_BEFORE_START_MINUTES=15",
+				"SELDON_PERIOD_READY_SUB_SERVICE_SECONDS=60",
+				"SELDON_MAX_LOAD_ELAPSED_TIME_MINUTES=120",
+				"SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES=15",
+				"SELDON_MAX_LOAD_RETRY_COUNT=5",
+				"SELDON_MAX_UNLOAD_RETRY_COUNT=1",
 			},
 			expectedAgentHost:                     "0.0.0.0",
 			expectedServerName:                    "mlserver",
@@ -216,6 +251,13 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			expectedModelInferenceLagThreshold:    50,
 			expectedModelInactiveSecondsThreshold: 60,
 			expectedScalingStatsPeriodSeconds:     70,
+			expectedMaxElapsedTimeReadySubServiceAfterStartSeconds:  30,
+			expectedMaxElapsedTimeReadySubServiceBeforeStartMinutes: 15,
+			expectedPeriodReadySubServiceSeconds:                    60,
+			expectedMaxLoadElapsedTimeMinute:                        120,
+			expectedMaxUnloadElapsedTimeMinute:                      15,
+			expectedMaxLoadRetryCount:                               5,
+			expectedMaxUnloadRetryCount:                             1,
 		},
 	}
 
@@ -264,7 +306,13 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			g.Expect(ModelInferenceLagThreshold).To(Equal(test.expectedModelInferenceLagThreshold))
 			g.Expect(ModelInactiveSecondsThreshold).To(Equal(test.expectedModelInactiveSecondsThreshold))
 			g.Expect(ScalingStatsPeriodSeconds).To(Equal(test.expectedScalingStatsPeriodSeconds))
-
+			g.Expect(MaxElapsedTimeReadySubServiceAfterStartSeconds).To(Equal(test.expectedMaxElapsedTimeReadySubServiceAfterStartSeconds))
+			g.Expect(MaxElapsedTimeReadySubServiceBeforeStartMinutes).To(Equal(test.expectedMaxElapsedTimeReadySubServiceBeforeStartMinutes))
+			g.Expect(PeriodReadySubServiceSeconds).To(Equal(test.expectedPeriodReadySubServiceSeconds))
+			g.Expect(MaxLoadElapsedTimeMinute).To(Equal(test.expectedMaxLoadElapsedTimeMinute))
+			g.Expect(MaxUnloadElapsedTimeMinute).To(Equal(test.expectedMaxUnloadElapsedTimeMinute))
+			g.Expect(MaxLoadRetryCount).To(Equal(test.expectedMaxLoadRetryCount))
+			g.Expect(MaxUnloadRetryCount).To(Equal(test.expectedMaxUnloadRetryCount))
 			// reset
 			flag.CommandLine = flag.NewFlagSet("cmd", flag.ExitOnError)
 			os.Clearenv()

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -40,23 +40,6 @@ import (
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/tracing"
 )
 
-const (
-	// the max time to wait for a subservice ready after client start, i.e. during operation
-	maxElapsedTimeReadySubServiceAfterStart = 30 * time.Second
-	// the max time to wait for a subservice ready before client start, i.e. during startup
-	maxElapsedTimeReadySubServiceBeforeStart = 15 * time.Minute // 15 mins is the default MaxElapsedTime
-	// period for subservice ready "cron"
-	periodReadySubService = 60 * time.Second
-	// max time to wait for a model server to load a model, including retries
-	maxLoadElapsedTime = 120 * time.Minute
-	// max time to wait for a model server to unload a model, including retries
-	maxUnloadElapsedTime = 15 * time.Minute // 15 mins is the default MaxElapsedTime
-	// number of retries for loading a model onto a server
-	maxLoadRetryCount = 5
-	// number of retries for unloading a model onto a server
-	maxUnloadRetryCount = 1
-)
-
 func makeDirs() (string, string, error) {
 	modelRepositoryDir := filepath.Join(cli.AgentFolder, "models")
 	rcloneRepositoryDir := filepath.Join(cli.AgentFolder, "rclone")
@@ -276,13 +259,13 @@ func main() {
 			cli.SchedulerHost,
 			cli.SchedulerPort,
 			cli.SchedulerTlsPort,
-			periodReadySubService,
-			maxElapsedTimeReadySubServiceBeforeStart,
-			maxElapsedTimeReadySubServiceAfterStart,
-			maxLoadElapsedTime,
-			maxUnloadElapsedTime,
-			maxLoadRetryCount,
-			maxUnloadRetryCount,
+			time.Duration(cli.MaxElapsedTimeReadySubServiceAfterStartSeconds),
+			time.Duration(cli.MaxElapsedTimeReadySubServiceBeforeStartMinutes),
+			time.Duration(cli.MaxElapsedTimeReadySubServiceAfterStartSeconds),
+			time.Duration(cli.MaxLoadElapsedTimeMinute),
+			time.Duration(cli.MaxUnloadElapsedTimeMinute),
+			uint8(cli.MaxLoadRetryCount),
+			uint8(cli.MaxUnloadRetryCount),
 		),
 		logger,
 		modelRepository,


### PR DESCRIPTION
**What this PR does / why we need it**:

These parameters (defaults) are currently hardcoded [here](https://github.com/SeldonIO/seldon-core/blob/4b233f9fe0980779e26013abd0adb3e4e32bee63/scheduler/cmd/agent/main.go#L43-L57).

These parameters could be exposed as env variables and also allow the user to get them configured via helm.

**Which issue(s) this PR fixes**:

Fixes # INFRA-1115