### PR TITLE
fix(scheduler): test for deleted resources that are recreated

### DIFF
--- a/scheduler/pkg/store/experiment/db_test.go
+++ b/scheduler/pkg/store/experiment/db_test.go
@@ -115,6 +115,7 @@ func TestSaveWithTTL(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(item.ExpiresAt()).ToNot(BeZero())
 
+	// check that the resource can be "undeleted"
 	experiment.Deleted = false
 	err = db.save(experiment)
 	g.Expect(err).To(BeNil())

--- a/scheduler/pkg/store/pipeline/db_test.go
+++ b/scheduler/pkg/store/pipeline/db_test.go
@@ -66,6 +66,7 @@ func TestSaveWithTTL(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(item.ExpiresAt()).ToNot(BeZero())
 
+	// check that the resource can be "undeleted"
 	pipeline.Deleted = false
 	err = db.save(pipeline)
 	g.Expect(err).To(BeNil())


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding a test to ensure that resources which have been deleted and saved with a ttl, will have that ttl removed, if they are recreated. 

**Which issue(s) this PR fixes**:
Fixes #  internal INFRA-901

**Special notes for your reviewer**:
