### PR TITLE
fix(agent): allow serial order for servers connection per instance

### DIFF
--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -394,7 +394,7 @@ func (s *Server) Subscribe(request *pb.AgentSubscribeRequest, stream pb.AgentSer
 	defer mu.(*sync.Mutex).Unlock()
 
 	logger.Infof("Received subscribe request from %s:%d", request.ServerName, request.ReplicaIdx)
-	
+
 	fin := make(chan bool)
 
 	s.mutex.Lock()

--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -385,7 +385,6 @@ func (s *Server) ModelScalingTrigger(stream pb.AgentService_ModelScalingTriggerS
 
 func (s *Server) Subscribe(request *pb.AgentSubscribeRequest, stream pb.AgentService_SubscribeServer) error {
 	logger := s.logger.WithField("func", "Subscribe")
-	logger.Infof("Received subscribe request from %s:%d", request.ServerName, request.ReplicaIdx)
 	key := ServerKey{serverName: request.ServerName, replicaIdx: request.ReplicaIdx}
 
 	// this is forcing a serial order per agent (serverName, replicaIdx)
@@ -394,6 +393,8 @@ func (s *Server) Subscribe(request *pb.AgentSubscribeRequest, stream pb.AgentSer
 	mu.(*sync.Mutex).Lock()
 	defer mu.(*sync.Mutex).Unlock()
 
+	logger.Infof("Received subscribe request from %s:%d", request.ServerName, request.ReplicaIdx)
+	
 	fin := make(chan bool)
 
 	s.mutex.Lock()

--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -417,6 +417,7 @@ func (s *Server) Subscribe(request *pb.AgentSubscribeRequest, stream pb.AgentSer
 			server, ok := s.agents[ServerKey{serverName: request.ServerName, replicaIdx: request.ReplicaIdx}]
 			skip := true
 			// we skip orphan streams, in the cases where we have a new stream for the same server replica
+			// the assumption here is that the last stream for a given replica is the one that is valid
 			if ok && server.stream == stream {
 				delete(s.agents, ServerKey{serverName: request.ServerName, replicaIdx: request.ReplicaIdx})
 				skip = false

--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -423,7 +423,7 @@ func (s *Server) Subscribe(request *pb.AgentSubscribeRequest, stream pb.AgentSer
 				skip = false
 			}
 			s.mutex.Unlock()
-			if !skip {
+			if !skip && ok {
 				s.removeServerReplicaImpl(request.GetServerName(), int(request.GetReplicaIdx())) // this is non-blocking beyond rescheduling models on removed server
 			} else {
 				logger.Infof("Skipping removal of (old) server replica %s:%d", request.ServerName, request.ReplicaIdx)

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -1062,7 +1062,7 @@ func TestSubscribe(t *testing.T) {
 				}(idx, s)
 			}
 
-			time.Sleep(1500 * time.Millisecond)
+			time.Sleep(5000 * time.Millisecond)
 
 			g.Expect(len(server.agents)).To(Equal(test.expectedAgentsCountAfterClose))
 

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -986,6 +986,14 @@ func TestSubscribe(t *testing.T) {
 			expectedAgentsCountAfterClose: 0,
 		},
 		{
+			name: "simple - no close",
+			agents: []ag{
+				{1, true}, {2, false},
+			},
+			expectedAgentsCount:           2,
+			expectedAgentsCountAfterClose: 1,
+		},
+		{
 			name: "duplicates",
 			agents: []ag{
 				{1, true}, {1, false},

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -1036,7 +1036,10 @@ func TestSubscribe(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			server.startServer(uint(port), false)
+			err = server.startServer(uint(port), false)
+			if err != nil {
+				t.Fatal(err)
+			}
 			time.Sleep(100 * time.Millisecond)
 
 			streams := make([]*grpc.ClientConn, 0)

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -1062,7 +1062,7 @@ func TestSubscribe(t *testing.T) {
 				}(idx, s)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(1500 * time.Millisecond)
 
 			g.Expect(len(server.agents)).To(Equal(test.expectedAgentsCountAfterClose))
 

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -10,6 +10,7 @@ the Change License after the Change Date as each is defined in accordance with t
 package agent
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -17,13 +18,30 @@ import (
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/seldonio/seldon-core/apis/go/v2/mlops/agent"
 	pb "github.com/seldonio/seldon-core/apis/go/v2/mlops/agent"
 	pbs "github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/coordinator"
+	testing_utils2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/scheduler"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store"
 )
+
+type mockScheduler struct {
+}
+
+var _ scheduler.Scheduler = (*mockScheduler)(nil)
+
+func (s mockScheduler) Schedule(_ string) error {
+	return nil
+}
+
+func (s mockScheduler) ScheduleFailedModels() ([]string, error) {
+	return nil, nil
+}
 
 type mockStore struct {
 	models map[string]*store.ModelSnapshot
@@ -91,7 +109,7 @@ func (m *mockStore) UpdateModelState(modelKey string, version uint32, serverKey 
 }
 
 func (m *mockStore) AddServerReplica(request *pb.AgentSubscribeRequest) error {
-	panic("implement me")
+	return nil
 }
 
 func (m *mockStore) ServerNotify(request *pbs.ServerNotify) error {
@@ -99,7 +117,7 @@ func (m *mockStore) ServerNotify(request *pbs.ServerNotify) error {
 }
 
 func (m *mockStore) RemoveServerReplica(serverName string, replicaIdx int) ([]string, error) {
-	panic("implement me")
+	return nil, nil
 }
 
 func (m *mockStore) DrainServerReplica(serverName string, replicaIdx int) ([]string, error) {
@@ -942,4 +960,98 @@ func TestAutoscalingEnabled(t *testing.T) {
 		})
 	}
 
+}
+
+func TestSubscribe(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	g := NewGomegaWithT(t)
+
+	type ag struct {
+		id      uint32
+		doClose bool
+	}
+	type test struct {
+		name                          string
+		agents                        []ag
+		expectedAgentsCount           int
+		expectedAgentsCountAfterClose int
+	}
+	tests := []test{
+		{
+			name: "simple",
+			agents: []ag{
+				{1, true}, {2, true},
+			},
+			expectedAgentsCount:           2,
+			expectedAgentsCountAfterClose: 0,
+		},
+		{
+			name: "duplicates",
+			agents: []ag{
+				{1, true}, {1, false},
+			},
+			expectedAgentsCount:           1,
+			expectedAgentsCountAfterClose: 1,
+		},
+		{
+			name: "duplicates with both close",
+			agents: []ag{
+				{1, true}, {1, true},
+			},
+			expectedAgentsCount:           1,
+			expectedAgentsCountAfterClose: 0,
+		},
+	}
+
+	getStream := func(id uint32, context context.Context, port int) *grpc.ClientConn {
+		conn, _ := grpc.NewClient(fmt.Sprintf(":%d", port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpcClient := agent.NewAgentServiceClient(conn)
+		_, _ = grpcClient.Subscribe(
+			context,
+			&agent.AgentSubscribeRequest{
+				ServerName:           "dummy",
+				ReplicaIdx:           id,
+				ReplicaConfig:        &agent.ReplicaConfig{},
+				Shared:               true,
+				AvailableMemoryBytes: 0,
+			},
+		)
+		return conn
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := log.New()
+			eventHub, err := coordinator.NewEventHub(logger)
+			g.Expect(err).To(BeNil())
+			server := NewAgentServer(logger, &mockStore{}, mockScheduler{}, eventHub, false)
+			port, err := testing_utils2.GetFreePortForTest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			server.startServer(uint(port), false)
+			time.Sleep(100 * time.Millisecond)
+
+			streams := make([]*grpc.ClientConn, 0)
+			for _, id := range test.agents {
+				conn := getStream(id.id, context.Background(), port)
+				streams = append(streams, conn)
+			}
+
+			time.Sleep(100 * time.Millisecond)
+
+			g.Expect(len(server.agents)).To(Equal(test.expectedAgentsCount))
+
+			for idx, s := range streams {
+				if test.agents[idx].doClose {
+					s.Close()
+				}
+			}
+
+			time.Sleep(100 * time.Millisecond)
+
+			g.Expect(len(server.agents)).To(Equal(test.expectedAgentsCountAfterClose))
+
+			server.StopAgentStreams()
+		})
+	}
 }

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -1062,7 +1062,7 @@ func TestSubscribe(t *testing.T) {
 				}(idx, s)
 			}
 
-			time.Sleep(5000 * time.Millisecond)
+			time.Sleep(10 * time.Second)
 
 			g.Expect(len(server.agents)).To(Equal(test.expectedAgentsCountAfterClose))
 

--- a/scheduler/pkg/agent/server_test.go
+++ b/scheduler/pkg/agent/server_test.go
@@ -25,7 +25,7 @@ import (
 	pbs "github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/coordinator"
-	testing_utils2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
+	testing_utils "github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/scheduler"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store"
 )
@@ -1032,7 +1032,7 @@ func TestSubscribe(t *testing.T) {
 			eventHub, err := coordinator.NewEventHub(logger)
 			g.Expect(err).To(BeNil())
 			server := NewAgentServer(logger, &mockStore{}, mockScheduler{}, eventHub, false)
-			port, err := testing_utils2.GetFreePortForTest()
+			port, err := testing_utils.GetFreePortForTest()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1050,7 +1050,7 @@ func TestSubscribe(t *testing.T) {
 				}(a.id)
 			}
 
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 
 			g.Expect(len(server.agents)).To(Equal(test.expectedAgentsCount))
 
@@ -1062,7 +1062,7 @@ func TestSubscribe(t *testing.T) {
 				}(idx, s)
 			}
 
-			time.Sleep(300 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 
 			g.Expect(len(server.agents)).To(Equal(test.expectedAgentsCountAfterClose))
 

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -127,7 +127,6 @@ func (c *ChainerServer) PipelineUpdateEvent(ctx context.Context, message *chaine
 
 func (c *ChainerServer) SubscribePipelineUpdates(req *chainer.PipelineSubscriptionRequest, stream chainer.Chainer_SubscribePipelineUpdatesServer) error {
 	logger := c.logger.WithField("func", "SubscribePipelineStatus")
-	logger.Infof("Received subscribe request from %s", req.GetName())
 
 	key := req.GetName()
 	// this is forcing a serial order per dataflow-engine
@@ -135,6 +134,8 @@ func (c *ChainerServer) SubscribePipelineUpdates(req *chainer.PipelineSubscripti
 	mu, _ := c.chainerMutex.LoadOrStore(key, &sync.Mutex{})
 	mu.(*sync.Mutex).Lock()
 	defer mu.(*sync.Mutex).Unlock()
+
+	logger.Infof("Received subscribe request from %s", req.GetName())
 
 	fin := make(chan bool)
 

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -44,6 +44,7 @@ type ChainerServer struct {
 	pipelineHandler pipeline.PipelineHandler
 	topicNamer      *kafka.TopicNamer
 	loadBalancer    util.LoadBalancer
+	chainerMutex    sync.Map
 	chainer.UnimplementedChainerServer
 }
 
@@ -66,6 +67,7 @@ func NewChainerServer(logger log.FieldLogger, eventHub *coordinator.EventHub, pi
 		pipelineHandler: pipelineHandler,
 		topicNamer:      topicNamer,
 		loadBalancer:    loadBalancer,
+		chainerMutex:    sync.Map{},
 	}
 
 	eventHub.RegisterPipelineEventHandler(
@@ -127,15 +129,22 @@ func (c *ChainerServer) SubscribePipelineUpdates(req *chainer.PipelineSubscripti
 	logger := c.logger.WithField("func", "SubscribePipelineStatus")
 	logger.Infof("Received subscribe request from %s", req.GetName())
 
+	key := req.GetName()
+	// this is forcing a serial order per dataflow-engine
+	// in general this will make sure that a given dataflow-engine disconnects fully before another dataflow-engine is allowed to connect
+	mu, _ := c.chainerMutex.LoadOrStore(key, &sync.Mutex{})
+	mu.(*sync.Mutex).Lock()
+	defer mu.(*sync.Mutex).Unlock()
+
 	fin := make(chan bool)
 
 	c.mu.Lock()
-	c.streams[req.Name] = &ChainerSubscription{
-		name:   req.Name,
+	c.streams[key] = &ChainerSubscription{
+		name:   key,
 		stream: stream,
 		fin:    fin,
 	}
-	c.loadBalancer.AddServer(req.Name)
+	c.loadBalancer.AddServer(key)
 	c.mu.Unlock()
 
 	// Handle addition of new server
@@ -148,13 +157,13 @@ func (c *ChainerServer) SubscribePipelineUpdates(req *chainer.PipelineSubscripti
 	for {
 		select {
 		case <-fin:
-			logger.Infof("Closing stream for %s", req.GetName())
+			logger.Infof("Closing stream for %s", key)
 			return nil
 		case <-ctx.Done():
-			logger.Infof("Stream disconnected %s", req.GetName())
+			logger.Infof("Stream disconnected %s", key)
 			c.mu.Lock()
-			c.loadBalancer.RemoveServer(req.Name)
-			delete(c.streams, req.Name)
+			c.loadBalancer.RemoveServer(key)
+			delete(c.streams, key)
 			c.mu.Unlock()
 			// Handle removal of server
 			c.rebalance()

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -324,7 +324,7 @@ func TestPipelineRollingUpgradeEvents(t *testing.T) {
 			}
 
 			// to allow events to propagate
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(700 * time.Millisecond)
 
 			if test.connection {
 				if test.loadReqV2 != nil {

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -749,7 +749,7 @@ func TestPipelineSubscribe(t *testing.T) {
 				}(idx, s)
 			}
 
-			time.Sleep(5000 * time.Millisecond)
+			time.Sleep(10 * time.Second)
 
 			g.Expect(len(s.streams)).To(Equal(test.expectedAgentsCountAfterClose))
 

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -749,7 +749,7 @@ func TestPipelineSubscribe(t *testing.T) {
 				}(idx, s)
 			}
 
-			time.Sleep(1500 * time.Millisecond)
+			time.Sleep(5000 * time.Millisecond)
 
 			g.Expect(len(s.streams)).To(Equal(test.expectedAgentsCountAfterClose))
 

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -737,7 +737,7 @@ func TestPipelineSubscribe(t *testing.T) {
 				}(a.id)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(700 * time.Millisecond)
 
 			g.Expect(len(s.streams)).To(Equal(test.expectedAgentsCount))
 
@@ -749,7 +749,7 @@ func TestPipelineSubscribe(t *testing.T) {
 				}(idx, s)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(1500 * time.Millisecond)
 
 			g.Expect(len(s.streams)).To(Equal(test.expectedAgentsCountAfterClose))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

In some cases during rolling upgrades of servers we can get a situation where the scheduler detects the disconnection of an old version of a server _after_ the new server had connected and in this case we dont want to actually act upon this disconnection.

We do that by enforcing a serial order per instance, meaning that the current server has to disconnect before the new one can connect.

There are 2 components affected: agent server and chainer server.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # INFRA-1226 (internal)

**Special notes for your reviewer**:

Tested by unit tests