### PR TITLE
feat(envoy): use the healthcheck filter and a prestop hook to gracefully terminate Envoy

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -952,7 +952,7 @@ spec:
               - -c
               - |
                 echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
-                sleep 30
+                sleep '{{ .Values.envoy.preStopSleepPeriodSeconds }}'
         name: envoy
         ports:
         - containerPort: 9000
@@ -978,7 +978,8 @@ spec:
 {{- end }}
       securityContext: {{- toYaml .Values.envoy.securityContext | nindent
         8 }}
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: {{ .Values.envoy.terminationGracePeriodSeconds
+        }}
     replicas: 1
   - annotations: {{- toYaml .Values.dataflow.annotations | nindent 8
       }}

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -951,7 +951,7 @@ spec:
               - /bin/sh
               - -c
               - |
-                echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
+                echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/{{ .Values.envoy.adminInterfacePort }}
                 sleep '{{ .Values.envoy.preStopSleepPeriodSeconds }}'
         name: envoy
         ports:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -944,6 +944,15 @@ spec:
         image: '{{ .Values.envoy.image.registry }}/{{ .Values.envoy.image.repository
           }}:{{ .Values.envoy.image.tag }}'
         imagePullPolicy: '{{ .Values.envoy.image.pullPolicy }}'
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
+                sleep 30
         name: envoy
         ports:
         - containerPort: 9000

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -201,6 +201,7 @@ envoy:
     runAsNonRoot: true
   preStopSleepPeriodSeconds: 30
   terminationGracePeriodSeconds: 120
+  adminInterfacePort: 9901
 
 scheduler:
   image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -199,6 +199,8 @@ envoy:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  preStopSleepPeriodSeconds: 30
+  terminationGracePeriodSeconds: 120
 
 scheduler:
   image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -201,6 +201,7 @@ envoy:
     runAsNonRoot: true
   preStopSleepPeriodSeconds: 30
   terminationGracePeriodSeconds: 120
+  adminInterfacePort: 9901
 
 scheduler:
   image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -199,6 +199,8 @@ envoy:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  preStopSleepPeriodSeconds: 30
+  terminationGracePeriodSeconds: 120
 
 scheduler:
   image:

--- a/k8s/kustomize/helm-components-sc/patch_envoy.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_envoy.yaml
@@ -39,3 +39,12 @@ spec:
                 name: '{{ .Values.security.controlplane.ssl.client.serverValidationSecret }}' 
                 key: ca.crt
                 optional: true 
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                  echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
+                  sleep 30

--- a/k8s/kustomize/helm-components-sc/patch_envoy.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_envoy.yaml
@@ -47,4 +47,4 @@ spec:
               - -c
               - |
                   echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
-                  sleep 30
+                  sleep '{{ .Values.envoy.preStopSleepPeriodSeconds }}'

--- a/k8s/kustomize/helm-components-sc/patch_envoy.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_envoy.yaml
@@ -46,5 +46,5 @@ spec:
               - /bin/sh
               - -c
               - |
-                  echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
+                  echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/{{ .Values.envoy.adminInterfacePort }}
                   sleep '{{ .Values.envoy.preStopSleepPeriodSeconds }}'

--- a/k8s/kustomize/helm-components-sc/patch_envoy_json6902.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_envoy_json6902.yaml
@@ -8,3 +8,6 @@
 - op: replace
   path: /spec/components/4/annotations
   value: HACK_REMOVE_ME{{- toYaml .Values.envoy.annotations | nindent 8 }}
+- op: replace
+  path: /spec/components/4/podSpec/terminationGracePeriodSeconds
+  value: HACK_REMOVE_ME{{ .Values.envoy.terminationGracePeriodSeconds }}

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -785,6 +785,15 @@ spec:
               optional: true
         image: 'docker.io/seldonio/seldon-envoy:latest'
         imagePullPolicy: 'IfNotPresent'
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - |
+                echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
+                sleep 30
         name: envoy
         ports:
         - containerPort: 9000

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -793,7 +793,7 @@ spec:
               - -c
               - |
                 echo -ne "POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" > /dev/tcp/localhost/9901
-                sleep 30
+                sleep '30'
         name: envoy
         ports:
         - containerPort: 9000
@@ -818,7 +818,7 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 120
     replicas: 1
   - annotations:
         null

--- a/scheduler/config/envoy-compose.yaml
+++ b/scheduler/config/envoy-compose.yaml
@@ -39,6 +39,13 @@ static_resources:
           port_value: 9003
       filter_chains:
       - filters:
+        - name: envoy.filters.http.health_check
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+            pass_through_mode: false
+            headers:
+              - exact_match: /ready
+                name: :path
         - name: envoy.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -55,10 +62,6 @@ static_resources:
                 routes:
                 - match:
                     prefix: /stats
-                  route:
-                    cluster: admin_interface_cluster
-                - match:
-                    prefix: /ready
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:

--- a/scheduler/config/envoy-local.yaml
+++ b/scheduler/config/envoy-local.yaml
@@ -39,6 +39,13 @@ static_resources:
           port_value: 9003
       filter_chains:
       - filters:
+        - name: envoy.filters.http.health_check
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+            pass_through_mode: false
+            headers:
+              - exact_match: /ready
+                name: :path
         - name: envoy.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -55,10 +62,6 @@ static_resources:
                 routes:
                 - match:
                     prefix: /stats
-                  route:
-                    cluster: admin_interface_cluster
-                - match:
-                    prefix: /ready
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:

--- a/scheduler/config/envoy-tls.yaml
+++ b/scheduler/config/envoy-tls.yaml
@@ -52,6 +52,13 @@ static_resources:
           port_value: 9003
       filter_chains:
       - filters:
+        - name: envoy.filters.http.health_check
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+            pass_through_mode: false
+            headers:
+              - exact_match: /ready
+                name: :path
         - name: envoy.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -68,10 +75,6 @@ static_resources:
                 routes:
                 - match:
                     prefix: /stats
-                  route:
-                    cluster: admin_interface_cluster
-                - match:
-                    prefix: /ready
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:

--- a/scheduler/config/envoy.yaml
+++ b/scheduler/config/envoy.yaml
@@ -44,6 +44,13 @@ static_resources:
             "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
             stat_prefix: util_endpoint_http
             http_filters:
+            - name: envoy.filters.http.health_check
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                pass_through_mode: false
+                headers:
+                  - exact_match: /ready
+                    name: :path
             - name: envoy.filters.http.router
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -55,10 +62,6 @@ static_resources:
                 routes:
                 - match:
                     prefix: /stats
-                  route:
-                    cluster: admin_interface_cluster
-                - match:
-                    prefix: /ready
                   route:
                     cluster: admin_interface_cluster
 dynamic_resources:

--- a/scheduler/k8s/envoy/envoy.yaml
+++ b/scheduler/k8s/envoy/envoy.yaml
@@ -47,4 +47,4 @@ spec:
           containerPort: 9000
         - name: envoy-stats
           containerPort: 9003
-      terminationGracePeriodSeconds: 5
+      terminationGracePeriodSeconds: 120


### PR DESCRIPTION
**What this PR does / why we need it**:

Some clients will receive resets when `seldon-envoy` is restarting. These can be reduced by slowing down the termination sequence and triggering readiness checks to fail, so the kubelet will remove the pod's endpoint from Service load balancing.   

**Which issue(s) this PR fixes**:

Fixes # INFRA-1254

**Special notes for your reviewer**:

Perhaps this should be improved in future with something that at least logs some information about the `preStop` sequence.  
