### PR TITLE
feat(k6): Add k6 controlplane with dataplane runs

### DIFF
--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -306,6 +306,20 @@ function enableStateCheck() {
     return true
 }
 
+function enableModeReplicaChange() {
+    if (__ENV.ENABLE_MODEL_REPLICA_CHANGE) {
+        return (__ENV.ENABLE_MODEL_REPLICA_CHANGE === "true")
+    }
+    return false
+}
+
+function sleepBetweenModelReplicaChange() {
+    if (__ENV.SLEEP_BETWEEN_REPLICA_CHANGE) {
+        return Number(__ENV.SLEEP_BETWEEN_REPLICA_CHANGE)
+    }
+    return 10
+}
+
 export function getConfig() {
     return {
         "useKubeControlPlane": useKubeControlPlane(),
@@ -348,5 +362,7 @@ export function getConfig() {
         "checkStateEverySec": checkStateEverySec(),
         "maxCheckTimeSec": maxCheckTimeSec(),
         "stopOnCheckFailure": stopOnCheckFailure(),
+        "enableModeReplicaChange": enableModeReplicaChange(),
+        "sleepBetweenModelReplicaChange": sleepBetweenModelReplicaChange(),
     }
 }

--- a/tests/k6/components/settings.js
+++ b/tests/k6/components/settings.js
@@ -362,7 +362,7 @@ export function getConfig() {
         "checkStateEverySec": checkStateEverySec(),
         "maxCheckTimeSec": maxCheckTimeSec(),
         "stopOnCheckFailure": stopOnCheckFailure(),
-        "enableModeReplicaChange": enableModeReplicaChange(),
+        "enableModelReplicaChange": enableModeReplicaChange(),
         "sleepBetweenModelReplicaChange": sleepBetweenModelReplicaChange(),
     }
 }

