### PR TITLE
fix(metrics): Fix model label metric in case of experiment

### DIFF
--- a/scheduler/pkg/agent/rproxy_grpc.go
+++ b/scheduler/pkg/agent/rproxy_grpc.go
@@ -355,7 +355,10 @@ func extractModelNamesFromHeaders(ctx context.Context) (string, string, bool) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		internalModelName := extractHeader(resources.SeldonInternalModelHeader, md)
-		externalModelName := extractHeader(resources.SeldonModelHeader, md)
+		externalModelName, _, err := util.GetOrignalModelNameAndVersion(internalModelName)
+		if err != nil {
+			externalModelName = extractHeader(resources.SeldonModelHeader, md)
+		}
 		return internalModelName, externalModelName, internalModelName != "" && externalModelName != ""
 	}
 	return "", "", false

--- a/scheduler/pkg/agent/rproxy_grpc_test.go
+++ b/scheduler/pkg/agent/rproxy_grpc_test.go
@@ -28,10 +28,11 @@ import (
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/modelscaling"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	testing_utils2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/metrics"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
-func setupReverseGRPCService(numModels int, modelPrefix string, backEndGRPCPort, rpPort, backEndServerPort int) *reverseGRPCProxy {
+func setupReverseGRPCService(numModels int, modelPrefix string, backEndGRPCPort, rpPort, backEndServerPort int, metricsHandler metrics.AgentMetricsHandler) *reverseGRPCProxy {
 	logger := log.New()
 	log.SetLevel(log.DebugLevel)
 
@@ -41,7 +42,7 @@ func setupReverseGRPCService(numModels int, modelPrefix string, backEndGRPCPort,
 		modelscaling.NewModelReplicaLagsKeeper(), modelscaling.NewModelReplicaLastUsedKeeper(),
 	)
 	rp := NewReverseGRPCProxy(
-		newFakeMetricsHandler(),
+		metricsHandler,
 		logger,
 		"localhost",
 		uint(backEndGRPCPort),
@@ -95,7 +96,8 @@ func TestReverseGRPCServiceSmoke(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rpGRPC := setupReverseGRPCService(10, dummyModelNamePrefix, backEndGRPCPort, rpPort, serverPort)
+	fakeMetricsHandler := newFakeMetricsHandler()
+	rpGRPC := setupReverseGRPCService(10, dummyModelNamePrefix, backEndGRPCPort, rpPort, serverPort, fakeMetricsHandler)
 	_ = rpGRPC.Start()
 
 	t.Log("Testing model found")
@@ -115,28 +117,28 @@ func TestReverseGRPCServiceSmoke(t *testing.T) {
 	}
 	defer conn.Close()
 
-	doInfer := func(modelSuffix string) (*v2.ModelInferResponse, error) {
+	doInfer := func(modelSuffixInternal, modelSuffix string) (*v2.ModelInferResponse, error) {
 		client := v2.NewGRPCInferenceServiceClient(conn)
 		ctx := context.Background()
-		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, resources.SeldonModelHeader, dummyModelNamePrefix+modelSuffix)
+		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffixInternal, resources.SeldonModelHeader, dummyModelNamePrefix+modelSuffix)
 		return client.ModelInfer(ctx, &v2.ModelInferRequest{ModelName: dummyModelNamePrefix}) // note without suffix
 	}
 
 	doMeta := func(modelSuffix string) (*v2.ModelMetadataResponse, error) {
 		client := v2.NewGRPCInferenceServiceClient(conn)
 		ctx := context.Background()
-		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, resources.SeldonModelHeader, dummyModelNamePrefix+modelSuffix)
+		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, resources.SeldonModelHeader, dummyModelNamePrefix)
 		return client.ModelMetadata(ctx, &v2.ModelMetadataRequest{Name: dummyModelNamePrefix}) // note without suffix
 	}
 
 	doModelReady := func(modelSuffix string) (*v2.ModelReadyResponse, error) {
 		client := v2.NewGRPCInferenceServiceClient(conn)
 		ctx := context.Background()
-		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, resources.SeldonModelHeader, dummyModelNamePrefix+modelSuffix)
+		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, resources.SeldonModelHeader, dummyModelNamePrefix)
 		return client.ModelReady(ctx, &v2.ModelReadyRequest{Name: dummyModelNamePrefix}) // note without suffix
 	}
 
-	responseInfer, errInfer := doInfer("_0")
+	responseInfer, errInfer := doInfer("_0", ".experiment")
 	g.Expect(errInfer).To(BeNil())
 	g.Expect(responseInfer.ModelName).To(Equal(dummyModelNamePrefix + "_0"))
 	g.Expect(responseInfer.ModelVersion).To(Equal("")) // in practice this should be something else
