### PR TITLE
fix: operator build fix for macOS arm chips

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -48,11 +48,11 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=v2-manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	sed -i '/namespace: seldon-mesh/d' config/rbac/role.yaml # remove namespace added by controller-gen
+	sed -i -e '/namespace: seldon-mesh/d' config/rbac/role.yaml # remove namespace added by controller-gen
 	cp config/rbac/role.yaml config/rbac/namespace_role.yaml
-	sed -i 's/ClusterRole/Role/' config/rbac/namespace_role.yaml
+	sed -i -e 's/ClusterRole/Role/' config/rbac/namespace_role.yaml
 	cp config/rbac/role_binding.yaml config/rbac/namespace_role_binding.yaml
-	sed -i 's/ClusterRole/Role/' config/rbac/namespace_role_binding.yaml
+	sed -i -e 's/ClusterRole/Role/' config/rbac/namespace_role_binding.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -176,7 +176,7 @@ build-push-deploy: build docker-build docker-push deploy-all
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.3)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the operator build on mac arm based chip
This was also reported here #5917 

I noticed that sed command is working differently on linux and macOS adding `-e` flag resolves the issue.