--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -617,3 +617,21 @@ export function checkPipelinesStateIsConsistent(k8sPipelines, schedPipelines) {
 export function checkExperimentsStateIsConsistent(k8sExperiments, schedExperiments) {
   return true // to implement
 }
+
+export function applyModelReplicaChange(config) {
+  if (config.enableModelReplicaChange) {
+    k8s.init()
+    for (let j = 0; j < config.maxNumModels.length; j++) {
+      if (config.maxNumModels[j] > 0) {
+        const modelId = Math.floor(Math.random() * config.maxNumModels[j])
+        const modelName = config.modelNamePrefix[j] + modelId.toString()
+
+        let replicas =  Math.floor(Math.random() * config.maxModelReplicas[j]) + 1
+        const model = generateModel(config.modelType[j], modelName, 1, replicas, config.isSchedulerProxy, config.modelMemoryBytes[j], config.inferBatchSize[j])
+        let opOk = k8s.loadModel(modelName, model.modelCRYaml, true)
+        console.log("Model load %s with replicas %d operation status:",modelName, replicas, opOk)
+      }
+    }
+    sleep(config.sleepBetweenModelReplicaChange)
+  }
+}

--- a/tests/k6/configs/k8s/base/k6.yaml
+++ b/tests/k6/configs/k8s/base/k6.yaml
@@ -111,6 +111,14 @@ spec:
         # times more likely than the Create.
         # - name: MODEL_CREATE_UPDATE_DELETE_BIAS
         #   value: "1,3,1"
+        # The following two variables are used to change the model replicas while doing 
+        # data plane tests. The ENABLE_MODEL_REPLICA_CHANGE variable should be set to true
+        # to enable the model replica change. The SLEEP_BETWEEN_REPLICA_CHANGE variable
+        # should be set to the number of seconds to wait between changing the model replicas.
+        # - name: ENABLE_MODEL_REPLICA_CHANGE
+        #   value: "true"
+        # - name: SLEEP_BETWEEN_REPLICA_CHANGE
+        #   value: "10"
         - name: WARMUP
           value: "false"
         - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/tests/k6/scenarios/infer_constant_rate.js
+++ b/tests/k6/scenarios/infer_constant_rate.js
@@ -1,9 +1,6 @@
 import { getConfig } from '../components/settings.js'
-import { doInfer, setupBase, teardownBase, getVersionSuffix } from '../components/utils.js'
-import { generateModel } from '../components/model.js';
-import * as k8s from '../components/k8s.js';
+import { doInfer, setupBase, teardownBase, getVersionSuffix, applyModelReplicaChange } from '../components/utils.js'
 import { vu } from 'k6/execution';
-import { sleep } from 'k6';
 
 var kubeClient = null
 
@@ -55,13 +52,8 @@ export default function (config) {
     }
 
     // for simplicity we only change model replicas in the first VU
-    if ((vu.idInTest == 1) && config.enableModelReplicaChange) {
-        kubeClient = k8s.init()
-        let replicas =  Math.floor(Math.random() * config.maxModelReplicas[idx]) + 1
-        const model = generateModel(config.modelType[idx], modelName, 1, replicas, config.isSchedulerProxy, config.modelMemoryBytes[idx], config.inferBatchSize[idx])
-        let opOk = k8s.loadModel(modelName, model.modelCRYaml, true)
-        console.log("Model load operation status:", opOk)
-        sleep(config.sleepBetweenModelReplicaChange)
+    if (vu.idInTest == 1 && config.enableModelReplicaChange) {
+        applyModelReplicaChange(config)
     }
 }
 

--- a/tests/k6/scenarios/infer_constant_rate.js
+++ b/tests/k6/scenarios/infer_constant_rate.js
@@ -55,9 +55,9 @@ export default function (config) {
     }
 
     // for simplicity we only change model replicas in the first VU
-    if (vu.idInTest === 1 && config.enableModelReplicaChange) {
+    if ((vu.idInTest == 1) && config.enableModelReplicaChange) {
         kubeClient = k8s.init()
-        let replicas =  Math.round(Math.random() * config.maxModelReplicas[idx])
+        let replicas =  Math.floor(Math.random() * config.maxModelReplicas[idx]) + 1
         const model = generateModel(config.modelType[idx], modelName, 1, replicas, config.isSchedulerProxy, config.modelMemoryBytes[idx], config.inferBatchSize[idx])
         let opOk = k8s.loadModel(modelName, model.modelCRYaml, true)
         console.log("Model load operation status:", opOk)

--- a/tests/k6/scenarios/infer_constant_vu.js
+++ b/tests/k6/scenarios/infer_constant_vu.js
@@ -1,9 +1,6 @@
 import { getConfig } from '../components/settings.js'
-import { doInfer, setupBase, teardownBase, getVersionSuffix } from '../components/utils.js'
-import { generateModel } from '../components/model.js';
-import * as k8s from '../components/k8s.js';
+import { doInfer, setupBase, teardownBase, getVersionSuffix, applyModelReplicaChange } from '../components/utils.js'
 import { vu } from 'k6/execution';
-import { sleep } from 'k6';
 
 var kubeClient = null
 
@@ -61,13 +58,8 @@ export default function (config) {
     }
 
     // for simplicity we only change model replicas in the first VU
-    if ((vu.idInTest == 1) && config.enableModelReplicaChange) {
-        kubeClient = k8s.init()
-        let replicas =  Math.floor(Math.random() * config.maxModelReplicas[idx]) + 1
-        const model = generateModel(config.modelType[idx], modelName, 1, replicas, config.isSchedulerProxy, config.modelMemoryBytes[idx], config.inferBatchSize[idx])
-        let opOk = k8s.loadModel(modelName, model.modelCRYaml, true)
-        console.log("Model load operation status:", opOk)
-        sleep(config.sleepBetweenModelReplicaChange)
+    if (vu.idInTest == 1 && config.enableModelReplicaChange) {
+        applyModelReplicaChange(config)
     }
 }
 

--- a/tests/k6/scenarios/infer_constant_vu.js
+++ b/tests/k6/scenarios/infer_constant_vu.js
@@ -61,9 +61,9 @@ export default function (config) {
     }
 
     // for simplicity we only change model replicas in the first VU
-    if (vu.idInTest === 1 && config.enableModelReplicaChange) {
+    if ((vu.idInTest == 1) && config.enableModelReplicaChange) {
         kubeClient = k8s.init()
-        let replicas =  Math.round(Math.random() * config.maxModelReplicas[idx])
+        let replicas =  Math.floor(Math.random() * config.maxModelReplicas[idx]) + 1
         const model = generateModel(config.modelType[idx], modelName, 1, replicas, config.isSchedulerProxy, config.modelMemoryBytes[idx], config.inferBatchSize[idx])
         let opOk = k8s.loadModel(modelName, model.modelCRYaml, true)
         console.log("Model load operation status:", opOk)

--- a/tests/k6/scenarios/infer_constant_vu.js
+++ b/tests/k6/scenarios/infer_constant_vu.js
@@ -1,5 +1,11 @@
 import { getConfig } from '../components/settings.js'
 import { doInfer, setupBase, teardownBase, getVersionSuffix } from '../components/utils.js'
+import { generateModel } from '../components/model.js';
+import * as k8s from '../components/k8s.js';
+import { vu } from 'k6/execution';
+import { sleep } from 'k6';
+
+var kubeClient = null
 
 // workaround: https://community.k6.io/t/exclude-http-requests-made-in-the-setup-and-teardown-functions/1525
 export let options = {
@@ -52,6 +58,16 @@ export default function (config) {
         doInfer(modelName, modelNameWithVersion, config, false, idx)
     } else {
         throw new Error('Both REST and GRPC protocols are disabled!')
+    }
+
+    // for simplicity we only change model replicas in the first VU
+    if (vu.idInTest === 1 && config.enableModelReplicaChange) {
+        kubeClient = k8s.init()
+        let replicas =  Math.round(Math.random() * config.maxModelReplicas[idx])
+        const model = generateModel(config.modelType[idx], modelName, 1, replicas, config.isSchedulerProxy, config.modelMemoryBytes[idx], config.inferBatchSize[idx])
+        let opOk = k8s.loadModel(modelName, model.modelCRYaml, true)
+        console.log("Model load operation status:", opOk)
+        sleep(config.sleepBetweenModelReplicaChange)
     }
 }
 


### PR DESCRIPTION
This PR introduces model replicas changes as inference go through to understand the behaviour of the system under such scenarios.

The scenarios that are enabled are:
- `infer_constant_rate`
- `infer_constant_vu`

To trigger model replica changes, set `ENABLE_MODEL_REPLICA_CHANGE`. The number of replicas is chosen uniformly between 1 and `MAX_MODEL_REPLICAS`. 

We also support sleeping after each model replica change by setting `SLEEP_BETWEEN_REPLICA_CHANGE`.