### PR TITLE
fix: Make status.selector field optional

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
+++ b/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
@@ -343,8 +343,6 @@ spec:
                 type: integer
               selector:
                 type: string
-            required:
-            - selector
             type: object
         type: object
     served: true

--- a/k8s/yaml/crds.yaml
+++ b/k8s/yaml/crds.yaml
@@ -346,8 +346,6 @@ spec:
                 type: integer
               selector:
                 type: string
-            required:
-            - selector
             type: object
         type: object
     served: true

--- a/operator/apis/mlops/v1alpha1/model_types.go
+++ b/operator/apis/mlops/v1alpha1/model_types.go
@@ -107,7 +107,7 @@ type InferenceArtifactSpec struct {
 type ModelStatus struct {
 	// Total number of replicas targeted by this model
 	Replicas      int32  `json:"replicas,omitempty"`
-	Selector      string `json:"selector"`
+	Selector      string `json:"selector,omitempty"`
 	duckv1.Status `json:",inline"`
 }
 

--- a/operator/config/crd/bases/mlops.seldon.io_models.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_models.yaml
@@ -195,8 +195,6 @@ spec:
                 type: integer
               selector:
                 type: string
-            required:
-            - selector
             type: object
         type: object
     served: true


### PR DESCRIPTION
In https://github.com/SeldonIO/seldon-core/pull/5932 we introduced `status.selector` to enable HPA model scaling. The field is marked as required and in some cases this will prevent clean migrations.

This change is thus making it optional, which should not affect the intended behaviour and will aid in migrations.

TODO:

- [x] Make sure we can populate the selector field with some values.