### PR TITLE
feat(helm): adding min and max replicas to the server helm chart

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
+++ b/k8s/helm-charts/seldon-core-v2-servers/templates/seldon-v2-servers.yaml
@@ -8,6 +8,8 @@ metadata:
   name: mlserver
   namespace: '{{ .Release.Namespace }}'
 spec:
+  maxReplicas: {{ .Values.mlserver.maxReplicas }}
+  minReplicas: {{ .Values.mlserver.minReplicas }}
   podSpec: {{ toJson .Values.mlserver.podSpec }}
   replicas: {{ .Values.mlserver.replicas }}
   serverConfig: mlserver
@@ -27,6 +29,8 @@ metadata:
   name: triton
   namespace: '{{ .Release.Namespace }}'
 spec:
+  maxReplicas: {{ .Values.triton.maxReplicas }}
+  minReplicas: {{ .Values.triton.minReplicas }}
   podSpec: {{ toJson .Values.triton.podSpec }}
   replicas: {{ .Values.triton.replicas }}
   serverConfig: triton

--- a/k8s/helm-charts/seldon-core-v2-servers/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-servers/values.yaml
@@ -1,11 +1,15 @@
 mlserver:
   replicas: 1
+  minReplicas: 1
+  maxReplicas: 1
   statefulSetPersistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
 
 triton:
   replicas: 1
+  minReplicas: 1
+  maxReplicas: 1
   statefulSetPersistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/k8s/kustomize/helm-servers/patch_mlserver.yaml
+++ b/k8s/kustomize/helm-servers/patch_mlserver.yaml
@@ -6,6 +6,8 @@ metadata:
   annotationz: HACK_REMOVE_ME{{ .Values.mlserver.annotations | toYaml }}
 spec:
   replicas: HACK_REMOVE_ME{{ .Values.mlserver.replicas }}
+  minReplicas: HACK_REMOVE_ME{{ .Values.mlserver.minReplicas }}
+  maxReplicas: HACK_REMOVE_ME{{ .Values.mlserver.maxReplicas }}
   podSpec: HACK_REMOVE_ME{{ toJson .Values.mlserver.podSpec }}
   statefulSetPersistentVolumeClaimRetentionPolicy:
     whenDeleted: HACK_REMOVE_ME{{ .Values.mlserver.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted }}

--- a/k8s/kustomize/helm-servers/patch_triton.yaml
+++ b/k8s/kustomize/helm-servers/patch_triton.yaml
@@ -6,6 +6,8 @@ metadata:
   annotationz: HACK_REMOVE_ME{{ .Values.triton.annotations | toYaml }}
 spec:
   replicas: HACK_REMOVE_ME{{ .Values.triton.replicas }}
+  minReplicas: HACK_REMOVE_ME{{ .Values.triton.minReplicas }}
+  maxReplicas: HACK_REMOVE_ME{{ .Values.triton.maxReplicas }}
   podSpec: HACK_REMOVE_ME{{ toJson .Values.triton.podSpec }}
   statefulSetPersistentVolumeClaimRetentionPolicy:
     whenDeleted: HACK_REMOVE_ME{{ .Values.triton.statefulSetPersistentVolumeClaimRetentionPolicy.whenDeleted }}

--- a/k8s/yaml/servers.yaml
+++ b/k8s/yaml/servers.yaml
@@ -9,6 +9,8 @@ metadata:
     null
   name: mlserver
 spec:
+  maxReplicas: 1
+  minReplicas: 1
   podSpec: null
   replicas: 1
   serverConfig: mlserver
@@ -26,6 +28,8 @@ metadata:
     null
   name: triton
 spec:
+  maxReplicas: 1
+  minReplicas: 1
   podSpec: null
   replicas: 1
   serverConfig: triton


### PR DESCRIPTION
**What this PR does / why we need it**:

Min and max replicas should be easily configurable for consumers of helm.

**Which issue(s) this PR fixes**:

Fixes # INFRA-1335

