### PR TITLE
fix(modelgateway): Allow modelgateway consumers for transient error

### DIFF
--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -162,7 +162,7 @@ func (kc *KafkaSchedulerClient) SubscribeModelEvents() error {
 		// if the model is in a failed state and the consumer exists then we skip the removal
 		// this is to prevent the consumer from being removed during transient failures of the control plane
 		// in this way data plane can potentially continue to serve requests
-		if latestVersionStatus.GetState().GetState() == scheduler.ModelStatus_ScheduleFailed {
+		if latestVersionStatus.GetState().GetState() == scheduler.ModelStatus_ScheduleFailed || latestVersionStatus.GetState().GetState() == scheduler.ModelStatus_ModelProgressing {
 			if kc.consumerManager.Exists(event.ModelName) {
 				logger.Warnf("Model %s schedule failed and consumer exists, skipping from removal", event.ModelName)
 				continue

--- a/scheduler/pkg/kafka/gateway/client.go
+++ b/scheduler/pkg/kafka/gateway/client.go
@@ -164,7 +164,7 @@ func (kc *KafkaSchedulerClient) SubscribeModelEvents() error {
 		// in this way data plane can potentially continue to serve requests
 		if latestVersionStatus.GetState().GetState() == scheduler.ModelStatus_ScheduleFailed || latestVersionStatus.GetState().GetState() == scheduler.ModelStatus_ModelProgressing {
 			if kc.consumerManager.Exists(event.ModelName) {
-				logger.Warnf("Model %s schedule failed and consumer exists, skipping from removal", event.ModelName)
+				logger.Warnf("Model %s schedule failed / progressing and consumer exists, skipping from removal", event.ModelName)
 				continue
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This changes allows modelgateway not to remove the consumer of particular model if it has transitioned to `ScheduleFailed` or `ModelProgressing`. There could be transient failures on the control plane which induce these issues but then data plane should be working just fine.

The consumer will be removed when the user eventually deletes the model.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
