### PR TITLE
fix: Use keep alive grpc settings on client side

### DIFF
--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -35,7 +35,7 @@ const (
 	// these 2 constants in combination with the backoff exponential function will give us a max backoff of 13.5 minutes
 	SchedulerConnectMaxRetries    = 12
 	SchedulerConnectBackoffScalar = 200 * time.Millisecond
-	ClientKeapAliveTime           = 10 * time.Second
+	ClientKeapAliveTime           = 30 * time.Second
 	ClientKeapAliveTimeout        = 2 * time.Second
 	ClientKeapAlivePermit         = true
 )

--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -228,7 +228,7 @@ func (s *SchedulerClient) connectToScheduler(host string, namespace string, plai
 			return nil, err
 		}
 	}
-	var kacp = keepalive.ClientParameters{
+	kacp := keepalive.ClientParameters{
 		Time:                ClientKeapAliveTime,
 		Timeout:             ClientKeapAliveTimeout,
 		PermitWithoutStream: ClientKeapAlivePermit,

--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -35,7 +35,7 @@ const (
 	// these 2 constants in combination with the backoff exponential function will give us a max backoff of 13.5 minutes
 	SchedulerConnectMaxRetries    = 12
 	SchedulerConnectBackoffScalar = 200 * time.Millisecond
-	ClientKeapAliveTime           = 30 * time.Second
+	ClientKeapAliveTime           = 60 * time.Second
 	ClientKeapAliveTimeout        = 2 * time.Second
 	ClientKeapAlivePermit         = true
 )

--- a/operator/scheduler/client.go
+++ b/operator/scheduler/client.go
@@ -36,7 +36,7 @@ const (
 	SchedulerConnectMaxRetries    = 12
 	SchedulerConnectBackoffScalar = 200 * time.Millisecond
 	ClientKeapAliveTime           = 10 * time.Second
-	ClientKeapAliveTimeout        = time.Second
+	ClientKeapAliveTimeout        = 2 * time.Second
 	ClientKeapAlivePermit         = true
 )
 

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -417,7 +417,7 @@ func (c *Client) getConnection(host string, plainTxtPort int, tlsPort int) (*grp
 
 	logger.Infof("Connecting (non-blocking) to scheduler at %s:%d", host, port)
 
-	var kacp = keepalive.ClientParameters{
+	kacp := keepalive.ClientParameters{
 		Time:                util.ClientKeapAliveTime,
 		Timeout:             util.ClientKeapAliveTimeout,
 		PermitWithoutStream: util.ClientKeapAlivePermit,

--- a/scheduler/pkg/agent/client.go
+++ b/scheduler/pkg/agent/client.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/seldonio/seldon-core/apis/go/v2/mlops/agent"
@@ -416,9 +417,16 @@ func (c *Client) getConnection(host string, plainTxtPort int, tlsPort int) (*grp
 
 	logger.Infof("Connecting (non-blocking) to scheduler at %s:%d", host, port)
 
+	var kacp = keepalive.ClientParameters{
+		Time:                util.ClientKeapAliveTime,
+		Timeout:             util.ClientKeapAliveTimeout,
+		PermitWithoutStream: util.ClientKeapAlivePermit,
+	}
+
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transCreds),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithKeepaliveParams(kacp),
 	}
 	conn, err := grpc.NewClient(fmt.Sprintf("%s:%d", host, port), opts...)
 	if err != nil {

--- a/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
+++ b/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
@@ -51,7 +51,7 @@ func CreateV2GrpcConnection(v2Config V2Config) (*grpc.ClientConn, error) {
 		grpc_retry.WithMax(v2Config.GRPRetryMaxCount),
 	}
 
-	var kacp = keepalive.ClientParameters{
+	kacp := keepalive.ClientParameters{
 		Time:                util.ClientKeapAliveTime,
 		Timeout:             util.ClientKeapAliveTimeout,
 		PermitWithoutStream: util.ClientKeapAlivePermit,

--- a/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
+++ b/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
@@ -50,12 +51,19 @@ func CreateV2GrpcConnection(v2Config V2Config) (*grpc.ClientConn, error) {
 		grpc_retry.WithMax(v2Config.GRPRetryMaxCount),
 	}
 
+	var kacp = keepalive.ClientParameters{
+		Time:                util.ClientKeapAliveTime,
+		Timeout:             util.ClientKeapAliveTimeout,
+		PermitWithoutStream: util.ClientKeapAlivePermit,
+	}
+
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(v2Config.GRPCMaxMsgSizeBytes), grpc.MaxCallSendMsgSize(v2Config.GRPCMaxMsgSizeBytes)),
 		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(retryOpts...)),
 		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(retryOpts...)),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithKeepaliveParams(kacp),
 	}
 	conn, err := grpc.NewClient(fmt.Sprintf("%s:%d", v2Config.Host, v2Config.GRPCPort), opts...)
 	if err != nil {

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 	seldontls "github.com/seldonio/seldon-core/components/tls/v2/pkg/tls"
+
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -80,7 +80,7 @@ func (kc *KafkaSchedulerClient) ConnectToScheduler(host string, plainTxtPort int
 		port = tlsPort
 	}
 
-	var kacp = keepalive.ClientParameters{
+	kacp := keepalive.ClientParameters{
 		Time:                util.ClientKeapAliveTime,
 		Timeout:             util.ClientKeapAliveTimeout,
 		PermitWithoutStream: util.ClientKeapAlivePermit,

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
@@ -123,6 +124,12 @@ func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceSer
 		creds = insecure.NewCredentials()
 	}
 
+	var kacp = keepalive.ClientParameters{
+		Time:                util.ClientKeapAliveTime,
+		Timeout:             util.ClientKeapAliveTimeout,
+		PermitWithoutStream: util.ClientKeapAlivePermit,
+	}
+
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultCallOptions(
@@ -135,6 +142,7 @@ func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceSer
 		grpc.WithUnaryInterceptor(
 			grpc_retry.UnaryClientInterceptor(retryOpts...),
 		),
+		grpc.WithKeepaliveParams(kacp),
 	}
 
 	conn, err := grpc.NewClient(fmt.Sprintf("%s:%d", host, port), opts...)

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -124,7 +124,7 @@ func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceSer
 		creds = insecure.NewCredentials()
 	}
 
-	var kacp = keepalive.ClientParameters{
+	kacp := keepalive.ClientParameters{
 		Time:                util.ClientKeapAliveTime,
 		Timeout:             util.ClientKeapAliveTimeout,
 		PermitWithoutStream: util.ClientKeapAlivePermit,

--- a/scheduler/pkg/kafka/pipeline/status/client.go
+++ b/scheduler/pkg/kafka/pipeline/status/client.go
@@ -22,12 +22,14 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 	seldontls "github.com/seldonio/seldon-core/components/tls/v2/pkg/tls"
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store/pipeline"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
 const (
@@ -84,9 +86,17 @@ func (pc *PipelineSchedulerClient) connectToScheduler(host string, plainTxtPort 
 		transCreds = pc.certificateStore.CreateClientTransportCredentials()
 		port = tlsPort
 	}
+
+	var kacp = keepalive.ClientParameters{
+		Time:                util.ClientKeapAliveTime,
+		Timeout:             util.ClientKeapAliveTimeout,
+		PermitWithoutStream: util.ClientKeapAlivePermit,
+	}
+
 	// note: retry is done in the caller
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transCreds),
+		grpc.WithKeepaliveParams(kacp),
 	}
 	logger.Infof("Connecting to scheduler at %s:%d", host, port)
 	conn, err := grpc.NewClient(fmt.Sprintf("%s:%d", host, port), opts...)

--- a/scheduler/pkg/kafka/pipeline/status/client.go
+++ b/scheduler/pkg/kafka/pipeline/status/client.go
@@ -87,7 +87,7 @@ func (pc *PipelineSchedulerClient) connectToScheduler(host string, plainTxtPort 
 		port = tlsPort
 	}
 
-	var kacp = keepalive.ClientParameters{
+	kacp := keepalive.ClientParameters{
 		Time:                util.ClientKeapAliveTime,
 		Timeout:             util.ClientKeapAliveTimeout,
 		PermitWithoutStream: util.ClientKeapAlivePermit,

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -36,7 +36,7 @@ const (
 
 const (
 	EnvoyUpdateDefaultBatchWait = 250 * time.Millisecond
-	ClientKeapAliveTime         = 10 * time.Second
+	ClientKeapAliveTime         = 30 * time.Second
 	ClientKeapAliveTimeout      = 2 * time.Second
 	ClientKeapAlivePermit       = true
 )

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -37,6 +37,6 @@ const (
 const (
 	EnvoyUpdateDefaultBatchWait = 250 * time.Millisecond
 	ClientKeapAliveTime         = 10 * time.Second
-	ClientKeapAliveTimeout      = time.Second
+	ClientKeapAliveTimeout      = 2 * time.Second
 	ClientKeapAlivePermit       = true
 )

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -9,10 +9,12 @@ the Change License after the Change Date as each is defined in accordance with t
 
 package util
 
-import "time"
+import (
+	"time"
+)
 
+// REST
 const (
-	// REST constants
 	DefaultReverseProxyHTTPPort = 9999
 	MaxIdleConnsHTTP            = 10
 	MaxIdleConnsPerHostHTTP     = 10
@@ -22,12 +24,19 @@ const (
 	IdleConnTimeoutSeconds      = 60 * 30
 )
 
+// GRPC
 const (
 	GRPCRetryBackoff             = 100 * time.Millisecond
 	GRPCRetryMaxCount            = 5 // around 3.2s in total wait duration
 	GRPCMaxMsgSizeBytes          = 1000 * 1024 * 1024
-	EnvoyUpdateDefaultBatchWait  = 250 * time.Millisecond
 	GRPCModelServerLoadTimeout   = 60 * time.Minute // How long to wait for a model to load? think of LLM Load, maybe should be a config
 	GRPCModelServerUnloadTimeout = 2 * time.Minute
 	GRPCControlPlaneTimeout      = 1 * time.Minute // For control plane operations except load/unload
+)
+
+const (
+	EnvoyUpdateDefaultBatchWait = 250 * time.Millisecond
+	ClientKeapAliveTime         = 10 * time.Second
+	ClientKeapAliveTimeout      = time.Second
+	ClientKeapAlivePermit       = true
 )

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -36,7 +36,7 @@ const (
 
 const (
 	EnvoyUpdateDefaultBatchWait = 250 * time.Millisecond
-	ClientKeapAliveTime         = 30 * time.Second
+	ClientKeapAliveTime         = 60 * time.Second
 	ClientKeapAliveTimeout      = 2 * time.Second
 	ClientKeapAlivePermit       = true
 )


### PR DESCRIPTION
This change introduces keepalive pings from the client side on grpc streams, otherwise in cases of short network partitions the stream might be broken and not re-established.

with keepalive settings we get this error
```
level=error msg="event recv failed" Name=Client error="rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout" func=StartService
```
which will break our loop and tries to reestablish the connection with the other end.

Check here: https://pkg.go.dev/google.golang.org/grpc/keepalive#ClientParameters