### PR TITLE
bug(scheduler): do not scale to zero if max replicas is missing

### DIFF
--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -37,7 +37,7 @@ func sendWithTimeout(f func() error, d time.Duration) (bool, error) {
 }
 
 func shouldScaleUp(server *store.ServerSnapshot) (bool, uint32) {
-	if server.ExpectedReplicas < 0 || server.MaxReplicas < 1 { // it's not set
+	if server.ExpectedReplicas < 0 || server.MaxReplicas < 1 {
 		return false, 0
 	}
 	if server.Stats != nil {

--- a/scheduler/pkg/server/utils.go
+++ b/scheduler/pkg/server/utils.go
@@ -37,7 +37,7 @@ func sendWithTimeout(f func() error, d time.Duration) (bool, error) {
 }
 
 func shouldScaleUp(server *store.ServerSnapshot) (bool, uint32) {
-	if server.ExpectedReplicas < 0 { // it's not set
+	if server.ExpectedReplicas < 0 || server.MaxReplicas < 1 { // it's not set
 		return false, 0
 	}
 	if server.Stats != nil {

--- a/scheduler/pkg/server/utils_test.go
+++ b/scheduler/pkg/server/utils_test.go
@@ -125,6 +125,15 @@ func TestSouldScaleUp(t *testing.T) {
 				Stats:            &store.ServerStats{MaxNumReplicaHostedModels: 3},
 			},
 		},
+		{
+			name:                "does not scale up for missing max replicas",
+			shouldScaleUp:       false,
+			newExpectedReplicas: 0,
+			server: &store.ServerSnapshot{
+				ExpectedReplicas: 1,
+				Stats:            &store.ServerStats{MaxNumReplicaHostedModels: 3},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

It should not scale servers to zero.
