### PR TITLE
fix(envoy): add keepalive settings to all envoy configs

### DIFF
--- a/scheduler/config/envoy-compose.yaml
+++ b/scheduler/config/envoy-compose.yaml
@@ -11,7 +11,12 @@ static_resources:
                     socket_address:
                       address: scheduler
                       port_value: 9002
-      http2_protocol_options: {}
+      http2_protocol_options: {
+        connection_keepalive: {
+          interval: 60s,
+          timeout: 2s,
+        }
+      }
       name: xds_cluster
     - connect_timeout: 0.250s
       type: LOGICAL_DNS

--- a/scheduler/config/envoy-local.yaml
+++ b/scheduler/config/envoy-local.yaml
@@ -11,7 +11,12 @@ static_resources:
                     socket_address:
                       address: 0.0.0.0
                       port_value: 9002
-      http2_protocol_options: {}
+      http2_protocol_options: {
+        connection_keepalive: {
+          interval: 60s,
+          timeout: 2s,
+        }
+      }
       name: xds_cluster
     - connect_timeout: 0.250s
       type: LOGICAL_DNS

--- a/scheduler/config/envoy-tls.yaml
+++ b/scheduler/config/envoy-tls.yaml
@@ -11,7 +11,12 @@ static_resources:
                     socket_address:
                       address: seldon-scheduler
                       port_value: 9002
-      http2_protocol_options: {}
+      http2_protocol_options: {
+        connection_keepalive: {
+          interval: 60s,
+          timeout: 2s,
+        }
+      }
       name: xds_cluster
       transport_socket:
          name: "envoy.transport_sockets.tls"


### PR DESCRIPTION
This is a change to add keepalive settings to other envoy config files that were missed in https://github.com/SeldonIO/seldon-core/pull/6016 (https://github.com/SeldonIO/seldon-core/pull/6016/commits/9f18ee222a6c6d2bd097c2ae8b4a678f7c92b365)