### PR TITLE
fix(controller): Adjust controller -> scheduler state recreation upton scheduler disconnect.

### DIFF
--- a/operator/scheduler/experiment.go
+++ b/operator/scheduler/experiment.go
@@ -81,21 +81,6 @@ func (s *SchedulerClient) SubscribeExperimentEvents(ctx context.Context, grpcCli
 		return err
 	}
 
-	// get experiments from the scheduler
-	// if there are no experiments in the scheduler state then we need to create them
-	// this is likely because of a restart of the scheduler that migrated the state
-	// to v2 (where we delete the experiments from the scheduler state)
-	numExperimentsFromScheduler, err := getNumExperimentsFromScheduler(ctx, grpcClient)
-	if err != nil {
-		return err
-	}
-	// if there are no experiments in the scheduler state then we need to create them if they exist in k8s
-	// also remove finalizers from experiments that are being deleted
-	if numExperimentsFromScheduler == 0 {
-		handleLoadedExperiments(ctx, namespace, s, grpcClient)
-		handlePendingDeleteExperiments(ctx, namespace, s)
-	}
-
 	for {
 		event, err := stream.Recv()
 		if err != nil {

--- a/operator/scheduler/experiment_test.go
+++ b/operator/scheduler/experiment_test.go
@@ -322,7 +322,9 @@ func TestSubscribeExperimentsEvents(t *testing.T) {
 				}
 			}
 			controller := newMockControllerClient(test.existing_resources...)
-			err := controller.SubscribeExperimentEvents(context.Background(), &grpcClient, "")
+			err := handleExperiments(context.Background(), "", controller, &grpcClient)
+			g.Expect(err).To(BeNil())
+			err = controller.SubscribeExperimentEvents(context.Background(), &grpcClient, "")
 			g.Expect(err).To(BeNil())
 
 			isBeingDeleted := map[string]bool{}

--- a/operator/scheduler/experiment_test.go
+++ b/operator/scheduler/experiment_test.go
@@ -322,7 +322,7 @@ func TestSubscribeExperimentsEvents(t *testing.T) {
 				}
 			}
 			controller := newMockControllerClient(test.existing_resources...)
-			err := handleExperiments(context.Background(), "", controller, &grpcClient)
+			err := controller.handleExperiments(context.Background(), &grpcClient, "")
 			g.Expect(err).To(BeNil())
 			err = controller.SubscribeExperimentEvents(context.Background(), &grpcClient, "")
 			g.Expect(err).To(BeNil())

--- a/operator/scheduler/model.go
+++ b/operator/scheduler/model.go
@@ -124,11 +124,6 @@ func (s *SchedulerClient) SubscribeModelEvents(ctx context.Context, grpcClient s
 		return err
 	}
 
-	// on new reconnects check if we have models that are stuck in deletion and therefore we need to reconcile their states
-	go handlePendingDeleteModels(ctx, namespace, s, grpcClient)
-	// on new reconnects we reload the models that are marked as loaded in k8s as the scheduler might have lost the state
-	go handleLoadedModels(ctx, namespace, s, grpcClient)
-
 	for {
 		event, err := stream.Recv()
 		if err != nil {

--- a/operator/scheduler/model_test.go
+++ b/operator/scheduler/model_test.go
@@ -60,7 +60,7 @@ func TestSubscribeModelEvents(t *testing.T) {
 								Generation: 1,
 							},
 							State: &scheduler.ModelStatus{
-								State: scheduler.ModelStatus_ModelAvailable,
+								State:             scheduler.ModelStatus_ModelAvailable,
 								AvailableReplicas: 1,
 							},
 						},
@@ -92,8 +92,8 @@ func TestSubscribeModelEvents(t *testing.T) {
 								Generation: 1,
 							},
 							State: &scheduler.ModelStatus{
-								State: scheduler.ModelStatus_ModelProgressing,
-								AvailableReplicas: 0,
+								State:               scheduler.ModelStatus_ModelProgressing,
+								AvailableReplicas:   0,
 								UnavailableReplicas: 1,
 							},
 						},
