### PR TITLE
fix(scheduler): Add grace period for model unload

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1575,6 +1575,8 @@ spec:
         value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
       - name: SELDON_MAX_UNLOAD_RETRY_COUNT
         value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
+      - name: SELDON_UNLOAD_GRACE_PERIOD_SECONDS
+        value: '{{ .Values.serverConfig.agent.unloadGracePeriodSeconds }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL
@@ -1839,6 +1841,8 @@ spec:
         value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
       - name: SELDON_MAX_UNLOAD_RETRY_COUNT
         value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
+      - name: SELDON_UNLOAD_GRACE_PERIOD_SECONDS
+        value: '{{ .Values.serverConfig.agent.unloadGracePeriodSeconds }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -255,6 +255,7 @@ serverConfig:
     maxUnloadElapsedTimeMinutes: "15"
     maxLoadRetryCount: "5"
     maxUnloadRetryCount: "1"
+    unloadGracePeriodSeconds: "2"
     resources:
       cpu: 200m
       memory: 1Gi

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -255,6 +255,7 @@ serverConfig:
     maxUnloadElapsedTimeMinutes: "15"
     maxLoadRetryCount: "5"
     maxUnloadRetryCount: "1"
+    unloadGracePeriodSeconds: "2"
     resources:
       cpu: 200m
       memory: 1Gi

--- a/k8s/kustomize/helm-components-sc/patch_mlserver.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_mlserver.yaml
@@ -38,6 +38,8 @@ spec:
         value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
       - name: SELDON_MAX_UNLOAD_RETRY_COUNT
         value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
+      - name: SELDON_UNLOAD_GRACE_PERIOD_SECONDS
+        value: '{{ .Values.serverConfig.agent.unloadGracePeriodSeconds }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL

--- a/k8s/kustomize/helm-components-sc/patch_triton.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_triton.yaml
@@ -38,6 +38,8 @@ spec:
         value: '{{ .Values.serverConfig.agent.maxLoadRetryCount }}'
       - name: SELDON_MAX_UNLOAD_RETRY_COUNT
         value: '{{ .Values.serverConfig.agent.maxUnloadRetryCount }}'
+      - name: SELDON_UNLOAD_GRACE_PERIOD_SECONDS
+        value: '{{ .Values.serverConfig.agent.unloadGracePeriodSeconds }}'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '{{ .Values.serverConfig.agent.overcommitPercentage }}'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -1198,6 +1198,8 @@ spec:
         value: '5'
       - name: SELDON_MAX_UNLOAD_RETRY_COUNT
         value: '1'
+      - name: SELDON_UNLOAD_GRACE_PERIOD_SECONDS
+        value: '2'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '10'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL
@@ -1452,6 +1454,8 @@ spec:
         value: '5'
       - name: SELDON_MAX_UNLOAD_RETRY_COUNT
         value: '1'
+      - name: SELDON_UNLOAD_GRACE_PERIOD_SECONDS
+        value: '2'
       - name: SELDON_OVERCOMMIT_PERCENTAGE
         value: '10'
       - name: CONTROL_PLANE_SECURITY_PROTOCOL

