### PR TITLE
fix(core1/tests): fix TestPrepack.test_mlflow_v2 by updating model to v1.19.0-dev build

### DIFF
--- a/testing/scripts/test_prepackaged_servers.py
+++ b/testing/scripts/test_prepackaged_servers.py
@@ -207,7 +207,7 @@ class TestPrepack(object):
             namespace=namespace,
             protocol="v2",
             model_implementation="MLFLOW_SERVER",
-            model_uri="gs://seldon-models/v1.12.0-dev/mlflow/elasticnet_wine",
+            model_uri="gs://seldon-models/v1.19.0-dev/mlflow/elasticnet_wine",
         )
         wait_for_status(tag, namespace)
         wait_for_rollout(tag, namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a fix for the following failing test (from the test_parallel set of tests).
* TestPrepack.test_mlflow_v2

Test fixed by using the v1.19.0-dev build of the model.

