### PR TITLE
feat: adding -ldflag and -trimpath to go build

### DIFF
--- a/components/tls/Makefile
+++ b/components/tls/Makefile
@@ -18,7 +18,7 @@ lint: ${.GOLANGCILINT_PATH}/golangci-lint
 
 .PHONY: build
 build: test
-	go build -trimpath -ldflags="-s -w" ./pkg/...
+	go build -trimpath -ldflags="-w" ./pkg/...
 
 .PHONY: licenses/dep.txt
 licenses/dep.txt:

--- a/components/tls/Makefile
+++ b/components/tls/Makefile
@@ -18,7 +18,7 @@ lint: ${.GOLANGCILINT_PATH}/golangci-lint
 
 .PHONY: build
 build: test
-	go build ./pkg/...
+	go build -trimpath -ldflags="-s -w" ./pkg/...
 
 .PHONY: licenses/dep.txt
 licenses/dep.txt:

--- a/components/tls/Makefile
+++ b/components/tls/Makefile
@@ -1,4 +1,4 @@
-GO_LDFLAGS := -s -w $(patsubst %,-X %, $(GO_BUILD_VARS))
+GO_LDFLAGS := -w $(patsubst %,-X %, $(GO_BUILD_VARS))
 
 .PHONY: test
 test:

--- a/hodometer/Makefile
+++ b/hodometer/Makefile
@@ -37,9 +37,10 @@ lint: ${.GOLANGCILINT_PATH}/golangci-lint
 .PHONY: build-hodometer
 build-hodometer: test-hodometer 
 	$(GO_ENV) \
-				go build -trimpath -ldflags="-w" \
+				go build -trimpath \
 				-o bin/hodometer \
 				-ldflags=" \
+				-w \
 				-X '$(VERSION_PACKAGE).BuildVersion=$(BUILD_VERSION)' \
 				-X '$(VERSION_PACKAGE).BuildTime=$(BUILD_TIME)' \
 				-X '$(VERSION_PACKAGE).GitBranch=$(GIT_BRANCH)' \
@@ -52,7 +53,7 @@ build-hodometer-local: copy-components build-hodometer
 
 .PHONY: build-receiver
 build-receiver: test-receiver
-	$(GO_ENV) go build -trimpath -ldflags="-s -w" -o bin/receiver ./cmd/receiver
+	$(GO_ENV) go build -trimpath -ldflags="-w" -o bin/receiver ./cmd/receiver
 
 .PHONY: build
 build: build-hodometer build-receiver

--- a/hodometer/Makefile
+++ b/hodometer/Makefile
@@ -37,7 +37,7 @@ lint: ${.GOLANGCILINT_PATH}/golangci-lint
 .PHONY: build-hodometer
 build-hodometer: test-hodometer 
 	$(GO_ENV) \
-				go build -trimpath -ldflags="-s -w" \
+				go build -trimpath -ldflags="-w" \
 				-o bin/hodometer \
 				-ldflags=" \
 				-X '$(VERSION_PACKAGE).BuildVersion=$(BUILD_VERSION)' \

--- a/hodometer/Makefile
+++ b/hodometer/Makefile
@@ -37,7 +37,7 @@ lint: ${.GOLANGCILINT_PATH}/golangci-lint
 .PHONY: build-hodometer
 build-hodometer: test-hodometer 
 	$(GO_ENV) \
-				go build \
+				go build -trimpath -ldflags="-s -w" \
 				-o bin/hodometer \
 				-ldflags=" \
 				-X '$(VERSION_PACKAGE).BuildVersion=$(BUILD_VERSION)' \
@@ -52,7 +52,7 @@ build-hodometer-local: copy-components build-hodometer
 
 .PHONY: build-receiver
 build-receiver: test-receiver
-	$(GO_ENV) go build -o bin/receiver ./cmd/receiver
+	$(GO_ENV) go build -trimpath -ldflags="-s -w" -o bin/receiver ./cmd/receiver
 
 .PHONY: build
 build: build-hodometer build-receiver

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -16,7 +16,7 @@ COPY operator/pkg/ pkg/
 COPY operator/main.go main.go
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.4-15
 WORKDIR /

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -16,7 +16,7 @@ COPY operator/pkg/ pkg/
 COPY operator/main.go main.go
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-w" -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.4-15
 WORKDIR /

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -88,20 +88,20 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -trimpath -ldflags="-s -w" -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 build-seldon: generate fmt vet
-	go build -o bin/seldon -v ./cmd/seldon
+	go build -trimpath -ldflags="-s -w" -o bin/seldon -v ./cmd/seldon
 
 build-seldon-arm: generate fmt vet
-	GOOS=darwin GOARCH=arm64 go build -tags dynamic -o bin/seldon -v ./cmd/seldon
+	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -tags dynamic -o bin/seldon -v ./cmd/seldon
 
 build-seldon-docgen:
-	go build -o bin/seldon-gendocs -v ./cmd/seldon/docs
+	go build -trimpath -ldflags="-s -w" -o bin/seldon-gendocs -v ./cmd/seldon/docs
 
 generate-cli-docs:
 	./bin/seldon-gendocs --out ../docs/source/contents/cli/docs

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -88,20 +88,20 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -trimpath -ldflags="-s -w" -o bin/manager main.go
+	go build -trimpath -ldflags="-w" -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 build-seldon: generate fmt vet
-	go build -trimpath -ldflags="-s -w" -o bin/seldon -v ./cmd/seldon
+	go build -trimpath -ldflags="-w" -o bin/seldon -v ./cmd/seldon
 
 build-seldon-arm: generate fmt vet
-	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-s -w" -tags dynamic -o bin/seldon -v ./cmd/seldon
+	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags="-w" -tags dynamic -o bin/seldon -v ./cmd/seldon
 
 build-seldon-docgen:
