### PR TITLE
feat(envoy): enable accesslog configuration

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -489,6 +489,9 @@ spec:
         - --scheduler-ready-timeout-seconds=$(SCHEDULER_READY_TIMEOUT_SECONDS)
         - --server-packing-enabled=$(SERVER_PACKING_ENABLED)
         - --server-packing-percentage=$(SERVER_PACKING_PERCENTAGE)
+        - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
+        - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
+        - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         command:
         - /bin/scheduler
         env:
@@ -541,6 +544,12 @@ spec:
           value: '{{ .Values.autoscaling.serverPackingEnabled }}'
         - name: SERVER_PACKING_PERCENTAGE
           value: '{{ .Values.autoscaling.serverPackingPercentage }}'
+        - name: ENVOY_ACCESSLOG_PATH
+          value: '{{ .Values.envoy.accesslogPath }}'
+        - name: ENABLE_ENVOY_ACCESSLOG
+          value: '{{ .Values.envoy.enableAccesslog }}'
+        - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
+          value: '{{ .Values.envoy.includeSuccessfulRequests }}'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -202,6 +202,9 @@ envoy:
   preStopSleepPeriodSeconds: 30
   terminationGracePeriodSeconds: 120
   adminInterfacePort: 9901
+  accesslogPath: /tmp/envoy-accesslog.txt
+  enableAccesslog: true
+  includeSuccessfulRequests: false
 
 scheduler:
   image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -202,6 +202,9 @@ envoy:
   preStopSleepPeriodSeconds: 30
   terminationGracePeriodSeconds: 120
   adminInterfacePort: 9901
+  accesslogPath: /tmp/envoy-accesslog.txt
+  enableAccesslog: true
+  includeSuccessfulRequests: false
 
 scheduler:
   image:

--- a/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
@@ -65,6 +65,12 @@ spec:
             value: '{{ .Values.autoscaling.serverPackingEnabled }}'
           - name: SERVER_PACKING_PERCENTAGE
             value: '{{ .Values.autoscaling.serverPackingPercentage }}'
+          - name: ENVOY_ACCESSLOG_PATH
+            value: '{{ .Values.envoy.accesslogPath }}'
+          - name: ENABLE_ENVOY_ACCESSLOG
+            value: '{{ .Values.envoy.enableAccesslog }}'
+          - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
+            value: '{{ .Values.envoy.includeSuccessfulRequests }}'
     volumeClaimTemplates:
     - name: scheduler-state
       spec:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -344,6 +344,9 @@ spec:
         - --scheduler-ready-timeout-seconds=$(SCHEDULER_READY_TIMEOUT_SECONDS)
         - --server-packing-enabled=$(SERVER_PACKING_ENABLED)
         - --server-packing-percentage=$(SERVER_PACKING_PERCENTAGE)
+        - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
+        - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
+        - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         command:
         - /bin/scheduler
         env:
@@ -393,6 +396,12 @@ spec:
           value: 'false'
         - name: SERVER_PACKING_PERCENTAGE
           value: '0'
+        - name: ENVOY_ACCESSLOG_PATH
+          value: '/tmp/envoy-accesslog.txt'
+        - name: ENABLE_ENVOY_ACCESSLOG
+          value: 'true'
+        - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
+          value: 'false'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -221,6 +221,9 @@ spec:
         - --scheduler-ready-timeout-seconds=$(SCHEDULER_READY_TIMEOUT_SECONDS)
         - --server-packing-enabled=$(SERVER_PACKING_ENABLED)
         - --server-packing-percentage=$(SERVER_PACKING_PERCENTAGE)
+        - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
+        - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
+        - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         command:
         - /bin/scheduler
         env:
@@ -232,6 +235,12 @@ spec:
           value: "false"
         - name: SERVER_PACKING_PERCENTAGE
           value: "0.0"
+        - name: ENVOY_ACCESSLOG_PATH
+          value: /tmp/envoy-accesslog.txt
+        - name: ENABLE_ENVOY_ACCESSLOG
+          value: "true"
+        - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
+          value: "false"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -206,7 +206,7 @@ func main() {
 	}
 
 	// Create envoy incremental processor
-	incrementalProcessor, err := processor.NewIncrementalProcessor(nodeID, logger, ss, es, ps, eventHub, &pipelineGatewayDetails, cleaner)
+	incrementalProcessor, err := processor.NewIncrementalProcessor(nodeID, logger, ss, es, ps, eventHub, &pipelineGatewayDetails, cleaner, &xdscache.EnvoyConfig{})
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to create incremental processor")
 	}

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -206,7 +206,8 @@ func main() {
 	}
 
 	// Create envoy incremental processor
-	incrementalProcessor, err := processor.NewIncrementalProcessor(nodeID, logger, ss, es, ps, eventHub, &pipelineGatewayDetails, cleaner, &xdscache.EnvoyConfig{})
+	incrementalProcessor, err := processor.NewIncrementalProcessor(
+		nodeID, logger, ss, es, ps, eventHub, &pipelineGatewayDetails, cleaner, &xdscache.EnvoyConfig{})
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to create incremental processor")
 	}

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -59,6 +59,9 @@ var (
 	deletedResourceTTLSeconds    uint
 	serverPackingEnabled         bool
 	serverPackingPercentage      float64
+	accessLogPath                string
+	enableAccessLog              bool
+	includeSuccessfulRequests    bool
 )
 
 const (
@@ -129,6 +132,11 @@ func init() {
 	// Server packing
 	flag.BoolVar(&serverPackingEnabled, "server-packing-enabled", false, "Enable server packing")
 	flag.Float64Var(&serverPackingPercentage, "server-packing-percentage", allowPackingPercentageDefault, "Percentage of time we try to pack server replicas")
+
+	// Envoy access log config
+	flag.StringVar(&accessLogPath, "access-log-path", "/tmp/envoy-accesslog.txt", "Envoy access log path")
+	flag.BoolVar(&enableAccessLog, "enable-access-log", true, "Enable Envoy access log")
+	flag.BoolVar(&includeSuccessfulRequests, "include-successful-requests", false, "Include successful requests in access log")
 }
 
 func getNamespace() string {
@@ -207,7 +215,8 @@ func main() {
 
 	// Create envoy incremental processor
 	incrementalProcessor, err := processor.NewIncrementalProcessor(
-		nodeID, logger, ss, es, ps, eventHub, &pipelineGatewayDetails, cleaner, &xdscache.EnvoyConfig{})
+		nodeID, logger, ss, es, ps, eventHub, &pipelineGatewayDetails, cleaner, &xdscache.EnvoyConfig{
+			AccessLogPath: accessLogPath, EnableAccessLog: enableAccessLog, IncludeSuccessfulRequests: includeSuccessfulRequests})
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to create incremental processor")
 	}

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -134,9 +134,9 @@ func init() {
 	flag.Float64Var(&serverPackingPercentage, "server-packing-percentage", allowPackingPercentageDefault, "Percentage of time we try to pack server replicas")
 
 	// Envoy access log config
-	flag.StringVar(&accessLogPath, "access-log-path", "/tmp/envoy-accesslog.txt", "Envoy access log path")
-	flag.BoolVar(&enableAccessLog, "enable-access-log", true, "Enable Envoy access log")
-	flag.BoolVar(&includeSuccessfulRequests, "include-successful-requests", false, "Include successful requests in access log")
+	flag.StringVar(&accessLogPath, "envoy-accesslog-path", "/tmp/envoy-accesslog.txt", "Envoy access log path")
+	flag.BoolVar(&enableAccessLog, "enable-envoy-accesslog", true, "Enable Envoy access log")
+	flag.BoolVar(&includeSuccessfulRequests, "include-successful-requests-envoy-accesslog", false, "Include successful requests in Envoy access log")
 }
 
 func getNamespace() string {

--- a/scheduler/pkg/envoy/processor/incremental.go
+++ b/scheduler/pkg/envoy/processor/incremental.go
@@ -63,8 +63,9 @@ func NewIncrementalProcessor(
 	hub *coordinator.EventHub,
 	pipelineGatewayDetails *xdscache.PipelineGatewayDetails,
 	versionCleaner cleaner.ModelVersionCleaner,
+	config *xdscache.EnvoyConfig,
 ) (*IncrementalProcessor, error) {
-	xdsCache, err := xdscache.NewSeldonXDSCache(logger, pipelineGatewayDetails)
+	xdsCache, err := xdscache.NewSeldonXDSCache(logger, pipelineGatewayDetails, config)
 	if err != nil {
 		return nil, err
 	}

--- a/scheduler/pkg/envoy/processor/incremental_benchmark_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_benchmark_test.go
@@ -137,6 +137,7 @@ func benchmarkModelUpdate(
 				GrpcPort: 2,
 			},
 			nil,
+			nil,
 		)
 		require.NoError(b, err)
 

--- a/scheduler/pkg/envoy/processor/incremental_test.go
+++ b/scheduler/pkg/envoy/processor/incremental_test.go
@@ -290,7 +290,7 @@ func TestUpdateEnvoyForModelVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2})
+			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2}, nil)
 			g.Expect(err).To(BeNil())
 			inc := IncrementalProcessor{
 				logger:   log.New(),
@@ -343,7 +343,7 @@ func TestRollingUpdate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			modelStore := store.NewMemoryStore(log.New(), store.NewLocalSchedulerStore(), nil)
-			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2})
+			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2}, nil)
 			g.Expect(err).To(BeNil())
 			inc := &IncrementalProcessor{
 				logger:           log.New(),
@@ -413,7 +413,7 @@ func TestDraining(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			modelStore := store.NewMemoryStore(log.New(), store.NewLocalSchedulerStore(), nil)
-			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2})
+			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2}, nil)
 			g.Expect(err).To(BeNil())
 			inc := &IncrementalProcessor{
 				logger:           log.New(),
@@ -557,7 +557,7 @@ func TestModelSync(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			modelStore := store.NewMemoryStore(log.New(), store.NewLocalSchedulerStore(), nil)
-			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2})
+			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2}, nil)
 			g.Expect(err).To(BeNil())
 			inc := &IncrementalProcessor{
 				logger:               log.New(),
@@ -801,7 +801,7 @@ func TestEnvoySettings(t *testing.T) {
 			logger := log.New()
 			eventHub, _ := coordinator.NewEventHub(logger)
 			memoryStore := store.NewMemoryStore(log.New(), store.NewLocalSchedulerStore(), eventHub)
-			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2})
+			xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{Host: "pipeline", GrpcPort: 1, HttpPort: 2}, nil)
 			g.Expect(err).To(BeNil())
 			inc := &IncrementalProcessor{
 				logger:           logger.WithField("source", "IncrementalProcessor"),

--- a/scheduler/pkg/envoy/processor/server_test.go
+++ b/scheduler/pkg/envoy/processor/server_test.go
@@ -46,7 +46,7 @@ func TestFetch(t *testing.T) {
 	memoryStore := store.NewMemoryStore(logger, store.NewLocalSchedulerStore(), nil)
 	pipelineHandler := pipeline.NewPipelineStore(logger, nil, memoryStore)
 
-	xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{})
+	xdsCache, err := xdscache.NewSeldonXDSCache(log.New(), &xdscache.PipelineGatewayDetails{}, nil)
 	g.Expect(err).To(BeNil())
 	inc := &IncrementalProcessor{
 		logger:           logger,

--- a/scheduler/pkg/envoy/xdscache/resource.go
+++ b/scheduler/pkg/envoy/xdscache/resource.go
@@ -101,7 +101,7 @@ func makeHTTPListener(listenerName, address string,
 	}
 	if config != nil && config.EnableAccessLog {
 		var filter *accesslog.AccessLogFilter = nil
-		if config.IncludeSuccessfulRequests {
+		if !config.IncludeSuccessfulRequests {
 			filter = createAccessLogFilterForErrors()
 		}
 		manager.AccessLog = []*accesslog.AccessLog{
@@ -792,7 +792,7 @@ func createTapConfig() *anypb.Any {
 }
 
 func createAccessLogConfig(path string) *anypb.Any {
-	accessFilter := accesslog_file.FileAccessLog{
+	config := accesslog_file.FileAccessLog{
 		Path: path,
 		AccessLogFormat: &accesslog_file.FileAccessLog_LogFormat{
 			LogFormat: &core.SubstitutionFormatString{
@@ -806,7 +806,7 @@ func createAccessLogConfig(path string) *anypb.Any {
 			},
 		},
 	}
-	accessAny, err := anypb.New(&accessFilter)
+	accessAny, err := anypb.New(&config)
 	if err != nil {
 		panic(err)
 	}

--- a/scheduler/pkg/envoy/xdscache/resource.go
+++ b/scheduler/pkg/envoy/xdscache/resource.go
@@ -814,6 +814,16 @@ func createAccessLogConfig(path string) *anypb.Any {
 }
 
 func createAccessLogFilterForErrors() *accesslog.AccessLogFilter {
+	grpcMatcher := &route.HeaderMatcher_StringMatch{
+		StringMatch: &matcherv3.StringMatcher{
+			MatchPattern: &matcherv3.StringMatcher_Prefix{
+				// for grpc content-type starts with application/grpc:
+				// Content-Type → “content-type” “application/grpc” [(“+proto” / “+json” / {custom})]
+				Prefix: "application/grpc",
+			},
+			IgnoreCase: true,
+		},
+	}
 	return &accesslog.AccessLogFilter{
 		FilterSpecifier: &accesslog.AccessLogFilter_OrFilter{
 			OrFilter: &accesslog.OrFilter{
@@ -838,7 +848,7 @@ func createAccessLogFilterForErrors() *accesslog.AccessLogFilter {
 											HeaderFilter: &accesslog.HeaderFilter{
 												Header: &route.HeaderMatcher{
 													Name:                 "content-type",
-													HeaderMatchSpecifier: &route.HeaderMatcher_ContainsMatch{ContainsMatch: "grpc"},
+													HeaderMatchSpecifier: grpcMatcher,
 													InvertMatch:          true,
 												},
 											},
@@ -866,7 +876,7 @@ func createAccessLogFilterForErrors() *accesslog.AccessLogFilter {
 											HeaderFilter: &accesslog.HeaderFilter{
 												Header: &route.HeaderMatcher{
 													Name:                 "content-type",
-													HeaderMatchSpecifier: &route.HeaderMatcher_ContainsMatch{ContainsMatch: "grpc"},
+													HeaderMatchSpecifier: grpcMatcher,
 												},
 											},
 										},

--- a/scheduler/pkg/envoy/xdscache/resource.go
+++ b/scheduler/pkg/envoy/xdscache/resource.go
@@ -48,6 +48,7 @@ import (
 const (
 	SeldonLoggingHeader           = "Seldon-Logging"
 	EnvoyLogPathPrefix            = "/tmp/request-log"
+	EnvoyAccessLogPath            = "/tmp/envoy-accesslog.txt"
 	SeldonRouteSeparator          = ":" // Tried % but this seemed to break envoy matching. Maybe % is a special character or connected to regexp. A bug?
 	DefaultRouteTimeoutSecs       = 0   // TODO allow configurable override
 	DefaultRouteConfigurationName = "listener_0"
@@ -785,7 +786,7 @@ func createTapConfig() *anypb.Any {
 
 func createAccessLogConfig() *anypb.Any {
 	accessFilter := accesslog_file.FileAccessLog{
-		Path: "/tmp/envoy-accesslog.txt",
+		Path: EnvoyAccessLogPath,
 		AccessLogFormat: &accesslog_file.FileAccessLog_LogFormat{
 			LogFormat: &core.SubstitutionFormatString{
 				Format: &core.SubstitutionFormatString_TextFormatSource{

--- a/scheduler/pkg/envoy/xdscache/resource.go
+++ b/scheduler/pkg/envoy/xdscache/resource.go
@@ -102,7 +102,7 @@ func makeHTTPListener(listenerName, address string,
 	if config != nil && config.EnableAccessLog {
 		var filter *accesslog.AccessLogFilter = nil
 		if !config.IncludeSuccessfulRequests {
-			filter = createAccessLogFilterForErrors()
+			filter = createAccessLogFilterMatchErrors()
 		}
 		manager.AccessLog = []*accesslog.AccessLog{
 			{
@@ -813,7 +813,7 @@ func createAccessLogConfig(path string) *anypb.Any {
 	return accessAny
 }
 
-func createAccessLogFilterForErrors() *accesslog.AccessLogFilter {
+func createAccessLogFilterMatchErrors() *accesslog.AccessLogFilter {
 	grpcMatcher := &route.HeaderMatcher_StringMatch{
 		StringMatch: &matcherv3.StringMatcher{
 			MatchPattern: &matcherv3.StringMatcher_Prefix{

--- a/scheduler/pkg/envoy/xdscache/seldoncache.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache.go
@@ -74,7 +74,6 @@ type PipelineGatewayDetails struct {
 
 type EnvoyConfig struct {
 	AccessLogPath             string
-	TapPath                   string
 	IncludeSuccessfulRequests bool
 	EnableAccessLog           bool
 }
@@ -244,8 +243,8 @@ func (xds *SeldonXDSCache) addPermanentListeners() error {
 		}
 	}
 	resources := make(map[string]types.Resource)
-	resources[defaultListenerName] = makeHTTPListener(defaultListenerName, defaultListenerAddress, defaultListenerPort, DefaultRouteConfigurationName, serverSecret)
-	resources[mirrorListenerName] = makeHTTPListener(mirrorListenerName, mirrorListenerAddress, mirrorListenerPort, MirrorRouteConfigurationName, serverSecret)
+	resources[defaultListenerName] = makeHTTPListener(defaultListenerName, defaultListenerAddress, defaultListenerPort, DefaultRouteConfigurationName, serverSecret, xds.config)
+	resources[mirrorListenerName] = makeHTTPListener(mirrorListenerName, mirrorListenerAddress, mirrorListenerPort, MirrorRouteConfigurationName, serverSecret, xds.config)
 	return xds.lds.UpdateResources(resources, nil)
 }
 

--- a/scheduler/pkg/envoy/xdscache/seldoncache.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache.go
@@ -63,6 +63,7 @@ type SeldonXDSCache struct {
 	logger                 logrus.FieldLogger
 	tlsActive              bool
 	snapshotVersion        int64
+	config                 *EnvoyConfig
 }
 
 type PipelineGatewayDetails struct {
@@ -71,7 +72,14 @@ type PipelineGatewayDetails struct {
 	GrpcPort int
 }
 
-func NewSeldonXDSCache(logger logrus.FieldLogger, pipelineGatewayDetails *PipelineGatewayDetails) (*SeldonXDSCache, error) {
+type EnvoyConfig struct {
+	AccessLogPath             string
+	TapPath                   string
+	IncludeSuccessfulRequests bool
+	EnableAccessLog           bool
+}
+
+func NewSeldonXDSCache(logger logrus.FieldLogger, pipelineGatewayDetails *PipelineGatewayDetails, config *EnvoyConfig) (*SeldonXDSCache, error) {
 	xdsCache := &SeldonXDSCache{
 		Clusters:               make(map[string]Cluster),
 		Pipelines:              make(map[string]PipelineRoute),
@@ -82,6 +90,7 @@ func NewSeldonXDSCache(logger logrus.FieldLogger, pipelineGatewayDetails *Pipeli
 		secrets:                make(map[string]Secret),
 		logger:                 logger.WithField("source", "SeldonXDSCache"),
 		snapshotVersion:        rand.Int63n(1000),
+		config:                 config,
 	}
 	err := xdsCache.init()
 	if err != nil {

--- a/scheduler/pkg/envoy/xdscache/seldoncache_benchmark_test.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache_benchmark_test.go
@@ -22,7 +22,7 @@ import (
 var results []types.Resource
 
 func benchmarkRouteContents(b *testing.B, numResources uint) {
-	x, _ := NewSeldonXDSCache(logrus.New(), nil)
+	x, _ := NewSeldonXDSCache(logrus.New(), nil, nil)
 
 	for n := 0; n < int(numResources); n++ {
 		x.AddPipelineRoute(strconv.Itoa(n), []PipelineTrafficSplit{{PipelineName: strconv.Itoa(n), TrafficWeight: 100}}, nil)

--- a/scheduler/pkg/envoy/xdscache/seldoncache_test.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache_test.go
@@ -28,7 +28,7 @@ func TestAddRemoveHttpAndGrpcRoute(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := log.New()
 
-	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{})
+	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{}, nil)
 	g.Expect(err).To(BeNil())
 	httpCluster := "m1_1_http"
 	grpcCluster := "m1_1_grpc"
@@ -63,7 +63,7 @@ func TestAddRemoveHttpAndGrpcRouteVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := log.New()
 
-	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{})
+	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{}, nil)
 	g.Expect(err).To(BeNil())
 
 	httpCluster1 := "m1_1_http"
@@ -148,7 +148,7 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForSameModel(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := log.New()
 
-	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{})
+	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{}, nil)
 	g.Expect(err).To(BeNil())
 
 	routeName := "r1"
@@ -205,7 +205,7 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForDifferentModels(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := log.New()
 
-	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{})
+	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{}, nil)
 	g.Expect(err).To(BeNil())
 
 	httpClusterModel1 := "m1_1_http"
@@ -274,7 +274,7 @@ func TestAddRemoveHttpAndGrpcRouteVersionsForDifferentRoutesSameModel(t *testing
 	g := NewGomegaWithT(t)
 	logger := log.New()
 
-	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{})
+	c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{}, nil)
 	g.Expect(err).To(BeNil())
 
 	route1 := "r1"
@@ -371,7 +371,7 @@ func TestSetupTLS(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{})
+			c, err := NewSeldonXDSCache(logger, &PipelineGatewayDetails{}, nil)
 			g.Expect(err).To(BeNil())
 			if test.setTLS {
 				t.Setenv(fmt.Sprintf("%s%s", seldontls.EnvSecurityPrefixEnvoy, seldontls.EnvSecurityProtocolSuffix), seldontls.SecurityProtocolSSL)

--- a/scheduler/pkg/envoy/xdscache/seldoncache_test.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache_test.go
@@ -481,7 +481,7 @@ func TestAccessLogSettings(t *testing.T) {
 								}
 								// this is a little bit cumbersome, but we need to check the filter
 								// as it is a nested structure
-								// the actual test to check the filter is correct (i.e. only fitlering bad requests) is 
+								// the actual test to check the filter is correct (i.e. only fitlering bad requests) is
 								// done manually.
 								expectedFilter := &accesslog.OrFilter{
 									Filters: []*accesslog.AccessLogFilter{

--- a/scheduler/pkg/envoy/xdscache/seldoncache_test.go
+++ b/scheduler/pkg/envoy/xdscache/seldoncache_test.go
@@ -479,6 +479,10 @@ func TestAccessLogSettings(t *testing.T) {
 										IgnoreCase: true,
 									},
 								}
+								// this is a little bit cumbersome, but we need to check the filter
+								// as it is a nested structure
+								// the actual test to check the filter is correct (i.e. only fitlering bad requests) is 
+								// done manually.
 								expectedFilter := &accesslog.OrFilter{
 									Filters: []*accesslog.AccessLogFilter{
 										// http


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This change introduces the ability to configure `Envoy` access log in a way that allows users to:
- turn it off completely
- only log errors (default)
- log all requests
- specify the file path for the log file

In helm this is configured in the components chart and the corresponding default are

```
envoy:
  accesslogPath: /tmp/envoy-accesslog.txt
  enableAccesslog: true
  includeSuccessfulRequests: false
```

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 
Infra-1341 (internal)

**Special notes for your reviewer**:

Tasks to do:

- [ ] Add docs
- [x] Test in kind
