### PR TITLE
fix(dataflow): make each replica use unique subscription names

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
@@ -27,6 +27,7 @@ import io.klogging.noCoLogger
 import io.seldon.dataflow.kafka.security.KafkaSaslMechanisms
 import io.seldon.dataflow.kafka.security.KafkaSecurityProtocols
 import java.net.InetAddress
+import java.util.UUID
 
 object Cli {
     private const val ENV_VAR_PREFIX = "SELDON_"
@@ -117,18 +118,18 @@ object Cli {
     }
 
     private fun getSystemConfig(): Configuration {
-        val dataflowIdPair = this.dataflowReplicaId to getDataflowId()
+        val dataflowIdPair = this.dataflowReplicaId to getNewDataflowId()
         return ConfigurationMap(dataflowIdPair)
     }
 
-    private fun getDataflowId(): String {
-        return try {
-            InetAddress.getLocalHost().hostName
-        } catch (e: Exception) {
-            val hexCharPool: List<Char> = ('a'..'f') + ('0'..'9')
-            val randomIdLength = 50
-            return "seldon-dataflow-engine-" + List(randomIdLength) { hexCharPool.random() }.joinToString("")
+    fun getNewDataflowId(assignRandomUuid: Boolean = false): String {
+        if (!assignRandomUuid) {
+            try {
+                return InetAddress.getLocalHost().hostName
+            } catch (_: Exception) {
+            }
         }
+        return "seldon-dataflow-engine-" + UUID.randomUUID().toString()
     }
 
     private fun parseArguments(rawArgs: Array<String>): Configuration {

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Main.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Main.kt
@@ -102,9 +102,11 @@ object Main {
                 describeRetries = config[Cli.topicDescribeRetries],
                 describeRetryDelayMillis = config[Cli.topicDescribeRetryDelayMillis],
             )
+        val subscriberId = config[Cli.dataflowReplicaId]
+
         val subscriber =
             PipelineSubscriber(
-                "seldon-dataflow-engine",
+                subscriberId,
                 kafkaProperties,
                 kafkaAdminProperties,
                 kafkaStreamsParams,

--- a/scheduler/data-flow/src/main/resources/local.properties
+++ b/scheduler/data-flow/src/main/resources/local.properties
@@ -1,5 +1,6 @@
 log.level.app=INFO
 log.level.kafka=WARN
+dataflow.replica.id=seldon-dataflow-engine
 kafka.bootstrap.servers=localhost:9092
 kafka.consumer.prefix=
 kafka.security.protocol=PLAINTEXT

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
@@ -17,9 +17,12 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import strikt.api.expectCatching
 import strikt.api.expectThat
+import strikt.assertions.hasLength
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEqualTo
 import strikt.assertions.isSuccess
+import strikt.assertions.startsWith
+import java.util.UUID
 import java.util.stream.Stream
 import kotlin.test.Test
 
@@ -51,6 +54,17 @@ internal class CliTest {
         expectThat(cli[Cli.dataflowReplicaId]) {
             isEqualTo(testReplicaId)
         }
+
+        // test random Uuid (v4)
+        val expectedReplicaIdPrefix = "seldon-dataflow-engine-"
+        val uuidStringLength = 36
+        val randomReplicaUuid = Cli.getNewDataflowId(true)
+        expectThat(randomReplicaUuid) {
+            startsWith(expectedReplicaIdPrefix)
+            hasLength(expectedReplicaIdPrefix.length + uuidStringLength)
+        }
+        expectCatching { UUID.fromString(randomReplicaUuid.removePrefix(expectedReplicaIdPrefix)) }
+            .isSuccess()
     }
 
     companion object {

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
@@ -16,9 +16,12 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import strikt.api.expectCatching
+import strikt.api.expectThat
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEqualTo
 import strikt.assertions.isSuccess
 import java.util.stream.Stream
+import kotlin.test.Test
 
 internal class CliTest {
     @DisplayName("Passing auth mechanism via cli argument")
@@ -34,6 +37,20 @@ internal class CliTest {
         expectCatching { cli[Cli.saslMechanism] }
             .isSuccess()
             .isEqualTo(expectedMechanism)
+    }
+
+    @Test
+    fun `should handle dataflow replica id`() {
+        val cliDefault = Cli.configWith(arrayOf<String>())
+        val testReplicaId = "dataflow-id-1"
+        val cli = Cli.configWith(arrayOf("--dataflow-replica-id", testReplicaId))
+
+        expectThat(cliDefault[Cli.dataflowReplicaId]) {
+            isNotEqualTo("seldon-dataflow-engine")
+        }
+        expectThat(cli[Cli.dataflowReplicaId]) {
+            isEqualTo(testReplicaId)
+        }
     }
 
     companion object {


### PR DESCRIPTION
Following #6020, it was no longer possible to have multiple replicas of dataflow-engine subscribing simultaneously to the scheduler, because all were connecting with the same subscriber name, and a lock was added per name, first waiting the disconnection of the old subscriber before allowing a new one to progress.

We update the dataflow-engine code so that each replica connects with its own hostname as the subscriber name. If the hostname can not be determined, we subscribe with the name `seldon-dataflow-engine-` followed by a hex string of 50 random characters.

The subscriber name can also be explicitly controlled by passing the `--dataflow-replica-id` argument or the `DATAFLOW_REPLICA_ID` environment variable, wich will take precedence, in that order, to setting the value as the hostname.

**Special notes for your reviewer**:

- tested in kind, hostname gets correctly picked up:
  - On the dataflow end:
    ![dataflow-id](https://github.com/user-attachments/assets/f122c05e-cbf6-4735-bc06-6611901c5c83)
  - On the scheduler end: 
    ![scheduler-dataflow-id](https://github.com/user-attachments/assets/10468d4d-3d2d-4231-9322-079112b2b409)