@@ -144,6 +146,11 @@ func TestReverseGRPCServiceSmoke(t *testing.T) {
 	t.Log("Testing model scaling stats")
 	g.Expect(rpGRPC.modelScalingStatsCollector.ModelLagStats.Get(dummyModelNamePrefix + "_0")).To(Equal(uint32(0)))
 	g.Expect(rpGRPC.modelScalingStatsCollector.ModelLastUsedStats.Get(dummyModelNamePrefix + "_0")).Should(BeNumerically("<=", time.Now().Unix())) // only triggered when we get results back
+
+	t.Log("Testing model infer")
+	g.Expect(fakeMetricsHandler.modelInferState[dummyModelNamePrefix].internalModelName).To(Equal(dummyModelNamePrefix + "_0"))
+	g.Expect(fakeMetricsHandler.modelInferState[dummyModelNamePrefix].method).To(Equal("grpc"))
+	g.Expect(fakeMetricsHandler.modelInferState[dummyModelNamePrefix].code).To(Equal("OK")) // note it is not 200 for grpc, should we change this?
 
 	responseMeta, errMeta := doMeta("_0")
 	g.Expect(responseMeta.Name).To(Equal(dummyModelNamePrefix + "_0"))
@@ -157,13 +164,13 @@ func TestReverseGRPCServiceSmoke(t *testing.T) {
 
 	t.Log("Testing lazy load")
 	mockMLServerState.setModelServerUnloaded(dummyModelNamePrefix + "_0")
-	responseInfer, errInfer = doInfer("_0")
+	responseInfer, errInfer = doInfer("_0", "")
 	g.Expect(errInfer).To(BeNil())
 	g.Expect(responseInfer.ModelName).To(Equal(dummyModelNamePrefix + "_0"))
 	g.Expect(responseInfer.ModelVersion).To(Equal("")) // in practice this should be something else
 
 	t.Log("Testing model not found")
-	_, errInfer = doInfer("_1")
+	_, errInfer = doInfer("_1", "")
 	g.Expect(errInfer).NotTo(BeNil())
 	g.Expect(mockMLServerState.isModelLoaded(dummyModelNamePrefix + "_1")).To(Equal(false))
 
@@ -184,7 +191,8 @@ func TestReverseGRPCServiceEarlyStop(t *testing.T) {
 
 	dummyModelNamePrefix := "dummy_model"
 
-	rpGRPC := setupReverseGRPCService(0, dummyModelNamePrefix, 1, 1, 1)
+	fakeMetricsHandler := newFakeMetricsHandler()
+	rpGRPC := setupReverseGRPCService(0, dummyModelNamePrefix, 1, 1, 1, fakeMetricsHandler)
 	err := rpGRPC.Stop()
 	g.Expect(err).To(BeNil())
 	ready := rpGRPC.Ready()

--- a/scheduler/pkg/agent/rproxy_grpc_test.go
+++ b/scheduler/pkg/agent/rproxy_grpc_test.go
@@ -147,7 +147,7 @@ func TestReverseGRPCServiceSmoke(t *testing.T) {
 	g.Expect(rpGRPC.modelScalingStatsCollector.ModelLagStats.Get(dummyModelNamePrefix + "_0")).To(Equal(uint32(0)))
 	g.Expect(rpGRPC.modelScalingStatsCollector.ModelLastUsedStats.Get(dummyModelNamePrefix + "_0")).Should(BeNumerically("<=", time.Now().Unix())) // only triggered when we get results back
 
-	t.Log("Testing model infer")
+	t.Log("Testing model infer metrics")
 	g.Expect(fakeMetricsHandler.modelInferState[dummyModelNamePrefix].internalModelName).To(Equal(dummyModelNamePrefix + "_0"))
 	g.Expect(fakeMetricsHandler.modelInferState[dummyModelNamePrefix].method).To(Equal("grpc"))
 	g.Expect(fakeMetricsHandler.modelInferState[dummyModelNamePrefix].code).To(Equal("OK")) // note it is not 200 for grpc, should we change this?

--- a/scheduler/pkg/agent/rproxy_test.go
+++ b/scheduler/pkg/agent/rproxy_test.go
@@ -289,7 +289,6 @@ func TestReverseProxySmoke(t *testing.T) {
 			if test.statusCode == http.StatusOK {
 				g.Expect(rpHTTP.modelScalingStatsCollector.ModelLagStats.Get(test.modelToRequest)).To(Equal(uint32(0)))
 				g.Expect(rpHTTP.modelScalingStatsCollector.ModelLastUsedStats.Get(test.modelToRequest)).Should(BeNumerically("<=", time.Now().Unix())) // only triggered when we get results back
-
 			}
 
 			//  test infer metrics


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR adjusts the metrics label value for `model` to be the actual model name as opposed to the header being passed in the request. Previously using the header in the request means that for experiment, where the `seldon-model` header has a suffix `.experiment`, can result in ambiguity on which actual model is being actually used.

The change in this PR is to use `seldon-model-internal` to extract the original model and use it for the `model` label.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes INFRA-1278 (internal)

**Special notes for your reviewer**:
