### PR TITLE
feat(chart): exposed retry constants as helm chart

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1539,6 +1539,22 @@ spec:
         value: '{{ .Values.serverConfig.agent.modelInactiveSecondsThreshold }}'
       - name: SELDON_SCALING_STATS_PERIOD_SECONDS
         value: '{{ .Values.serverConfig.agent.scalingStatsPeriodSeconds }}'
+      - name: SELDON_MAX_TIME_READY_SUB_SERVICE_AFTER_START_SECONDS
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceAfterStartSeconds
+          }}'
+      - name: SELDON_MAX_ELAPSED_TIME_READY_SUB_SERVICE_BEFORE_START_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceBeforeStartMinutes
+          }}'
+      - name: SELDON_PERIOD_READY_SUB_SERVICE_SECONDS
+        value: '{{ .Values.serverConfig.agent.periodReadySubServiceSeconds }}'
+      - name: SELDON_MAX_LOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxLoadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxUnloadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_LOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
+      - name: SELDON_MAX_UNLOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL
@@ -1787,6 +1803,22 @@ spec:
         value: '{{ .Values.serverConfig.agent.modelInactiveSecondsThreshold }}'
       - name: SELDON_SCALING_STATS_PERIOD_SECONDS
         value: '{{ .Values.serverConfig.agent.scalingStatsPeriodSeconds }}'
+      - name: SELDON_MAX_TIME_READY_SUB_SERVICE_AFTER_START_SECONDS
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceAfterStartSeconds
+          }}'
+      - name: SELDON_MAX_ELAPSED_TIME_READY_SUB_SERVICE_BEFORE_START_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceBeforeStartMinutes
+          }}'
+      - name: SELDON_PERIOD_READY_SUB_SERVICE_SECONDS
+        value: '{{ .Values.serverConfig.agent.periodReadySubServiceSeconds }}'
+      - name: SELDON_MAX_LOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxLoadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxUnloadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_LOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
+      - name: SELDON_MAX_UNLOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -243,6 +243,13 @@ serverConfig:
     scalingStatsPeriodSeconds: "20"
     modelInferenceLagThreshold: "30"
     modelInactiveSecondsThreshold: "600"
+    maxElapsedTimeReadySubServiceAfterStartSeconds: "30"
+    maxElapsedTimeReadySubServiceBeforeStartMinutes: "15"
+    periodReadySubServiceSeconds: "60"
+    maxLoadElapsedTimeMinutes: "120"
+    maxUnloadElapsedTimeMinutes: "15"
+    maxLoadRetryCount: "5"
+    maxUnloadRetryCount: "1"
     resources:
       cpu: 200m
       memory: 1Gi

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -243,6 +243,13 @@ serverConfig:
     scalingStatsPeriodSeconds: "20"
     modelInferenceLagThreshold: "30"
     modelInactiveSecondsThreshold: "600"
+    maxElapsedTimeReadySubServiceAfterStartSeconds: "30"
+    maxElapsedTimeReadySubServiceBeforeStartMinutes: "15"
+    periodReadySubServiceSeconds: "60"
+    maxLoadElapsedTimeMinutes: "120"
+    maxUnloadElapsedTimeMinutes: "15"
+    maxLoadRetryCount: "5"
+    maxUnloadRetryCount: "1"
     resources:
       cpu: 200m
       memory: 1Gi

--- a/k8s/kustomize/helm-components-sc/patch_mlserver.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_mlserver.yaml
@@ -24,6 +24,20 @@ spec:
         value: '{{ .Values.serverConfig.agent.modelInactiveSecondsThreshold }}'
       - name: SELDON_SCALING_STATS_PERIOD_SECONDS
         value: '{{ .Values.serverConfig.agent.scalingStatsPeriodSeconds }}'
+      - name: SELDON_MAX_TIME_READY_SUB_SERVICE_AFTER_START_SECONDS
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceAfterStartSeconds }}'
+      - name: SELDON_MAX_ELAPSED_TIME_READY_SUB_SERVICE_BEFORE_START_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceBeforeStartMinutes }}'
+      - name: SELDON_PERIOD_READY_SUB_SERVICE_SECONDS
+        value: '{{ .Values.serverConfig.agent.periodReadySubServiceSeconds }}'
+      - name: SELDON_MAX_LOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxLoadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxUnloadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_LOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
+      - name: SELDON_MAX_UNLOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL

--- a/k8s/kustomize/helm-components-sc/patch_triton.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_triton.yaml
@@ -24,6 +24,20 @@ spec:
         value: '{{ .Values.serverConfig.agent.modelInactiveSecondsThreshold }}'
       - name: SELDON_SCALING_STATS_PERIOD_SECONDS
         value: '{{ .Values.serverConfig.agent.scalingStatsPeriodSeconds }}'
+      - name: SELDON_MAX_TIME_READY_SUB_SERVICE_AFTER_START_SECONDS
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceAfterStartSeconds }}'
+      - name: SELDON_MAX_ELAPSED_TIME_READY_SUB_SERVICE_BEFORE_START_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxElapsedTimeReadySubServiceBeforeStartMinutes }}'
+      - name: SELDON_PERIOD_READY_SUB_SERVICE_SECONDS
+        value: '{{ .Values.serverConfig.agent.periodReadySubServiceSeconds }}'
+      - name: SELDON_MAX_LOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxLoadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES
+        value: '{{ .Values.serverConfig.agent.maxUnloadElapsedTimeMinutes }}'
+      - name: SELDON_MAX_LOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
+      - name: SELDON_MAX_UNLOAD_RETRY_COUNT
+        value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -1157,6 +1157,20 @@ spec:
         value: '20'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '10'
+      - name: SELDON_MAX_TIME_READY_SUB_SERVICE_AFTER_START_SECONDS
+        value: '30'
+      - name: SELDON_MAX_ELAPSED_TIME_READY_SUB_SERVICE_BEFORE_START_MINUTES
+        value: '15'
+      - name: SELDON_PERIOD_READY_SUB_SERVICE_SECONDS
+        value: '60'
+      - name: SELDON_MAX_LOAD_ELAPSED_TIME_MINUTES
+        value: '120'
+      - name: SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES
+        value: '15'
+      - name: SELDON_MAX_LOAD_RETRY_COUNT
+        value: '5'
+      - name: SELDON_MAX_UNLOAD_RETRY_COUNT
+        value: '1'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL
         value: 'PLAINTEXT'
       - name: CONTROL_PLANE_CLIENT_TLS_SECRET_NAME


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up PR of https://github.com/SeldonIO/seldon-core/pull/5875

These parameters (defaults) are currently hardcoded [here](https://github.com/SeldonIO/seldon-core/blob/4b233f9fe0980779e26013abd0adb3e4e32bee63/scheduler/cmd/agent/main.go#L43-L57).

These parameters could be exposed as env variables and also allow the user to get them configured via helm.

**Which issue(s) this PR fixes**:

Fixes  # INFRA-1115