### PR TITLE
refactor(envoy): moving envoy/resources headers to util

### DIFF
--- a/scheduler/pkg/agent/rproxy_grpc.go
+++ b/scheduler/pkg/agent/rproxy_grpc.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/modelscaling"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/modelserver_controlplane/oip"
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/metrics"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
@@ -169,10 +168,10 @@ func (rp *reverseGRPCProxy) extractModelNamesFromContext(ctx context.Context) (s
 	var internalModelName, externalModelName string
 	var inHeader bool
 	if internalModelName, externalModelName, inHeader = extractModelNamesFromHeaders(ctx); inHeader {
-		rp.logger.Debugf("Extracted model name %s:%s %s:%s", resources.SeldonInternalModelHeader, internalModelName, resources.SeldonModelHeader, externalModelName)
+		rp.logger.Debugf("Extracted model name %s:%s %s:%s", util.SeldonInternalModelHeader, internalModelName, util.SeldonModelHeader, externalModelName)
 		return internalModelName, externalModelName, nil
 	} else {
-		msg := fmt.Sprintf("Failed to extract model name %s:[%s] %s:[%s]", resources.SeldonInternalModelHeader, internalModelName, resources.SeldonModelHeader, externalModelName)
+		msg := fmt.Sprintf("Failed to extract model name %s:[%s] %s:[%s]", util.SeldonInternalModelHeader, internalModelName, util.SeldonModelHeader, externalModelName)
 		rp.logger.Error(msg)
 		return "", "", status.Error(codes.FailedPrecondition, msg)
 	}
@@ -354,10 +353,10 @@ func extractHeader(key string, md metadata.MD) string {
 func extractModelNamesFromHeaders(ctx context.Context) (string, string, bool) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
-		internalModelName := extractHeader(resources.SeldonInternalModelHeader, md)
+		internalModelName := extractHeader(util.SeldonInternalModelHeader, md)
 		externalModelName, _, err := util.GetOrignalModelNameAndVersion(internalModelName)
 		if err != nil {
-			externalModelName = extractHeader(resources.SeldonModelHeader, md)
+			externalModelName = extractHeader(util.SeldonModelHeader, md)
 		}
 		return internalModelName, externalModelName, internalModelName != "" && externalModelName != ""
 	}

--- a/scheduler/pkg/agent/rproxy_grpc_test.go
+++ b/scheduler/pkg/agent/rproxy_grpc_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/modelscaling"
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	testing_utils2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/metrics"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
@@ -120,21 +119,21 @@ func TestReverseGRPCServiceSmoke(t *testing.T) {
 	doInfer := func(modelSuffixInternal, modelSuffix string) (*v2.ModelInferResponse, error) {
 		client := v2.NewGRPCInferenceServiceClient(conn)
 		ctx := context.Background()
-		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffixInternal, resources.SeldonModelHeader, dummyModelNamePrefix+modelSuffix)
+		ctx = metadata.AppendToOutgoingContext(ctx, util.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffixInternal, util.SeldonModelHeader, dummyModelNamePrefix+modelSuffix)
 		return client.ModelInfer(ctx, &v2.ModelInferRequest{ModelName: dummyModelNamePrefix}) // note without suffix
 	}
 
 	doMeta := func(modelSuffix string) (*v2.ModelMetadataResponse, error) {
 		client := v2.NewGRPCInferenceServiceClient(conn)
 		ctx := context.Background()
-		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, resources.SeldonModelHeader, dummyModelNamePrefix)
+		ctx = metadata.AppendToOutgoingContext(ctx, util.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, util.SeldonModelHeader, dummyModelNamePrefix)
 		return client.ModelMetadata(ctx, &v2.ModelMetadataRequest{Name: dummyModelNamePrefix}) // note without suffix
 	}
 
 	doModelReady := func(modelSuffix string) (*v2.ModelReadyResponse, error) {
 		client := v2.NewGRPCInferenceServiceClient(conn)
 		ctx := context.Background()
-		ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, resources.SeldonModelHeader, dummyModelNamePrefix)
+		ctx = metadata.AppendToOutgoingContext(ctx, util.SeldonInternalModelHeader, dummyModelNamePrefix+modelSuffix, util.SeldonModelHeader, dummyModelNamePrefix)
 		return client.ModelReady(ctx, &v2.ModelReadyRequest{Name: dummyModelNamePrefix}) // note without suffix
 	}
 

