### PR TITLE
feat(scheduler):  set a ttl on deleted pipelines and experiments

### DIFF
--- a/scheduler/pkg/store/experiment/db.go
+++ b/scheduler/pkg/store/experiment/db.go
@@ -10,8 +10,6 @@ the Change License after the Change Date as each is defined in accordance with t
 package experiment
 
 import (
-	"time"
-
 	"github.com/dgraph-io/badger/v3"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
@@ -75,8 +73,7 @@ func (edb *ExperimentDBManager) save(experiment *Experiment) error {
 			return err
 		})
 	} else {
-		// useful for testing
-		ttl := time.Until(experiment.DeletedAt.Add(utils.DeletedResourceTTL))
+		ttl := utils.DeletedResourceTTL
 		return edb.db.Update(func(txn *badger.Txn) error {
 			e := badger.NewEntry([]byte(experiment.Name), experimentBytes).WithTTL(ttl)
 			err = txn.SetEntry(e)

--- a/scheduler/pkg/store/experiment/db_test.go
+++ b/scheduler/pkg/store/experiment/db_test.go
@@ -357,12 +357,12 @@ func TestSaveAndRestoreDeletedExperiments(t *testing.T) {
 
 	tests := []test{
 		{
-			name:       "deleted experiment with ttl",
+			name:       "deleted experiment with ttl does not exist after restore",
 			experiment: createDeletedExperiment("with-ttl"),
 			withTTL:    true,
 		},
 		{
-			name:       "deleted experiment without ttl",
+			name:       "deleted experiment without ttl does exist after restore",
 			experiment: createDeletedExperiment("without-ttl"),
 			withTTL:    false,
 		},

--- a/scheduler/pkg/store/experiment/db_test.go
+++ b/scheduler/pkg/store/experiment/db_test.go
@@ -107,7 +107,8 @@ func TestSaveWithTTL(t *testing.T) {
 	logger := log.New()
 	db, err := newExperimentDbManager(getExperimentDbFolder(path), logger)
 	g.Expect(err).To(BeNil())
-	err = db.save(experiment, &ttl)
+	experiment.DeletedAt = time.Now().Add(ttl - utils.DeletedResourceTTL)
+	err = db.save(experiment)
 	g.Expect(err).To(BeNil())
 
 	persistedExp, err := db.get(experiment.Name)
@@ -303,7 +304,7 @@ func TestSaveAndRestore(t *testing.T) {
 			db, err := newExperimentDbManager(getExperimentDbFolder(path), logger)
 			g.Expect(err).To(BeNil())
 			for _, p := range test.experiments {
-				err := db.save(p, nil)
+				err := db.save(p)
 				g.Expect(err).To(BeNil())
 			}
 			err = db.Stop()
@@ -375,12 +376,11 @@ func TestSaveAndRestoreDeletedExperiments(t *testing.T) {
 			edb, err := newExperimentDbManager(getExperimentDbFolder(path), logger)
 			g.Expect(err).To(BeNil())
 			if !test.withTTL {
-				err := edb.save(&test.experiment, nil)
+				err := edb.save(&test.experiment)
 				g.Expect(err).To(BeNil())
 			} else {
-				ttl := time.Duration(time.Microsecond * 2)
-				err := edb.save(&test.experiment, &ttl)
-				time.Sleep(ttl * 2)
+				test.experiment.DeletedAt = time.Now().Add(-utils.DeletedResourceTTL)
+				err := edb.save(&test.experiment)
 				g.Expect(err).To(BeNil())
 			}
 			err = edb.Stop()
@@ -523,7 +523,7 @@ func TestGetExperimentFromDB(t *testing.T) {
 			db, err := newExperimentDbManager(getExperimentDbFolder(path), logger)
 			g.Expect(err).To(BeNil())
 			for _, p := range test.experiments {
-				err := db.save(p, nil)
+				err := db.save(p)
 				g.Expect(err).To(BeNil())
 			}
 
@@ -663,7 +663,7 @@ func TestDeleteExperimentFromDB(t *testing.T) {
 			db, err := newExperimentDbManager(getExperimentDbFolder(path), logger)
 			g.Expect(err).To(BeNil())
 			for _, p := range test.experiments {
-				err := db.save(p, nil)
+				err := db.save(p)
 				g.Expect(err).To(BeNil())
 			}
 

--- a/scheduler/pkg/store/experiment/experiment.go
+++ b/scheduler/pkg/store/experiment/experiment.go
@@ -9,6 +9,8 @@ the Change License after the Change Date as each is defined in accordance with t
 
 package experiment
 
+import "time"
+
 type ResourceType uint32
 
 const (
@@ -20,6 +22,7 @@ type Experiment struct {
 	Name              string
 	Active            bool
 	Deleted           bool
+	DeletedAt         time.Time
 	Default           *string
 	ResourceType      ResourceType
 	Candidates        []*Candidate

--- a/scheduler/pkg/store/experiment/store.go
+++ b/scheduler/pkg/store/experiment/store.go
@@ -357,7 +357,7 @@ func (es *ExperimentStore) startExperimentImpl(experiment *Experiment) (*coordin
 				ModelName: *resourceName,
 			}
 		default:
-			return nil, nil, nil, fmt.Errorf("Unknown resource type %v", experiment.ResourceType)
+			return nil, nil, nil, fmt.Errorf("unknown resource type %v", experiment.ResourceType)
 		}
 	}
 	es.updateExperimentState(experiment)
@@ -381,8 +381,7 @@ func (es *ExperimentStore) StopExperiment(experimentName string) error {
 			es.eventHub.PublishModelEvent(experimentStopEventSource, *modelEvt)
 		}
 		if pipelineEvt != nil {
-			// TODO: is this a bug?
-			es.eventHub.PublishPipelineEvent(experimentStartEventSource, *pipelineEvt)
+			es.eventHub.PublishPipelineEvent(experimentStopEventSource, *pipelineEvt)
 		}
 		if expEvt != nil {
 			es.eventHub.PublishExperimentEvent(experimentStopEventSource, *expEvt)

--- a/scheduler/pkg/store/experiment/store.go
+++ b/scheduler/pkg/store/experiment/store.go
@@ -480,9 +480,11 @@ func (es *ExperimentStore) cleanupDeletedExperiments() {
 			defer es.mu.Unlock()
 			if experiment.DeletedAt.IsZero() {
 				experiment.DeletedAt = time.Now()
-				err := es.db.save(experiment)
-				if err != nil {
-					es.logger.Warnf("could not update DB TTL for experiment: %s", experiment.Name)
+				if es.db != nil {
+					err := es.db.save(experiment)
+					if err != nil {
+						es.logger.Warnf("could not update DB TTL for experiment: %s", experiment.Name)
+					}
 				}
 			} else if experiment.DeletedAt.Add(utils.DeletedResourceTTL).Before(time.Now()) {
 				es.experiments[experiment.Name] = nil

--- a/scheduler/pkg/store/experiment/store.go
+++ b/scheduler/pkg/store/experiment/store.go
@@ -128,7 +128,6 @@ func (es *ExperimentStore) InitialiseOrRestoreDB(path string) error {
 	}
 	go func() {
 		ticker := time.NewTicker(utils.DeletedResourceCleanupFrequency)
-		defer ticker.Stop()
 		for range ticker.C {
 			es.cleanupDeletedExperiments()
 		}
@@ -473,11 +472,11 @@ func (es *ExperimentStore) GetExperiments() ([]*Experiment, error) {
 }
 
 func (es *ExperimentStore) cleanupDeletedExperiments() {
+	es.mu.Lock()
+	defer es.mu.Unlock()
 	es.logger.Info("cleaning up deleted experiments")
 	for _, experiment := range es.experiments {
 		if experiment.Deleted {
-			es.mu.Lock()
-			defer es.mu.Unlock()
 			if experiment.DeletedAt.IsZero() {
 				experiment.DeletedAt = time.Now()
 				if es.db != nil {

--- a/scheduler/pkg/store/experiment/store.go
+++ b/scheduler/pkg/store/experiment/store.go
@@ -486,7 +486,7 @@ func (es *ExperimentStore) cleanupDeletedExperiments() {
 					}
 				}
 			} else if experiment.DeletedAt.Add(utils.DeletedResourceTTL).Before(time.Now()) {
-				es.experiments[experiment.Name] = nil
+				delete(es.experiments, experiment.Name)
 			}
 		}
 	}

--- a/scheduler/pkg/store/experiment/store.go
+++ b/scheduler/pkg/store/experiment/store.go
@@ -480,7 +480,10 @@ func (es *ExperimentStore) cleanupDeletedExperiments() {
 			defer es.mu.Unlock()
 			if experiment.DeletedAt.IsZero() {
 				experiment.DeletedAt = time.Now()
-				es.db.save(experiment)
+				err := es.db.save(experiment)
+				if err != nil {
+					es.logger.Warnf("could not update DB TTL for experiment: %s", experiment.Name)
+				}
 			} else if experiment.DeletedAt.Add(utils.DeletedResourceTTL).Before(time.Now()) {
 				es.experiments[experiment.Name] = nil
 			}

--- a/scheduler/pkg/store/experiment/store.go
+++ b/scheduler/pkg/store/experiment/store.go
@@ -100,8 +100,8 @@ func (es *ExperimentStore) addExperimentInMap(experiment *Experiment) error {
 	logger := es.logger.WithField("func", "AddExperimentInMap")
 	es.mu.Lock()
 	defer es.mu.Unlock()
-	// ensure a reasonable ttl is set for deleted experiments
-	if experiment.Deleted && time.Now().After(experiment.DeletedAt) {
+	// ensure a ttl is set for deleted experiments
+	if experiment.Deleted && experiment.DeletedAt.IsZero() {
 		logger.Infof("updating ttl for experiment %s", experiment.Name)
 		experiment.DeletedAt = time.Now()
 		err := es.db.save(experiment)

--- a/scheduler/pkg/store/experiment/store_test.go
+++ b/scheduler/pkg/store/experiment/store_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -264,7 +265,7 @@ func TestStopExperiment(t *testing.T) {
 			err := test.store.InitialiseOrRestoreDB(path)
 			g.Expect(err).To(BeNil())
 			for _, p := range test.store.experiments {
-				err := test.store.db.save(p, nil)
+				err := test.store.db.save(p)
 				g.Expect(err).To(BeNil())
 			}
 
@@ -415,7 +416,7 @@ func TestRestoreExperiments(t *testing.T) {
 			err := store.InitialiseOrRestoreDB(path)
 			g.Expect(err).To(BeNil())
 			for _, p := range test.experiments {
-				err := store.db.save(p, nil)
+				err := store.db.save(p)
 				g.Expect(err).To(BeNil())
 			}
 			_ = store.db.Stop()
@@ -432,10 +433,13 @@ func TestRestoreExperiments(t *testing.T) {
 				expectedExperiment, ok := test.experiments[p.Name]
 				g.Expect(ok).To(BeTrue())
 				g.Expect(expectedExperiment.Deleted).To(Equal(p.Deleted))
-				g.Expect(cmp.Equal(p, expectedExperiment)).To(BeTrue())
-			}
+				g.Expect(cmp.Equal(p.Name, expectedExperiment.Name)).To(BeTrue())
+				if expectedExperiment.Deleted {
+					g.Expect(expectedExperiment.DeletedAt.Before(time.Now())).To(BeTrue())
+				}
 
-			g.Expect(len(store.experiments)).To(Equal(len(test.experiments)))
+				g.Expect(len(store.experiments)).To(Equal(len(test.experiments)))
+			}
 		})
 	}
 }

--- a/scheduler/pkg/store/experiment/store_test.go
+++ b/scheduler/pkg/store/experiment/store_test.go
@@ -264,7 +264,7 @@ func TestStopExperiment(t *testing.T) {
 			err := test.store.InitialiseOrRestoreDB(path)
 			g.Expect(err).To(BeNil())
 			for _, p := range test.store.experiments {
-				err := test.store.db.save(p)
+				err := test.store.db.save(p, nil)
 				g.Expect(err).To(BeNil())
 			}
 
@@ -372,7 +372,8 @@ func TestRestoreExperiments(t *testing.T) {
 							Name: "model2",
 						},
 					},
-					Deleted: false},
+					Deleted: false,
+				},
 			},
 		},
 		{
@@ -394,7 +395,8 @@ func TestRestoreExperiments(t *testing.T) {
 							Name: "model2",
 						},
 					},
-					Deleted: false},
+					Deleted: false,
+				},
 				"b": {Name: "b", Deleted: true},
 			},
 		},
@@ -413,7 +415,7 @@ func TestRestoreExperiments(t *testing.T) {
 			err := store.InitialiseOrRestoreDB(path)
 			g.Expect(err).To(BeNil())
 			for _, p := range test.experiments {
-				err := store.db.save(p)
+				err := store.db.save(p, nil)
 				g.Expect(err).To(BeNil())
 			}
 			_ = store.db.Stop()

--- a/scheduler/pkg/store/pipeline/db.go
+++ b/scheduler/pkg/store/pipeline/db.go
@@ -10,8 +10,6 @@ the Change License after the Change Date as each is defined in accordance with t
 package pipeline
 
 import (
-	"time"
-
 	"github.com/dgraph-io/badger/v3"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
@@ -72,7 +70,7 @@ func save(pipeline *Pipeline, db *badger.DB) error {
 		})
 	} else {
 		// useful for testing
-		ttl := time.Until(pipeline.DeletedAt.Add(utils.DeletedResourceTTL))
+		ttl := utils.DeletedResourceTTL
 		return db.Update(func(txn *badger.Txn) error {
 			e := badger.NewEntry([]byte(pipeline.Name), pipelineBytes).WithTTL(ttl)
 			err = txn.SetEntry(e)

--- a/scheduler/pkg/store/pipeline/db.go
+++ b/scheduler/pkg/store/pipeline/db.go
@@ -71,7 +71,8 @@ func save(pipeline *Pipeline, db *badger.DB) error {
 			return err
 		})
 	} else {
-		ttl := time.Until(pipeline.DeletesAt)
+		// useful for testing
+		ttl := time.Until(pipeline.DeletedAt.Add(utils.DeletedResourceTTL))
 		return db.Update(func(txn *badger.Txn) error {
 			e := badger.NewEntry([]byte(pipeline.Name), pipelineBytes).WithTTL(ttl)
 			err = txn.SetEntry(e)
@@ -126,7 +127,7 @@ func (pdb *PipelineDBManager) restore(createPipelineCb func(pipeline *Pipeline))
 				}
 
 				if pipeline.Deleted {
-					pipeline.DeletesAt = utils.GetDeletesAt(item)
+					pipeline.DeletedAt = utils.GetDeletedAt(item)
 				}
 
 				createPipelineCb(pipeline)

--- a/scheduler/pkg/store/pipeline/db_test.go
+++ b/scheduler/pkg/store/pipeline/db_test.go
@@ -201,7 +201,7 @@ func TestSaveAndRestoreDeletedPipelines(t *testing.T) {
 
 	createdDeletedPipeline := func(name string) Pipeline {
 		return Pipeline{
-			Name:        "test-with",
+			Name:        name,
 			LastVersion: 0,
 			Versions: []*PipelineVersion{
 				{
@@ -228,12 +228,12 @@ func TestSaveAndRestoreDeletedPipelines(t *testing.T) {
 
 	tests := []test{
 		{
-			name:     "test deleted pipeline with TTL",
+			name:     "test deleted pipeline with TTL should not exist after restore",
 			pipeline: createdDeletedPipeline("with-ttl"),
 			withTTL:  true,
 		},
 		{
-			name:     "test deleted pipeline without TTL",
+			name:     "test deleted pipeline without TTL should exist after restore",
 			pipeline: createdDeletedPipeline("without-ttl"),
 			withTTL:  false,
 		},

--- a/scheduler/pkg/store/pipeline/db_test.go
+++ b/scheduler/pkg/store/pipeline/db_test.go
@@ -50,7 +50,7 @@ func TestSaveWithTTL(t *testing.T) {
 		Deleted: true,
 	}
 	ttl := time.Duration(time.Second)
-	pipeline.DeletesAt = time.Now().Add(ttl)
+	pipeline.DeletedAt = time.Now().Add(-utils.DeletedResourceTTL).Add(ttl)
 
 	path := fmt.Sprintf("%s/db", t.TempDir())
 	logger := log.New()
@@ -248,8 +248,7 @@ func TestSaveAndRestoreDeletedPipelines(t *testing.T) {
 			if !test.withTTL {
 				err = pdb.save(&test.pipeline)
 			} else {
-				ttl := time.Duration(time.Microsecond * 10)
-				test.pipeline.DeletesAt = time.Now().Add(-ttl)
+				test.pipeline.DeletedAt = time.Now().Add(-utils.DeletedResourceTTL)
 				err = pdb.save(&test.pipeline)
 			}
 			g.Expect(err).To(BeNil())

--- a/scheduler/pkg/store/pipeline/db_test.go
+++ b/scheduler/pkg/store/pipeline/db_test.go
@@ -227,12 +227,12 @@ func TestSaveAndRestoreDeletedPipelines(t *testing.T) {
 
 	tests := []test{
 		{
-			name:     "test deleted pipeline with TTL should not exist after restore",
+			name:     "test deleted pipeline with TTL should have deletedAt set",
 			pipeline: createdDeletedPipeline("with-ttl"),
 			withTTL:  true,
 		},
 		{
-			name:     "test deleted pipeline without TTL should exist after restore",
+			name:     "test deleted pipeline without TTL should have deletedAt set after cleanup",
 			pipeline: createdDeletedPipeline("without-ttl"),
 			withTTL:  false,
 		},

--- a/scheduler/pkg/store/pipeline/pipeline.go
+++ b/scheduler/pkg/store/pipeline/pipeline.go
@@ -19,7 +19,7 @@ type Pipeline struct {
 	LastVersion uint32
 	Versions    []*PipelineVersion
 	Deleted     bool
-	DeletesAt   time.Time
+	DeletedAt   time.Time
 }
 
 func (p *Pipeline) GetPipelineVersion(versionNumber uint32) *PipelineVersion {

--- a/scheduler/pkg/store/pipeline/pipeline.go
+++ b/scheduler/pkg/store/pipeline/pipeline.go
@@ -19,6 +19,7 @@ type Pipeline struct {
 	LastVersion uint32
 	Versions    []*PipelineVersion
 	Deleted     bool
+	DeletesAt   time.Time
 }
 
 func (p *Pipeline) GetPipelineVersion(versionNumber uint32) *PipelineVersion {

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -102,7 +102,6 @@ func (ps *PipelineStore) InitialiseOrRestoreDB(path string) error {
 
 	go func() {
 		ticker := time.NewTicker(utils.DeletedResourceCleanupFrequency)
-		defer ticker.Stop()
 		for range ticker.C {
 			ps.cleanupDeletedPipelines()
 		}
@@ -447,11 +446,11 @@ func (ps *PipelineStore) handleModelEvents(event coordinator.ModelEventMsg) {
 }
 
 func (ps *PipelineStore) cleanupDeletedPipelines() {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
 	ps.logger.Info("cleaning up deleted pipelines")
 	for _, pipeline := range ps.pipelines {
 		if pipeline.Deleted {
-			ps.mu.Lock()
-			defer ps.mu.Unlock()
 			if pipeline.DeletedAt.IsZero() {
 				pipeline.DeletedAt = time.Now()
 				if ps.db != nil {

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -105,8 +105,8 @@ func (ps *PipelineStore) InitialiseOrRestoreDB(path string) error {
 func (ps *PipelineStore) restorePipeline(pipeline *Pipeline) {
 	logger := ps.logger.WithField("func", "restorePipeline")
 
-	// ensure a resonable ttl is set for deleted pipelines
-	if pipeline.Deleted && time.Now().After(pipeline.DeletedAt) {
+	// ensure a ttl is set for deleted pipelines
+	if pipeline.Deleted && pipeline.DeletedAt.IsZero() {
 		logger.Infof("updating ttl for pipeline %s", pipeline.Name)
 		pipeline.DeletedAt = time.Now()
 		err := ps.db.save(pipeline)

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -454,9 +454,11 @@ func (ps *PipelineStore) cleanupDeletedPipelines() {
 			defer ps.mu.Unlock()
 			if pipeline.DeletedAt.IsZero() {
 				pipeline.DeletedAt = time.Now()
-				err := ps.db.save(pipeline)
-				if err != nil {
-					ps.logger.Warnf("could not update DB TTL for pipeline: %s", pipeline.Name)
+				if ps.db != nil {
+					err := ps.db.save(pipeline)
+					if err != nil {
+						ps.logger.Warnf("could not update DB TTL for pipeline: %s", pipeline.Name)
+					}
 				}
 			} else if pipeline.DeletedAt.Add(utils.DeletedResourceTTL).Before(time.Now()) {
 				ps.pipelines[pipeline.Name] = nil

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -460,7 +460,7 @@ func (ps *PipelineStore) cleanupDeletedPipelines() {
 					}
 				}
 			} else if pipeline.DeletedAt.Add(utils.DeletedResourceTTL).Before(time.Now()) {
-				ps.pipelines[pipeline.Name] = nil
+				delete(ps.pipelines, pipeline.Name)
 			}
 		}
 	}

--- a/scheduler/pkg/store/pipeline/store.go
+++ b/scheduler/pkg/store/pipeline/store.go
@@ -454,7 +454,10 @@ func (ps *PipelineStore) cleanupDeletedPipelines() {
 			defer ps.mu.Unlock()
 			if pipeline.DeletedAt.IsZero() {
 				pipeline.DeletedAt = time.Now()
-				ps.db.save(pipeline)
+				err := ps.db.save(pipeline)
+				if err != nil {
+					ps.logger.Warnf("could not update DB TTL for pipeline: %s", pipeline.Name)
+				}
 			} else if pipeline.DeletedAt.Add(utils.DeletedResourceTTL).Before(time.Now()) {
 				ps.pipelines[pipeline.Name] = nil
 			}

--- a/scheduler/pkg/store/utils/utils.go
+++ b/scheduler/pkg/store/utils/utils.go
@@ -48,7 +48,11 @@ func SaveVersion(db *badger.DB, version string) error {
 }
 
 func GetDeletedAt(item *badger.Item) time.Time {
-	return time.Unix(int64(item.ExpiresAt()), 0).Add(-DeletedResourceTTL)
+	if item.ExpiresAt() == 0 {
+		return time.Time{}
+	} else {
+		return time.Unix(int64(item.ExpiresAt()), 0).Add(-DeletedResourceTTL)
+	}
 }
 
 func GetVersion(db *badger.DB, defaultVal string) (string, error) {

--- a/scheduler/pkg/store/utils/utils.go
+++ b/scheduler/pkg/store/utils/utils.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	VersionKey                       = "__version_key__"
-	DeletedResourceTTL time.Duration = time.Duration(24 * time.Hour)
+	VersionKey                                    = "__version_key__"
+	DeletedResourceTTL              time.Duration = time.Duration(24 * time.Hour)
+	DeletedResourceCleanupFrequency time.Duration = time.Duration(10 * time.Minute)
 )
 
 func Open(path string, logger logrus.FieldLogger, source string) (*badger.DB, error) {

--- a/scheduler/pkg/store/utils/utils.go
+++ b/scheduler/pkg/store/utils/utils.go
@@ -47,8 +47,8 @@ func SaveVersion(db *badger.DB, version string) error {
 	})
 }
 
-func GetDeletesAt(item *badger.Item) time.Time {
-	return time.Unix(int64(item.ExpiresAt()), 0).Add(DeletedResourceTTL)
+func GetDeletedAt(item *badger.Item) time.Time {
+	return time.Unix(int64(item.ExpiresAt()), 0).Add(-DeletedResourceTTL)
 }
 
 func GetVersion(db *badger.DB, defaultVal string) (string, error) {

--- a/scheduler/pkg/store/utils/utils.go
+++ b/scheduler/pkg/store/utils/utils.go
@@ -10,12 +10,15 @@ the Change License after the Change Date as each is defined in accordance with t
 package utils
 
 import (
+	"time"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	VersionKey = "__version_key__"
+	VersionKey                       = "__version_key__"
+	DeletedResourceTTL time.Duration = time.Duration(24 * time.Hour)
 )
 
 func Open(path string, logger logrus.FieldLogger, source string) (*badger.DB, error) {
@@ -42,6 +45,10 @@ func SaveVersion(db *badger.DB, version string) error {
 	return db.Update(func(txn *badger.Txn) error {
 		return txn.Set([]byte(VersionKey), []byte(version))
 	})
+}
+
+func GetDeletesAt(item *badger.Item) time.Time {
+	return time.Unix(int64(item.ExpiresAt()), 0).Add(DeletedResourceTTL)
 }
 
 func GetVersion(db *badger.DB, defaultVal string) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a TTL to deleted pipeline and experiment DB items. The store will continue to grow unless deleted resources are cleaned up. Also, on restarts, the event hub needlessly processes the entire history of pipelines and experiments.

The state of the in-memory store (which is a map) will not be in sync with the DB, until the cleanup goroutine run, but this shouldn't cause any issues.

Disk space should be reclaimed whenever Badger runs GC and removes expired items (this is acutally the client's resposibility). We don't run GC explicitly, but it seems to occur whenever the DB is restored.

**Which issue(s) this PR fixes**:

Fixes #

INFRA-901

**Special notes for your reviewer**:

Please see - https://github.com/SeldonIO/seldon-core/compare/v2...driev:seldon-core:INFRA-901/scheduler-store-terminated-resource-cleanup?expand=1#diff-dd478884b4e1e3881b7a1e581ba1fe8e1db1e840b47f616a6eeac2674c342892R384
