### PR TITLE
feat(o11y): Envoy Grafana Dashbaord

### DIFF
--- a/ansible/roles/grafana/defaults/main.yaml
+++ b/ansible/roles/grafana/defaults/main.yaml
@@ -7,3 +7,5 @@ grafana_preloaded_dashboards:
     json: "{{ lookup('file', playbook_dir + '/../../prometheus/dashboards/provisioning/seldon.json') }}"
   - name: perf
     json: "{{ lookup('file', playbook_dir + '/../../prometheus/dashboards/provisioning/perf_and_scaling.json') }}"
+  - name: envoy
+    json: "{{ lookup('file', playbook_dir + '/../../prometheus/dashboards/provisioning/envoy.json') }}"

--- a/prometheus/dashboards/envoy.json
+++ b/prometheus/dashboards/envoy.json
@@ -1,0 +1,2501 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "3.1.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.3.0"
+    }
+  ],
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "deckbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(envoy_server_memory_heap_size{namespace=\"$namespace\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pod}}-heap-size",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Heap Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.1
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 9,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_xx{namespace=\"$namespace\", envoy_response_code_class=\"5\"}[$interval]))\n/\nsum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\"}[$interval]))) * 100",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 30
+              },
+              {
+                "color": "dark-red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
+      "id": 25,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "envoy_server_concurrency{namespace=\"$namespace\", pod=\"$pod\"}",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of Threads",
+      "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Downstream Stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "dash": [
+                10,
+                10
+              ],
+              "fill": "dash"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "width": 200
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_response_code_class) (rate(envoy_http_downstream_rq_xx{namespace=\"$namespace\", pod=\"$pod\", envoy_http_conn_manager_prefix=\"http\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{envoy_response_code_class}}xx",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Downstream Request Response Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "id": 12,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "envoy_http_downstream_rq_active{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\"}",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Downstream Requests Active",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\",envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}-total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_tx_reset{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{pod}}-reset",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Downstream Requests Stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 18,
+        "x": 6,
+        "y": 24
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Downstream Request Time Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 9,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 100,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "width": 200
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "10.1.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "{{envoy_response_code_class}}xx-{{envoy_cluster_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Upstream Request Response Codes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 15,
+            "w": 6,
+            "x": 0,
+            "y": 40
+          },
+          "id": 1,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.1.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "envoy_cluster_upstream_cx_active{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}",
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-{{pod}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Connections Active",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 6,
+            "y": 40
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Upstream Request Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 18,
+            "x": 6,
+            "y": 48
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p99",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p90",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p50",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Cluster Upstream Request Time Milliseconds",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 55
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Upstream Connect Destroyed",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 55
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_timeout{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Upstream Connect Timeouts",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 100,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 63
+          },
+          "id": 23,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "width": 200
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "10.1.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "total-{{envoy_cluster_name}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry_success{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "success-{{envoy_cluster_name}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Cluster Retry Stats",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Cluster Stats",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 16,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 54,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "dash": [
+                    0,
+                    10
+                  ],
+                  "fill": "dot"
+                },
+                "lineWidth": 2,
+                "pointSize": 11,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "degraded"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "total"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "healthy"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 72
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.1.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (envoy_cluster_membership_total{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
+              "instant": false,
+              "legendFormat": "total",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum (envoy_cluster_membership_healthy{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "healthy",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum (envoy_cluster_membership_degraded{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "degraded",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Cluster Membership Stats",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 79
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p99",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p90",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p50",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Cluster CDS Update Duration Milliseconds",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 2,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 79
+          },
+          "id": 18,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "fullHighlight": false,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "normal",
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            },
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 100
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_cluster_manager_cluster_added{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "clusters-added",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_cluster_manager_cluster_modified{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "clusters-modified",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_cluster_manager_cluster_removed{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "clusters-removed",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "CDS Updates",
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 87
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p99",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p90",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p50",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Listener LDS Update Duration Milliseconds",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 2,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 87
+          },
+          "id": 20,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "fullHighlight": false,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "normal",
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            },
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 100
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_listener_manager_lds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "update-success",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_listener_manager_lds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "update-failure",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_listener_manager_lds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "update-rejected",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "LDS Updates",
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 95
+          },
+          "id": 21,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "format": "time_series",
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p99",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p90",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{envoy_cluster_name}}-p50",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Route RDS Update Duration Milliseconds",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 2,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 95
+          },
+          "id": 22,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "fullHighlight": false,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "normal",
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            },
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 100
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_http_rds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "instant": false,
+              "legendFormat": "update-success",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_http_rds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "update-failure",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum (increase(envoy_http_rds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "update-rejected",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "LDS Updates",
+          "type": "barchart"
+        }
+      ],
+      "title": "xDS",
+      "type": "row"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "seldon-mesh",
+          "value": "seldon-mesh"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "1m",
+          "value": "1m"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Interval",
+        "multi": false,
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          }
+        ],
+        "query": "30s,1m,5m,10m,15m,30m",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(envoy_cluster_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "envoy_cluster_name",
+        "options": [],
+        "query": {
+          "query": "label_values(envoy_cluster_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "seldon-envoy-58f947767c-r4nv9",
+          "value": "seldon-envoy-58f947767c-r4nv9"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(envoy_server_live{namespace=\"$namespace\"},pod)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pod",
+        "multi": false,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(envoy_server_live{namespace=\"$namespace\"},pod)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Seldon Envoy",
+  "uid": "d615ae74-7ddd-4487-b040-bc0bddb95f4e",
+  "version": 9,
+  "weekStart": ""
+}

--- a/prometheus/dashboards/envoy.json
+++ b/prometheus/dashboards/envoy.json
@@ -559,7 +559,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
-          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\",envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\", pod=\"$pod\"}[$interval]))",
           "instant": false,
           "legendFormat": "{{pod}}-total",
           "range": true,
@@ -568,7 +568,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
-          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_tx_reset{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_tx_reset{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\", pod=\"$pod\"}[$interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pod}}-reset",
@@ -659,7 +659,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", pod=\"$pod\"}[$interval])))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p99",
@@ -669,7 +669,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", pod=\"$pod\"}[$interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "p90",
@@ -679,7 +679,7 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", pod=\"$pod\"}[$interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "p50",
@@ -691,7 +691,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -699,1466 +699,1465 @@
         "y": 31
       },
       "id": 9,
-      "panels": [
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "bars",
-                "fillOpacity": 100,
-                "gradientMode": "hue",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 32
-          },
-          "id": 7,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true,
-              "width": 200
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "10.1.5",
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{envoy_response_code_class}}xx-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Request Response Codes",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 15,
-            "w": 6,
-            "x": 0,
-            "y": 40
-          },
-          "id": 1,
-          "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
-          },
-          "pluginVersion": "11.1.3",
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "envoy_cluster_upstream_cx_active{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-{{pod}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Connections Active",
-          "type": "gauge"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 6,
-            "y": 40
-          },
-          "id": 5,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Request Count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 18,
-            "x": 6,
-            "y": 48
-          },
-          "id": 6,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Cluster Upstream Request Time Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 55
-          },
-          "id": 3,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Connect Destroyed",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 55
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_timeout{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Connect Timeouts",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "bars",
-                "fillOpacity": 100,
-                "gradientMode": "hue",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 63
-          },
-          "id": 23,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true,
-              "width": 200
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "10.1.5",
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "total-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry_success{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "success-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Cluster Retry Stats",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "Cluster Stats",
       "type": "row"
     },
     {
-      "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 32
       },
-      "id": 16,
-      "panels": [
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "width": 200
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 54,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "dash": [
-                    0,
-                    10
-                  ],
-                  "fill": "dot"
-                },
-                "lineWidth": 2,
-                "pointSize": 11,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{envoy_response_code_class}}xx-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Request Response Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "degraded"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-red",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "total"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "healthy"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-green",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
+                "color": "green",
+                "value": null
               }
             ]
           },
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 72
-          },
-          "id": 24,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.1.3",
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (envoy_cluster_membership_total{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
-              "instant": false,
-              "legendFormat": "total",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum (envoy_cluster_membership_healthy{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "healthy",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum (envoy_cluster_membership_degraded{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "degraded",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Cluster Membership Stats",
-          "type": "timeseries"
+          "unit": "none"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 6,
+        "x": 0,
+        "y": 40
+      },
+      "id": 1,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 79
-          },
-          "id": 4,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Cluster CDS Update Duration Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 2,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 79
-          },
-          "id": 18,
-          "options": {
-            "barRadius": 0,
-            "barWidth": 0.97,
-            "fullHighlight": false,
-            "groupWidth": 0.7,
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "orientation": "auto",
-            "showValue": "auto",
-            "stacking": "normal",
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            },
-            "xTickLabelRotation": 0,
-            "xTickLabelSpacing": 100
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_cluster_manager_cluster_added{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "clusters-added",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_cluster_manager_cluster_modified{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "clusters-modified",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_cluster_manager_cluster_removed{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "clusters-removed",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "CDS Updates",
-          "type": "barchart"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 87
-          },
-          "id": 19,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Listener LDS Update Duration Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 2,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 87
-          },
-          "id": 20,
-          "options": {
-            "barRadius": 0,
-            "barWidth": 0.97,
-            "fullHighlight": false,
-            "groupWidth": 0.7,
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "orientation": "auto",
-            "showValue": "auto",
-            "stacking": "normal",
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            },
-            "xTickLabelRotation": 0,
-            "xTickLabelSpacing": 100
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_listener_manager_lds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "update-success",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_listener_manager_lds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-failure",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_listener_manager_lds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-rejected",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "LDS Updates",
-          "type": "barchart"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 95
-          },
-          "id": 21,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Route RDS Update Duration Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 2,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 95
-          },
-          "id": 22,
-          "options": {
-            "barRadius": 0,
-            "barWidth": 0.97,
-            "fullHighlight": false,
-            "groupWidth": 0.7,
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "orientation": "auto",
-            "showValue": "auto",
-            "stacking": "normal",
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            },
-            "xTickLabelRotation": 0,
-            "xTickLabelSpacing": 100
-          },
-          "targets": [
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_http_rds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "update-success",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_http_rds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-failure",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "${DS_PROMETHEUS}",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_http_rds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-rejected",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "LDS Updates",
-          "type": "barchart"
+          "editorMode": "code",
+          "expr": "envoy_cluster_upstream_cx_active{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-{{pod}}",
+          "range": true,
+          "refId": "A"
         }
       ],
+      "title": "Cluster Connections Active",
+      "type": "gauge"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 40
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Request Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 18,
+        "x": 6,
+        "y": 48
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cluster Upstream Request Time Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Connect Destroyed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_timeout{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Connect Timeouts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "width": 200
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "total-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry_success{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "success-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Retry Stats",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 16,
+      "panels": [],
       "title": "xDS",
       "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 54,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "dash": [
+                0,
+                10
+              ],
+              "fill": "dot"
+            },
+            "lineWidth": 2,
+            "pointSize": 11,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "degraded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "healthy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (envoy_cluster_membership_total{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"})",
+          "instant": false,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum (envoy_cluster_membership_healthy{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "healthy",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum (envoy_cluster_membership_degraded{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "degraded",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cluster Membership Stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cluster CDS Update Duration Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 18,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_cluster_manager_cluster_added{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "clusters-added",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_cluster_manager_cluster_modified{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "clusters-modified",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_cluster_manager_cluster_removed{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "clusters-removed",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "CDS Updates",
+      "type": "barchart"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 87
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Listener LDS Update Duration Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "id": 20,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_listener_manager_lds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "update-success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_listener_manager_lds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-failure",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_listener_manager_lds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-rejected",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "LDS Updates",
+      "type": "barchart"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 95
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Route RDS Update Duration Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 95
+      },
+      "id": 22,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_http_rds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "update-success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_http_rds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-failure",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_http_rds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-rejected",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RDS Updates",
+      "type": "barchart"
     }
   ],
   "refresh": "5s",
@@ -2168,11 +2167,14 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "seldon-mesh",
           "value": "seldon-mesh"
         },
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
         "definition": "label_values(namespace)",
         "hide": 0,
         "includeAll": false,
@@ -2249,8 +2251,11 @@
             "$__all"
           ]
         },
-        "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(envoy_cluster_name)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(envoy_cluster_upstream_rq_total{pod=\"$pod\"},envoy_cluster_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Cluster",
@@ -2258,7 +2263,8 @@
         "name": "envoy_cluster_name",
         "options": [],
         "query": {
-          "query": "label_values(envoy_cluster_name)",
+          "qryType": 1,
+          "query": "label_values(envoy_cluster_upstream_rq_total{pod=\"$pod\"},envoy_cluster_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -2270,10 +2276,13 @@
       {
         "current": {
           "selected": true,
-          "text": "seldon-envoy-58f947767c-r4nv9",
-          "value": "seldon-envoy-58f947767c-r4nv9"
+          "text": "seldon-envoy-58f947767c-vvmpc",
+          "value": "seldon-envoy-58f947767c-vvmpc"
         },
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
         "definition": "label_values(envoy_server_live{namespace=\"$namespace\"},pod)",
         "hide": 0,
         "includeAll": false,
@@ -2294,13 +2303,13 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Seldon Envoy",
+  "title": "Envoy Gateway",
   "uid": "d615ae74-7ddd-4487-b040-bc0bddb95f4e",
-  "version": 9,
+  "version": 12,
   "weekStart": ""
 }

--- a/prometheus/dashboards/provisioning/envoy.json
+++ b/prometheus/dashboards/provisioning/envoy.json
@@ -559,7 +559,7 @@
         {
           "datasource": "",
           "editorMode": "code",
-          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\",envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\", pod=\"$pod\"}[$interval]))",
           "instant": false,
           "legendFormat": "{{pod}}-total",
           "range": true,
@@ -568,7 +568,7 @@
         {
           "datasource": "",
           "editorMode": "code",
-          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_tx_reset{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_tx_reset{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\", pod=\"$pod\"}[$interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "{{pod}}-reset",
@@ -659,7 +659,7 @@
         {
           "datasource": "",
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", pod=\"$pod\"}[$interval])))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "p99",
@@ -669,7 +669,7 @@
         {
           "datasource": "",
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", pod=\"$pod\"}[$interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "p90",
@@ -679,7 +679,7 @@
         {
           "datasource": "",
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", pod=\"$pod\"}[$interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "p50",
@@ -691,7 +691,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -699,1466 +699,1465 @@
         "y": 31
       },
       "id": 9,
-      "panels": [
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "bars",
-                "fillOpacity": 100,
-                "gradientMode": "hue",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 32
-          },
-          "id": 7,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true,
-              "width": 200
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "10.1.5",
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{envoy_response_code_class}}xx-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Request Response Codes",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 15,
-            "w": 6,
-            "x": 0,
-            "y": 40
-          },
-          "id": 1,
-          "options": {
-            "minVizHeight": 75,
-            "minVizWidth": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
-          },
-          "pluginVersion": "11.1.3",
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "envoy_cluster_upstream_cx_active{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-{{pod}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Connections Active",
-          "type": "gauge"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 6,
-            "y": 40
-          },
-          "id": 5,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Request Count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 18,
-            "x": 6,
-            "y": 48
-          },
-          "id": 6,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Cluster Upstream Request Time Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 55
-          },
-          "id": 3,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Connect Destroyed",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 55
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_timeout{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Upstream Connect Timeouts",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "bars",
-                "fillOpacity": 100,
-                "gradientMode": "hue",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 63
-          },
-          "id": 23,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true,
-              "width": 200
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "10.1.5",
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "total-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry_success{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "success-{{envoy_cluster_name}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Cluster Retry Stats",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "Cluster Stats",
       "type": "row"
     },
     {
-      "collapsed": true,
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 1,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 32
       },
-      "id": 16,
-      "panels": [
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "width": 200
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
         {
           "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 54,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "dash": [
-                    0,
-                    10
-                  ],
-                  "fill": "dot"
-                },
-                "lineWidth": 2,
-                "pointSize": 11,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{envoy_response_code_class}}xx-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Request Response Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "degraded"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-red",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "total"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "healthy"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-green",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
+                "color": "green",
+                "value": null
               }
             ]
           },
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 72
-          },
-          "id": 24,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.1.3",
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (envoy_cluster_membership_total{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
-              "instant": false,
-              "legendFormat": "total",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum (envoy_cluster_membership_healthy{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "healthy",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum (envoy_cluster_membership_degraded{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "degraded",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Cluster Membership Stats",
-          "type": "timeseries"
+          "unit": "none"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 6,
+        "x": 0,
+        "y": 40
+      },
+      "id": 1,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
         {
           "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 79
-          },
-          "id": 4,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Cluster CDS Update Duration Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 2,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 79
-          },
-          "id": 18,
-          "options": {
-            "barRadius": 0,
-            "barWidth": 0.97,
-            "fullHighlight": false,
-            "groupWidth": 0.7,
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "orientation": "auto",
-            "showValue": "auto",
-            "stacking": "normal",
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            },
-            "xTickLabelRotation": 0,
-            "xTickLabelSpacing": 100
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_cluster_manager_cluster_added{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "clusters-added",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_cluster_manager_cluster_modified{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "clusters-modified",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_cluster_manager_cluster_removed{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "clusters-removed",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "CDS Updates",
-          "type": "barchart"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 87
-          },
-          "id": 19,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Listener LDS Update Duration Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 2,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 87
-          },
-          "id": 20,
-          "options": {
-            "barRadius": 0,
-            "barWidth": 0.97,
-            "fullHighlight": false,
-            "groupWidth": 0.7,
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "orientation": "auto",
-            "showValue": "auto",
-            "stacking": "normal",
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            },
-            "xTickLabelRotation": 0,
-            "xTickLabelSpacing": 100
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_listener_manager_lds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "update-success",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_listener_manager_lds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-failure",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_listener_manager_lds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-rejected",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "LDS Updates",
-          "type": "barchart"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 95
-          },
-          "id": 21,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p99",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p90",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{envoy_cluster_name}}-p50",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Route RDS Update Duration Milliseconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 2,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 95
-          },
-          "id": 22,
-          "options": {
-            "barRadius": 0,
-            "barWidth": 0.97,
-            "fullHighlight": false,
-            "groupWidth": 0.7,
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "orientation": "auto",
-            "showValue": "auto",
-            "stacking": "normal",
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            },
-            "xTickLabelRotation": 0,
-            "xTickLabelSpacing": 100
-          },
-          "targets": [
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_http_rds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "instant": false,
-              "legendFormat": "update-success",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_http_rds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-failure",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": "",
-              "editorMode": "code",
-              "expr": "sum (increase(envoy_http_rds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "update-rejected",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "LDS Updates",
-          "type": "barchart"
+          "editorMode": "code",
+          "expr": "envoy_cluster_upstream_cx_active{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-{{pod}}",
+          "range": true,
+          "refId": "A"
         }
       ],
+      "title": "Cluster Connections Active",
+      "type": "gauge"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 40
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Request Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 18,
+        "x": 6,
+        "y": 48
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cluster Upstream Request Time Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Connect Destroyed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_timeout{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "{{pod}}-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Upstream Connect Timeouts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "width": 200
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "total-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry_success{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "success-{{envoy_cluster_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Retry Stats",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 16,
+      "panels": [],
       "title": "xDS",
       "type": "row"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 54,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "dash": [
+                0,
+                10
+              ],
+              "fill": "dot"
+            },
+            "lineWidth": 2,
+            "pointSize": 11,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "degraded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "healthy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (envoy_cluster_membership_total{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"})",
+          "instant": false,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum (envoy_cluster_membership_healthy{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "healthy",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum (envoy_cluster_membership_degraded{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\", pod=\"$pod\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "degraded",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cluster Membership Stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cluster CDS Update Duration Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 18,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_cluster_manager_cluster_added{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "clusters-added",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_cluster_manager_cluster_modified{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "clusters-modified",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_cluster_manager_cluster_removed{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "clusters-removed",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "CDS Updates",
+      "type": "barchart"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 87
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Listener LDS Update Duration Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "id": 20,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_listener_manager_lds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "update-success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_listener_manager_lds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-failure",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_listener_manager_lds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-rejected",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "LDS Updates",
+      "type": "barchart"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 95
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\", pod=\"$pod\"}[$interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{envoy_cluster_name}}-p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Route RDS Update Duration Milliseconds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 95
+      },
+      "id": 22,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "targets": [
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_http_rds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "instant": false,
+          "legendFormat": "update-success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_http_rds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-failure",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "",
+          "editorMode": "code",
+          "expr": "sum (increase(envoy_http_rds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "update-rejected",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "RDS Updates",
+      "type": "barchart"
     }
   ],
   "refresh": "5s",
@@ -2168,7 +2167,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "seldon-mesh",
           "value": "seldon-mesh"
         },
@@ -2250,7 +2249,7 @@
           ]
         },
         "datasource": "",
-        "definition": "label_values(envoy_cluster_name)",
+        "definition": "label_values(envoy_cluster_upstream_rq_total{pod=\"$pod\"},envoy_cluster_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Cluster",
@@ -2258,7 +2257,8 @@
         "name": "envoy_cluster_name",
         "options": [],
         "query": {
-          "query": "label_values(envoy_cluster_name)",
+          "qryType": 1,
+          "query": "label_values(envoy_cluster_upstream_rq_total{pod=\"$pod\"},envoy_cluster_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -2270,8 +2270,8 @@
       {
         "current": {
           "selected": true,
-          "text": "seldon-envoy-58f947767c-r4nv9",
-          "value": "seldon-envoy-58f947767c-r4nv9"
+          "text": "seldon-envoy-58f947767c-vvmpc",
+          "value": "seldon-envoy-58f947767c-vvmpc"
         },
         "datasource": "",
         "definition": "label_values(envoy_server_live{namespace=\"$namespace\"},pod)",
@@ -2294,13 +2294,13 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Seldon Envoy",
+  "title": "Envoy Gateway",
   "uid": "d615ae74-7ddd-4487-b040-bc0bddb95f4e",
-  "version": 9,
+  "version": 12,
   "weekStart": ""
 }

--- a/prometheus/dashboards/provisioning/envoy.json
+++ b/prometheus/dashboards/provisioning/envoy.json
@@ -31,7 +31,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -108,7 +108,7 @@
       },
       "targets": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "sum by (pod) (rate(envoy_server_memory_heap_size{namespace=\"$namespace\"}[$interval]))",
           "hide": false,
@@ -122,7 +122,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -175,7 +175,7 @@
       "pluginVersion": "11.1.3",
       "targets": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "(sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_xx{namespace=\"$namespace\", envoy_response_code_class=\"5\"}[$interval]))\n/\nsum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\"}[$interval]))) * 100",
           "instant": false,
@@ -188,7 +188,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -241,7 +241,7 @@
       "pluginVersion": "11.1.3",
       "targets": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "envoy_server_concurrency{namespace=\"$namespace\", pod=\"$pod\"}",
           "instant": false,
@@ -267,7 +267,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -410,7 +410,7 @@
       },
       "targets": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "sum by (pod, envoy_response_code_class) (rate(envoy_http_downstream_rq_xx{namespace=\"$namespace\", pod=\"$pod\", envoy_http_conn_manager_prefix=\"http\"}[$interval]))",
           "instant": false,
@@ -423,7 +423,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -468,7 +468,7 @@
       "pluginVersion": "11.1.3",
       "targets": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "envoy_http_downstream_rq_active{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\"}",
           "instant": false,
@@ -481,7 +481,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -557,7 +557,7 @@
       },
       "targets": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_total{namespace=\"$namespace\",envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
           "instant": false,
@@ -566,7 +566,7 @@
           "refId": "A"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_http_downstream_rq_tx_reset{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval]))",
           "hide": false,
@@ -580,7 +580,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -657,7 +657,7 @@
       },
       "targets": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\", envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
           "format": "time_series",
@@ -667,7 +667,7 @@
           "refId": "A"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
           "hide": false,
@@ -677,7 +677,7 @@
           "refId": "B"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "editorMode": "code",
           "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_http_downstream_rq_time_bucket{namespace=\"$namespace\", envoy_http_conn_manager_prefix=\"http\",  envoy_cluster_name!=\"xds_cluster\"}[$interval])))",
           "hide": false,
@@ -701,7 +701,7 @@
       "id": 9,
       "panels": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -778,7 +778,7 @@
           "pluginVersion": "10.1.5",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
               "instant": false,
@@ -791,7 +791,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -836,7 +836,7 @@
           "pluginVersion": "11.1.3",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "envoy_cluster_upstream_cx_active{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}",
               "instant": false,
@@ -849,7 +849,7 @@
           "type": "gauge"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -925,7 +925,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
               "instant": false,
@@ -938,7 +938,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1015,7 +1015,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.99,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
               "format": "time_series",
@@ -1025,7 +1025,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.90,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
               "hide": false,
@@ -1035,7 +1035,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.50,  sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval])))",
               "hide": false,
@@ -1049,7 +1049,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1125,7 +1125,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
               "instant": false,