-	go build -trimpath -ldflags="-s -w" -o bin/seldon-gendocs -v ./cmd/seldon/docs
+	go build -trimpath -ldflags="-w" -o bin/seldon-gendocs -v ./cmd/seldon/docs
 
 generate-cli-docs:
 	./bin/seldon-gendocs --out ../docs/source/contents/cli/docs

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -24,7 +24,7 @@ GID ?= $(shell id -g)
 
 KIND_NAME=seldon
 
-GO_LDFLAGS := -s -w $(patsubst %,-X %, $(GO_BUILD_VARS))
+GO_LDFLAGS := -w $(patsubst %,-X %, $(GO_BUILD_VARS))
 
 #####################################
 # Build

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -32,31 +32,31 @@ GO_LDFLAGS := -s -w $(patsubst %,-X %, $(GO_BUILD_VARS))
 
 .PHONY: build-scheduler
 build-scheduler: test-go
-	go build -buildvcs=false -o bin/scheduler ./cmd/scheduler
+	go build -trimpath -ldflags="-s -w" -buildvcs=false -o bin/scheduler ./cmd/scheduler
 
 .PHONY: build-proxy
 build-proxy: test-go
-	CGO_ENABLED=0 go build -o bin/proxy ./cmd/proxy
+	CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/proxy ./cmd/proxy
 
 .PHONY: build-agent
 build-agent: test-go
-	CGO_ENABLED=0 go build -buildvcs=false -o bin/agent ./cmd/agent
+	CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -buildvcs=false -o bin/agent ./cmd/agent
 
 .PHONY: build-modelgateway
 build-modelgateway: test-go
-	go build -o bin/modelgateway -v ./cmd/modelgateway
+	go build -trimpath -ldflags="-s -w" -o bin/modelgateway -v ./cmd/modelgateway
 
 .PHONY: build-pipelinegateway
 build-pipelinegateway: test-go
-	go build -o bin/pipelinegateway -v ./cmd/pipelinegateway
+	go build -trimpath -ldflags="-s -w" -o bin/pipelinegateway -v ./cmd/pipelinegateway
 
 .PHONY: build-dataflow-producer
 build-dataflow-producer: test-jvm
-	go build -o data-flow/scripts/bin/producer ./data-flow/scripts/producer.go ./data-flow/scripts/common.go
+	go build -trimpath -ldflags="-s -w" -o data-flow/scripts/bin/producer ./data-flow/scripts/producer.go ./data-flow/scripts/common.go
 
 .PHONY: build-dataflow-consumer
 build-dataflow-consumer:
-	go build -o data-flow/scripts/bin/consumer ./data-flow/scripts/consumer.go ./data-flow/scripts/common.go
+	go build -trimpath -ldflags="-s -w" -o data-flow/scripts/bin/consumer ./data-flow/scripts/consumer.go ./data-flow/scripts/common.go
 
 .PHONY: build-dataflow-engine
 build-dataflow-engine:

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -32,31 +32,31 @@ GO_LDFLAGS := -s -w $(patsubst %,-X %, $(GO_BUILD_VARS))
 
 .PHONY: build-scheduler
 build-scheduler: test-go
-	go build -trimpath -ldflags="-s -w" -buildvcs=false -o bin/scheduler ./cmd/scheduler
+	go build -trimpath -ldflags="-w" -buildvcs=false -o bin/scheduler ./cmd/scheduler
 
 .PHONY: build-proxy
 build-proxy: test-go
-	CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o bin/proxy ./cmd/proxy
+	CGO_ENABLED=0 go build -trimpath -ldflags="-w" -o bin/proxy ./cmd/proxy
 
 .PHONY: build-agent
 build-agent: test-go
-	CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -buildvcs=false -o bin/agent ./cmd/agent
+	CGO_ENABLED=0 go build -trimpath -ldflags="-w" -buildvcs=false -o bin/agent ./cmd/agent
 
 .PHONY: build-modelgateway
 build-modelgateway: test-go
-	go build -trimpath -ldflags="-s -w" -o bin/modelgateway -v ./cmd/modelgateway
+	go build -trimpath -ldflags="-w" -o bin/modelgateway -v ./cmd/modelgateway
 
 .PHONY: build-pipelinegateway
 build-pipelinegateway: test-go
-	go build -trimpath -ldflags="-s -w" -o bin/pipelinegateway -v ./cmd/pipelinegateway
+	go build -trimpath -ldflags="-w" -o bin/pipelinegateway -v ./cmd/pipelinegateway
 
 .PHONY: build-dataflow-producer
 build-dataflow-producer: test-jvm
-	go build -trimpath -ldflags="-s -w" -o data-flow/scripts/bin/producer ./data-flow/scripts/producer.go ./data-flow/scripts/common.go
+	go build -trimpath -ldflags="-w" -o data-flow/scripts/bin/producer ./data-flow/scripts/producer.go ./data-flow/scripts/common.go
 
 .PHONY: build-dataflow-consumer
 build-dataflow-consumer:
-	go build -trimpath -ldflags="-s -w" -o data-flow/scripts/bin/consumer ./data-flow/scripts/consumer.go ./data-flow/scripts/common.go
+	go build -trimpath -ldflags="-w" -o data-flow/scripts/bin/consumer ./data-flow/scripts/consumer.go ./data-flow/scripts/common.go
 
 .PHONY: build-dataflow-engine
 build-dataflow-engine:


### PR DESCRIPTION
**What this PR does / why we need it**:

It will reduce the binary size of output and will also remove prefixes from recorded source file paths.

This can be particularly useful for creating reproducible builds and for privacy reasons, as it strips out paths that might contain sensitive information like usernames or directory structures.
