### PR TITLE
fix: Allow model versions to increase in k6 tests

### DIFF
--- a/tests/k6/components/utils.js
+++ b/tests/k6/components/utils.js
@@ -626,10 +626,12 @@ export function applyModelReplicaChange(config) {
         const modelId = Math.floor(Math.random() * config.maxNumModels[j])
         const modelName = config.modelNamePrefix[j] + modelId.toString()
 
-        let replicas =  Math.floor(Math.random() * config.maxModelReplicas[j]) + 1
-        const model = generateModel(config.modelType[j], modelName, 1, replicas, config.isSchedulerProxy, config.modelMemoryBytes[j], config.inferBatchSize[j])
+        const rand = Math.random()
+        const replicas =  Math.floor(rand * config.maxModelReplicas[j]) + 1
+        const memory = (rand > 0.5)? replicas + "k": "1k"   // this will induce a change in memory causing a new version of the model to be created
+        const model = generateModel(config.modelType[j], modelName, 1, replicas, config.isSchedulerProxy, memory, config.inferBatchSize[j])
         let opOk = k8s.loadModel(modelName, model.modelCRYaml, true)
-        console.log("Model load %s with replicas %d operation status:",modelName, replicas, opOk)
+        console.log("Model load with replicas/memory operation status", modelName, replicas, memory, opOk)
       }
     }
     sleep(config.sleepBetweenModelReplicaChange)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This change adds some randomisation to rollout new versions of a model as opposed to new replicas.