--- a/scheduler/pkg/agent/rproxy_test.go
+++ b/scheduler/pkg/agent/rproxy_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/interfaces"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/agent/modelscaling"
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	testing_utils2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/metrics"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
@@ -272,8 +271,8 @@ func TestReverseProxySmoke(t *testing.T) {
 			req, err := http.NewRequest(http.MethodPost, url, nil)
 			g.Expect(err).To(BeNil())
 			req.Header.Set("contentType", "application/json")
-			req.Header.Set(resources.SeldonModelHeader, test.modelExternalHeader)
-			req.Header.Set(resources.SeldonInternalModelHeader, test.modelToRequest)
+			req.Header.Set(util.SeldonModelHeader, test.modelExternalHeader)
+			req.Header.Set(util.SeldonInternalModelHeader, test.modelToRequest)
 			resp, err := http.DefaultClient.Do(req)
 			g.Expect(err).To(BeNil())
 
@@ -459,7 +458,7 @@ func TestLazyLoadRoundTripper(t *testing.T) {
 			httpClient.Transport = &lazyModelLoadTransport{
 				loader, http.DefaultTransport, metricsHandler, modelScalingStatsCollector, log.New()}
 			mockMLServerState.setModelServerUnloaded(dummyModel)
-			req.Header.Set(resources.SeldonInternalModelHeader, dummyModel)
+			req.Header.Set(util.SeldonInternalModelHeader, dummyModel)
 			resp, err := httpClient.Do(req)
 			g.Expect(err).To(BeNil())
 			g.Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/scheduler/pkg/envoy/xdscache/cache.go
+++ b/scheduler/pkg/envoy/xdscache/cache.go
@@ -7,7 +7,7 @@ Use of this software is governed by
 the Change License after the Change Date as each is defined in accordance with the LICENSE file.
 */
 
-package resources
+package xdscache
 
 import "github.com/seldonio/seldon-core/components/tls/v2/pkg/tls"
 

--- a/scheduler/pkg/envoy/xdscache/resource_test.go
+++ b/scheduler/pkg/envoy/xdscache/resource_test.go
@@ -7,7 +7,7 @@ Use of this software is governed by
 the Change License after the Change Date as each is defined in accordance with the LICENSE file.
 */
 
-package resources
+package xdscache
 
 import (
 	"testing"
@@ -28,132 +28,138 @@ func TestMakeRoute(t *testing.T) {
 	tests := []test{
 		{
 			name: "one model",
-			modelRoutes: map[string]Route{"r1": {
-				RouteName: "r1",
-				Clusters: []TrafficSplit{
-					{
-						ModelName:     "m1",
-						ModelVersion:  1,
-						TrafficWeight: 100,
-						HttpCluster:   "h1",
-						GrpcCluster:   "g1",
+			modelRoutes: map[string]Route{
+				"r1": {
+					RouteName: "r1",
+					Clusters: []TrafficSplit{
+						{
+							ModelName:     "m1",
+							ModelVersion:  1,
+							TrafficWeight: 100,
+							HttpCluster:   "h1",
+							GrpcCluster:   "g1",
+						},
 					},
 				},
-			},
 			},
 			expectedDefaultRoutes: 2,
 			expectedMirrorRoutes:  0,
 		},
 		{
 			name: "one pipeline",
-			pipelineRoutes: map[string]PipelineRoute{"r1": {
-				RouteName: "r1",
-				Clusters: []PipelineTrafficSplit{
-					{
-						PipelineName:  "p1",
-						TrafficWeight: 100,
+			pipelineRoutes: map[string]PipelineRoute{
+				"r1": {
+					RouteName: "r1",
+					Clusters: []PipelineTrafficSplit{
+						{
+							PipelineName:  "p1",
+							TrafficWeight: 100,
+						},
 					},
 				},
-			},
 			},
 			expectedDefaultRoutes: 2,
 			expectedMirrorRoutes:  0,
 		},
 		{
 			name: "pipeline experiment",
-			pipelineRoutes: map[string]PipelineRoute{"r1": {
-				RouteName: "r1",
-				Clusters: []PipelineTrafficSplit{
-					{
-						PipelineName:  "p1",
-						TrafficWeight: 50,
-					},
-					{
-						PipelineName:  "p2",
-						TrafficWeight: 50,
+			pipelineRoutes: map[string]PipelineRoute{
+				"r1": {
+					RouteName: "r1",
+					Clusters: []PipelineTrafficSplit{
+						{
+							PipelineName:  "p1",
+							TrafficWeight: 50,
+						},
+						{
+							PipelineName:  "p2",
+							TrafficWeight: 50,
+						},
 					},
 				},
-			},
 			},
 			expectedDefaultRoutes: 6,
 			expectedMirrorRoutes:  0,
 		},
 		{
 			name: "pipeline experiment with mirror",
-			pipelineRoutes: map[string]PipelineRoute{"r1": {
-				RouteName: "r1",
-				Clusters: []PipelineTrafficSplit{
-					{
-						PipelineName:  "p1",
-						TrafficWeight: 50,
+			pipelineRoutes: map[string]PipelineRoute{
+				"r1": {
+					RouteName: "r1",
+					Clusters: []PipelineTrafficSplit{
+						{
+							PipelineName:  "p1",
+							TrafficWeight: 50,
+						},
+						{
+							PipelineName:  "p2",
+							TrafficWeight: 50,
+						},
 					},
-					{
-						PipelineName:  "p2",
-						TrafficWeight: 50,
+					Mirror: &PipelineTrafficSplit{
+						PipelineName:  "p3",
+						TrafficWeight: 100,
 					},
 				},
-				Mirror: &PipelineTrafficSplit{
-					PipelineName:  "p3",
-					TrafficWeight: 100,
-				},
-			},
 			},
 			expectedDefaultRoutes: 6,
 			expectedMirrorRoutes:  2,
 		},
 		{
 			name: "model experiment",
-			modelRoutes: map[string]Route{"r1": {
-				RouteName: "r1",
-				Clusters: []TrafficSplit{
-					{
-						ModelName:     "m1",
-						ModelVersion:  1,
-						TrafficWeight: 50,
-						HttpCluster:   "h1",
-						GrpcCluster:   "g1",
-					},
-					{
-						ModelName:     "m2",
-						ModelVersion:  1,
-						TrafficWeight: 50,
-						HttpCluster:   "h1",
-						GrpcCluster:   "g1",
+			modelRoutes: map[string]Route{
+				"r1": {
+					RouteName: "r1",
+					Clusters: []TrafficSplit{
+						{
+							ModelName:     "m1",
+							ModelVersion:  1,
+							TrafficWeight: 50,
+							HttpCluster:   "h1",
+							GrpcCluster:   "g1",
+						},
+						{
+							ModelName:     "m2",
+							ModelVersion:  1,
+							TrafficWeight: 50,
+							HttpCluster:   "h1",
+							GrpcCluster:   "g1",
+						},
 					},
 				},
-			},
 			},
 			expectedDefaultRoutes: 6,
 			expectedMirrorRoutes:  0,
 		},
 		{
 			name: "experiment with model mirror",
-			modelRoutes: map[string]Route{"r1": {
-				RouteName: "r1",
-				Clusters: []TrafficSplit{
-					{
-						ModelName:     "m1",
-						ModelVersion:  1,
-						TrafficWeight: 50,
-						HttpCluster:   "h1",
-						GrpcCluster:   "g1",
+			modelRoutes: map[string]Route{
+				"r1": {
+					RouteName: "r1",
+					Clusters: []TrafficSplit{
+						{
+							ModelName:     "m1",
+							ModelVersion:  1,
+							TrafficWeight: 50,
+							HttpCluster:   "h1",
+							GrpcCluster:   "g1",
+						},
+						{
+							ModelName:     "m2",
+							ModelVersion:  1,
+							TrafficWeight: 50,
+							HttpCluster:   "h1",
+							GrpcCluster:   "g1",
+						},
 					},
-					{
-						ModelName:     "m2",
+					Mirror: &TrafficSplit{
+						ModelName:     "m3",
 						ModelVersion:  1,
-						TrafficWeight: 50,
+						TrafficWeight: 100,
 						HttpCluster:   "h1",
 						GrpcCluster:   "g1",
 					},
 				},
-				Mirror: &TrafficSplit{
-					ModelName:     "m3",
-					ModelVersion:  1,
-					TrafficWeight: 100,
-					HttpCluster:   "h1",
-					GrpcCluster:   "g1",
-				},
-			},
 			},
 			expectedDefaultRoutes: 6,
 			expectedMirrorRoutes:  2,

--- a/scheduler/pkg/envoy/xdscache/seldoncache_benchmark_test.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache_benchmark_test.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/sirupsen/logrus"
-
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 )
 
 // Prevent compiler from optimising away benchmarks
@@ -27,7 +25,7 @@ func benchmarkRouteContents(b *testing.B, numResources uint) {
 	x := NewSeldonXDSCache(logrus.New(), nil)
 
 	for n := 0; n < int(numResources); n++ {
-		x.AddPipelineRoute(strconv.Itoa(n), []resources.PipelineTrafficSplit{{PipelineName: strconv.Itoa(n), TrafficWeight: 100}}, nil)
+		x.AddPipelineRoute(strconv.Itoa(n), []PipelineTrafficSplit{{PipelineName: strconv.Itoa(n), TrafficWeight: 100}}, nil)
 
 		x.AddRouteClusterTraffic(
 			fmt.Sprintf("model-%d", n),

--- a/scheduler/pkg/envoy/xdscache/seldoncache_test.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/seldonio/seldon-core/apis/go/v2/mlops/scheduler"
 	seldontls "github.com/seldonio/seldon-core/components/tls/v2/pkg/tls"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store"
 )
 
@@ -80,10 +79,10 @@ func TestAddRemoveHttpAndGrpcRouteVersions(t *testing.T) {
 	g.Expect(len(c.Clusters[grpcCluster1].Endpoints)).To(Equal(1))
 	g.Expect(c.Clusters[httpCluster1].Grpc).To(BeFalse())
 	g.Expect(c.Clusters[grpcCluster1].Grpc).To(BeTrue())
-	g.Expect(c.Clusters[httpCluster1].Routes[resources.RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcCluster1].Routes[resources.RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[httpCluster2].Routes[resources.RouteVersionKey{RouteName: route1, ModelName: model1, Version: 2}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcCluster2].Routes[resources.RouteVersionKey{RouteName: route1, ModelName: model1, Version: 2}]).To(BeTrue())
+	g.Expect(c.Clusters[httpCluster1].Routes[RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcCluster1].Routes[RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[httpCluster2].Routes[RouteVersionKey{RouteName: route1, ModelName: model1, Version: 2}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcCluster2].Routes[RouteVersionKey{RouteName: route1, ModelName: model1, Version: 2}]).To(BeTrue())
 
 	addVersionedRoute(c, route2, model1, httpCluster1, grpcCluster1, 100, 1)
 
@@ -91,8 +90,8 @@ func TestAddRemoveHttpAndGrpcRouteVersions(t *testing.T) {
 	g.Expect(len(c.Routes[route2].Clusters)).To(Equal(1))
 	clusters = c.Routes[route2].Clusters
 	g.Expect(clusters[0].TrafficWeight).To(Equal(uint32(100)))
-	g.Expect(c.Clusters[httpCluster1].Routes[resources.RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcCluster1].Routes[resources.RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[httpCluster1].Routes[RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcCluster1].Routes[RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
 	g.Expect(len(c.Clusters[httpCluster1].Endpoints)).To(Equal(1))
 	g.Expect(len(c.Clusters[grpcCluster1].Endpoints)).To(Equal(1))
 
@@ -136,10 +135,10 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForSameModel(t *testing.T) {
 	g.Expect(len(c.Clusters[grpcCluster1].Endpoints)).To(Equal(1))
 	g.Expect(c.Clusters[httpCluster1].Grpc).To(BeFalse())
 	g.Expect(c.Clusters[grpcCluster1].Grpc).To(BeTrue())
-	g.Expect(c.Clusters[httpCluster1].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcCluster1].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[httpCluster2].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 2}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcCluster2].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 2}]).To(BeTrue())
+	g.Expect(c.Clusters[httpCluster1].Routes[RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcCluster1].Routes[RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[httpCluster2].Routes[RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 2}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcCluster2].Routes[RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 2}]).To(BeTrue())
 
 	err := c.RemoveRoute(routeName)
 	g.Expect(err).To(BeNil())
@@ -176,10 +175,10 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForDifferentModels(t *testing.T) {
 	g.Expect(len(c.Clusters[grpcClusterModel1].Endpoints)).To(Equal(1))
 	g.Expect(c.Clusters[httpClusterModel1].Grpc).To(BeFalse())
 	g.Expect(c.Clusters[grpcClusterModel1].Grpc).To(BeTrue())
-	g.Expect(c.Clusters[httpClusterModel1].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcClusterModel1].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[httpClusterModel2].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model2, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcClusterModel2].Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: model2, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[httpClusterModel1].Routes[RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcClusterModel1].Routes[RouteVersionKey{RouteName: routeName, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[httpClusterModel2].Routes[RouteVersionKey{RouteName: routeName, ModelName: model2, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcClusterModel2].Routes[RouteVersionKey{RouteName: routeName, ModelName: model2, Version: 1}]).To(BeTrue())
 
 	err := c.RemoveRoute(routeName)
 	g.Expect(err).To(BeNil())
@@ -217,10 +216,10 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForDifferentRoutesSameModel(t *testing
 	g.Expect(len(c.Clusters[grpcClusterModel1].Endpoints)).To(Equal(1))
 	g.Expect(c.Clusters[httpClusterModel1].Grpc).To(BeFalse())
 	g.Expect(c.Clusters[grpcClusterModel1].Grpc).To(BeTrue())
-	g.Expect(c.Clusters[httpClusterModel1].Routes[resources.RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcClusterModel1].Routes[resources.RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[httpClusterModel1].Routes[resources.RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
-	g.Expect(c.Clusters[grpcClusterModel1].Routes[resources.RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[httpClusterModel1].Routes[RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcClusterModel1].Routes[RouteVersionKey{RouteName: route1, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[httpClusterModel1].Routes[RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
+	g.Expect(c.Clusters[grpcClusterModel1].Routes[RouteVersionKey{RouteName: route2, ModelName: model1, Version: 1}]).To(BeTrue())
 
 	err := c.RemoveRoute(route1)
 	g.Expect(err).To(BeNil())
@@ -331,21 +330,21 @@ func addCluster(
 ) {
 	cluster, ok := xds.Clusters[name]
 	if !ok {
-		cluster = resources.Cluster{
+		cluster = Cluster{
 			Name:      name,
-			Endpoints: make(map[string]resources.Endpoint),
-			Routes:    make(map[resources.RouteVersionKey]bool),
+			Endpoints: make(map[string]Endpoint),
+			Routes:    make(map[RouteVersionKey]bool),
 			Grpc:      isGrpc,
 		}
 	}
-	cluster.Routes[resources.RouteVersionKey{RouteName: routeName, ModelName: modelName, Version: modelVersion}] = true
+	cluster.Routes[RouteVersionKey{RouteName: routeName, ModelName: modelName, Version: modelVersion}] = true
 	xds.Clusters[name] = cluster
 }
 
 func addEndpoint(xds *SeldonXDSCache, clusterName, upstreamHost string, upstreamPort uint32) {
 	cluster := xds.Clusters[clusterName]
 	k := fmt.Sprintf("%s:%d", upstreamHost, upstreamPort)
-	cluster.Endpoints[k] = resources.Endpoint{
+	cluster.Endpoints[k] = Endpoint{
 		UpstreamHost: upstreamHost,
 		UpstreamPort: upstreamPort,
 	}

--- a/scheduler/pkg/envoy/xdscache/tls.go
+++ b/scheduler/pkg/envoy/xdscache/tls.go
@@ -7,7 +7,7 @@ Use of this software is governed by
 the Change License after the Change Date as each is defined in accordance with the LICENSE file.
 */
 
-package resources
+package xdscache
 
 import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"

--- a/scheduler/pkg/envoy/xdscache/tls_test.go
+++ b/scheduler/pkg/envoy/xdscache/tls_test.go
@@ -7,7 +7,7 @@ Use of this software is governed by
 the Change License after the Change Date as each is defined in accordance with the LICENSE file.
 */
 
-package resources
+package xdscache
 
 import (
 	"crypto/tls"
@@ -28,32 +28,32 @@ type FakeCertificateStore struct {
 }
 
 func (f FakeCertificateStore) GetServerCertificate(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (f FakeCertificateStore) GetClientCertificate(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (f FakeCertificateStore) CreateClientTLSConfig() *tls.Config {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (f FakeCertificateStore) CreateClientTransportCredentials() credentials.TransportCredentials {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (f FakeCertificateStore) CreateServerTLSConfig() *tls.Config {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (f FakeCertificateStore) CreateServerTransportCredentials() credentials.TransportCredentials {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -808,7 +808,6 @@ func createTestScheduler(t *testing.T, serverName string) (*ChainerServer, *coor
 	configFilePath := fmt.Sprintf("%s/kafka.json", t.TempDir())
 	_ = os.WriteFile(configFilePath, []byte(data), 0644)
 	kc, _ := kafka_config.NewKafkaConfig(configFilePath)
-
 	b := util.NewRingLoadBalancer(1)
 	b.AddServer(serverName)
 	s, _ := NewChainerServer(logger, eventHub, pipelineServer, "test-ns", b, kc)

--- a/scheduler/pkg/kafka/gateway/utils.go
+++ b/scheduler/pkg/kafka/gateway/utils.go
@@ -13,8 +13,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
 func extractHeadersHttp(headers http.Header) map[string][]string {

--- a/scheduler/pkg/kafka/gateway/utils.go
+++ b/scheduler/pkg/kafka/gateway/utils.go
@@ -13,15 +13,14 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 	"google.golang.org/grpc/metadata"
-
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 )
 
 func extractHeadersHttp(headers http.Header) map[string][]string {
 	filteredHeaders := make(map[string][]string)
 	for k, v := range headers {
-		if strings.HasPrefix(k, resources.ExternalHeaderPrefix) {
+		if strings.HasPrefix(k, util.ExternalHeaderPrefix) {
 			filteredHeaders[k] = v
 		}
 	}
@@ -31,12 +30,12 @@ func extractHeadersHttp(headers http.Header) map[string][]string {
 func extractHeadersGrpc(headers metadata.MD, trailers metadata.MD) map[string][]string {
 	filteredHeaders := make(map[string][]string)
 	for k, v := range headers {
-		if strings.HasPrefix(k, resources.ExternalHeaderPrefix) {
+		if strings.HasPrefix(k, util.ExternalHeaderPrefix) {
 			filteredHeaders[k] = v
 		}
 	}
 	for k, v := range trailers {
-		if strings.HasPrefix(k, resources.ExternalHeaderPrefix) {
+		if strings.HasPrefix(k, util.ExternalHeaderPrefix) {
 			filteredHeaders[k] = v
 		}
 	}

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -37,7 +37,6 @@ import (
 
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	kafka2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka"
 	pipeline "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/pipeline"
 	seldontracer "github.com/seldonio/seldon-core/scheduler/v2/pkg/tracing"
@@ -313,7 +312,7 @@ func (iw *InferWorker) restRequest(ctx context.Context, job *InferWork, maybeCon
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(resources.SeldonModelHeader, job.modelName)
+	req.Header.Set(util.SeldonModelHeader, job.modelName)
 	if reqId, ok := job.headers[util.RequestIdHeader]; ok {
 		req.Header[util.RequestIdHeader] = []string{reqId}
 	}
@@ -358,13 +357,13 @@ func (iw *InferWorker) restRequest(ctx context.Context, job *InferWork, maybeCon
 // Add all external headers to request metadata
 func addMetadataToOutgoingContext(ctx context.Context, job *InferWork, logger log.FieldLogger) context.Context {
 	for k, v := range job.headers {
-		if strings.HasPrefix(k, resources.ExternalHeaderPrefix) &&
-			k != resources.SeldonRouteHeader { // We don;t want to send x-seldon-route as this will confuse envoy
+		if strings.HasPrefix(k, util.ExternalHeaderPrefix) &&
+			k != util.SeldonRouteHeader { // We don;t want to send x-seldon-route as this will confuse envoy
 			logger.Debugf("Adding outgoing ctx metadata %s:%s", k, v)
 			ctx = metadata.AppendToOutgoingContext(ctx, k, v)
 		}
 	}
-	ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonModelHeader, job.modelName)
+	ctx = metadata.AppendToOutgoingContext(ctx, util.SeldonModelHeader, job.modelName)
 	return ctx
 }
 

--- a/scheduler/pkg/kafka/gateway/worker_test.go
+++ b/scheduler/pkg/kafka/gateway/worker_test.go
@@ -31,7 +31,6 @@ import (
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
 	kafka_config "github.com/seldonio/seldon-core/components/kafka/v2/pkg/config"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	kafka2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka"
 	seldontracer "github.com/seldonio/seldon-core/scheduler/v2/pkg/tracing"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
@@ -482,26 +481,26 @@ func TestAddMetadataToOutgoingContext(t *testing.T) {
 		{
 			name:            "ignore xseldon-route header",
 			ctx:             metadata.NewIncomingContext(context.TODO(), metadata.New(map[string]string{})),
-			job:             &InferWork{modelName: "foo", headers: map[string]string{resources.SeldonRouteHeader: ":a:"}},
-			expectedHeaders: map[string][]string{resources.SeldonModelHeader: {"foo"}},
+			job:             &InferWork{modelName: "foo", headers: map[string]string{util.SeldonRouteHeader: ":a:"}},
+			expectedHeaders: map[string][]string{util.SeldonModelHeader: {"foo"}},
 		},
 		{
 			name:            "pass x-request-id header",
 			ctx:             metadata.NewIncomingContext(context.TODO(), metadata.New(map[string]string{})),
 			job:             &InferWork{modelName: "foo", headers: map[string]string{util.RequestIdHeader: "1234"}},
-			expectedHeaders: map[string][]string{resources.SeldonModelHeader: {"foo"}, util.RequestIdHeader: {"1234"}},
+			expectedHeaders: map[string][]string{util.SeldonModelHeader: {"foo"}, util.RequestIdHeader: {"1234"}},
 		},
 		{
 			name:            "pass custom header",
 			ctx:             metadata.NewIncomingContext(context.TODO(), metadata.New(map[string]string{})),
 			job:             &InferWork{modelName: "foo", headers: map[string]string{"x-myheader": "1234"}},
-			expectedHeaders: map[string][]string{resources.SeldonModelHeader: {"foo"}, "x-myheader": {"1234"}},
+			expectedHeaders: map[string][]string{util.SeldonModelHeader: {"foo"}, "x-myheader": {"1234"}},
 		},
 		{
 			name:            "ignore non x- prefix headers",
 			ctx:             metadata.NewIncomingContext(context.TODO(), metadata.New(map[string]string{})),
 			job:             &InferWork{modelName: "foo", headers: map[string]string{"myheader": "1234"}},
-			expectedHeaders: map[string][]string{resources.SeldonModelHeader: {"foo"}},
+			expectedHeaders: map[string][]string{util.SeldonModelHeader: {"foo"}},
 		},
 	}
 	for _, test := range tests {

--- a/scheduler/pkg/kafka/pipeline/grpcserver.go
+++ b/scheduler/pkg/kafka/pipeline/grpcserver.go
@@ -26,7 +26,6 @@ import (
 
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	status2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/pipeline/status"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/metrics"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
@@ -111,16 +110,16 @@ func (g *GatewayGrpcServer) getRequestId(md metadata.MD) string {
 func (g *GatewayGrpcServer) ModelInfer(ctx context.Context, r *v2.ModelInferRequest) (*v2.ModelInferResponse, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("failed to find any metadata - required %s or %s", resources.SeldonModelHeader, resources.SeldonInternalModelHeader))
+		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("failed to find any metadata - required %s or %s", util.SeldonModelHeader, util.SeldonInternalModelHeader))
 	}
-	g.logger.Debugf("Seldon model header %v and seldon internal model header %v", md[resources.SeldonModelHeader], md[resources.SeldonInternalModelHeader])
-	header := extractHeader(resources.SeldonInternalModelHeader, md) // Internal model header has precedence
-	if header == "" {                                                // If we don't find internal model header fall back on public one
-		header = extractHeader(resources.SeldonModelHeader, md)
+	g.logger.Debugf("Seldon model header %v and seldon internal model header %v", md[util.SeldonModelHeader], md[util.SeldonInternalModelHeader])
+	header := extractHeader(util.SeldonInternalModelHeader, md) // Internal model header has precedence
+	if header == "" {                                           // If we don't find internal model header fall back on public one
+		header = extractHeader(util.SeldonModelHeader, md)
 	}
 	resourceName, isModel, err := createResourceNameFromHeader(header)
 	if err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("failed to find valid header %s, found %s", resources.SeldonModelHeader, resourceName))
+		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("failed to find valid header %s, found %s", util.SeldonModelHeader, resourceName))
 	}
 
 	startTime := time.Now()
@@ -159,7 +158,7 @@ func (g *GatewayGrpcServer) ModelInfer(ctx context.Context, r *v2.ModelInferRequ
 func (g *GatewayGrpcServer) ModelReady(ctx context.Context, req *v2.ModelReadyRequest) (*v2.ModelReadyResponse, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("failed to find any metadata - required %s or %s", resources.SeldonModelHeader, resources.SeldonInternalModelHeader))
+		return nil, status.Errorf(codes.FailedPrecondition, fmt.Sprintf("failed to find any metadata - required %s or %s", util.SeldonModelHeader, util.SeldonInternalModelHeader))
 	}
 	ready, err := g.pipelineReadyChecker.CheckPipelineReady(ctx, req.GetName(), g.getRequestId(md))
 	if err != nil {

--- a/scheduler/pkg/kafka/pipeline/grpcserver_test.go
+++ b/scheduler/pkg/kafka/pipeline/grpcserver_test.go
@@ -24,7 +24,6 @@ import (
 
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
@@ -133,7 +132,7 @@ func TestGrpcServer(t *testing.T) {
 			g.Expect(err).To(BeNil())
 			client := v2.NewGRPCInferenceServiceClient(conn)
 			ctx := context.TODO()
-			ctx = metadata.AppendToOutgoingContext(ctx, resources.SeldonModelHeader, test.header)
+			ctx = metadata.AppendToOutgoingContext(ctx, util.SeldonModelHeader, test.header)
 			var header, trailer metadata.MD
 			res, err := client.ModelInfer(ctx, test.req, grpc.Header(&header), grpc.Trailer(&trailer))
 			if test.error {

--- a/scheduler/pkg/kafka/pipeline/httpserver.go
+++ b/scheduler/pkg/kafka/pipeline/httpserver.go
@@ -23,7 +23,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka/pipeline/status"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/metrics"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
@@ -187,9 +186,9 @@ func (g *GatewayHttpServer) infer(w http.ResponseWriter, req *http.Request, reso
 }
 
 func getResourceFromHeaders(req *http.Request, logger log.FieldLogger) (string, bool, error) {
-	modelHeader := req.Header.Get(resources.SeldonModelHeader)
+	modelHeader := req.Header.Get(util.SeldonModelHeader)
 	// may have multiple header values due to shadow/mirror processing
-	modelInternalHeader := req.Header.Values(resources.SeldonInternalModelHeader)
+	modelInternalHeader := req.Header.Values(util.SeldonInternalModelHeader)
 	logger.Debugf("Seldon model header %s and seldon internal model header %s", modelHeader, modelInternalHeader)
 	if len(modelInternalHeader) > 0 {
 		return createResourceNameFromHeader(modelInternalHeader[len(modelInternalHeader)-1]) // get last header if multiple

--- a/scheduler/pkg/kafka/pipeline/httpserver_test.go
+++ b/scheduler/pkg/kafka/pipeline/httpserver_test.go
@@ -28,7 +28,6 @@ import (
 
 	v2 "github.com/seldonio/seldon-core/apis/go/v2/mlops/v2_dataplane"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/internal/testing_utils"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
@@ -174,7 +173,7 @@ func TestHttpServer(t *testing.T) {
 			r := strings.NewReader(test.req)
 			req, err := http.NewRequest(http.MethodPost, url, r)
 			g.Expect(err).To(BeNil())
-			req.Header.Set(resources.SeldonModelHeader, test.header)
+			req.Header.Set(util.SeldonModelHeader, test.header)
 			req.Header.Set("contentType", "application/json")
 			resp, err := http.DefaultClient.Do(req)
 			g.Expect(err).To(BeNil())

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -24,7 +24,6 @@ import (
 	kafka_config "github.com/seldonio/seldon-core/components/kafka/v2/pkg/config"
 	config_tls "github.com/seldonio/seldon-core/components/tls/v2/pkg/config"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	kafka2 "github.com/seldonio/seldon-core/scheduler/v2/pkg/kafka"
 	seldontracer "github.com/seldonio/seldon-core/scheduler/v2/pkg/tracing"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
@@ -220,7 +219,7 @@ func (km *KafkaManager) Infer(
 		outputTopic = km.topicNamer.GetModelTopicInputs(resourceName)
 	}
 	logger.Debugf("Produce on topic %s with key %s", outputTopic, compositeKey)
-	kafkaHeaders := append(headers, kafka.Header{Key: resources.SeldonPipelineHeader, Value: []byte(resourceName)})
+	kafkaHeaders := append(headers, kafka.Header{Key: util.SeldonPipelineHeader, Value: []byte(resourceName)})
 	kafkaHeaders = addRequestIdToKafkaHeadersIfMissing(kafkaHeaders, requestId)
 
 	msg := &kafka.Message{

--- a/scheduler/pkg/kafka/pipeline/status/model_rest.go
+++ b/scheduler/pkg/kafka/pipeline/status/model_rest.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
@@ -66,7 +65,7 @@ func (mr *ModelRestCaller) CheckModelReady(ctx context.Context, modelName string
 	if err != nil {
 		return false, err
 	}
-	req.Header.Set(resources.SeldonModelHeader, modelName)
+	req.Header.Set(util.SeldonModelHeader, modelName)
 	req.Header.Set(util.RequestIdHeader, requestId)
 	response, err := mr.httpClient.Do(req)
 	if err != nil {

--- a/scheduler/pkg/kafka/pipeline/utils.go
+++ b/scheduler/pkg/kafka/pipeline/utils.go
@@ -17,7 +17,6 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/envoy/resources"
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/util"
 )
 
@@ -30,14 +29,14 @@ func createResourceNameFromHeader(header string) (string, bool, error) {
 		}
 	case 2:
 		switch parts[1] {
-		case resources.SeldonPipelineHeaderSuffix:
+		case util.SeldonPipelineHeaderSuffix:
 			return parts[0], false, nil
-		case resources.SeldonModelHeaderSuffix:
+		case util.SeldonModelHeaderSuffix:
 			return parts[0], true, nil
 		}
 	}
 	return "", false, fmt.Errorf(
-		"Bad or missing header %s %s", resources.SeldonModelHeader, header)
+		"Bad or missing header %s %s", util.SeldonModelHeader, header)
 }
 
 func addRequestIdToKafkaHeadersIfMissing(headers []kafka.Header, requestId string) []kafka.Header {
@@ -57,7 +56,7 @@ func convertHttpHeadersToKafkaHeaders(httpHeaders http.Header) []kafka.Header {
 	var kafkaHeaders []kafka.Header
 	for k, vals := range httpHeaders {
 		key := strings.ToLower(k)
-		if strings.HasPrefix(key, resources.ExternalHeaderPrefix) {
+		if strings.HasPrefix(key, util.ExternalHeaderPrefix) {
 			for _, headerValue := range vals {
 				kafkaHeaders = append(kafkaHeaders, kafka.Header{Key: key, Value: []byte(headerValue)})
 			}
@@ -69,7 +68,7 @@ func convertHttpHeadersToKafkaHeaders(httpHeaders http.Header) []kafka.Header {
 func convertKafkaHeadersToHttpHeaders(kafkaHeaders []kafka.Header) http.Header {
 	httpHeaders := make(http.Header)
 	for _, kafkaHeader := range kafkaHeaders {
-		if strings.HasPrefix(strings.ToLower(kafkaHeader.Key), resources.ExternalHeaderPrefix) {
+		if strings.HasPrefix(strings.ToLower(kafkaHeader.Key), util.ExternalHeaderPrefix) {
 			if val, ok := httpHeaders[kafkaHeader.Key]; ok {
 				val = append(val, string(kafkaHeader.Value))
 				httpHeaders[kafkaHeader.Key] = val
@@ -84,7 +83,7 @@ func convertKafkaHeadersToHttpHeaders(kafkaHeaders []kafka.Header) http.Header {
 func convertGrpcMetadataToKafkaHeaders(grpcMetadata metadata.MD) []kafka.Header {
 	var kafkaHeaders []kafka.Header
 	for k, vals := range grpcMetadata {
-		if strings.HasPrefix(strings.ToLower(k), resources.ExternalHeaderPrefix) {
+		if strings.HasPrefix(strings.ToLower(k), util.ExternalHeaderPrefix) {
 			for _, headerValue := range vals {
 				kafkaHeaders = append(kafkaHeaders, kafka.Header{Key: k, Value: []byte(headerValue)})
 			}
@@ -96,7 +95,7 @@ func convertGrpcMetadataToKafkaHeaders(grpcMetadata metadata.MD) []kafka.Header 
 func convertKafkaHeadersToGrpcMetadata(kafkaHeaders []kafka.Header) metadata.MD {
 	grpcMetadata := make(metadata.MD)
 	for _, kafkaHeader := range kafkaHeaders {
-		if strings.HasPrefix(strings.ToLower(kafkaHeader.Key), resources.ExternalHeaderPrefix) {
+		if strings.HasPrefix(strings.ToLower(kafkaHeader.Key), util.ExternalHeaderPrefix) {
 			if val, ok := grpcMetadata[kafkaHeader.Key]; ok {
 				val = append(val, string(kafkaHeader.Value))
 				grpcMetadata[kafkaHeader.Key] = val

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -14,7 +14,6 @@ import (
 )
 
 // Headers
-
 const (
 	SeldonModelHeader          = "seldon-model"
 	SeldonPipelineHeader       = "pipeline"

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -13,6 +13,19 @@ import (
 	"time"
 )
 
+// Headers
+
+const (
+	SeldonModelHeader          = "seldon-model"
+	SeldonPipelineHeader       = "pipeline"
+	SeldonInternalModelHeader  = "seldon-internal-model"
+	SeldonLoggingHeader        = "Seldon-Logging"
+	SeldonRouteHeader          = "x-seldon-route"
+	ExternalHeaderPrefix       = "x-"
+	SeldonModelHeaderSuffix    = "model"
+	SeldonPipelineHeaderSuffix = "pipeline"
+)
+
 // REST
 const (
 	DefaultReverseProxyHTTPPort = 9999


### PR DESCRIPTION
**What this PR does / why we need it**:

Moving some headers from the envoy package to util, as they are used in other components.

Moving `envoy/resourses` to `envoy/xdscache`. 

Fixes # 

Part of INFRA-1420

**Special notes for your reviewer**:
