### PR TITLE
feat(scheduler): mms send scaling request when model shceduling fails

### DIFF
--- a/scheduler/pkg/coordinator/types.go
+++ b/scheduler/pkg/coordinator/types.go
@@ -11,6 +11,13 @@ package coordinator
 
 import "fmt"
 
+type ModelEventUpdateContext int
+
+const (
+	MODEL_STATUS_UPDATE ModelEventUpdateContext = iota
+	MODEL_SCHEDULE_FAILED
+)
+
 type ServerEventUpdateContext int
 
 const (
@@ -19,8 +26,9 @@ const (
 )
 
 type ModelEventMsg struct {
-	ModelName    string
-	ModelVersion uint32
+	ModelName     string
+	ModelVersion  uint32
+	UpdateContext ModelEventUpdateContext
 }
 
 func (m ModelEventMsg) String() string {

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -47,9 +47,7 @@ const (
 	sendTimeout                     = 30 * time.Second // Timeout for sending events to subscribers via grpc `sendMsg`
 )
 
-var (
-	ErrAddServerEmptyServerName = status.Errorf(codes.FailedPrecondition, "Empty server name passed")
-)
+var ErrAddServerEmptyServerName = status.Errorf(codes.FailedPrecondition, "Empty server name passed")
 
 type SchedulerServer struct {
 	pb.UnimplementedSchedulerServer
@@ -445,7 +443,7 @@ func (s *SchedulerServer) ServerStatus(
 		}
 
 		for _, s := range servers {
-			resp := createServerStatusResponse(s)
+			resp := createServerStatusUpdateResponse(s)
 			err := stream.Send(resp)
 			if err != nil {
 				return status.Errorf(codes.Internal, err.Error())
@@ -458,7 +456,7 @@ func (s *SchedulerServer) ServerStatus(
 		if err != nil {
 			return status.Errorf(codes.FailedPrecondition, err.Error())
 		}
-		resp := createServerStatusResponse(server)
+		resp := createServerStatusUpdateResponse(server)
 		err = stream.Send(resp)
 		if err != nil {
 			return status.Errorf(codes.Internal, err.Error())
@@ -467,7 +465,7 @@ func (s *SchedulerServer) ServerStatus(
 	}
 }
 
-func createServerStatusResponse(s *store.ServerSnapshot) *pb.ServerStatusResponse {
+func createServerStatusUpdateResponse(s *store.ServerSnapshot) *pb.ServerStatusResponse {
 	// note we dont count draining replicas in available replicas
 
 	resp := &pb.ServerStatusResponse{

--- a/scheduler/pkg/store/memory_status.go
+++ b/scheduler/pkg/store/memory_status.go
@@ -116,11 +116,13 @@ func (m *MemoryStore) FailedScheduling(modelVersion *ModelVersion, reason string
 	if reset {
 		modelVersion.server = ""
 	}
+
 	m.eventHub.PublishModelEvent(
 		modelFailureEventSource,
 		coordinator.ModelEventMsg{
-			ModelName:    modelVersion.GetMeta().GetName(),
-			ModelVersion: modelVersion.GetVersion(),
+			ModelName:     modelVersion.GetMeta().GetName(),
+			ModelVersion:  modelVersion.GetVersion(),
+			UpdateContext: coordinator.MODEL_SCHEDULE_FAILED,
 		},
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When the number of server replicas is less than number of desired model replicas, i.e. when a model is partially available, the scheduler needs to send a scaling request to the operator to increase the number of server replicas. 

**Which issue(s) this PR fixes**:

Fixes # INFRA-1048 

**Special notes for your reviewer**:

 - [ ] kind test
