### PR TITLE
feat: stateful set persistent volume claim retention policy

### DIFF
--- a/operator/apis/mlops/v1alpha1/server_types.go
+++ b/operator/apis/mlops/v1alpha1/server_types.go
@@ -10,6 +10,7 @@ the Change License after the Change Date as each is defined in accordance with t
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -37,6 +38,8 @@ type ServerSpec struct {
 	// PodSpec overrides
 	// Slices such as containers would be appended not overridden
 	PodSpec *PodSpec `json:"podSpec,omitempty"`
+	// StatefulSetPersistentVolumeClaimRetentionPolicy policy for stateful set pvc
+	StatefulSetPersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"statefulSetPersistentVolumeClaimRetentionPolicy,omitempty"`
 	// Scaling spec
 	ScalingSpec `json:",inline"`
 	// +Optional

--- a/operator/controllers/reconcilers/server/server_reconciler.go
+++ b/operator/controllers/reconcilers/server/server_reconciler.go
@@ -137,6 +137,7 @@ func (s *ServerReconciler) createStatefulSetReconciler(server *mlopsv1alpha1.Ser
 		podSpec,
 		serverConfig.Spec.VolumeClaimTemplates,
 		&server.Spec.ScalingSpec,
+		server.Spec.StatefulSetPersistentVolumeClaimRetentionPolicy,
 		serverConfig.ObjectMeta,
 		annotator)
 	return statefulSetReconciler, nil

--- a/operator/controllers/reconcilers/server/server_reconciler_test.go
+++ b/operator/controllers/reconcilers/server/server_reconciler_test.go
@@ -72,6 +72,40 @@ func TestServerReconcile(t *testing.T) {
 			expectedSvcNames:        []string{"myserver-0"},
 			expectedStatefulSetName: "myserver",
 		},
+		{
+			name: "Test StatefulSetPersistentVolumeClaimRetentionPolicy",
+			serverConfig: &mlopsv1alpha1.ServerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mlserverConfigName,
+					Namespace: constants.SeldonNamespace,
+				},
+				Spec: mlopsv1alpha1.ServerConfigSpec{
+					PodSpec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "mlserver",
+								Image: "seldonio/mlserver:0.5",
+							},
+						},
+					},
+				},
+			},
+			server: &mlopsv1alpha1.Server{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myserver",
+					Namespace: constants.SeldonNamespace,
+				},
+				Spec: mlopsv1alpha1.ServerSpec{
+					ServerConfig: mlserverConfigName,
+					StatefulSetPersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+						WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+						WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+					},
+				},
+			},
+			expectedSvcNames:        []string{"myserver-0"},
+			expectedStatefulSetName: "myserver",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/operator/controllers/reconcilers/server/statefulset_reconciler.go
+++ b/operator/controllers/reconcilers/server/statefulset_reconciler.go
@@ -41,6 +41,7 @@ func NewServerStatefulSetReconciler(
 	podSpec *v1.PodSpec,
 	volumeClaimTemplates []mlopsv1alpha1.PersistentVolumeClaim,
 	scaling *mlopsv1alpha1.ScalingSpec,
+	policy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy,
 	serverConfigMeta metav1.ObjectMeta,
 	annotator *patch.Annotator,
 ) *ServerStatefulSetReconciler {
@@ -48,7 +49,7 @@ func NewServerStatefulSetReconciler(
 	annotations := utils.MergeMaps(meta.Annotations, serverConfigMeta.Annotations)
 	return &ServerStatefulSetReconciler{
 		ReconcilerConfig: common,
-		StatefulSet:      toStatefulSet(meta, podSpec, volumeClaimTemplates, scaling, labels, annotations),
+		StatefulSet:      toStatefulSet(meta, podSpec, volumeClaimTemplates, scaling, policy, labels, annotations),
 		Annotator:        annotator,
 	}
 }
@@ -61,6 +62,7 @@ func toStatefulSet(meta metav1.ObjectMeta,
 	podSpec *v1.PodSpec,
 	volumeClaimTemplates []mlopsv1alpha1.PersistentVolumeClaim,
 	scaling *mlopsv1alpha1.ScalingSpec,
+	policy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy,
 	labels map[string]string,
 	annotations map[string]string) *appsv1.StatefulSet {
 	labels[constants.KubernetesNameLabelKey] = constants.ServerLabelValue
@@ -88,7 +90,8 @@ func toStatefulSet(meta metav1.ObjectMeta,
 				},
 				Spec: *podSpec,
 			},
-			PodManagementPolicy: appsv1.ParallelPodManagement,
+			PodManagementPolicy:                  appsv1.ParallelPodManagement,
+			PersistentVolumeClaimRetentionPolicy: policy,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is to enhance this default behaviour from Core v2, such that a PVC should be released/deleted when the associated STS pod is scaled down or deleted. 

```
  persistentVolumeClaimRetentionPolicy:
    whenDeleted: Retain
    whenScaled: Retain
```

**Screenshot from unit test**

<img width="929" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/e597f4b2-3c1c-45e6-8dc2-2d0fe1cee604">

**Quick info**

From k8s v1.27 we have a beta feature called PersistentVolumeClaim retention [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) which can be used to manage the pvc’s which are created by STS. In Core v2 we are creating the PVC for a model as a part of serverconfig's volumeClaimTemplates spec which will be present in the statefulset which gets created as soon as a server is created.


**Which issue(s) this PR fixes**:

Fixes #INFRA-851
