### PR TITLE
feat: bump k8s kind to 1.31

### DIFF
--- a/ansible/playbooks/kind-cluster.yaml
+++ b/ansible/playbooks/kind-cluster.yaml
@@ -7,8 +7,8 @@
     kind_cluster_name: seldon
 
     # For compatible version of image for each kind version please see https://github.com/kubernetes-sigs/kind/releases
-    kind_version: v0.22.0
-    kind_image_version: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+    kind_version: v0.24.0
+    kind_image_version: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 
     kind_kubectl_default_namespace: seldon-mesh
     vars_file: vars/default.yaml

--- a/ansible/roles/kind/defaults/main.yaml
+++ b/ansible/roles/kind/defaults/main.yaml
@@ -4,8 +4,8 @@ seldon_cache_directory: "{{ ansible_env.HOME }}/.cache/seldon"
 kind_cluster_name: ansible
 
 # For compatible version of image for each kind version please see https://github.com/kubernetes-sigs/kind/releases
-kind_version: v0.22.0
-kind_image_version: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
+kind_version: v0.24.0
+kind_image_version: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 
 kind_url:  "https://kind.sigs.k8s.io/dl/{{ kind_version }}/kind-linux-amd64"
 kind_download_cli: true


### PR DESCRIPTION
This PR updates KinD installation to use k8s ver 1.31 and  kind 0.24
