### PR TITLE
fix(agent): Skip agent out of order control messages

### DIFF
--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -477,7 +477,7 @@ func (c *Client) StartService() error {
 
 		c.logger.Infof("Received operation")
 
-		timestamp := time.Now().Unix()
+		timestamp := time.Now().UnixMilli()
 		switch operation.Operation {
 		case agent.ModelOperationMessage_LOAD_MODEL:
 			c.logger.Infof("calling load model")

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -695,7 +695,7 @@ func (c *Client) UnloadModel(request *agent.ModelOperationMessage, timestamp int
 		return err
 	}
 
-	c.logger.Infof("Unload model %s:%d success", modelName, modelVersion)
+	logger.Infof("Unload model %s:%d success", modelName, modelVersion)
 	return c.sendAgentEvent(modelName, modelVersion, agent.ModelEventMessage_UNLOADED)
 }
 

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -479,7 +479,9 @@ func (c *Client) StartService() error {
 
 		c.logger.Infof("Received operation")
 
+		// Get the time since the start of the agent, this is monotonic as time.Now contains a monotonic clock
 		ticksSinceStart := time.Since(c.startTime).Milliseconds()
+
 		switch operation.Operation {
 		case agent.ModelOperationMessage_LOAD_MODEL:
 			c.logger.Infof("calling load model")

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -583,7 +583,7 @@ func (c *Client) LoadModel(request *agent.ModelOperationMessage, timestamp int64
 	// if it is out of order message, ignore it
 	ignore := ignoreIfOutOfOrder(modelWithVersion, timestamp, &c.modelTimestamps)
 	if ignore {
-		logger.Warnf("Ignoring out of order message for model %s:%d", modelName, modelVersion)
+		logger.Warnf("Ignoring out of order message for model %s:%d at %s", modelName, modelVersion, time.UnixMilli(timestamp).String())
 		return nil
 	}
 	defer c.modelTimestamps.Store(modelWithVersion, timestamp)
@@ -662,7 +662,7 @@ func (c *Client) UnloadModel(request *agent.ModelOperationMessage, timestamp int
 	// if it is out of order message, ignore it
 	ignore := ignoreIfOutOfOrder(modelWithVersion, timestamp, &c.modelTimestamps)
 	if ignore {
-		logger.Warnf("Ignoring out of order message for model %s:%d", modelName, modelVersion)
+		logger.Warnf("Ignoring out of order message for model %s:%d at %s", modelName, modelVersion, time.UnixMilli(timestamp).String())
 		return nil
 	}
 	defer c.modelTimestamps.Store(modelWithVersion, timestamp)

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -974,7 +974,7 @@ func TestUnloadModelOutOfOrder(t *testing.T) {
 			drainerServicePort, _ := testing_utils2.GetFreePortForTest()
 			drainerService := drainservice.NewDrainerService(logger, uint(drainerServicePort))
 			client := NewClient(
-				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1),
+				NewClientSettings("mlserver", 1, "scheduler", 9002, 9055, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1*time.Minute, 1, 1, 1),
 				logger, modelRepository, v2Client, &pb.ReplicaConfig{MemoryBytes: 1000}, "default",
 				rpHTTP, rpGRPC, agentDebug, modelScalingService, drainerService, newFakeMetricsHandler())
 			mockAgentV2Server := &mockAgentV2Server{models: []string{}}

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -393,7 +393,7 @@ func TestLoadModel(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 
 			// Do the actual function call that is being tested
-			err := client.LoadModel(test.op)
+			err := client.LoadModel(test.op, time.Now().Unix())
 
 			if test.success {
 				g.Expect(err).To(BeNil())
@@ -543,8 +543,10 @@ parameters:
 			go func() {
 				_ = client.Start()
 			}()
+			// Give the client time to start (?)
 			time.Sleep(50 * time.Millisecond)
-			err := client.LoadModel(test.op)
+
+			err := client.LoadModel(test.op, time.Now().Unix())
 			if test.success {
 				g.Expect(err).To(BeNil())
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(1))
@@ -680,10 +682,12 @@ func TestUnloadModel(t *testing.T) {
 			go func() {
 				_ = client.Start()
 			}()
+			// Give the client time to start (?)
 			time.Sleep(50 * time.Millisecond)
-			err := client.LoadModel(test.loadOp)
+
+			err := client.LoadModel(test.loadOp, time.Now().Unix())
 			g.Expect(err).To(BeNil())
-			err = client.UnloadModel(test.unloadOp)
+			err = client.UnloadModel(test.unloadOp, time.Now().Unix())
 			if test.success {
 				g.Expect(err).To(BeNil())
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(1))

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -914,7 +914,7 @@ func TestUnloadModelOutOfOrder(t *testing.T) {
 			},
 			unloadTicks: time.Now().Unix() + 10,
 			success:     true,
-		}, // Success
+		},
 		{
 			name:   "out-of-order",
 			models: []string{"iris"},

--- a/scheduler/pkg/agent/client_test.go
+++ b/scheduler/pkg/agent/client_test.go
@@ -393,7 +393,7 @@ func TestLoadModel(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 
 			// Do the actual function call that is being tested
-			err := client.LoadModel(test.op, time.Now().Unix())
+			err := client.LoadModel(test.op, 1)
 
 			if test.success {
 				g.Expect(err).To(BeNil())
@@ -546,7 +546,7 @@ parameters:
 			// Give the client time to start (?)
 			time.Sleep(50 * time.Millisecond)
 
-			err := client.LoadModel(test.op, time.Now().Unix())
+			err := client.LoadModel(test.op, 1)
 			if test.success {
 				g.Expect(err).To(BeNil())
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(1))
@@ -685,9 +685,9 @@ func TestUnloadModel(t *testing.T) {
 			// Give the client time to start (?)
 			time.Sleep(50 * time.Millisecond)
 
-			err := client.LoadModel(test.loadOp, time.Now().Unix())
+			err := client.LoadModel(test.loadOp, 1)
 			g.Expect(err).To(BeNil())
-			err = client.UnloadModel(test.unloadOp, time.Now().Unix())
+			err = client.UnloadModel(test.unloadOp, 2)
 			if test.success {
 				g.Expect(err).To(BeNil())
 				g.Expect(mockAgentV2Server.loadedEvents).To(Equal(1))
@@ -900,7 +900,7 @@ func TestUnloadModelOutOfOrder(t *testing.T) {
 					},
 				},
 			},
-			loadTicks: time.Now().Unix(),
+			loadTicks: 1,
 			unloadOp: &pb.ModelOperationMessage{
 				Operation: pb.ModelOperationMessage_UNLOAD_MODEL,
 				ModelVersion: &pb.ModelVersion{
@@ -912,7 +912,7 @@ func TestUnloadModelOutOfOrder(t *testing.T) {
 					},
 				},
 			},
-			unloadTicks: time.Now().Unix() + 10,
+			unloadTicks: 2,
 			success:     true,
 		},
 		{
@@ -929,7 +929,7 @@ func TestUnloadModelOutOfOrder(t *testing.T) {
 					},
 				},
 			},
-			loadTicks: time.Now().Unix(),
+			loadTicks: 2,
 			unloadOp: &pb.ModelOperationMessage{
 				Operation: pb.ModelOperationMessage_LOAD_MODEL,
 				ModelVersion: &pb.ModelVersion{
@@ -941,7 +941,7 @@ func TestUnloadModelOutOfOrder(t *testing.T) {
 					},
 				},
 			},
-			unloadTicks: time.Now().Unix() - 10,
+			unloadTicks: 1,
 			success:     false,
 		},
 	}

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -11,6 +11,7 @@ package agent
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	backoff "github.com/cenkalti/backoff/v4"
@@ -117,4 +118,16 @@ func (b *backOffWithMaxCount) NextBackOff() time.Duration {
 		b.currentCount++
 		return b.backoffPolicy.NextBackOff()
 	}
+}
+
+func ignoreIfOutOfOrder(key string, timestamp int64, timestamps *sync.Map) bool {
+	tick, ok := timestamps.Load(key)
+	if !ok {
+		timestamps.Store(key, timestamp)
+	} else {
+		if timestamp > tick.(int64) {
+			return true
+		}
+	}
+	return false
 }

--- a/scheduler/pkg/agent/client_utils.go
+++ b/scheduler/pkg/agent/client_utils.go
@@ -125,7 +125,7 @@ func ignoreIfOutOfOrder(key string, timestamp int64, timestamps *sync.Map) bool 
 	if !ok {
 		timestamps.Store(key, timestamp)
 	} else {
-		if timestamp > tick.(int64) {
+		if timestamp < tick.(int64) {
 			return true
 		}
 	}

--- a/scheduler/pkg/agent/client_utils_test.go
+++ b/scheduler/pkg/agent/client_utils_test.go
@@ -118,7 +118,7 @@ func TestFnWrapperWithMax(t *testing.T) {
 
 func TestOutOfOrderUtil(t *testing.T) {
 	ticks := sync.Map{}
-	ticks.Store("key", time.Now().Unix())
+	ticks.Store("key", int64(1))
 
 	type test struct {
 		name         string
@@ -132,21 +132,21 @@ func TestOutOfOrderUtil(t *testing.T) {
 			name:         "empty",
 			ticks:        &sync.Map{},
 			key:          "key",
-			timestamp:    time.Now().Unix(), // dummy
+			timestamp:    2, // dummy
 			isOutOfOrder: false,
 		},
 		{
 			name:         "in order",
 			ticks:        &ticks,
 			key:          "key",
-			timestamp:    time.Now().Unix() + 10,
+			timestamp:    3,
 			isOutOfOrder: false,
 		},
 		{
 			name:         "out of order",
 			ticks:        &ticks,
 			key:          "key",
-			timestamp:    time.Now().Unix() - 10,
+			timestamp:    0,
 			isOutOfOrder: true,
 		},
 	}

--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -39,7 +39,7 @@ const (
 	pendingSyncsQueueSize          int = 1000
 	modelEventHandlerName              = "agent.server.models"
 	modelScalingCoolingDownSeconds     = 60 // this is currently used in scale down events
-	serverDrainingExtraWaitMillis      = 5000
+	serverDrainingExtraWaitMillis      = 3000
 )
 
 type modelRelocatedWaiter struct {

--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -39,7 +39,7 @@ const (
 	pendingSyncsQueueSize          int = 1000
 	modelEventHandlerName              = "agent.server.models"
 	modelScalingCoolingDownSeconds     = 60 // this is currently used in scale down events
-	serverDrainingExtraWaitMillis      = 2000
+	serverDrainingExtraWaitMillis      = 5000
 )
 
 type modelRelocatedWaiter struct {

--- a/scheduler/pkg/synchroniser/sync_test.go
+++ b/scheduler/pkg/synchroniser/sync_test.go
@@ -40,8 +40,8 @@ func TestSimpleSynchroniser(t *testing.T) {
 			signal:  true,
 		},
 		{
-			name:    "No timer",
-			timeout: 0 * time.Millisecond,
+			name:    "Small timer",
+			timeout: 1 * time.Millisecond,
 			signal:  true,
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Currently the agent, due to the way it processes control messages from the scheduler, can see out of order messages. For example consider the following flow
```
- Model A unload request
- Model A unload request - sleep
- Model A load request proceeds and lets scheduler model is loaded
- Model A unload request (out of order) proceeds and scheduler is confused
- Model A is unloaded while route to it exists in envoy
```

In this PR we introduce a way to detect out-of-order messages and we skip them. We record the milli ticks for successful operations per model and if an incoming operation has a tick that is earlier than whats recorded, we skip it.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
INFRA-1204 (internal)

This PR also bumps up server drain grace period to 3s, in a future PR this will be configuratble.
