### PR TITLE
feat(envoy): switch to ADS

### DIFF
--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/coordinator"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/processor"
-	envoyServer "github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/server"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/xdscache"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/config"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/dataflow"
@@ -167,7 +166,7 @@ func main() {
 	go makeSignalHandler(logger, done)
 
 	// Create a cache
-	xdsCache := cache.NewSnapshotCache(false, cache.IDHash{}, logger)
+	xdsCache := cache.NewSnapshotCache(true, cache.IDHash{}, logger)
 
 	tracer, err := tracing.NewTraceProvider("seldon-scheduler", &tracingConfigPath, logger)
 	if err != nil {
@@ -270,7 +269,7 @@ func main() {
 	// so that the xDS server can start sending valid updates to envoy.
 	ctx := context.Background()
 	srv := envoyServerControlPlaneV3.NewServer(ctx, xdsCache, nil)
-	xdsServer := envoyServer.NewXDSServer(srv, logger)
+	xdsServer := processor.NewXDSServer(srv, logger)
 	err = xdsServer.StartXDSServer(envoyPort)
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to start envoy xDS server")

--- a/scheduler/config/envoy-compose.yaml
+++ b/scheduler/config/envoy-compose.yaml
@@ -62,24 +62,19 @@ static_resources:
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
   cds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
   lds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
 node:
   cluster: test-cluster
   id: test-id
@@ -89,12 +84,7 @@ layered_runtime:
       rtds_layer:
         rtds_config:
           resource_api_version: V3
-          api_config_source:
-            transport_api_version: V3
-            api_type: DELTA_GRPC
-            grpc_services:
-              envoy_grpc:
-                cluster_name: xds_cluster
+          ads: {}
         name: runtime-0
 admin:
   access_log_path: /dev/null

--- a/scheduler/config/envoy-local.yaml
+++ b/scheduler/config/envoy-local.yaml
@@ -62,24 +62,19 @@ static_resources:
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
   cds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
   lds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
 node:
   cluster: test-cluster
   id: test-id
@@ -89,12 +84,7 @@ layered_runtime:
       rtds_layer:
         rtds_config:
           resource_api_version: V3
-          api_config_source:
-            transport_api_version: V3
-            api_type: DELTA_GRPC
-            grpc_services:
-              envoy_grpc:
-                cluster_name: xds_cluster
+          ads: {}
         name: runtime-0
 admin:
   access_log_path: /dev/null

--- a/scheduler/config/envoy-tls.yaml
+++ b/scheduler/config/envoy-tls.yaml
@@ -75,24 +75,19 @@ static_resources:
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
   cds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
   lds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
 node:
   cluster: test-cluster
   id: test-id
@@ -102,12 +97,7 @@ layered_runtime:
       rtds_layer:
         rtds_config:
           resource_api_version: V3
-          api_config_source:
-            transport_api_version: V3
-            api_type: DELTA_GRPC
-            grpc_services:
-              envoy_grpc:
-                cluster_name: xds_cluster
+          ads: {}
         name: runtime-0
 admin:
   access_log_path: /dev/null

--- a/scheduler/config/envoy.yaml
+++ b/scheduler/config/envoy.yaml
@@ -62,24 +62,19 @@ static_resources:
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
   cds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
   lds_config:
     resource_api_version: V3
-    api_config_source:
-      api_type: DELTA_GRPC
-      transport_api_version: V3
-      grpc_services:
-        - envoy_grpc:
-            cluster_name: xds_cluster
-      set_node_on_first_message_only: true
+    ads: {}
 node:
   cluster: test-cluster
   id: test-id
@@ -89,12 +84,7 @@ layered_runtime:
       rtds_layer:
         rtds_config:
           resource_api_version: V3
-          api_config_source:
-            transport_api_version: V3
-            api_type: DELTA_GRPC
-            grpc_services:
-              envoy_grpc:
-                cluster_name: xds_cluster
+          ads: {}
         name: runtime-0
 admin:
   access_log_path: /dev/null

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -258,7 +258,7 @@ func (p *IncrementalProcessor) updateEnvoyForModelVersion(modelRouteName string,
 	clusterNameBase := modelVersion.GetMeta().GetName() + "_" + strconv.FormatInt(int64(modelVersion.GetVersion()), 10)
 	httpClusterName := clusterNameBase + "_http"
 	grpcClusterName := clusterNameBase + "_grpc"
-	p.xdsCache.AddCluster(httpClusterName, modelRouteName, modelVersion.GetModel().GetMeta().GetName(), modelVersion.GetVersion(), false)
+	p.xdsCache.AddCluster(httpClusterName, false)
 	for _, replicaIdx := range assignment {
 		replica, ok := server.Replicas[replicaIdx]
 		if !ok {
@@ -267,7 +267,7 @@ func (p *IncrementalProcessor) updateEnvoyForModelVersion(modelRouteName string,
 			p.xdsCache.AddEndpoint(httpClusterName, replica.GetInferenceSvc(), uint32(replica.GetInferenceHttpPort()))
 		}
 	}
-	p.xdsCache.AddCluster(grpcClusterName, modelRouteName, modelVersion.GetModel().GetMeta().GetName(), modelVersion.GetVersion(), true)
+	p.xdsCache.AddCluster(grpcClusterName, true)
 	for _, replicaIdx := range assignment {
 		replica, ok := server.Replicas[replicaIdx]
 		if !ok {

--- a/scheduler/pkg/envoy/processor/server.go
+++ b/scheduler/pkg/envoy/processor/server.go
@@ -7,18 +7,13 @@ Use of this software is governed by
 the Change License after the Change Date as each is defined in accordance with the LICENSE file.
 */
 
-package server
+package processor
 
 import (
 	"fmt"
 	"net"
 
-	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
-	routeservice "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
-	runtimeservice "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
-	secretservice "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -48,12 +43,6 @@ func NewXDSServer(server serverv3.Server, logger log.FieldLogger) *XDSServer {
 func registerServer(grpcServer *grpc.Server, server serverv3.Server) {
 	// register services
 	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
-	//endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
-	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
-	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)
-	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, server)
-	secretservice.RegisterSecretDiscoveryServiceServer(grpcServer, server)
-	runtimeservice.RegisterRuntimeDiscoveryServiceServer(grpcServer, server)
 }
 
 // StartXDSServer starts an xDS server at the given port.

--- a/scheduler/pkg/envoy/processor/server_test.go
+++ b/scheduler/pkg/envoy/processor/server_test.go
@@ -1,0 +1,115 @@
+package processor
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	client "github.com/envoyproxy/go-control-plane/pkg/client/sotw/v3"
+	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	envoyServerControlPlaneV3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/xdscache"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store/experiment"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store/pipeline"
+)
+
+func TestFetch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	logger := log.New()
+
+	snapCache := cache.NewSnapshotCache(true, cache.IDHash{}, logger)
+	go func() {
+		err := startAdsServer(ctx, snapCache, 18001)
+		g.Expect(err).To(BeNil())
+	}()
+
+	memoryStore := store.NewMemoryStore(logger, store.NewLocalSchedulerStore(), nil)
+	pipelineHandler := pipeline.NewPipelineStore(logger, nil, memoryStore)
+
+	inc := &IncrementalProcessor{
+		cache:            snapCache,
+		logger:           logger,
+		xdsCache:         xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{}),
+		pipelineHandler:  pipelineHandler,
+		modelStore:       memoryStore,
+		experimentServer: experiment.NewExperimentServer(logger, nil, memoryStore, pipelineHandler),
+		nodeID:           "node_1",
+	}
+
+	err := inc.setListeners()
+	g.Expect(err).To(BeNil())
+
+	conn, err := grpc.NewClient(":18001", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	g.Expect(err).To(BeNil())
+	defer conn.Close()
+
+	c := client.NewADSClient(ctx, &core.Node{Id: "node_1"}, resource.ClusterType)
+	err = c.InitConnect(conn)
+	g.Expect(err).To(BeNil())
+
+	t.Run("Test initial fetch with model 1", testInitialFetch(g, inc, c))
+}
+
+func testInitialFetch(g *WithT, inc *IncrementalProcessor, c client.ADSClient) func(t *testing.T) {
+	expectedClusterNames := []string{"pipelinegateway_http", "pipelinegateway_grpc", "mirror_http", "mirror_grpc", "model_1_grpc", "model_1_http"}
+
+	return func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+
+		ops := []func(inc *IncrementalProcessor, g *WithT){
+			createTestServer("server", 1),
+			createTestModel("model", "server", 1, []int{0}, 1, []store.ModelReplicaState{store.Available}),
+		}
+
+		for _, op := range ops {
+			op(inc, g)
+		}
+
+		go func() {
+			// watch for configs
+			resp, err := c.Fetch()
+			g.Expect(err).To(BeNil())
+			for _, r := range resp.Resources {
+				cluster := &clusterv3.Cluster{}
+				err := anypb.UnmarshalTo(r, cluster, proto.UnmarshalOptions{})
+				g.Expect(err).To(BeNil())
+				g.Expect(slices.Contains(expectedClusterNames, cluster.Name)).To(BeTrue())
+			}
+
+			err = c.Ack()
+			g.Expect(err).To(BeNil())
+			wg.Done()
+		}()
+
+		wg.Wait()
+	}
+}
+
+func startAdsServer(ctx context.Context, snapCache cache.SnapshotCache, port uint) error {
+	logger := log.New()
+	srv := envoyServerControlPlaneV3.NewServer(ctx, snapCache, nil)
+	xdsServer := NewXDSServer(srv, logger)
+	err := xdsServer.StartXDSServer(port)
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to start envoy xDS server")
+	}
+
+	return err
+}

--- a/scheduler/pkg/envoy/xdscache/seldoncache.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache.go
@@ -74,7 +74,7 @@ func (xds *SeldonXDSCache) ClusterContents() []types.Resource {
 		}
 	}
 
-	//Add pipeline gateway clusters
+	// Add pipeline gateway clusters
 	xds.logger.Infof("Add http pipeline cluster %s host:%s port:%d", resources.PipelineGatewayHttpClusterName, xds.PipelineGatewayDetails.Host, xds.PipelineGatewayDetails.HttpPort)
 	r = append(r, resources.MakeCluster(resources.PipelineGatewayHttpClusterName, []resources.Endpoint{
 		{
@@ -303,9 +303,6 @@ func (xds *SeldonXDSCache) AddRouteClusterTraffic(
 
 func (xds *SeldonXDSCache) AddCluster(
 	name string,
-	routeName string,
-	modelName string,
-	modelVersion uint32,
 	isGrpc bool,
 ) {
 	cluster, ok := xds.Clusters[name]
@@ -318,6 +315,7 @@ func (xds *SeldonXDSCache) AddCluster(
 		}
 	}
 	cluster.Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: modelName, Version: modelVersion}] = true
+
 	xds.Clusters[name] = cluster
 }
 

--- a/scheduler/pkg/envoy/xdscache/seldoncache_test.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache_test.go
@@ -29,8 +29,8 @@ func TestAddRemoveHttpAndGrpcRoute(t *testing.T) {
 	c := NewSeldonXDSCache(logger, &PipelineGatewayDetails{})
 
 	addVersionedRoute := func(c *SeldonXDSCache, routeName string, modelName string, httpCluster string, grpcCluster string, traffic uint32, version uint32) {
-		c.AddCluster(httpCluster, routeName, modelName, version, false)
-		c.AddCluster(grpcCluster, routeName, modelName, version, true)
+		c.AddCluster(httpCluster, false)
+		c.AddCluster(grpcCluster, true)
 		c.AddRouteClusterTraffic(routeName, modelName, version, traffic, httpCluster, grpcCluster, true, false)
 		c.AddEndpoint(httpCluster, "0.0.0.0", 9000)
 		c.AddEndpoint(grpcCluster, "0.0.0.0", 9001)
@@ -63,8 +63,8 @@ func TestAddRemoveHttpAndGrpcRouteVersions(t *testing.T) {
 	logger := log.New()
 
 	addVersionedRoute := func(c *SeldonXDSCache, routeName string, modelName string, httpCluster string, grpcCluster string, traffic uint32, version uint32) {
-		c.AddCluster(httpCluster, routeName, modelName, version, false)
-		c.AddCluster(grpcCluster, routeName, modelName, version, true)
+		c.AddCluster(httpCluster, false)
+		c.AddCluster(grpcCluster, true)
 		c.AddRouteClusterTraffic(routeName, modelName, version, traffic, httpCluster, grpcCluster, true, false)
 		c.AddEndpoint(httpCluster, "0.0.0.0", 9000)
 		c.AddEndpoint(grpcCluster, "0.0.0.0", 9001)
@@ -124,8 +124,8 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForSameModel(t *testing.T) {
 	logger := log.New()
 
 	addVersionedRoute := func(c *SeldonXDSCache, routeName string, modelName string, httpCluster string, grpcCluster string, traffic uint32, version uint32) {
-		c.AddCluster(httpCluster, routeName, modelName, version, false)
-		c.AddCluster(grpcCluster, routeName, modelName, version, true)
+		c.AddCluster(httpCluster, false)
+		c.AddCluster(grpcCluster, true)
 		c.AddRouteClusterTraffic(routeName, modelName, version, traffic, httpCluster, grpcCluster, true, false)
 		c.AddEndpoint(httpCluster, "0.0.0.0", 9000)
 		c.AddEndpoint(grpcCluster, "0.0.0.0", 9001)
@@ -168,8 +168,8 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForDifferentModels(t *testing.T) {
 	logger := log.New()
 
 	addVersionedRoute := func(c *SeldonXDSCache, modelRouteName string, modelName string, httpCluster string, grpcCluster string, traffic uint32, version uint32) {
-		c.AddCluster(httpCluster, modelRouteName, modelName, version, false)
-		c.AddCluster(grpcCluster, modelRouteName, modelName, version, true)
+		c.AddCluster(httpCluster, false)
+		c.AddCluster(grpcCluster, true)
 		c.AddRouteClusterTraffic(modelRouteName, modelName, version, traffic, httpCluster, grpcCluster, true, false)
 		c.AddEndpoint(httpCluster, "0.0.0.0", 9000)
 		c.AddEndpoint(grpcCluster, "0.0.0.0", 9001)
@@ -217,8 +217,8 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForDifferentRoutesSameModel(t *testing
 	logger := log.New()
 
 	addVersionedRoute := func(c *SeldonXDSCache, modelRouteName string, modelName string, httpCluster string, grpcCluster string, traffic uint32, version uint32) {
-		c.AddCluster(httpCluster, modelRouteName, modelName, version, false)
-		c.AddCluster(grpcCluster, modelRouteName, modelName, version, true)
+		c.AddCluster(httpCluster, false)
+		c.AddCluster(grpcCluster, true)
 		c.AddRouteClusterTraffic(modelRouteName, modelName, version, traffic, httpCluster, grpcCluster, true, false)
 		c.AddEndpoint(httpCluster, "0.0.0.0", 9000)
 		c.AddEndpoint(grpcCluster, "0.0.0.0", 9001)


### PR DESCRIPTION
**What this PR does / why we need it**:

ADS allows for guranteed order of updates, as the xDS resources are sent over the same stream, instead of independent streams. This will be important later, as we'd like to send cluster Y to a node, before updating a route to point to Y instead of another cluster.

**Which issue(s) this PR fixes**:

Fixes # INFRA-1420

**Special notes for your reviewer**:

Moved `server.go` under `processor`, so it's easier to test. 
