### PR TITLE
fix: Model gateway silently ignores errors

### DIFF
--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -287,8 +287,13 @@ func (iw *InferWorker) produce(
 		return err
 	}
 	go func() {
-		<-deliveryChan
+		e := <-deliveryChan
 		span.End()
+		m := e.(*kafka.Message)
+		if m.TopicPartition.Error != nil {
+			iw.logger.WithError(m.TopicPartition.Error).Errorf("Failed to produce event for model %s", topic)
+		}
+		close(deliveryChan)
 	}()
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is adding errors to kafka errorTopic.

**Which issue(s) this PR fixes**:
To replicate this issue follow: #5125

Fixes #INFRA-1165