### PR TITLE
fix(k6): set headers key for http k6 test

### DIFF
--- a/tests/k6/components/v2.js
+++ b/tests/k6/components/v2.js
@@ -21,7 +21,7 @@ export function inferHttp(endpoint, modelName, payload, viaEnvoy, pipelineSuffix
         metadata['seldon-internal-model'] = modelName
     }
     const params = {
-        metadata:  metadata
+        headers:  metadata
     };
     //console.log("URL:",url,"Payload:",payloadStr,"Params:",JSON.stringify(params))
     const response = http.post(url, payloadStr, params);


### PR DESCRIPTION
This is a fix to set the headers properly for k6 REST  tests. 
