### PR TITLE
fix: Deal with zero servers control plane synchronisation

### DIFF
--- a/operator/scheduler/server.go
+++ b/operator/scheduler/server.go
@@ -25,9 +25,6 @@ import (
 
 func (s *SchedulerClient) ServerNotify(ctx context.Context, grpcClient scheduler.SchedulerClient, servers []v1alpha1.Server, isFirstSync bool) error {
 	logger := s.logger.WithName("NotifyServer")
-	if len(servers) == 0 {
-		return nil
-	}
 
 	if grpcClient == nil {
 		// we assume that all servers are in the same namespace
@@ -74,6 +71,7 @@ func (s *SchedulerClient) ServerNotify(ctx context.Context, grpcClient scheduler
 		logger.Error(err, "Failed to send notify server to scheduler")
 		return err
 	}
+	logger.V(1).Info("Sent notify server to scheduler", "servers", len(servers), "isFirstSync", isFirstSync)
 	return nil
 }
 

--- a/scheduler/pkg/server/server_test.go
+++ b/scheduler/pkg/server/server_test.go
@@ -744,6 +744,15 @@ func TestServerNotify(t *testing.T) {
 			signalTriggered: true,
 		},
 		{
+			name: "Initial sync - no servers",
+			req: &pb.ServerNotifyRequest{
+				Servers:     []*pb.ServerNotify{},
+				IsFirstSync: true,
+			},
+			expectedServerStates: nil,
+			signalTriggered:      true,
+		},
+		{
 			// this should not trigger sync.Signal()
 			name: "normal sync",
 			req: &pb.ServerNotifyRequest{

--- a/scheduler/pkg/synchroniser/servers_sync.go
+++ b/scheduler/pkg/synchroniser/servers_sync.go
@@ -111,6 +111,10 @@ func (s *ServerBasedSynchroniser) Signals(numSignals uint) {
 		if swapped {
 			atomic.AddUint64(&s.maxEvents, uint64(numSignals))
 			s.signalWg.Done()
+			// in the case where we have no servers to connect, we should trigger the doneFn
+			if numSignals == 0 {
+				s.doneFn()
+			}
 		}
 	}
 }

--- a/scheduler/pkg/synchroniser/servers_sync_test.go
+++ b/scheduler/pkg/synchroniser/servers_sync_test.go
@@ -93,6 +93,13 @@ func TestServersSyncSynchroniser(t *testing.T) {
 			initialSignals: 0,
 			context:        coordinator.SERVER_REPLICA_CONNECTED,
 		},
+		{
+			name:           "long timeout - no signal", // timeout will not be reached
+			timeout:        200 * time.Second,
+			signals:        0,
+			initialSignals: 0,
+			context:        coordinator.SERVER_REPLICA_CONNECTED,
+		},
 	}
 
 	for _, test := range tests {
@@ -140,7 +147,11 @@ func TestServersSyncSynchroniser(t *testing.T) {
 				}
 			}
 
-			g.Expect(s.IsReady()).To(BeFalse())
+			if test.signals+test.initialSignals > 0 {
+				g.Expect(s.IsReady()).To(BeFalseBecause("still need to process events"))
+			} else {
+				g.Expect(s.IsReady()).To(BeTrueBecause("no events to process"))
+			}
 
 			time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This change allows fast synchronisation of the scheduler state in the cases we dont have any model server deployed. While this is an edge case and not likely to happen in practice as core 2 cant operate without model servers in the first place, we consider it for sanity reasons.

The change in the code deals with zero servers conditions, covered also by testing.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes INFRA-1217 (internal)

**Special notes for your reviewer**:
