### PR TITLE
fix(operator): allow scaling requests for older generation

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -69,7 +69,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .GOLANGCILINT_VERSION := v1.63.4
-.GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint/$(.GOLANGCILINT_VERSION)
+.GOLANGCILINT_PATH := $(shell go env GOPATH)/bin/golangci-lint-versions/$(.GOLANGCILINT_VERSION)
 
 ${.GOLANGCILINT_PATH}/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \

--- a/operator/scheduler/server.go
+++ b/operator/scheduler/server.go
@@ -137,7 +137,8 @@ func (s *SchedulerClient) SubscribeServerEvents(ctx context.Context, grpcClient 
 			if err != nil {
 				return err
 			}
-			if event.GetKubernetesMeta().Generation != server.Generation {
+			// we allow scaling requests for any generation (coming from scheduler), but we ignore status updates for old generations
+			if event.GetKubernetesMeta().Generation != server.Generation && event.GetType() != scheduler.ServerStatusResponse_ScalingRequest {
 				logger.Info("Ignoring event for old generation", "currentGeneration", server.Generation, "eventGeneration", event.GetKubernetesMeta().Generation, "server", event.ServerName)
 				return nil
 			}

--- a/operator/scheduler/server_test.go
+++ b/operator/scheduler/server_test.go
@@ -247,7 +247,7 @@ func TestSubscribeServerEvents(t *testing.T) {
 				NumLoadedModelReplicas: 0,
 				KubernetesMeta: &scheduler.KubernetesMeta{
 					Namespace:  "seldon",
-					Generation: 1,  // older generation is still allowed for scaling requests
+					Generation: 1, // older generation is still allowed for scaling requests
 				},
 			},
 		},

--- a/operator/scheduler/server_test.go
+++ b/operator/scheduler/server_test.go
@@ -219,6 +219,39 @@ func TestSubscribeServerEvents(t *testing.T) {
 			},
 		},
 		{
+			name: "server - with a valid scaling request - different generation",
+			existingServer: mlopsv1alpha1.Server{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "foo",
+					Namespace:  "seldon",
+					Generation: 2,
+				},
+				Spec: v1alpha1.ServerSpec{
+					ScalingSpec: v1alpha1.ScalingSpec{
+						Replicas:    getIntPtr(1),
+						MinReplicas: getIntPtr(1),
+						MaxReplicas: getIntPtr(5),
+					},
+				},
+			},
+			response: &scheduler.ServerStatusResponse{
+				Type:       scheduler.ServerStatusResponse_ScalingRequest,
+				ServerName: "foo",
+				Resources: []*scheduler.ServerReplicaResources{
+					{
+						ReplicaIdx: 0,
+					},
+				},
+				AvailableReplicas:      1,
+				ExpectedReplicas:       2,
+				NumLoadedModelReplicas: 0,
+				KubernetesMeta: &scheduler.KubernetesMeta{
+					Namespace:  "seldon",
+					Generation: 1,  // older generation is still allowed for scaling requests
+				},
+			},
+		},
+		{
 			name: "server - with an invalid scaling request",
 			existingServer: mlopsv1alpha1.Server{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

When we are scaling/up down servers automatically from the scheduler and using the current flow, there is a period of time where generation of the CR is not yet reflected in the scheduler at the time of making the request to scale (because of concurrency).

This change allows all scaling requests to go ahead even if the generations dont match.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
Is this safe in all cases?
