### PR TITLE
always send model events for deleted models

### DIFF
--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -69,6 +69,8 @@ func calcModelVersionStatistics(modelVersion *ModelVersion, deleted bool) *model
 }
 
 func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersion *ModelVersion, stats *modelVersionStateStatistics, deleted bool) {
+	modelVersion.mu.Lock()
+	defer modelVersion.mu.Unlock()
 	var modelState ModelState
 	var modelReason string
 	modelTimestamp := stats.latestTime
@@ -88,7 +90,7 @@ func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersio
 			modelReason = stats.lastFailedReason
 			modelTimestamp = stats.lastFailedStateTime
 		} else if (modelVersion.GetDeploymentSpec() != nil && stats.replicasAvailable == modelVersion.GetDeploymentSpec().Replicas) || // equal to desired replicas
-			(stats.replicasAvailable > 0 && prevModelVersion != nil && modelVersion != prevModelVersion && prevModelVersion.state.State == ModelAvailable) { //TODO In future check if available replicas is > minReplicas
+			(stats.replicasAvailable > 0 && prevModelVersion != nil && modelVersion != prevModelVersion && prevModelVersion.state.State == ModelAvailable) { // TODO In future check if available replicas is > minReplicas
 			modelState = ModelAvailable
 		} else {
 			modelState = ModelProgressing
@@ -105,6 +107,8 @@ func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersio
 }
 
 func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string, reset bool) {
+	modelVersion.mu.Lock()
+	defer modelVersion.mu.Unlock()
 	modelVersion.state = ModelStatus{
 		State:               ScheduleFailed,
 		Reason:              reason,

--- a/scheduler/pkg/store/memory_test.go
+++ b/scheduler/pkg/store/memory_test.go
@@ -684,9 +684,10 @@ func TestUpdateLoadedModels(t *testing.T) {
 				test.store.models[test.modelKey].SetDeleted()
 			}
 			ms := NewMemoryStore(logger, test.store, eventHub)
-			err = ms.UpdateLoadedModels(test.modelKey, test.version, test.serverKey, test.replicas)
+			msg, err := ms.updateLoadedModelsImpl(test.modelKey, test.version, test.serverKey, test.replicas)
 			if !test.err {
 				g.Expect(err).To(BeNil())
+				g.Expect(msg).ToNot(BeNil())
 				for replicaIdx, state := range test.expectedStates {
 					mv := test.store.models[test.modelKey].Latest()
 					g.Expect(mv).ToNot(BeNil())
@@ -700,6 +701,7 @@ func TestUpdateLoadedModels(t *testing.T) {
 				}
 			} else {
 				g.Expect(err).ToNot(BeNil())
+				g.Expect(msg).To(BeNil())
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Some deleted models can end up in a state where model status events are not sent when the model is deleted. This leads to the deleted model getting stuck and it's never removed by the operator. 

The change is to always send model update events for deleted models.

**Which issue(s) this PR fixes**:

Internal : INFRA-1118

Fixes #

**Special notes for your reviewer**:

The test case `DeletedModelNoReplicas` covers this change and replicates the state of the model referenced in the logs attached to the ticket.
