### PR TITLE
feat(scheduler): add partial scheduling based on min replicas

### DIFF
--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -94,7 +94,8 @@ func (s *SimpleScheduler) getFailedModels() ([]string, error) {
 		version := model.GetLatest()
 		if version != nil {
 			versionState := version.ModelState()
-			if versionState.State == store.ModelFailed || versionState.State == store.ScheduleFailed {
+			if versionState.State == store.ModelFailed || versionState.State == store.ScheduleFailed || 
+			(versionState.State == store.ModelAvailable && versionState.AvailableReplicas < version.GetDeploymentSpec().GetReplicas()) {
 				failedModels = append(failedModels, model.Name)
 			}
 		}

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -189,7 +189,7 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 		okWithMinReplicas = s.findAndUpdateToServers(filteredServers, latestModel, desiredReplicas, int(minReplicas))
 		if okWithMinReplicas {
 			msg := "Failed to schedule model as no matching server had enough suitable replicas, managed to schedule with min replicas"
-			logger.Debug(msg)
+			logger.Warn(msg)
 		}
 	}
 

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -43,7 +43,7 @@ func DefaultSchedulerConfig(store store.ModelStore) SchedulerConfig {
 	return SchedulerConfig{
 		serverFilters:  []filters.ServerFilter{filters.ServerReplicaFilter{}, filters.SharingServerFilter{}, filters.DeletedServerFilter{}, filters.ServerRequirementFilter{}},
 		replicaFilters: []filters.ReplicaFilter{filters.AvailableMemoryReplicaFilter{}, filters.ExplainerFilter{}, filters.ReplicaDrainingFilter{}},
-		serverSorts:    []sorters.ServerSorter{},
+		serverSorts:    []sorters.ServerSorter{sorters.ModelAlreadyLoadedOnServerSorter{}},
 		replicaSorts:   []sorters.ReplicaSorter{sorters.ReplicaIndexSorter{}, sorters.AvailableMemorySorter{}, sorters.ModelAlreadyLoadedSorter{}},
 	}
 }

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -169,6 +169,12 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 		WithField("desired_replicas", desiredReplicas).
 		Debug("Identified candidate servers for model")
 
+	// The main logic of trying to find a server for the model is as follows:
+	// 1. If there are enough replicas on a server, schedule the model
+	// 2. If there are not enough replicas on a server, try to schedule with min replicas. In this case we actually should get 
+	// the models loaded on all the replicas of the servers (assuming min replicas is less than the number of replicas on the server)
+	// we also mark the model in this case as failed to schedule so that if the infra changes in the future we can try to reschedule
+
 	// For each server filter and sort replicas and attempt schedule if enough replicas
 	ok := s.findAndUpdateToServers(filteredServers, latestModel, desiredReplicas, desiredReplicas)
 	// Try to scheduler with min replicas if not enough replicas

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -84,6 +84,11 @@ func (s *SimpleScheduler) ScheduleFailedModels() ([]string, error) {
 	return updatedModels, nil
 }
 
+// Get failed models
+// Currently this includes:
+// - models that have failed to schedule
+// - models that have failed to load
+// - models that have loaded but not all replicas are available (e.g. min replicas is met but not desired replicas)
 func (s *SimpleScheduler) getFailedModels() ([]string, error) {
 	models, err := s.store.GetModels()
 	if err != nil {
@@ -94,8 +99,8 @@ func (s *SimpleScheduler) getFailedModels() ([]string, error) {
 		version := model.GetLatest()
 		if version != nil {
 			versionState := version.ModelState()
-			if versionState.State == store.ModelFailed || versionState.State == store.ScheduleFailed || 
-			(versionState.State == store.ModelAvailable && versionState.AvailableReplicas < version.GetDeploymentSpec().GetReplicas()) {
+			if versionState.State == store.ModelFailed || versionState.State == store.ScheduleFailed ||
+				(versionState.State == store.ModelAvailable && versionState.AvailableReplicas < version.GetDeploymentSpec().GetReplicas()) {
 				failedModels = append(failedModels, model.Name)
 			}
 		}

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -171,7 +171,7 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 
 	// The main logic of trying to find a server for the model is as follows:
 	// 1. If there are enough replicas on a server, schedule the model
-	// 2. If there are not enough replicas on a server, try to schedule with min replicas. In this case we actually should get 
+	// 2. If there are not enough replicas on a server, try to schedule with min replicas. In this case we actually should get
 	// the models loaded on all the replicas of the servers (assuming min replicas is less than the number of replicas on the server)
 	// we also mark the model in this case as failed to schedule so that if the infra changes in the future we can try to reschedule
 

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -185,25 +185,21 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 	ok := s.findAndUpdateToServers(filteredServers, latestModel, desiredReplicas, desiredReplicas)
 	// Try to scheduler with min replicas if not enough replicas
 	okWithMinReplicas := false
-	if !ok {
-		if minReplicas > 0 {
-			okWithMinReplicas = s.findAndUpdateToServers(filteredServers, latestModel, desiredReplicas, int(minReplicas))
-		}
+	if !ok && minReplicas > 0 {
+		okWithMinReplicas = s.findAndUpdateToServers(filteredServers, latestModel, desiredReplicas, int(minReplicas))
+		msg := "Failed to schedule model as no matching server had enough suitable replicas, managed to schedule with min replicas"
+		logger.Debug(msg)
 	}
 
-	if !ok {
+	if !ok && !okWithMinReplicas {
 		msg := "Failed to schedule model as no matching server had enough suitable replicas"
-		if okWithMinReplicas {
-			msg = "Failed to schedule model as no matching server had enough suitable replicas, managed to schedule with min replicas"
-		}
 		logger.Debug(msg)
 		// we do not want to reset the server if it has live replicas or loading replicas
 		// in the case of loading replicas, we need to make sure that we can unload them later.
 		// for example in the case that a model is just marked as loading on a particular server replica
 		// then it gets a delete request (before it is marked as loaded or available) we need to make sure
 		// that we can unload it from the server
-		// we also do not want to reset the server if we managed to schedule with min replicas
-		s.store.FailedScheduling(latestModel, msg, !latestModel.HasLiveReplicas() && !latestModel.IsLoadingOrLoadedOnServer() && !okWithMinReplicas)
+		s.store.FailedScheduling(latestModel, msg, !latestModel.HasLiveReplicas() && !latestModel.IsLoadingOrLoadedOnServer())
 		return errors.New(msg)
 	}
 

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -187,8 +187,10 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) error {
 	okWithMinReplicas := false
 	if !ok && minReplicas > 0 {
 		okWithMinReplicas = s.findAndUpdateToServers(filteredServers, latestModel, desiredReplicas, int(minReplicas))
-		msg := "Failed to schedule model as no matching server had enough suitable replicas, managed to schedule with min replicas"
-		logger.Debug(msg)
+		if okWithMinReplicas {
+			msg := "Failed to schedule model as no matching server had enough suitable replicas, managed to schedule with min replicas"
+			logger.Debug(msg)
+		}
 	}
 
 	if !ok && !okWithMinReplicas {

--- a/scheduler/pkg/scheduler/scheduler_test.go
+++ b/scheduler/pkg/scheduler/scheduler_test.go
@@ -241,7 +241,7 @@ func TestScheduler(t *testing.T) {
 					ExpectedReplicas: -1,
 				},
 			},
-			scheduled:         false, // not here that we still mark the model as scheduleFailed
+			scheduled:         true, // not here that we still trying to mark the model as Available
 			scheduledServer:   "server2",
 			scheduledReplicas: []int{0, 1},
 		},
@@ -464,7 +464,7 @@ func TestScheduler(t *testing.T) {
 					ExpectedReplicas: -1,
 				},
 			},
-			scheduled:         false,
+			scheduled:         true, // note that we are still trying to make the model as Available
 			scheduledServer:   "server1",
 			scheduledReplicas: []int{0, 1, 2, 3}, // used all replicas
 		},

--- a/scheduler/pkg/scheduler/scheduler_test.go
+++ b/scheduler/pkg/scheduler/scheduler_test.go
@@ -126,8 +126,8 @@ func TestScheduler(t *testing.T) {
 	logger := log.New()
 	g := NewGomegaWithT(t)
 
-	newTestModel := func(name string, requiredMemory uint64, requirements []string, server *string, replicas uint32, loadedModels []int, deleted bool, scheduledServer string, drainedModels []int) *store.ModelSnapshot {
-		config := &pb.Model{ModelSpec: &pb.ModelSpec{MemoryBytes: &requiredMemory, Requirements: requirements, Server: server}, DeploymentSpec: &pb.DeploymentSpec{Replicas: replicas}}
+	newTestModel := func(name string, requiredMemory uint64, requirements []string, server *string, replicas, minReplicas uint32, loadedModels []int, deleted bool, scheduledServer string, drainedModels []int) *store.ModelSnapshot {
+		config := &pb.Model{ModelSpec: &pb.ModelSpec{MemoryBytes: &requiredMemory, Requirements: requirements, Server: server}, DeploymentSpec: &pb.DeploymentSpec{Replicas: replicas, MinReplicas: minReplicas}}
 		rmap := make(map[int]store.ReplicaStatus)
 		for _, ridx := range loadedModels {
 			rmap[ridx] = store.ReplicaStatus{State: store.Loaded}
@@ -162,7 +162,7 @@ func TestScheduler(t *testing.T) {
 	tests := []test{
 		{
 			name:  "SmokeTest",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -177,7 +177,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "ReplicasTwo",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, []int{}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, 0, []int{}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -201,7 +201,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "NotEnoughReplicas",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, []int{}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, 0, []int{}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -222,8 +222,32 @@ func TestScheduler(t *testing.T) {
 			scheduled: false,
 		},
 		{
+			name:  "NotEnoughReplicas - schedule min replicas",
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 3, 2, []int{}, false, "", nil),
+			servers: []*store.ServerSnapshot{
+				{
+					Name:             "server1",
+					Replicas:         map[int]*store.ServerReplica{0: gsr(0, 200, []string{"sklearn"}, "server1", true, false)},
+					Shared:           true,
+					ExpectedReplicas: -1,
+				},
+				{
+					Name: "server2",
+					Replicas: map[int]*store.ServerReplica{
+						0: gsr(0, 200, []string{"sklearn"}, "server2", true, false), // expect schedule here
+						1: gsr(1, 200, []string{"sklearn"}, "server2", true, false), // expect schedule here
+					},
+					Shared:           true,
+					ExpectedReplicas: -1,
+				},
+			},
+			scheduled:         false, // not here that we still mark the model as scheduleFailed
+			scheduledServer:   "server2",
+			scheduledReplicas: []int{0, 1},
+		},
+		{
 			name:  "MemoryOneServer",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -246,7 +270,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "ModelsLoaded",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, []int{1}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, 0, []int{1}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -270,7 +294,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "ModelUnLoaded",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, []int{1}, true, "server2", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, 0, []int{1}, true, "server2", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server2",
@@ -288,7 +312,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "DeletedServer",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -312,7 +336,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "Reschedule",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{0}, false, "server1", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{0}, false, "server1", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -336,7 +360,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "DeletedServerFail",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{1}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{1}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name:             "server1",
@@ -349,7 +373,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "Available memory sorting",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{1}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{1}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server2",
@@ -367,7 +391,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "Available memory sorting with multiple replicas",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, []int{1}, false, "", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, 0, []int{1}, false, "", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server2",
@@ -386,7 +410,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "Scale up",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 3, []int{1, 2}, false, "server1", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 3, 0, []int{1, 2}, false, "server1", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server1",
@@ -406,7 +430,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "Scale down",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{1, 2}, false, "server1", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{1, 2}, false, "server1", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server1",
@@ -425,8 +449,28 @@ func TestScheduler(t *testing.T) {
 			scheduledReplicas: []int{1},
 		},
 		{
+			name:  "Scale up - not enough replicas use max of the server",
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 5, 3, []int{1, 2}, false, "server1", nil),
+			servers: []*store.ServerSnapshot{
+				{
+					Name: "server1",
+					Replicas: map[int]*store.ServerReplica{
+						0: gsr(0, 100, []string{"sklearn"}, "server1", true, false), // expect schedule here
+						1: gsr(1, 100, []string{"sklearn"}, "server1", true, false), // expect schedule here - nop
+						2: gsr(2, 100, []string{"sklearn"}, "server1", true, false), // expect schedule here - nop
+						3: gsr(3, 100, []string{"sklearn"}, "server1", true, false), // expect schedule here
+					},
+					Shared:           true,
+					ExpectedReplicas: -1,
+				},
+			},
+			scheduled:         false,
+			scheduledServer:   "server1",
+			scheduledReplicas: []int{0, 1, 2, 3}, // used all replicas
+		},
+		{
 			name:  "Scale up - no capacity on loaded replica servers, should still go there",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 3, []int{1, 2}, false, "server1", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 3, 0, []int{1, 2}, false, "server1", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server1",
@@ -446,7 +490,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "Scale down - no capacity on loaded replica servers, should still go there",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, []int{1, 2}, false, "server1", nil),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 1, 0, []int{1, 2}, false, "server1", nil),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server1",
@@ -466,7 +510,7 @@ func TestScheduler(t *testing.T) {
 		},
 		{
 			name:  "Drain",
-			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, []int{1}, false, "server1", []int{2}),
+			model: newTestModel("model1", 100, []string{"sklearn"}, nil, 2, 0, []int{1}, false, "server1", []int{2}),
 			servers: []*store.ServerSnapshot{
 				{
 					Name: "server1",
@@ -502,12 +546,14 @@ func TestScheduler(t *testing.T) {
 			err := scheduler.Schedule(test.model.Name)
 			if test.scheduled {
 				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).ToNot(BeNil())
+			}
+			if test.scheduledServer != "" {
 				g.Expect(test.scheduledServer).To(Equal(mockStore.scheduledServer))
 				sort.Ints(test.scheduledReplicas)
 				sort.Ints(mockStore.scheduledReplicas)
 				g.Expect(test.scheduledReplicas).To(Equal(mockStore.scheduledReplicas))
-			} else {
-				g.Expect(err).ToNot(BeNil())
 			}
 		})
 	}

--- a/scheduler/pkg/scheduler/sorters/loaded.go
+++ b/scheduler/pkg/scheduler/sorters/loaded.go
@@ -21,7 +21,8 @@ func (m ModelAlreadyLoadedSorter) IsLess(i *CandidateReplica, j *CandidateReplic
 	return iIsLoading && !jIsLoading
 }
 
-// This sorter favours servers that have the models already loaded on them
+// This sorter favours servers that have the models already loaded on them, this is useful to minimise ping-pong of models between servers
+// which can be expensive in terms of model loading time.
 type ModelAlreadyLoadedOnServerSorter struct{}
 
 func (m ModelAlreadyLoadedOnServerSorter) Name() string {

--- a/scheduler/pkg/scheduler/sorters/loaded.go
+++ b/scheduler/pkg/scheduler/sorters/loaded.go
@@ -20,3 +20,17 @@ func (m ModelAlreadyLoadedSorter) IsLess(i *CandidateReplica, j *CandidateReplic
 	jIsLoading := j.Model.IsLoadingOrLoaded(j.Server.Name, j.Replica.GetReplicaIdx())
 	return iIsLoading && !jIsLoading
 }
+
+// This sorter favours servers that have the models already loaded on them
+type ModelAlreadyLoadedOnServerSorter struct{}
+
+func (m ModelAlreadyLoadedOnServerSorter) Name() string {
+	return "ModelAlreadyLoadedOnServerSorter"
+}
+
+func (m ModelAlreadyLoadedOnServerSorter) IsLess(i *CandidateServer, j *CandidateServer) bool {
+	if i.Model.Server() == i.Server.Name {
+		return true
+	}
+	return false
+}

--- a/scheduler/pkg/scheduler/sorters/loaded.go
+++ b/scheduler/pkg/scheduler/sorters/loaded.go
@@ -29,8 +29,5 @@ func (m ModelAlreadyLoadedOnServerSorter) Name() string {
 }
 
 func (m ModelAlreadyLoadedOnServerSorter) IsLess(i *CandidateServer, j *CandidateServer) bool {
-	if i.Model.Server() == i.Server.Name {
-		return true
-	}
-	return false
+	return i.Model.Server() == i.Server.Name
 }

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -377,6 +377,8 @@ func (m *MemoryStore) updateLoadedModelsImpl(
 	// also send an update for progressing models so the operator can update the status in the case of a network glitch where the model generation has been updated
 	// also send an update if the model is not yet at desired replicas, if we have partial scheduling
 
+	// note that we use len(modelVersion.GetAssignment()) to calculate the number of replicas as the status of the model at this point might not reflect the actual number of replicas
+	// in modelVersion.state.AvailableReplicas (we call updateModelStatus later)
 	if replicaStateUpdated || modelVersion.state.State == ScheduleFailed || model.IsDeleted() || modelVersion.state.State == ModelProgressing ||
 		(modelVersion.state.State == ModelAvailable && len(modelVersion.GetAssignment()) < modelVersion.DesiredReplicas()) {
 		logger.Debugf("Updating model status for model %s server %s", modelKey, serverKey)

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -379,6 +379,8 @@ func (m *MemoryStore) updateLoadedModelsImpl(
 
 	// note that we use len(modelVersion.GetAssignment()) to calculate the number of replicas as the status of the model at this point might not reflect the actual number of replicas
 	// in modelVersion.state.AvailableReplicas (we call updateModelStatus later)
+
+	// TODO: the conditions here keep growing, refactor or consider a simpler check.
 	if replicaStateUpdated || modelVersion.state.State == ScheduleFailed || model.IsDeleted() || modelVersion.state.State == ModelProgressing ||
 		(modelVersion.state.State == ModelAvailable && len(modelVersion.GetAssignment()) < modelVersion.DesiredReplicas()) {
 		logger.Debugf("Updating model status for model %s server %s", modelKey, serverKey)

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -375,7 +375,10 @@ func (m *MemoryStore) updateLoadedModelsImpl(
 	// this could be in the cases where we are scaling down a model and the new replica count can be all deployed
 	// and always send an update for deleted models, so the operator will remove them from k8s
 	// also send an update for progressing models so the operator can update the status in the case of a network glitch where the model generation has been updated
-	if replicaStateUpdated || modelVersion.state.State == ScheduleFailed || model.IsDeleted() || modelVersion.state.State == ModelProgressing {
+	// also send an update if the model is not yet at desired replicas, if we have partial scheduling
+
+	if replicaStateUpdated || modelVersion.state.State == ScheduleFailed || model.IsDeleted() || modelVersion.state.State == ModelProgressing ||
+		(modelVersion.state.State == ModelAvailable && len(modelVersion.GetAssignment()) < modelVersion.DesiredReplicas()) {
 		logger.Debugf("Updating model status for model %s server %s", modelKey, serverKey)
 		modelVersion.server = serverKey
 		m.updateModelStatus(true, model.IsDeleted(), modelVersion, model.GetLastAvailableModelVersion())

--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -106,12 +106,14 @@ func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersio
 }
 
 func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string, reset bool) {
+	availableReplicas := uint32(len(modelVersion.GetAssignment()))
+
 	modelVersion.state = ModelStatus{
 		State:               ScheduleFailed,
 		Reason:              reason,
 		Timestamp:           time.Now(),
-		AvailableReplicas:   modelVersion.state.AvailableReplicas,
-		UnavailableReplicas: modelVersion.GetModel().GetDeploymentSpec().GetReplicas() - modelVersion.state.AvailableReplicas,
+		AvailableReplicas:   availableReplicas,
+		UnavailableReplicas: modelVersion.GetModel().GetDeploymentSpec().GetReplicas() - availableReplicas,
 	}
 	// make sure we reset server but only if there are no available replicas
 	if reset {

--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -88,7 +88,8 @@ func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersio
 			modelReason = stats.lastFailedReason
 			modelTimestamp = stats.lastFailedStateTime
 		} else if (modelVersion.GetDeploymentSpec() != nil && stats.replicasAvailable == modelVersion.GetDeploymentSpec().Replicas) || // equal to desired replicas
-			(stats.replicasAvailable > 0 && prevModelVersion != nil && modelVersion != prevModelVersion && prevModelVersion.state.State == ModelAvailable) { // TODO In future check if available replicas is > minReplicas
+			(modelVersion.GetDeploymentSpec() != nil && stats.replicasAvailable >= modelVersion.GetDeploymentSpec().MinReplicas && modelVersion.GetDeploymentSpec().MinReplicas > 0) || // min replicas is set and available replicas are greater than or equal to min replicas
+			(stats.replicasAvailable > 0 && prevModelVersion != nil && modelVersion != prevModelVersion && prevModelVersion.state.State == ModelAvailable) {
 			modelState = ModelAvailable
 		} else {
 			modelState = ModelProgressing

--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -106,7 +106,7 @@ func updateModelState(isLatest bool, modelVersion *ModelVersion, prevModelVersio
 }
 
 func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string, reset bool) {
-	availableReplicas := uint32(len(modelVersion.GetAssignment()))
+	availableReplicas := modelVersion.state.AvailableReplicas
 
 	modelVersion.state = ModelStatus{
 		State:               ScheduleFailed,

--- a/scheduler/pkg/store/memory_status_test.go
+++ b/scheduler/pkg/store/memory_status_test.go
@@ -97,6 +97,69 @@ func TestUpdateStatus(t *testing.T) {
 			expectedModelStatus: ModelAvailable,
 		},
 		{
+			name: "Available - Min replicas",
+			store: &LocalSchedulerStore{
+				models: map[string]*Model{
+					"model": {
+						versions: []*ModelVersion{
+							{
+								version: 1,
+								modelDefn: &pb.Model{
+									Meta: &pb.MetaData{
+										Name: "model",
+									},
+									ModelSpec: &pb.ModelSpec{},
+									DeploymentSpec: &pb.DeploymentSpec{
+										Replicas: 1,
+									},
+								},
+								server: "server2",
+								replicas: map[int]ReplicaStatus{
+									0: {State: Loaded},
+								},
+							},
+							{
+								version: 2,
+								modelDefn: &pb.Model{
+									Meta: &pb.MetaData{
+										Name: "model",
+									},
+									ModelSpec: &pb.ModelSpec{},
+									DeploymentSpec: &pb.DeploymentSpec{
+										Replicas:    2,
+										MinReplicas: 1,
+									},
+								},
+								server: "server1",
+								replicas: map[int]ReplicaStatus{
+									0: {State: Available},
+								},
+							},
+						},
+					},
+				},
+				servers: map[string]*Server{
+					"server1": {
+						name: "server1",
+						replicas: map[int]*ServerReplica{
+							0: {},
+						},
+					},
+					"server2": {
+						name: "server2",
+						replicas: map[int]*ServerReplica{
+							0: {},
+						},
+					},
+				},
+			},
+			modelName:           "model",
+			serverName:          "server2",
+			version:             2,
+			prevVersion:         nil,
+			expectedModelStatus: ModelAvailable,
+		},
+		{
 			name: "NotEnoughReplicasButPreviousAvailable",
 			store: &LocalSchedulerStore{
 				models: map[string]*Model{

--- a/scheduler/pkg/store/memory_test.go
+++ b/scheduler/pkg/store/memory_test.go
@@ -725,6 +725,42 @@ func TestUpdateLoadedModels(t *testing.T) {
 			expectedStates:     map[int]ReplicaStatus{0: {State: Available}, 1: {State: Unloaded}},
 			expectedModelState: &ModelStatus{State: ModelAvailable},
 		},
+		{
+			name: "PartiallyAvailableModels",
+			store: &LocalSchedulerStore{
+				models: map[string]*Model{"model": {
+					versions: []*ModelVersion{
+						{
+							modelDefn: &pb.Model{ModelSpec: &pb.ModelSpec{MemoryBytes: &memBytes}, DeploymentSpec: &pb.DeploymentSpec{Replicas: 3, MinReplicas: 2}},
+							server:    "server",
+							version:   1,
+							replicas: map[int]ReplicaStatus{
+								0: {State: Available},
+								1: {State: Available},
+							},
+							state: ModelStatus{State: ModelProgressing},
+						},
+					},
+				}},
+				servers: map[string]*Server{
+					"server": {
+						name: "server",
+						replicas: map[int]*ServerReplica{
+							0: {},
+							1: {},
+						},
+					},
+				},
+			},
+			modelKey:  "model",
+			version:   1,
+			serverKey: "server",
+			replicas: []*ServerReplica{
+				{replicaIdx: 0}, {replicaIdx: 1},
+			},
+			expectedStates:     map[int]ReplicaStatus{0: {State: Available}, 1: {State: Available}},
+			expectedModelState: &ModelStatus{State: ModelAvailable},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
This PR introduces the ability to do partial scheduling for a given model if:
- The number of replicas for all candidate servers is less than the desired replica of the model
- The min replicas of the model is less than the available replicas of the server to load the model onto

In this case we load the model on as many replicas as possible assuming it meets min replicas requirement; we mark the model as Available. We also make sure that when there is more capacity available we retry scheduling to make sure so that the model can potentially make use of this extra capacity.

We also favour servers that have the models loaded to minimise ping-ping behaviour.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