--- a/scheduler/cmd/agent/cli/cli.go
+++ b/scheduler/cmd/agent/cli/cli.go
@@ -49,6 +49,7 @@ const (
 	envMaxUnloadElapsedTimeMinutes                     = "SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES"
 	envMaxLoadRetryCount                               = "SELDON_MAX_LOAD_RETRY_COUNT"
 	envMaxUnloadRetryCount                             = "SELDON_MAX_UNLOAD_RETRY_COUNT"
+	envUnloadGraceSeconds                              = "SELDON_UNLOAD_GRACE_SECONDS"
 
 	flagSchedulerHost                                   = "scheduler-host"
 	flagSchedulerPlaintxtPort                           = "scheduler-port"
@@ -81,6 +82,7 @@ const (
 	flagMaxUnloadElapsedTimeMinutes                     = "max-unload-elapsed-time-minutes"
 	flagMaxLoadRetryCount                               = "max-load-retry-count"
 	flagMaxUnloadRetryCount                             = "max-unload-retry-count"
+	flagUnloadGraceSeconds                              = "unload-grace-seconds"
 )
 
 const (
@@ -103,6 +105,7 @@ const (
 	defaultMaxUnloadElapsedTimeMinute                      = 15
 	defaultMaxLoadRetryCount                               = 5
 	defaultMaxUnloadRetryCount                             = 1
+	defautUnloadGraceSeconds                               = 2
 )
 
 var (
@@ -148,6 +151,7 @@ var (
 	MaxUnloadElapsedTimeMinute                      int
 	MaxLoadRetryCount                               int
 	MaxUnloadRetryCount                             int
+	UnloadGraceSeconds                              int
 )
 
 func init() {
@@ -191,6 +195,7 @@ func updateFlagsFromEnv() {
 	maybeMaxUnloadElapsedTimeMinute()
 	maybeMaxLoadRetryCount()
 	maybeMaxUnloadRetryCount()
+	maybeUpdateUnloadGraceSeconds()
 }
 
 func maybeUpdateModelInferenceLagThreshold() {
@@ -433,6 +438,15 @@ func maybeMaxUnloadRetryCount() {
 		envMaxUnloadRetryCount,
 		&MaxUnloadRetryCount,
 		"max unload retry count",
+	)
+}
+
+func maybeUpdateUnloadGraceSeconds() {
+	maybeUpdateFromIntEnv(
+		flagUnloadGraceSeconds,
+		envUnloadGraceSeconds,
+		&UnloadGraceSeconds,
+		"unload grace seconds",
 	)
 }
 

--- a/scheduler/cmd/agent/cli/cli.go
+++ b/scheduler/cmd/agent/cli/cli.go
@@ -82,7 +82,7 @@ const (
 	flagMaxUnloadElapsedTimeMinutes                     = "max-unload-elapsed-time-minutes"
 	flagMaxLoadRetryCount                               = "max-load-retry-count"
 	flagMaxUnloadRetryCount                             = "max-unload-retry-count"
-	flagUnloadGraceSeconds                              = "unload-grace-seconds"
+	flagUnloadGraceSeconds                              = "unload-grace-period-seconds"
 )
 
 const (

--- a/scheduler/cmd/agent/cli/cli.go
+++ b/scheduler/cmd/agent/cli/cli.go
@@ -49,7 +49,7 @@ const (
 	envMaxUnloadElapsedTimeMinutes                     = "SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES"
 	envMaxLoadRetryCount                               = "SELDON_MAX_LOAD_RETRY_COUNT"
 	envMaxUnloadRetryCount                             = "SELDON_MAX_UNLOAD_RETRY_COUNT"
-	envUnloadGraceSeconds                              = "SELDON_UNLOAD_GRACE_SECONDS"
+	envUnloadGraceSeconds                              = "SELDON_UNLOAD_GRACE_PERIOD_SECONDS"
 
 	flagSchedulerHost                                   = "scheduler-host"
 	flagSchedulerPlaintxtPort                           = "scheduler-port"

--- a/scheduler/cmd/agent/cli/flags.go
+++ b/scheduler/cmd/agent/cli/flags.go
@@ -58,6 +58,7 @@ func makeArgs() {
 	flag.IntVar(&MaxUnloadElapsedTimeMinute, flagMaxUnloadElapsedTimeMinutes, defaultMaxUnloadElapsedTimeMinute, "Max time in minutes to wait for a model server to unload a model, including retries")
 	flag.IntVar(&MaxLoadRetryCount, flagMaxLoadRetryCount, defaultMaxLoadRetryCount, "Number of retries for loading a model onto a server")
 	flag.IntVar(&MaxUnloadRetryCount, flagMaxUnloadRetryCount, defaultMaxUnloadRetryCount, "Number of retries for unloading a model onto a server")
+	flag.IntVar(&UnloadGraceSeconds, flagUnloadGraceSeconds, defautUnloadGraceSeconds, "Grace period in seconds before unloading a model")
 }
 
 func parseFlags() {

--- a/scheduler/cmd/agent/cli/flags_test.go
+++ b/scheduler/cmd/agent/cli/flags_test.go
@@ -64,6 +64,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 		expectedMaxUnloadElapsedTimeMinute                      int
 		expectedMaxLoadRetryCount                               int
 		expectedMaxUnloadRetryCount                             int
+		expectedUnloadGraceSeconds                              int
 	}
 	tests := []test{
 		{
@@ -107,6 +108,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			expectedMaxUnloadElapsedTimeMinute:                      defaultMaxUnloadElapsedTimeMinute,
 			expectedMaxLoadRetryCount:                               defaultMaxLoadRetryCount,
 			expectedMaxUnloadRetryCount:                             defaultMaxUnloadRetryCount,
+			expectedUnloadGraceSeconds:                              defautUnloadGraceSeconds,
 		},
 		{
 			name: "good args",
@@ -148,6 +150,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"--max-unload-elapsed-time-minutes=15",
 				"--max-load-retry-count=5",
 				"--max-unload-retry-count=1",
+				"--unload-grace-seconds=10",
 			},
 			envs:                                  []string{},
 			expectedAgentHost:                     "1.1.1.1",
@@ -187,6 +190,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			expectedMaxUnloadElapsedTimeMinute:                      15,
 			expectedMaxLoadRetryCount:                               5,
 			expectedMaxUnloadRetryCount:                             1,
+			expectedUnloadGraceSeconds: 							10,
 		},
 		{
 			name: "good envs",
@@ -220,6 +224,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES=15",
 				"SELDON_MAX_LOAD_RETRY_COUNT=5",
 				"SELDON_MAX_UNLOAD_RETRY_COUNT=1",
+				"SELDON_UNLOAD_GRACE_SECONDS=5",
 			},
 			expectedAgentHost:                     "0.0.0.0",
 			expectedServerName:                    "mlserver",
@@ -258,6 +263,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			expectedMaxUnloadElapsedTimeMinute:                      15,
 			expectedMaxLoadRetryCount:                               5,
 			expectedMaxUnloadRetryCount:                             1,
+			expectedUnloadGraceSeconds:                              5,
 		},
 	}
 
@@ -313,6 +319,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			g.Expect(MaxUnloadElapsedTimeMinute).To(Equal(test.expectedMaxUnloadElapsedTimeMinute))
 			g.Expect(MaxLoadRetryCount).To(Equal(test.expectedMaxLoadRetryCount))
 			g.Expect(MaxUnloadRetryCount).To(Equal(test.expectedMaxUnloadRetryCount))
+			g.Expect(UnloadGraceSeconds).To(Equal(test.expectedUnloadGraceSeconds))
 			// reset
 			flag.CommandLine = flag.NewFlagSet("cmd", flag.ExitOnError)
 			os.Clearenv()

--- a/scheduler/cmd/agent/cli/flags_test.go
+++ b/scheduler/cmd/agent/cli/flags_test.go
@@ -150,7 +150,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"--max-unload-elapsed-time-minutes=15",
 				"--max-load-retry-count=5",
 				"--max-unload-retry-count=1",
-				"--unload-grace-seconds=10",
+				"--unload-grace-period-seconds=10",
 			},
 			envs:                                  []string{},
 			expectedAgentHost:                     "1.1.1.1",

--- a/scheduler/cmd/agent/cli/flags_test.go
+++ b/scheduler/cmd/agent/cli/flags_test.go
@@ -224,7 +224,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 				"SELDON_MAX_UNLOAD_ELAPSED_TIME_MINUTES=15",
 				"SELDON_MAX_LOAD_RETRY_COUNT=5",
 				"SELDON_MAX_UNLOAD_RETRY_COUNT=1",
-				"SELDON_UNLOAD_GRACE_SECONDS=5",
+				"SELDON_UNLOAD_GRACE_PERIOD_SECONDS=5",
 			},
 			expectedAgentHost:                     "0.0.0.0",
 			expectedServerName:                    "mlserver",

--- a/scheduler/cmd/agent/cli/flags_test.go
+++ b/scheduler/cmd/agent/cli/flags_test.go
@@ -190,7 +190,7 @@ func TestAgentCliArgsDefault(t *testing.T) {
 			expectedMaxUnloadElapsedTimeMinute:                      15,
 			expectedMaxLoadRetryCount:                               5,
 			expectedMaxUnloadRetryCount:                             1,
-			expectedUnloadGraceSeconds: 							10,
+			expectedUnloadGraceSeconds:                              10,
 		},
 		{
 			name: "good envs",

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -266,6 +266,7 @@ func main() {
 			time.Duration(cli.MaxUnloadElapsedTimeMinute)*time.Minute,
 			uint8(cli.MaxLoadRetryCount),
 			uint8(cli.MaxUnloadRetryCount),
+			time.Duration(cli.PeriodReadySubServiceSeconds)*time.Second,
 		),
 		logger,
 		modelRepository,

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -266,7 +266,7 @@ func main() {
 			time.Duration(cli.MaxUnloadElapsedTimeMinute)*time.Minute,
 			uint8(cli.MaxLoadRetryCount),
 			uint8(cli.MaxUnloadRetryCount),
-			time.Duration(cli.PeriodReadySubServiceSeconds)*time.Second,
+			time.Duration(cli.UnloadGraceSeconds)*time.Second,
 		),
 		logger,
 		modelRepository,

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -634,6 +634,9 @@ func (c *Client) UnloadModel(request *agent.ModelOperationMessage) error {
 
 	logger := c.logger.WithField("func", "UnloadModel")
 
+	// As envoy is eventually consistent, we need to wait for a grace period before unloading the model
+	// to give envoy time to drain the connections and reflect the cluster changes
+	// this should be ~500ms
 	time.Sleep(c.settings.unloadGraceTime)
 
 	modelName := request.GetModelVersion().GetModel().GetMeta().GetName()

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -92,6 +92,7 @@ type ClientSettings struct {
 	maxUnloadElapsedTime                     time.Duration
 	maxLoadRetryCount                        uint8
 	maxUnloadRetryCount                      uint8
+	unloadGraceTime                          time.Duration
 }
 
 func NewClientSettings(
@@ -107,6 +108,7 @@ func NewClientSettings(
 	maxUnloadElapsedTime time.Duration,
 	maxLoadRetryCount,
 	maxUnloadRetryCount uint8,
+	unloadGraceTime time.Duration,
 ) *ClientSettings {
 	return &ClientSettings{
 		serverName:                               serverName,
@@ -121,6 +123,7 @@ func NewClientSettings(
 		maxUnloadElapsedTime:                     maxUnloadElapsedTime,
 		maxLoadRetryCount:                        maxLoadRetryCount,
 		maxUnloadRetryCount:                      maxUnloadRetryCount,
+		unloadGraceTime:                          unloadGraceTime,
 	}
 }
 
@@ -630,6 +633,8 @@ func (c *Client) UnloadModel(request *agent.ModelOperationMessage) error {
 	}
 
 	logger := c.logger.WithField("func", "UnloadModel")
+
+	time.Sleep(c.settings.unloadGraceTime)
 
 	modelName := request.GetModelVersion().GetModel().GetMeta().GetName()
 	modelVersion := request.GetModelVersion().GetVersion()

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -210,7 +210,7 @@ func TestClientCreate(t *testing.T) {
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1, 1),
 				logger, modelRepository, v2Client,
 				test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -373,7 +373,7 @@ func TestLoadModel(t *testing.T) {
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 
@@ -524,7 +524,7 @@ parameters:
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1, 1),
 				logger, modelRepository,
 				v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService,
@@ -670,7 +670,7 @@ func TestUnloadModel(t *testing.T) {
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1, 1),
 				logger, modelRepository, v2Client, test.replicaConfig, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 			mockAgentV2Server := &mockAgentV2Server{models: []string{}}
@@ -728,7 +728,7 @@ func TestClientClose(t *testing.T) {
 	drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 	drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 	client := NewClient(
-		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+		NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1, 1),
 		logger, modelRepository, v2Client,
 		&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 		rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
@@ -826,16 +826,13 @@ func TestAgentStopOnSubServicesFailure(t *testing.T) {
 				_ = drainerService.Start()
 			}()
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, period, maxTimeBeforeStart, maxTimeAfterStart, 1*time.Minute, 1*time.Minute, 1, 1, 1),
 				logger, modelRepository, v2Client,
 				&pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 			mockAgentV2Server := &mockAgentV2Server{}
 			conn, err := grpc.NewClient("passthrough://", grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(dialerv2(mockAgentV2Server)))
-			// conn, err := grpc.DialContext(
-			// 	context.Background(), "", grpc.WithTransportCredentials(insecure.NewCredentials()),
-			// 	grpc.WithContextDialer(dialerv2(mockAgentV2Server)))
 			g.Expect(err).To(BeNil())
 			client.conn = conn
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Currently when a model is scaling down (reducing the number of replicas),  and while we make sure that we issue a remove route to the server containing the replica before unloading the replica, we found issues where there are still race conditions between envoy actually applying the cluster change and the model replica unloading. 

This PR introduces a grace period that is applied before any unload to a particular replica to guard against this race condition. Typically envoy cluster updates take ~500ms and we set the default grace period to 2s.

The value can be changed via envar on seldon-agent `SELDON_UNLOAD_GRACE_PERIOD_SECONDS`.


