### PR TITLE
fix(scheduler): Increase drain grace period wait

### DIFF
--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -39,7 +39,7 @@ const (
 	pendingSyncsQueueSize          int = 1000
 	modelEventHandlerName              = "agent.server.models"
 	modelScalingCoolingDownSeconds     = 60 // this is currently used in scale down events
-	serverDrainingExtraWaitMillis      = 500
+	serverDrainingExtraWaitMillis      = 2000
 )
 
 type modelRelocatedWaiter struct {


### PR DESCRIPTION
This PR increases the drain grace period to 2s inline with other changes for grace periods. This is to allow envoy to settle down after changes.
