### PR TITLE
feat(scheduler): Scale down server logic

### DIFF
--- a/scheduler/pkg/coordinator/types.go
+++ b/scheduler/pkg/coordinator/types.go
@@ -16,7 +16,8 @@ type ServerEventUpdateContext int
 const (
 	SERVER_STATUS_UPDATE ServerEventUpdateContext = iota
 	SERVER_REPLICA_CONNECTED
-	SERVER_SCALE
+	SERVER_SCALE_UP
+	SERVER_SCALE_DOWN
 )
 
 type ModelEventMsg struct {

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -325,7 +325,7 @@ func TestPipelineRollingUpgradeEvents(t *testing.T) {
 			}
 
 			// to allow events to propagate
-			time.Sleep(700 * time.Millisecond)
+			time.Sleep(1000 * time.Millisecond)
 
 			if test.connection {
 				if test.loadReqV2 != nil {

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -307,6 +307,9 @@ func TestPipelineRollingUpgradeEvents(t *testing.T) {
 			}
 			g.Expect(err).To(BeNil())
 
+			// to allow events to propagate
+			time.Sleep(500 * time.Millisecond)
+
 			if test.loadReqV2 != nil {
 				err = s.pipelineHandler.AddPipeline(test.loadReqV2) // version 2
 				g.Expect(err).To(BeNil())
@@ -325,7 +328,7 @@ func TestPipelineRollingUpgradeEvents(t *testing.T) {
 			}
 
 			// to allow events to propagate
-			time.Sleep(1000 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 
 			if test.connection {
 				if test.loadReqV2 != nil {

--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -307,7 +307,7 @@ func (s *SimpleScheduler) serverScaleUp(modelVersion *store.ModelVersion) *coord
 
 	return &coordinator.ServerEventMsg{
 		ServerName:    modelVersion.Server(),
-		UpdateContext: coordinator.SERVER_SCALE,
+		UpdateContext: coordinator.SERVER_SCALE_UP,
 	}
 }
 

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -506,6 +506,19 @@ func createServerStatusUpdateResponse(s *store.ServerSnapshot) *pb.ServerStatusR
 	return resp
 }
 
+func createServerScaleResponse(s *store.ServerSnapshot, expectedReplicas uint32) *pb.ServerStatusResponse {
+	// we dont care about populating the other fields as they should not be used by the controller, reconsider if this changes
+
+	resp := &pb.ServerStatusResponse{
+		Type:             pb.ServerStatusResponse_ScalingRequest,
+		ServerName:       s.Name,
+		ExpectedReplicas: int32(expectedReplicas),
+		KubernetesMeta:   s.KubernetesMeta,
+	}
+
+	return resp
+}
+
 func (s *SchedulerServer) StartExperiment(ctx context.Context, req *pb.StartExperimentRequest) (*pb.StartExperimentResponse, error) {
 	err := s.experimentServer.StartExperiment(experiment.CreateExperimentFromRequest(req.Experiment))
 	if err != nil {

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -249,7 +249,7 @@ func NewSchedulerServer(
 		serverEventHandlerName,
 		pendingEventsQueueSize,
 		s.logger,
-		s.handleServerEvent,
+		s.handleServerEvents,
 	)
 
 	return s

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -207,7 +207,7 @@ func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
 	if event.UpdateContext == coordinator.SERVER_SCALE {
 		if shouldScaleDown(server, AllowPackingPercentage) {
 			logger.Infof("Server %s is scaling down", event.ServerName)
-			// TODO send control message to scale down
+			s.sendServerScale(server, uint32(server.ExpectedReplicas)-1)
 		}
 	}
 }

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -194,6 +194,16 @@ func (s *SchedulerServer) handleModelEventForServerStatus(event coordinator.Mode
 	}
 }
 
+func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
+	logger := s.logger.WithField("func", "handleServerEvent")
+	logger.Debugf("Got server state %s change for %s", event.ServerName, event.String())
+
+	server, _ := s.modelStore.GetServer(event.ServerName, true, true)
+	if server.Stats.ScaleDownFlag {
+		logger.Infof("Server %s is scaling down", event.ServerName)
+	}
+}
+
 func (s *SchedulerServer) StopSendServerEvents() {
 	s.serverEventStream.mu.Lock()
 	defer s.serverEventStream.mu.Unlock()

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -205,9 +205,9 @@ func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
 	}
 
 	if event.UpdateContext == coordinator.SERVER_SCALE {
-		if shouldScaleDown(server, AllowPackingPercentage) {
-			logger.Infof("Server %s is scaling down", event.ServerName)
-			s.sendServerScale(server, uint32(server.ExpectedReplicas)-1)
+		if scaleFlag, replicas := shouldScaleDown(server, AllowPackingPercentage); scaleFlag {
+			logger.Infof("Server %s is scaling down to %d", event.ServerName, replicas)
+			s.sendServerScale(server, replicas)
 		}
 	}
 }

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -200,7 +200,7 @@ func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
 
 	server, _ := s.modelStore.GetServer(event.ServerName, true, true)
 
-	if shouldScaleDown(server) {
+	if shouldScaleDown(server, AllowPackingPercentage) {
 		logger.Infof("Server %s is scaling down", event.ServerName)
 		// TODO send control message to scale down
 	}

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -200,19 +200,29 @@ func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
 	logger.Debugf("Got server state %s change for %s", event.ServerName, event.String())
 
 	server, _ := s.modelStore.GetServer(event.ServerName, true, true)
-	if server.Stats != nil {
-		stats := server.Stats
-		// 25% chance of trying to pack replicas if models are not fully packed
-		tryPack := false
-		rand := rand.Float32()
-		if rand > 0.75 {
-			if stats.MaxNumReplicaHostedModels < uint32(server.ExpectedReplicas) {
-				tryPack = true
+
+	scaleDownFlag := func() bool {
+		if server.Stats != nil {
+			stats := server.Stats
+			// 25% chance of trying to pack replicas if models are not fully packed
+			tryPack := false
+			rand := rand.Float32()
+			if rand > 0.75 {
+				if stats.MaxNumReplicaHostedModels < uint32(server.ExpectedReplicas) {
+					tryPack = true
+				}
 			}
+			// we do scaling down if:
+			// 1. we are trying to pack replicas: max number of replicas for any hosted model is less than the number of expected replicas (only 25% of the time)
+			// 2. we have empty replicas and the server has more than one expected replicas
+			return tryPack || (stats.NumEmptyReplicas > 0 && server.ExpectedReplicas > 1)
 		}
-		if tryPack || stats.NumEmptyReplicas > 0 {
-			logger.Infof("Server %s is scaling down", event.ServerName)
-		}
+		return false
+	}
+
+	if scaleDownFlag() {
+		logger.Infof("Server %s is scaling down", event.ServerName)
+		// TODO send control message to scale down
 	}
 }
 

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -253,22 +253,7 @@ func (s *SchedulerServer) sendServerStatus() {
 			continue
 		}
 		ssr := createServerStatusUpdateResponse(server)
-		s.sendServerStatusResponse(ssr)
-	}
-}
-
-func (s *SchedulerServer) sendServerStatusResponse(ssr *pb.ServerStatusResponse) {
-	logger := s.logger.WithField("func", "sendServerStatusResponse")
-	for stream, subscription := range s.serverEventStream.streams {
-		hasExpired, err := sendWithTimeout(func() error { return stream.Send(ssr) }, s.timeout)
-		if hasExpired {
-			// this should trigger a reconnect from the client
-			close(subscription.fin)
-			delete(s.serverEventStream.streams, stream)
-		}
-		if err != nil {
-			logger.WithError(err).Errorf("Failed to send server status response to %s", subscription.name)
-		}
+		s.sendServerResponse(ssr)
 	}
 }
 
@@ -282,7 +267,7 @@ func (s *SchedulerServer) sendServerScale(server *store.ServerSnapshot, expected
 }
 
 func (s *SchedulerServer) sendServerResponse(ssr *pb.ServerStatusResponse) {
-	logger := s.logger.WithField("func", "sendServerStatusResponse")
+	logger := s.logger.WithField("func", "sendServerResponse")
 	for stream, subscription := range s.serverEventStream.streams {
 		hasExpired, err := sendWithTimeout(func() error { return stream.Send(ssr) }, s.timeout)
 		if hasExpired {

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -198,11 +198,17 @@ func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
 	logger := s.logger.WithField("func", "handleServerEvent")
 	logger.Debugf("Got server state %s change for %s", event.ServerName, event.String())
 
-	server, _ := s.modelStore.GetServer(event.ServerName, true, true)
+	server, err := s.modelStore.GetServer(event.ServerName, true, true)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to get server %s", event.ServerName)
+		return
+	}
 
-	if shouldScaleDown(server, AllowPackingPercentage) {
-		logger.Infof("Server %s is scaling down", event.ServerName)
-		// TODO send control message to scale down
+	if event.UpdateContext == coordinator.SERVER_SCALE {
+		if shouldScaleDown(server, AllowPackingPercentage) {
+			logger.Infof("Server %s is scaling down", event.ServerName)
+			// TODO send control message to scale down
+		}
 	}
 }
 

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -90,26 +90,6 @@ func (s *SchedulerServer) handleModelEvent(event coordinator.ModelEventMsg) {
 	}
 }
 
-func (s *SchedulerServer) handleServerEvent(event coordinator.ServerEventMsg) {
-	logger := s.logger.WithField("func", "handleServerEvent")
-
-	if event.UpdateContext == coordinator.SERVER_SCALE {
-		logger.Debugf("Got server event msg for %s", event.String())
-
-		server, err := s.modelStore.GetServer(event.ServerName, true, true)
-		if err != nil {
-			logger.WithError(err).Errorf("Failed to handle server event for server %s", event.ServerName)
-		}
-
-		ok, expectedReplicas := shouldScaleUp(server)
-		if ok {
-			s.sendScalingRequest(server, expectedReplicas)
-		} else {
-			logger.Debugf("Will not scale server for event %s", event.String())
-		}
-	}
-}
-
 func (s *SchedulerServer) StopSendModelEvents() {
 	s.modelEventStream.mu.Lock()
 	defer s.modelEventStream.mu.Unlock()
@@ -195,7 +175,7 @@ func (s *SchedulerServer) handleModelEventForServerStatus(event coordinator.Mode
 }
 
 func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
-	logger := s.logger.WithField("func", "handleServerEvent")
+	logger := s.logger.WithField("func", "handleServerEvents")
 	logger.Debugf("Got server state %s change for %s", event.ServerName, event.String())
 
 	server, err := s.modelStore.GetServer(event.ServerName, true, true)
@@ -204,9 +184,14 @@ func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
 		return
 	}
 
-	if event.UpdateContext == coordinator.SERVER_SCALE {
-		if scaleFlag, replicas := shouldScaleDown(server, AllowPackingPercentage); scaleFlag {
+	if event.UpdateContext == coordinator.SERVER_SCALE_DOWN {
+		if ok, replicas := shouldScaleDown(server, AllowPackingPercentage); ok {
 			logger.Infof("Server %s is scaling down to %d", event.ServerName, replicas)
+			s.sendServerScale(server, replicas)
+		}
+	} else if event.UpdateContext == coordinator.SERVER_SCALE_UP {
+		if ok, replicas := shouldScaleUp(server); ok {
+			logger.Infof("Server %s is scaling up to %d", event.ServerName, replicas)
 			s.sendServerScale(server, replicas)
 		}
 	}
@@ -246,17 +231,6 @@ func (s *SchedulerServer) updateServerModelsStatus(evt coordinator.ModelEventMsg
 	s.serverEventStream.pendingLock.Unlock()
 
 	return err
-}
-
-func (s *SchedulerServer) sendScalingRequest(server *store.ServerSnapshot, expectedReplicas uint32) {
-	// TODO: should there be some sort of velocity check ?
-	logger := s.logger.WithField("func", "sendScalingRequest")
-	logger.Debugf("will attempt to scale servers to %d for %v", server.Stats.MaxNumReplicaHostedModels, server.Name)
-
-	ssr := createServerStatusUpdateResponse(server)
-	ssr.ExpectedReplicas = int32(expectedReplicas)
-	ssr.Type = pb.ServerStatusResponse_ScalingRequest
-	s.sendServerStatusResponse(ssr)
 }
 
 func (s *SchedulerServer) sendServerStatus() {

--- a/scheduler/pkg/server/server_status_test.go
+++ b/scheduler/pkg/server/server_status_test.go
@@ -419,7 +419,7 @@ func TestModelEventsForServerStatus(t *testing.T) {
 	}
 }
 
-func TestServerScalingEvents(t *testing.T) {
+func TestServerScaleUpEvents(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
@@ -455,7 +455,7 @@ func TestServerScalingEvents(t *testing.T) {
 			},
 		},
 		{
-			name: "scale up requested to match max model replicas",
+			name: "scale up requested to match max model replicas - 2",
 			loadReq: &pba.AgentSubscribeRequest{
 				ServerName: "foo-server",
 			},
@@ -546,7 +546,7 @@ func TestServerScalingEvents(t *testing.T) {
 			g.Expect(s.serverEventStream.streams[stream]).ToNot(BeNil())
 
 			hub.PublishServerEvent(serverEventHandlerName, coordinator.ServerEventMsg{
-				ServerName: "foo-server", UpdateContext: coordinator.SERVER_SCALE,
+				ServerName: "foo-server", UpdateContext: coordinator.SERVER_SCALE_UP,
 			})
 
 			if !test.scaleUp {
@@ -577,7 +577,7 @@ func TestServerScalingEvents(t *testing.T) {
 	}
 }
 
-func TestServersScaleEvents(t *testing.T) {
+func TestServerScaleDownEvents(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
@@ -659,7 +659,7 @@ func TestServersScaleEvents(t *testing.T) {
 			// publish a scale event
 			event.PublishServerEvent("", coordinator.ServerEventMsg{
 				ServerName:    test.serverName,
-				UpdateContext: coordinator.SERVER_SCALE,
+				UpdateContext: coordinator.SERVER_SCALE_DOWN,
 			})
 
 			// to allow events to propagate

--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -13,7 +13,6 @@ import (
 	"math/rand/v2"
 	"time"
 
-	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -78,9 +78,10 @@ func shouldScaleDown(server *store.ServerSnapshot, perc float32) (bool, uint32) 
 
 		targetReplicas := max(minReplicas, currentReplicas-stats.NumEmptyReplicas)
 		if tryPack {
-			toRemoveReplicas := currentReplicas - stats.MaxNumReplicaHostedModels
-			if toRemoveReplicas > stats.NumEmptyReplicas {
-				targetReplicas = max(minReplicas, currentReplicas-toRemoveReplicas)
+			toRemoveReplicasfromPack := currentReplicas - stats.MaxNumReplicaHostedModels
+			remainingReplicasfromPack := currentReplicas-toRemoveReplicasfromPack
+			if toRemoveReplicasfromPack > stats.NumEmptyReplicas && remainingReplicasfromPack > 0 {
+				targetReplicas = max(minReplicas, remainingReplicasfromPack)
 			}
 
 			return (tryPack || stats.NumEmptyReplicas > 0) && server.ExpectedReplicas > 1, targetReplicas

--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -26,7 +26,7 @@ const (
 	// increased latency in the case of MMS
 	// in the future we should have more metrics to decide whether packing can lead
 	// to better performance
-	ALLOW_PACKING_PERCENTAGE = 0.25
+	AllowPackingPercentage = 0.25
 )
 
 func sendWithTimeout(f func() error, d time.Duration) (bool, error) {
@@ -56,14 +56,16 @@ func shouldScaleUp(server *store.ServerSnapshot) (bool, uint32) {
 		return maxNumReplicaHostedModels > uint32(server.ExpectedReplicas), min(maxNumReplicaHostedModels, uint32(server.MaxReplicas))
 	}
 	return false, 0
-func shouldScaleDown(server *store.ServerSnapshot) bool {
+}
+
+func shouldScaleDown(server *store.ServerSnapshot, perc float32) bool {
 
 	if server.Stats != nil {
 		stats := server.Stats
 		// 25% chance of trying to pack replicas if models are not fully packed
 		tryPack := false
 		rand := rand.Float32()
-		if rand > (1 - ALLOW_PACKING_PERCENTAGE) {
+		if rand > (1 - perc) {
 			if stats.MaxNumReplicaHostedModels < uint32(server.ExpectedReplicas) {
 				tryPack = true
 			}
@@ -71,7 +73,7 @@ func shouldScaleDown(server *store.ServerSnapshot) bool {
 		// we do scaling down if:
 		// 1. we are trying to pack replicas: max number of replicas for any hosted model is less than the number of expected replicas (only 25% of the time)
 		// 2. we have empty replicas and the server has more than one expected replicas
-		return tryPack || (stats.NumEmptyReplicas > 0 && server.ExpectedReplicas > 1)
+		return (tryPack || stats.NumEmptyReplicas > 0) && server.ExpectedReplicas > 1
 	}
 	return false
 

--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	// percentage of time we try to pack server replicas if models are not fully packed
+	// percentage of time we try to pack server replicas, i.e. number of server replicas is greater than `MaxNumReplicaHostedModels`
 	// this is to be a bit more conservative and not pack all the time as it can lead to
 	// increased latency in the case of MMS
 	// in the future we should have more metrics to decide whether packing can lead

--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -64,6 +64,9 @@ func shouldScaleDown(server *store.ServerSnapshot, perc float32) (bool, uint32) 
 		stats := server.Stats
 		currentReplicas := uint32(server.ExpectedReplicas)
 		minReplicas := uint32(server.MinReplicas)
+		if minReplicas == 0 {
+			minReplicas = 1
+		}
 		// 25% chance of trying to pack replicas if models are not fully packed
 		tryPack := false
 		rand := rand.Float32()
@@ -79,13 +82,13 @@ func shouldScaleDown(server *store.ServerSnapshot, perc float32) (bool, uint32) 
 		targetReplicas := max(minReplicas, currentReplicas-stats.NumEmptyReplicas)
 		if tryPack {
 			toRemoveReplicasfromPack := currentReplicas - stats.MaxNumReplicaHostedModels
-			remainingReplicasfromPack := currentReplicas-toRemoveReplicasfromPack
+			remainingReplicasfromPack := currentReplicas - toRemoveReplicasfromPack
 			if toRemoveReplicasfromPack > stats.NumEmptyReplicas && remainingReplicasfromPack > 0 {
 				targetReplicas = max(minReplicas, remainingReplicasfromPack)
 			}
-
-			return (tryPack || stats.NumEmptyReplicas > 0) && server.ExpectedReplicas > 1, targetReplicas
 		}
+
+		return (tryPack || stats.NumEmptyReplicas > 0) && server.ExpectedReplicas > 1, targetReplicas
 	}
 	return false, 0
 }

--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -10,12 +10,23 @@ the Change License after the Change Date as each is defined in accordance with t
 package server
 
 import (
+	"math/rand/v2"
 	"time"
 
+	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/seldonio/seldon-core/scheduler/v2/pkg/store"
+)
+
+const (
+	// percentage of time we try to pack server replicas if models are not fully packed
+	// this is to be a bit more conservative and not pack all the time as it can lead to
+	// increased latency in the case of MMS
+	// in the future we should have more metrics to decide whether packing can lead
+	// to better performance
+	ALLOW_PACKING_PERCENTAGE = 0.25
 )
 
 func sendWithTimeout(f func() error, d time.Duration) (bool, error) {
@@ -45,4 +56,23 @@ func shouldScaleUp(server *store.ServerSnapshot) (bool, uint32) {
 		return maxNumReplicaHostedModels > uint32(server.ExpectedReplicas), min(maxNumReplicaHostedModels, uint32(server.MaxReplicas))
 	}
 	return false, 0
+func shouldScaleDown(server *store.ServerSnapshot) bool {
+
+	if server.Stats != nil {
+		stats := server.Stats
+		// 25% chance of trying to pack replicas if models are not fully packed
+		tryPack := false
+		rand := rand.Float32()
+		if rand > (1 - ALLOW_PACKING_PERCENTAGE) {
+			if stats.MaxNumReplicaHostedModels < uint32(server.ExpectedReplicas) {
+				tryPack = true
+			}
+		}
+		// we do scaling down if:
+		// 1. we are trying to pack replicas: max number of replicas for any hosted model is less than the number of expected replicas (only 25% of the time)
+		// 2. we have empty replicas and the server has more than one expected replicas
+		return tryPack || (stats.NumEmptyReplicas > 0 && server.ExpectedReplicas > 1)
+	}
+	return false
+
 }

--- a/scheduler/pkg/server/utils_test.go
+++ b/scheduler/pkg/server/utils_test.go
@@ -86,9 +86,10 @@ func TestShouldScaleDown(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
-		name            string
-		server          *store.ServerSnapshot
-		shouldScaleDown bool
+		name             string
+		server           *store.ServerSnapshot
+		shouldScaleDown  bool
+		expectedReplicas uint32
 	}
 
 	tests := []test{
@@ -138,8 +139,10 @@ func TestShouldScaleDown(t *testing.T) {
 					MaxNumReplicaHostedModels: 0,
 				},
 				ExpectedReplicas: 2,
+				MinReplicas:      1,
 			},
-			shouldScaleDown: true,
+			shouldScaleDown:  true,
+			expectedReplicas: 1,
 		},
 		{
 			name: "should scale down - pack",
@@ -149,8 +152,10 @@ func TestShouldScaleDown(t *testing.T) {
 					MaxNumReplicaHostedModels: 1,
 				},
 				ExpectedReplicas: 2,
+				MinReplicas:      1,
 			},
-			shouldScaleDown: true,
+			shouldScaleDown:  true,
+			expectedReplicas: 1,
 		},
 		{
 			name: "should not scale down - empty replicas - last replica",
@@ -160,8 +165,10 @@ func TestShouldScaleDown(t *testing.T) {
 					MaxNumReplicaHostedModels: 0,
 				},
 				ExpectedReplicas: 1,
+				MinReplicas:      1,
 			},
-			shouldScaleDown: false,
+			shouldScaleDown:  false,
+			expectedReplicas: 0,
 		},
 		{
 			name: "should not scale down - pack - last replica",
@@ -171,19 +178,29 @@ func TestShouldScaleDown(t *testing.T) {
 					MaxNumReplicaHostedModels: 0,
 				},
 				ExpectedReplicas: 1,
+				MinReplicas:      1,
 			},
-			shouldScaleDown: false,
+			shouldScaleDown:  false,
+			expectedReplicas: 0,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+<<<<<<< HEAD
 			ok, expectedReplicas := shouldScaleUp(test.server)
 			g.Expect(ok).To(Equal(test.shouldScaleUp))
 			if ok {
 				g.Expect(expectedReplicas).To(Equal(test.newExpectedReplicas))
 			}
 			g.Expect(shouldScaleDown(test.server, 1.0)).To(Equal(test.shouldScaleDown))
+=======
+			scaleDown, replicas := shouldScaleDown(test.server, 1.0)
+			g.Expect(scaleDown).To(Equal(test.shouldScaleDown))
+			if scaleDown {
+				g.Expect(replicas).To(Equal(test.expectedReplicas))
+			}
+>>>>>>> 49f623d79 (fix test)
 		})
 	}
 }

--- a/scheduler/pkg/server/utils_test.go
+++ b/scheduler/pkg/server/utils_test.go
@@ -197,6 +197,19 @@ func TestShouldScaleDown(t *testing.T) {
 			expectedReplicas: 1,
 		},
 		{
+			name: "should scale down - pack > 1",
+			server: &store.ServerSnapshot{
+				Stats: &store.ServerStats{
+					NumEmptyReplicas:          0,
+					MaxNumReplicaHostedModels: 1,
+				},
+				ExpectedReplicas: 3,
+				MinReplicas:      1,
+			},
+			shouldScaleDown:  true,
+			expectedReplicas: 1,
+		},
+		{
 			name: "should not scale down - empty replicas - last replica",
 			server: &store.ServerSnapshot{
 				Stats: &store.ServerStats{

--- a/scheduler/pkg/server/utils_test.go
+++ b/scheduler/pkg/server/utils_test.go
@@ -82,15 +82,6 @@ func TestSouldScaleUp(t *testing.T) {
 		shouldScaleUp       bool
 		newExpectedReplicas uint32
 		server              *store.ServerSnapshot
-func TestShouldScaleDown(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	type test struct {
-		name             string
-		server           *store.ServerSnapshot
-		shouldScaleDown  bool
-		expectedReplicas uint32
-		packThreshold    float32
 	}
 
 	tests := []test{
@@ -133,6 +124,33 @@ func TestShouldScaleDown(t *testing.T) {
 				ExpectedReplicas: -1,
 				Stats:            &store.ServerStats{MaxNumReplicaHostedModels: 3},
 			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ok, expectedReplicas := shouldScaleUp(test.server)
+			g.Expect(ok).To(Equal(test.shouldScaleUp))
+			if ok {
+				g.Expect(expectedReplicas).To(Equal(test.newExpectedReplicas))
+			}
+		})
+	}
+}
+
+func TestShouldScaleDown(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name             string
+		server           *store.ServerSnapshot
+		shouldScaleDown  bool
+		expectedReplicas uint32
+		packThreshold    float32
+	}
+
+	tests := []test{
+		{
 			name: "should scale down - empty replicas",
 			server: &store.ServerSnapshot{
 				Stats: &store.ServerStats{
@@ -262,12 +280,11 @@ func TestShouldScaleDown(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			scaleDown, replicas := shouldScaleDown(test.server, 1.0)
+			scaleDown, replicas := shouldScaleDown(test.server, test.packThreshold)
 			g.Expect(scaleDown).To(Equal(test.shouldScaleDown))
 			if scaleDown {
 				g.Expect(replicas).To(Equal(test.expectedReplicas))
 			}
->>>>>>> 49f623d79 (fix test)
 		})
 	}
 }

--- a/scheduler/pkg/server/utils_test.go
+++ b/scheduler/pkg/server/utils_test.go
@@ -90,6 +90,7 @@ func TestShouldScaleDown(t *testing.T) {
 		server           *store.ServerSnapshot
 		shouldScaleDown  bool
 		expectedReplicas uint32
+		packThreshold    float32
 	}
 
 	tests := []test{
@@ -143,6 +144,7 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  true,
 			expectedReplicas: 1,
+			packThreshold:    0.0,
 		},
 		{
 			name: "should scale down - empty replicas > 1 - 1",
@@ -156,6 +158,7 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  true,
 			expectedReplicas: 1,
+			packThreshold:    0.0,
 		},
 		{
 			name: "should scale down - violate min replicas",
@@ -169,6 +172,7 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  true,
 			expectedReplicas: 2,
+			packThreshold:    0.0,
 		},
 		{
 			name: "should scale down - empty replicas > 1 - 2",
@@ -182,6 +186,7 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  true,
 			expectedReplicas: 2,
+			packThreshold:    0.0,
 		},
 		{
 			name: "should scale down - pack",
@@ -195,6 +200,7 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  true,
 			expectedReplicas: 1,
+			packThreshold:    1.0,
 		},
 		{
 			name: "should scale down - pack > 1",
@@ -208,6 +214,21 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  true,
 			expectedReplicas: 1,
+			packThreshold:    1.0,
+		},
+		{
+			name: "should not scale down - pack threshold",
+			server: &store.ServerSnapshot{
+				Stats: &store.ServerStats{
+					NumEmptyReplicas:          0,
+					MaxNumReplicaHostedModels: 1,
+				},
+				ExpectedReplicas: 3,
+				MinReplicas:      1,
+			},
+			shouldScaleDown:  false,
+			expectedReplicas: 0,
+			packThreshold:    0.0,
 		},
 		{
 			name: "should not scale down - empty replicas - last replica",
@@ -221,6 +242,7 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  false,
 			expectedReplicas: 0,
+			packThreshold:    0.0,
 		},
 		{
 			name: "should not scale down - pack - last replica",
@@ -234,19 +256,12 @@ func TestShouldScaleDown(t *testing.T) {
 			},
 			shouldScaleDown:  false,
 			expectedReplicas: 0,
+			packThreshold:    1.0,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-<<<<<<< HEAD
-			ok, expectedReplicas := shouldScaleUp(test.server)
-			g.Expect(ok).To(Equal(test.shouldScaleUp))
-			if ok {
-				g.Expect(expectedReplicas).To(Equal(test.newExpectedReplicas))
-			}
-			g.Expect(shouldScaleDown(test.server, 1.0)).To(Equal(test.shouldScaleDown))
-=======
 			scaleDown, replicas := shouldScaleDown(test.server, 1.0)
 			g.Expect(scaleDown).To(Equal(test.shouldScaleDown))
 			if scaleDown {

--- a/scheduler/pkg/server/utils_test.go
+++ b/scheduler/pkg/server/utils_test.go
@@ -145,6 +145,45 @@ func TestShouldScaleDown(t *testing.T) {
 			expectedReplicas: 1,
 		},
 		{
+			name: "should scale down - empty replicas > 1 - 1",
+			server: &store.ServerSnapshot{
+				Stats: &store.ServerStats{
+					NumEmptyReplicas:          2,
+					MaxNumReplicaHostedModels: 0,
+				},
+				ExpectedReplicas: 3,
+				MinReplicas:      1,
+			},
+			shouldScaleDown:  true,
+			expectedReplicas: 1,
+		},
+		{
+			name: "should scale down - violate min replicas",
+			server: &store.ServerSnapshot{
+				Stats: &store.ServerStats{
+					NumEmptyReplicas:          2,
+					MaxNumReplicaHostedModels: 0,
+				},
+				ExpectedReplicas: 3,
+				MinReplicas:      2,
+			},
+			shouldScaleDown:  true,
+			expectedReplicas: 2,
+		},
+		{
+			name: "should scale down - empty replicas > 1 - 2",
+			server: &store.ServerSnapshot{
+				Stats: &store.ServerStats{
+					NumEmptyReplicas:          1,
+					MaxNumReplicaHostedModels: 0,
+				},
+				ExpectedReplicas: 3,
+				MinReplicas:      1,
+			},
+			shouldScaleDown:  true,
+			expectedReplicas: 2,
+		},
+		{
 			name: "should scale down - pack",
 			server: &store.ServerSnapshot{
 				Stats: &store.ServerStats{

--- a/scheduler/pkg/store/memory.go
+++ b/scheduler/pkg/store/memory.go
@@ -417,7 +417,7 @@ func (m *MemoryStore) updateLoadedModelsImpl(
 				},
 				&coordinator.ServerEventMsg{
 					ServerName:    serverKey,
-					UpdateContext: coordinator.SERVER_SCALE,
+					UpdateContext: coordinator.SERVER_SCALE_DOWN,
 				},
 				nil
 		} else {

--- a/scheduler/pkg/store/memory_test.go
+++ b/scheduler/pkg/store/memory_test.go
@@ -983,7 +983,7 @@ func TestUpdateLoadedModels(t *testing.T) {
 				if test.isModelUnloaded {
 					g.Expect(msgServer).ToNot(BeNil())
 					g.Expect(msgServer.ServerName).To(Equal(test.serverKey))
-					g.Expect(msgServer.UpdateContext).To(Equal(coordinator.SERVER_SCALE))
+					g.Expect(msgServer.UpdateContext).To(Equal(coordinator.SERVER_SCALE_DOWN))
 				} else {
 					g.Expect(msgServer).To(BeNil())
 				}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR implements policies for scaling down servers naively as part of the system. The policies are:
- we are trying to pack replicas: max number of replicas for any hosted model is less than the number of expected replicas. If this is met we only trigger it  25% of the time to reduce impact on infer latency.
- we have empty replicas and the server has more than one expected replicas.

Currently the trigger of this logic happens when we unload a model replica as it is a good signal that we might need to also reduce the number of server replicas.  However this doesnt capture all edge cases and in a follow up PR we add more triggers for scaling down.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # (internal INFRA-1234)

**Special notes for your reviewer**:

- main logic is defined in `shouldScaleDown`