@@ -160,7 +160,7 @@ func TestSubscribeModelEvents(t *testing.T) {
 								Generation: 1,
 							},
 							State: &scheduler.ModelStatus{
-								State: scheduler.ModelStatus_ModelTerminating,
+								State:             scheduler.ModelStatus_ModelTerminating,
 								AvailableReplicas: 1,
 							},
 						},

--- a/operator/scheduler/model_test.go
+++ b/operator/scheduler/model_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
+
+	mlopsv1alpha1 "github.com/seldonio/seldon-core/operator/v2/apis/mlops/v1alpha1"
+	"github.com/seldonio/seldon-core/operator/v2/pkg/constants"
+)
+
+func TestSubscribeModelEvents(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name               string
+		existing_resources []client.Object
+		results            []*scheduler.ModelStatusResponse
+		noSchedulerState   bool
+	}
+	now := metav1.Now()
+
+	// note expected state is derived in the test, maybe we should be explictl about it in the future
+	tests := []test{
+		{
+			name: "model available",
+			existing_resources: []client.Object{
+				&mlopsv1alpha1.Model{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "foo",
+						Namespace:  "default",
+						Generation: 1,
+					},
+					Status: mlopsv1alpha1.ModelStatus{
+						Replicas: 1,
+					},
+				},
+			},
+			results: []*scheduler.ModelStatusResponse{
+				{
+					ModelName: "foo",
+					Versions: []*scheduler.ModelVersionStatus{
+						{
+							KubernetesMeta: &scheduler.KubernetesMeta{
+								Namespace:  "default",
+								Generation: 1,
+							},
+							State: &scheduler.ModelStatus{
+								State: scheduler.ModelStatus_ModelAvailable,
+								AvailableReplicas: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "model not available",
+			existing_resources: []client.Object{
+				&mlopsv1alpha1.Model{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "foo",
+						Namespace:  "default",
+						Generation: 1,
+					},
+					Status: mlopsv1alpha1.ModelStatus{
+						Replicas: 1,
+					},
+				},
+			},
+			results: []*scheduler.ModelStatusResponse{
+				{
+					ModelName: "foo",
+					Versions: []*scheduler.ModelVersionStatus{
+						{
+							KubernetesMeta: &scheduler.KubernetesMeta{
+								Namespace:  "default",
+								Generation: 1,
+							},
+							State: &scheduler.ModelStatus{
+								State: scheduler.ModelStatus_ModelProgressing,
+								AvailableReplicas: 0,
+								UnavailableReplicas: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "model being removed",
+			existing_resources: []client.Object{
+				&mlopsv1alpha1.Model{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "foo",
+						Namespace:         "default",
+						Generation:        1,
+						DeletionTimestamp: &now,
+						Finalizers:        []string{constants.ModelFinalizerName},
+					},
+					Status: mlopsv1alpha1.ModelStatus{
+						Replicas: 1,
+					},
+				},
+			},
+			results: []*scheduler.ModelStatusResponse{
+				{
+					ModelName: "foo",
+					Versions: []*scheduler.ModelVersionStatus{
+						{
+							KubernetesMeta: &scheduler.KubernetesMeta{
+								Namespace:  "default",
+								Generation: 1,
+							},
+							State: &scheduler.ModelStatus{
+								State: scheduler.ModelStatus_ModelTerminated,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "model not removed",
+			existing_resources: []client.Object{
+				&mlopsv1alpha1.Model{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "foo",
+						Namespace:         "default",
+						Generation:        1,
+						DeletionTimestamp: &now,
+						Finalizers:        []string{constants.ModelFinalizerName},
+					},
+					Status: mlopsv1alpha1.ModelStatus{
+						Replicas: 1,
+					},
+				},
+			},
+			results: []*scheduler.ModelStatusResponse{
+				{
+					ModelName: "foo",
+					Versions: []*scheduler.ModelVersionStatus{
+						{
+							KubernetesMeta: &scheduler.KubernetesMeta{
+								Namespace:  "default",
+								Generation: 1,
+							},
+							State: &scheduler.ModelStatus{
+								State: scheduler.ModelStatus_ModelTerminating,
+								AvailableReplicas: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// note that if responses_pipelines is nil -> scheduler state is not existing
+			var grpcClient mockSchedulerGrpcClient
+			if !test.noSchedulerState {
+				grpcClient = mockSchedulerGrpcClient{
+					responses_subscribe_models: test.results,
+					responses_models:           test.results,
+				}
+			} else {
+				grpcClient = mockSchedulerGrpcClient{
+					responses_subscribe_models: test.results,
+				}
+			}
+			controller := newMockControllerClient(test.existing_resources...)
+			err := controller.handleModels(context.Background(), &grpcClient, "")
+			g.Expect(err).To(BeNil())
+			err = controller.SubscribeModelEvents(context.Background(), &grpcClient, "")
+			g.Expect(err).To(BeNil())
+
+			isBeingDeleted := map[string]bool{}
+			for _, req := range test.existing_resources {
+				if !req.GetDeletionTimestamp().IsZero() {
+					isBeingDeleted[req.GetName()] = true
+				} else {
+					isBeingDeleted[req.GetName()] = false
+				}
+			}
+
+			// for model resources that are not deleted we reload them
+			// this is not necessary check but added for sanity
+			activeResources := 0
+			for idx, req := range test.existing_resources {
+				if req.GetDeletionTimestamp().IsZero() {
+					g.Expect(req.GetName()).To(Equal(grpcClient.requests_models[idx].Model.GetMeta().GetName()))
+					activeResources++
+				}
+			}
+			g.Expect(len(grpcClient.requests_models)).To(Equal(activeResources))
+
+			// check state is correct for each model
+			for _, r := range test.results {
+				if r.Versions[0].State.GetState() != scheduler.ModelStatus_ModelTerminated {
+					model := &mlopsv1alpha1.Model{}
+					err := controller.Get(
+						context.Background(),
+						client.ObjectKey{
+							Name:      r.GetModelName(),
+							Namespace: r.Versions[0].KubernetesMeta.Namespace,
+						},
+						model,
+					)
+					// we check if the model is not in k8s (existing_resources) then we should not act on it
+					if _, ok := isBeingDeleted[r.GetModelName()]; !ok {
+						g.Expect(err).ToNot(BeNil())
+					} else {
+						g.Expect(err).To(BeNil())
+					}
+					if r.Versions[0].State.GetState() == scheduler.ModelStatus_ModelAvailable {
+						g.Expect(model.Status.IsReady()).To(BeTrueBecause("Model state is ModelAvailable"))
+					} else {
+						g.Expect(model.Status.IsReady()).To(BeFalseBecause("Model state is not ModelAvailable"))
+					}
+
+					g.Expect(uint32(model.Status.Replicas)).To(Equal(r.Versions[0].State.GetAvailableReplicas() + r.Versions[0].State.GetUnavailableReplicas()))
+					g.Expect(model.Status.Selector).To(Equal("server=" + r.Versions[0].ServerName))
+				} else {
+					model := &mlopsv1alpha1.Pipeline{}
+					err := controller.Get(
+						context.Background(),
+						client.ObjectKey{
+							Name:      r.GetModelName(),
+							Namespace: r.Versions[0].KubernetesMeta.Namespace,
+						},
+						model,
+					)
+					g.Expect(err).ToNot(BeNil())
+
+				}
+			}
+
+		})
+	}
+}

--- a/operator/scheduler/pipeline.go
+++ b/operator/scheduler/pipeline.go
@@ -92,20 +92,6 @@ func (s *SchedulerClient) SubscribePipelineEvents(ctx context.Context, grpcClien
 		return err
 	}
 
-	// get pipelines from the scheduler
-	// if there are no pipelines in the scheduler state then we need to create them
-	// this is likely because of the scheduler state got deleted
-	numPipelinesFromScheduler, err := getNumPipelinesFromScheduler(ctx, grpcClient)
-	if err != nil {
-		return err
-	}
-	// if there are no pipelines in the scheduler state then we need to create them if they exist in k8s
-	// also remove finalizers from pipelines that are being deleted
-	if numPipelinesFromScheduler == 0 {
-		handleLoadedPipelines(ctx, namespace, s, grpcClient)
-		handlePendingDeletePipelines(ctx, namespace, s)
-	}
-
 	for {
 		event, err := stream.Recv()
 		if err != nil {

--- a/operator/scheduler/pipeline_test.go
+++ b/operator/scheduler/pipeline_test.go
@@ -376,7 +376,7 @@ func TestSubscribePipelineEvents(t *testing.T) {
 				}
 			}
 			controller := newMockControllerClient(test.existing_resources...)
-			err := handlePipelines(context.Background(), "", controller, &grpcClient)
+			err := controller.handlePipelines(context.Background(), &grpcClient, "")
 			g.Expect(err).To(BeNil())
 			err = controller.SubscribePipelineEvents(context.Background(), &grpcClient, "")
 			g.Expect(err).To(BeNil())

--- a/operator/scheduler/pipeline_test.go
+++ b/operator/scheduler/pipeline_test.go
@@ -376,7 +376,9 @@ func TestSubscribePipelineEvents(t *testing.T) {
 				}
 			}
 			controller := newMockControllerClient(test.existing_resources...)
-			err := controller.SubscribePipelineEvents(context.Background(), &grpcClient, "")
+			err := handlePipelines(context.Background(), "", controller, &grpcClient)
+			g.Expect(err).To(BeNil())
+			err = controller.SubscribePipelineEvents(context.Background(), &grpcClient, "")
 			g.Expect(err).To(BeNil())
 
 			isBeingDeleted := map[string]bool{}

--- a/operator/scheduler/server.go
+++ b/operator/scheduler/server.go
@@ -91,9 +91,6 @@ func (s *SchedulerClient) SubscribeServerEvents(ctx context.Context, grpcClient 
 		return err
 	}
 
-	// // on new reconnects we send a list of servers to the schedule
-	// go handleRegisteredServers(ctx, namespace, s, grpcClient)
-
 	for {
 		event, err := stream.Recv()
 		if err != nil {

--- a/operator/scheduler/server.go
+++ b/operator/scheduler/server.go
@@ -91,8 +91,8 @@ func (s *SchedulerClient) SubscribeServerEvents(ctx context.Context, grpcClient 
 		return err
 	}
 
-	// on new reconnects we send a list of servers to the schedule
-	go handleRegisteredServers(ctx, namespace, s, grpcClient)
+	// // on new reconnects we send a list of servers to the schedule
+	// go handleRegisteredServers(ctx, namespace, s, grpcClient)
 
 	for {
 		event, err := stream.Recv()

--- a/operator/scheduler/server_test.go
+++ b/operator/scheduler/server_test.go
@@ -185,7 +185,7 @@ func TestSubscribeServerEvents(t *testing.T) {
 		noSchedulerState   bool
 	}
 
-	// note expected state is derived in the test, maybe we should be explictl about it in the future
+	// note expected state is derived in the test, maybe we should be explict about it in the future
 	tests := []test{
 		{
 			// no scheduler state means lost servers metadata

--- a/operator/scheduler/server_test.go
+++ b/operator/scheduler/server_test.go
@@ -185,7 +185,7 @@ func TestSubscribeServerEvents(t *testing.T) {
 		noSchedulerState   bool
 	}
 
-	// note expected state is derived in the test, maybe we should be explict about it in the future
+	// note expected state is derived in the test, maybe we should be explicit about it in the future
 	tests := []test{
 		{
 			// no scheduler state means lost servers metadata

--- a/operator/scheduler/utils.go
+++ b/operator/scheduler/utils.go
@@ -117,7 +117,7 @@ func handleLoadedModels(
 }
 
 func handleRegisteredServers(
-	ctx context.Context, namespace string, s *SchedulerClient, grpcClient scheduler.SchedulerClient) {
+	ctx context.Context, namespace string, s *SchedulerClient, grpcClient scheduler.SchedulerClient) error {
 	serverList := &v1alpha1.ServerList{}
 	// Get all servers in the namespace
 	err := s.List(
@@ -127,12 +127,15 @@ func handleRegisteredServers(
 	)
 	if err != nil {
 		s.logger.Error(err, "Failed to list servers", "namespace", namespace)
-		return
+		return err
 	}
 
 	if err := s.ServerNotify(ctx, grpcClient, serverList.Items, true); err != nil {
 		s.logger.Error(err, "Failed to notify servers", "servers", serverList.Items)
+		return err
 	}
+
+	return nil
 }
 
 func handlePendingDeleteModels(

--- a/operator/scheduler/utils.go
+++ b/operator/scheduler/utils.go
@@ -126,6 +126,7 @@ func handleRegisteredServers(
 		client.InNamespace(namespace),
 	)
 	if err != nil {
+		s.logger.Error(err, "Failed to list servers", "namespace", namespace)
 		return
 	}
 

--- a/operator/scheduler/utils.go
+++ b/operator/scheduler/utils.go
@@ -315,7 +315,7 @@ func getNumPipelinesFromScheduler(ctx context.Context, grpcClient scheduler.Sche
 }
 
 func (s *SchedulerClient) handleExperiments(
-	ctx context.Context, grpcClient scheduler.SchedulerClient, namespace string,) error {
+	ctx context.Context, grpcClient scheduler.SchedulerClient, namespace string) error {
 	// get experiments from the scheduler
 	// if there are no experiments in the scheduler state then we need to create them
 	// this is likely because of a restart of the scheduler that migrated the state
@@ -339,7 +339,7 @@ func (s *SchedulerClient) handleExperiments(
 }
 
 func (s *SchedulerClient) handlePipelines(
-	ctx context.Context, grpcClient scheduler.SchedulerClient, namespace string, ) error {
+	ctx context.Context, grpcClient scheduler.SchedulerClient, namespace string) error {
 	// get pipelines from the scheduler
 	// if there are no pipelines in the scheduler state then we need to create them
 	// this is likely because of a restart of the scheduler that migrated the state

--- a/operator/scheduler/utils_test.go
+++ b/operator/scheduler/utils_test.go
@@ -305,7 +305,7 @@ func TestHandleLoadedExperiments(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			handleLoadedExperiments(context.Background(), "", client, &grpcClient)
+			client.handleLoadedExperiments(context.Background(), &grpcClient, "")
 			activeResources := 0
 			// TODO check the entire object
 			for idx, req := range test.resources {
@@ -375,7 +375,7 @@ func TestHandleLoadedModels(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			handleLoadedModels(context.Background(), "", client, &grpcClient)
+			client.handleLoadedModels(context.Background(), &grpcClient, "")
 			activeResources := 0
 			// TODO check the entire object
 			for idx, req := range test.resources {
@@ -445,7 +445,7 @@ func TestHandleLoadedPipelines(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			handleLoadedPipelines(context.Background(), "", client, &grpcClient)
+			client.handleLoadedPipelines(context.Background(), &grpcClient, "")
 			activeResources := 0
 			// TODO check the entire object
 			for idx, req := range test.resources {
@@ -514,7 +514,7 @@ func TestHandleDeletedExperiments(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			s := newMockControllerClient(test.resources...)
-			handlePendingDeleteExperiments(context.Background(), "", s)
+			s.handlePendingDeleteExperiments(context.Background(), "")
 
 			actualResourcesList := &mlopsv1alpha1.ExperimentList{}
 			// Get all experiments in the namespace
@@ -592,7 +592,7 @@ func TestHandleDeletedPipelines(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			s := newMockControllerClient(test.resources...)
-			handlePendingDeletePipelines(context.Background(), "", s)
+			s.handlePendingDeletePipelines(context.Background(), "")
 
 			actualResourcesList := &mlopsv1alpha1.PipelineList{}
 			// Get all pipelines in the namespace
@@ -675,7 +675,7 @@ func TestHandleDeletedModels(t *testing.T) {
 				},
 			}
 			s := newMockControllerClient(test.resources...)
-			handlePendingDeleteModels(context.Background(), "", s, &grpcClient)
+			s.handlePendingDeleteModels(context.Background(), &grpcClient, "")
 
 			actualResourcesList := &mlopsv1alpha1.ModelList{}
 			// Get all models in the namespace
@@ -777,7 +777,7 @@ func TestHandleRegisteredServers(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			handleRegisteredServers(context.Background(), "", client, &grpcClient)
+			client.handleRegisteredServers(context.Background(), &grpcClient, "")
 			g.Expect(grpcClient.requests_servers).To(Equal(test.expected))
 		})
 	}

--- a/operator/scheduler/utils_test.go
+++ b/operator/scheduler/utils_test.go
@@ -332,7 +332,8 @@ func TestHandleLoadedExperiments(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			client.handleLoadedExperiments(context.Background(), &grpcClient, "")
+			err := client.handleLoadedExperiments(context.Background(), &grpcClient, "")
+			g.Expect(err).To(BeNil())
 			activeResources := 0
 			// TODO check the entire object
 			for idx, req := range test.resources {
@@ -402,7 +403,8 @@ func TestHandleLoadedModels(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			client.handleLoadedModels(context.Background(), &grpcClient, "")
+			err := client.handleLoadedModels(context.Background(), &grpcClient, "")
+			g.Expect(err).To(BeNil())
 			activeResources := 0
 			// TODO check the entire object
 			for idx, req := range test.resources {
@@ -472,7 +474,8 @@ func TestHandleLoadedPipelines(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			client.handleLoadedPipelines(context.Background(), &grpcClient, "")
+			err := client.handleLoadedPipelines(context.Background(), &grpcClient, "")
+			g.Expect(err).To(BeNil())
 			activeResources := 0
 			// TODO check the entire object
 			for idx, req := range test.resources {
@@ -541,11 +544,12 @@ func TestHandleDeletedExperiments(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			s := newMockControllerClient(test.resources...)
-			s.handlePendingDeleteExperiments(context.Background(), "")
+			err := s.handlePendingDeleteExperiments(context.Background(), "")
+			g.Expect(err).To(BeNil())
 
 			actualResourcesList := &mlopsv1alpha1.ExperimentList{}
 			// Get all experiments in the namespace
-			err := s.List(
+			err = s.List(
 				context.Background(),
 				actualResourcesList,
 				client.InNamespace(""),
@@ -619,11 +623,12 @@ func TestHandleDeletedPipelines(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			s := newMockControllerClient(test.resources...)
-			s.handlePendingDeletePipelines(context.Background(), "")
+			err := s.handlePendingDeletePipelines(context.Background(), "")
+			g.Expect(err).To(BeNil())
 
 			actualResourcesList := &mlopsv1alpha1.PipelineList{}
 			// Get all pipelines in the namespace
-			err := s.List(
+			err = s.List(
 				context.Background(),
 				actualResourcesList,
 				client.InNamespace(""),
@@ -702,11 +707,12 @@ func TestHandleDeletedModels(t *testing.T) {
 				},
 			}
 			s := newMockControllerClient(test.resources...)
-			s.handlePendingDeleteModels(context.Background(), &grpcClient, "")
+			err := s.handlePendingDeleteModels(context.Background(), &grpcClient, "")
+			g.Expect(err).To(BeNil())
 
 			actualResourcesList := &mlopsv1alpha1.ModelList{}
 			// Get all models in the namespace
-			err := s.List(
+			err = s.List(
 				context.Background(),
 				actualResourcesList,
 				client.InNamespace(""),
@@ -804,7 +810,8 @@ func TestHandleRegisteredServers(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			grpcClient := mockSchedulerGrpcClient{}
 			client := newMockControllerClient(test.resources...)
-			client.handleRegisteredServers(context.Background(), &grpcClient, "")
+			err := client.handleRegisteredServers(context.Background(), &grpcClient, "")
+			g.Expect(err).To(BeNil())
 			g.Expect(grpcClient.requests_servers).To(Equal(test.expected))
 		})
 	}

--- a/operator/scheduler/utils_test.go
+++ b/operator/scheduler/utils_test.go
@@ -156,6 +156,31 @@ func (s *mockSchedulerExperimentSubscribeGrpcClient) Recv() (*scheduler.Experime
 	return nil, io.EOF
 }
 
+// Model subscribe mock grpc client
+
+type mockSchedulerModelSubscribeGrpcClient struct {
+	counter int
+	results []*scheduler.ModelStatusResponse
+	grpc.ClientStream
+}
+
+var _ scheduler.Scheduler_SubscribeModelStatusClient = (*mockSchedulerModelSubscribeGrpcClient)(nil)
+
+func newMockSchedulerModelSubscribeGrpcClient(results []*scheduler.ModelStatusResponse) *mockSchedulerModelSubscribeGrpcClient {
+	return &mockSchedulerModelSubscribeGrpcClient{
+		results: results,
+		counter: 0,
+	}
+}
+
+func (s *mockSchedulerModelSubscribeGrpcClient) Recv() (*scheduler.ModelStatusResponse, error) {
+	if s.counter < len(s.results) {
+		s.counter++
+		return s.results[s.counter-1], nil
+	}
+	return nil, io.EOF
+}
+
 // Scheduler mock grpc client
 
 type mockSchedulerGrpcClient struct {
@@ -165,6 +190,8 @@ type mockSchedulerGrpcClient struct {
 	responses_subscribe_pipelines   []*scheduler.PipelineStatusResponse
 	responses_servers               []*scheduler.ServerStatusResponse
 	responses_subscribe_servers     []*scheduler.ServerStatusResponse
+	responses_models                []*scheduler.ModelStatusResponse
+	responses_subscribe_models      []*scheduler.ModelStatusResponse
 	requests_experiments            []*scheduler.StartExperimentRequest
 	requests_pipelines              []*scheduler.LoadPipelineRequest
 	requests_models                 []*scheduler.LoadModelRequest
@@ -226,7 +253,7 @@ func (s *mockSchedulerGrpcClient) SubscribeServerStatus(ctx context.Context, in 
 	return newMockSchedulerServerSubscribeGrpcClient(s.responses_subscribe_servers), nil
 }
 func (s *mockSchedulerGrpcClient) SubscribeModelStatus(ctx context.Context, in *scheduler.ModelSubscriptionRequest, opts ...grpc.CallOption) (scheduler.Scheduler_SubscribeModelStatusClient, error) {
-	return nil, nil
+	return newMockSchedulerModelSubscribeGrpcClient(s.responses_subscribe_models), nil
 }
 func (s *mockSchedulerGrpcClient) SubscribeExperimentStatus(ctx context.Context, in *scheduler.ExperimentSubscriptionRequest, opts ...grpc.CallOption) (scheduler.Scheduler_SubscribeExperimentStatusClient, error) {
 	return newMockSchedulerExperimentSubscribeGrpcClient(s.responses_subscribe_experiments), nil

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -245,7 +245,7 @@ func (s *SchedulerServer) ServerNotify(ctx context.Context, req *pb.ServerNotify
 		}
 		numExpectedReplicas += uint(server.ExpectedReplicas)
 	}
-	if req.IsFirstSync {
+	if req.IsFirstSync && !s.synchroniser.IsReady() {
 		s.synchroniser.Signals(numExpectedReplicas)
 		logger.Infof("Signalling synchroniser with %d expected server agents to connect", numExpectedReplicas)
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR changes the way we are resetting scheduler / controller state upon connection drops. Previously the state reconstruction was tightly couples with stream handling and this had a few issues:
- blutring of concerns as establishing streams didnt overlap really with state reconstruction
- Not all streams disconnected (because of the way we handled errors) and therefore it is not always that we recreate the entire state upon disconnection.

The solution is to separate out the logic and trigger state reconstruction if _any_ of the streams disconnects. These oeprations are idempotent and therefore it is fine to send them anyway. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

INFRA-1198 (internal).

**Special notes for your reviewer**:
