### PR TITLE
fix(ci): use go 1.22 for k6 image build

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -32,6 +32,49 @@ jobs:
         run: make -C components/tls test
       - name: test-components-kafka
         run: make -C components/kafka test
+  
+  # k6 latest (0.14.0 at the time of writing) uses go 1.22
+  docker-k6:
+    runs-on: ubuntu-latest
+    if: github.repository == 'SeldonIO/seldon-core' # Do not run this on forks.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: false
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          overprovision-lvm: 'true'
+          swap-size-mb: 1024
+          
+      - name: Checkout Git Commit
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set default docker tag for builds from master
+        id: docker-tag
+        run: |
+          USER_INPUT="${{ github.event.inputs.docker-tag }}"
+          echo "value=${USER_INPUT:-latest}" >> $GITHUB_OUTPUT
+
+      - name: Echo the tags that will be used to push images
+        run: echo "Will push images with tag ${{ steps.docker-tag.outputs.value }}"
+
+      - name: Push Docker Image for k6 Load Testing
+        working-directory: ./tests/k6
+        run: CUSTOM_IMAGE_TAG=${{ steps.docker-tag.outputs.value }} make docker-build docker-push
 
   docker:
     needs: test
@@ -83,6 +126,3 @@ jobs:
         working-directory: ./hodometer
         run: BUILD_VERSION=${{ steps.docker-tag.outputs.value }} IMAGE_TAG=${{ steps.docker-tag.outputs.value }} make build-hodometer-docker push-hodometer-docker
 
-      - name: Push Docker Image for k6 Load Testing
-        working-directory: ./tests/k6
-        run: CUSTOM_IMAGE_TAG=${{ steps.docker-tag.outputs.value }} make docker-build docker-push


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Currently xk6 go library uses go 1.22 so lets pin go version to 1.22 when we build k6 image.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
