### PR TITLE
fix(k6): change default k6 image in kustomize

### DIFF
--- a/tests/k6/configs/k8s/base/kustomization.yaml
+++ b/tests/k6/configs/k8s/base/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
 
 images:
 - name: k6
-  newName: sakoush/seldon-k6
+  newName: seldonio/seldon-k6
   newTag: latest


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This is for sanity reasons we change the default image name for seldonio. In practice this is not really required as users should deploy via `make` targets.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
