### PR TITLE
feat: Expose pvc retention policy via helm

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
+++ b/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
@@ -12,9 +12,9 @@ spec:
   replicas: {{ .Values.mlserver.replicas }}
   serverConfig: mlserver
   statefulSetPersistentVolumeClaimRetentionPolicy:
-    whenDeleted: {{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted
+    whenDeleted: {{ .Values.mlserver.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted
       }}
-    whenScaled: {{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled
+    whenScaled: {{ .Values.mlserver.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled
       }}
 ---
 apiVersion: mlops.seldon.io/v1alpha1

--- a/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
+++ b/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
@@ -11,6 +11,11 @@ spec:
   podSpec: {{ toJson .Values.mlserver.podSpec }}
   replicas: {{ .Values.mlserver.replicas }}
   serverConfig: mlserver
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted
+      }}
+    whenScaled: {{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled
+      }}
 ---
 apiVersion: mlops.seldon.io/v1alpha1
 kind: Server
@@ -25,3 +30,8 @@ spec:
   podSpec: {{ toJson .Values.triton.podSpec }}
   replicas: {{ .Values.triton.replicas }}
   serverConfig: triton
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted
+      }}
+    whenScaled: {{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled
+      }}

--- a/k8s/helm-charts/seldon-core-v2-servers/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-servers/values.yaml
@@ -1,5 +1,11 @@
 mlserver:
   replicas: 1
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
 
 triton:
   replicas: 1
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain

--- a/k8s/kustomize/helm-servers/patch_mlserver.yaml
+++ b/k8s/kustomize/helm-servers/patch_mlserver.yaml
@@ -7,3 +7,6 @@ metadata:
 spec:
   replicas: HACK_REMOVE_ME{{ .Values.mlserver.replicas }}
   podSpec: HACK_REMOVE_ME{{ toJson .Values.mlserver.podSpec }}
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: HACK_REMOVE_ME{{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: HACK_REMOVE_ME{{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled }}

--- a/k8s/kustomize/helm-servers/patch_mlserver.yaml
+++ b/k8s/kustomize/helm-servers/patch_mlserver.yaml
@@ -8,5 +8,5 @@ spec:
   replicas: HACK_REMOVE_ME{{ .Values.mlserver.replicas }}
   podSpec: HACK_REMOVE_ME{{ toJson .Values.mlserver.podSpec }}
   statefulSetPersistentVolumeClaimRetentionPolicy:
-    whenDeleted: HACK_REMOVE_ME{{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted }}
-    whenScaled: HACK_REMOVE_ME{{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled }}
+    whenDeleted: HACK_REMOVE_ME{{ .Values.mlserver.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: HACK_REMOVE_ME{{ .Values.mlserver.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled }}

--- a/k8s/kustomize/helm-servers/patch_triton.yaml
+++ b/k8s/kustomize/helm-servers/patch_triton.yaml
@@ -7,3 +7,6 @@ metadata:
 spec:
   replicas: HACK_REMOVE_ME{{ .Values.triton.replicas }}
   podSpec: HACK_REMOVE_ME{{ toJson .Values.triton.podSpec }}
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: HACK_REMOVE_ME{{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: HACK_REMOVE_ME{{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenScaled }}

--- a/k8s/yaml/servers.yaml
+++ b/k8s/yaml/servers.yaml
@@ -12,6 +12,9 @@ spec:
   podSpec: null
   replicas: 1
   serverConfig: mlserver
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
 ---
 # Source: seldon-core-v2-servers/templates/seldon-v2-servers.yaml
 apiVersion: mlops.seldon.io/v1alpha1
@@ -26,3 +29,6 @@ spec:
   podSpec: null
   replicas: 1
   serverConfig: triton
+  statefulSetPersistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose PVC retention policy via helm. **Retain** is the default value.
Info on retention policy can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention


Example YAML

```yaml
apiVersion: mlops.seldon.io/v1alpha1
kind: Server
  name: triton
  namespace: seldon
spec:
  replicas: 1
  serverConfig: triton
  statefulSetPersistentVolumeClaimRetentionPolicy:
    whenDeleted: Retain
    whenScaled: Retain
```

Fixes #INFRA-1235