@@ -1138,7 +1138,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1214,7 +1214,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_timeout{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
               "instant": false,
@@ -1227,7 +1227,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1304,7 +1304,7 @@
           "pluginVersion": "10.1.5",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
               "instant": false,
@@ -1313,7 +1313,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum by (pod, envoy_cluster_name, envoy_response_code_class) (rate(envoy_cluster_upstream_rq_retry_success{namespace=\"$namespace\", envoy_cluster_name=~\"$envoy_cluster_name\"}[$interval]))",
               "hide": false,
@@ -1341,7 +1341,7 @@
       "id": 16,
       "panels": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1468,7 +1468,7 @@
           "pluginVersion": "11.1.3",
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (envoy_cluster_membership_total{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
               "instant": false,
@@ -1477,7 +1477,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum (envoy_cluster_membership_healthy{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
@@ -1489,7 +1489,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum (envoy_cluster_membership_degraded{namespace=\"$namespace\", pod=\"$pod\", envoy_cluster_name=~\"$envoy_cluster_name\"})",
@@ -1506,7 +1506,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1586,7 +1586,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "format": "time_series",
@@ -1596,7 +1596,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "hide": false,
@@ -1606,7 +1606,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_cluster_manager_cds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "hide": false,
@@ -1620,7 +1620,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1690,7 +1690,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_cluster_manager_cluster_added{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "instant": false,
@@ -1699,7 +1699,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_cluster_manager_cluster_modified{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "hide": false,
@@ -1709,7 +1709,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_cluster_manager_cluster_removed{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "hide": false,
@@ -1723,7 +1723,7 @@
           "type": "barchart"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1803,7 +1803,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "format": "time_series",
@@ -1813,7 +1813,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "hide": false,
@@ -1823,7 +1823,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_listener_manager_lds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "hide": false,
@@ -1837,7 +1837,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1907,7 +1907,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_listener_manager_lds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "instant": false,
@@ -1916,7 +1916,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_listener_manager_lds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "hide": false,
@@ -1926,7 +1926,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_listener_manager_lds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "hide": false,
@@ -1940,7 +1940,7 @@
           "type": "barchart"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2020,7 +2020,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.99,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "format": "time_series",
@@ -2030,7 +2030,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.90,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "hide": false,
@@ -2040,7 +2040,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "histogram_quantile(0.50,  sum by (le) (rate(envoy_http_rds_update_duration_bucket{namespace=\"$namespace\"}[$interval])))",
               "hide": false,
@@ -2054,7 +2054,7 @@
           "type": "timeseries"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2124,7 +2124,7 @@
           },
           "targets": [
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_http_rds_update_success{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "instant": false,
@@ -2133,7 +2133,7 @@
               "refId": "A"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_http_rds_update_failure{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "hide": false,
@@ -2143,7 +2143,7 @@
               "refId": "B"
             },
             {
-              "datasource": "${DS_PROMETHEUS}",
+              "datasource": "",
               "editorMode": "code",
               "expr": "sum (increase(envoy_http_rds_update_rejected{namespace=\"$namespace\", pod=\"$pod\"}[$interval]))",
               "hide": false,
@@ -2172,7 +2172,7 @@
           "text": "seldon-mesh",
           "value": "seldon-mesh"
         },
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "",
         "definition": "label_values(namespace)",
         "hide": 0,
         "includeAll": false,
@@ -2249,7 +2249,7 @@
             "$__all"
           ]
         },
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "",
         "definition": "label_values(envoy_cluster_name)",
         "hide": 0,
         "includeAll": true,
@@ -2273,7 +2273,7 @@
           "text": "seldon-envoy-58f947767c-r4nv9",
           "value": "seldon-envoy-58f947767c-r4nv9"
         },
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "",
         "definition": "label_values(envoy_server_live{namespace=\"$namespace\"},pod)",
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds an envoy grafana dashboard, which is useful to have better o11y of envoy. 

Fixes #

It is related to INFRA-1150

TODOs:

- [x]  Add some more visualisations, perhaps. 