### PR TITLE
feat: add helm for disabling native autoscaling feature

### DIFF
--- a/docs-gb/installation/helm/README.md
+++ b/docs-gb/installation/helm/README.md
@@ -32,6 +32,8 @@ This section details the key Helm configuration parameters for Envoy, Autoscalin
 
 | Key | Chart | Description | Default
 | --- | --- | --- | --- |
+| `autoscaling.autoscalingModelEnabled` | components | Enable _native_ autoscaling for Models. This is orthogonal to external autoscaling services e.g. HPA. | false |
+| `autoscaling.autoscalingServerEnabled` | components | Enable _native_ autoscaling for Models. This is orthogonal to external autoscaling services e.g. HPA. | true |
 | `agent.scalingStatsPeriodSeconds` | components | Sampling rate for metrics used for autoscaling. | 20 |
 | `agent.modelInferenceLagThreshold` | components | Queue lag threshold to trigger scaling up of a model replica. | 30 |
 | `agent.modelInactiveSecondsThreshold` | components | Period with no activity after which to trigger scaling down of a model replica. | 600 |

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -493,6 +493,7 @@ spec:
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
+        - --enable-server-autoscaling=$(ENABLE_SERVER_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -553,6 +554,8 @@ spec:
           value: '{{ .Values.envoy.includeSuccessfulRequests }}'
         - name: ENABLE_MODEL_AUTOSCALING
           value: '{{ .Values.autoscaling.autoscalingModelEnabled }}'
+        - name: ENABLE_SERVER_AUTOSCALING
+          value: '{{ .Values.autoscaling.autoscalingServerEnabled }}'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -492,7 +492,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-model-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
+        - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -555,7 +555,7 @@ spec:
           value: '{{ .Values.autoscaling.autoscalingDisabled }}'
         - name: ALLOW_PLAINTXT
           value: "true"
-        - name: DISABLE_MODEL_AUTOSCALING
+        - name: ENABLE_MODEL_AUTOSCALING
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -492,6 +492,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
+        - --disable-autoscaling=$(DISABLE_AUTOSCALING)
         command:
         - /bin/scheduler
         env:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -551,11 +551,9 @@ spec:
           value: '{{ .Values.envoy.enableAccesslog }}'
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: '{{ .Values.envoy.includeSuccessfulRequests }}'
-        - name: DISABLE_AUTOSCALING
-          value: '{{ .Values.autoscaling.autoscalingDisabled }}'
-        - name: ALLOW_PLAINTXT
-          value: "true"
         - name: ENABLE_MODEL_AUTOSCALING
+          value: '{{ .Values.autoscaling.autoscalingModelEnabled }}'
+        - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -492,7 +492,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-autoscaling=$(DISABLE_AUTOSCALING)
+        - --disable-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -554,6 +554,8 @@ spec:
         - name: DISABLE_AUTOSCALING
           value: '{{ .Values.autoscaling.autoscalingDisabled }}'
         - name: ALLOW_PLAINTXT
+          value: "true"
+        - name: DISABLE_MODEL_AUTOSCALING
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -550,6 +550,8 @@ spec:
           value: '{{ .Values.envoy.enableAccesslog }}'
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: '{{ .Values.envoy.includeSuccessfulRequests }}'
+        - name: DISABLE_AUTOSCALING
+          value: '{{ .Values.autoscaling.autoscalingDisabled }}'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -492,7 +492,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
+        - --disable-model-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -227,6 +227,7 @@ scheduler:
   
 autoscaling:
   autoscalingModelEnabled: false
+  autoscalingServerEnabled: false
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -227,7 +227,7 @@ scheduler:
   
 autoscaling:
   autoscalingModelEnabled: false
-  autoscalingServerEnabled: false
+  autoscalingServerEnabled: true
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -226,6 +226,7 @@ scheduler:
   schedulerReadyTimeoutSeconds: 600
   
 autoscaling:
+  autoscalingDisabled: true
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -226,7 +226,7 @@ scheduler:
   schedulerReadyTimeoutSeconds: 600
   
 autoscaling:
-  autoscalingDisabled: true
+  autoscalingModelDisabled: true
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -226,7 +226,7 @@ scheduler:
   schedulerReadyTimeoutSeconds: 600
   
 autoscaling:
-  autoscalingModelDisabled: true
+  autoscalingModelEnabled: false
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -227,6 +227,7 @@ scheduler:
   
 autoscaling:
   autoscalingModelEnabled: false
+  autoscalingServerEnabled: false
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -227,7 +227,7 @@ scheduler:
   
 autoscaling:
   autoscalingModelEnabled: false
-  autoscalingServerEnabled: false
+  autoscalingServerEnabled: true
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -226,6 +226,7 @@ scheduler:
   schedulerReadyTimeoutSeconds: 600
   
 autoscaling:
+  autoscalingDisabled: true
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -226,7 +226,7 @@ scheduler:
   schedulerReadyTimeoutSeconds: 600
   
 autoscaling:
-  autoscalingDisabled: true
+  autoscalingModelDisabled: true
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -226,7 +226,7 @@ scheduler:
   schedulerReadyTimeoutSeconds: 600
   
 autoscaling:
-  autoscalingModelDisabled: true
+  autoscalingModelEnabled: false
   serverPackingEnabled: false
   serverPackingPercentage: 0.0
 

--- a/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
@@ -71,8 +71,8 @@ spec:
             value: '{{ .Values.envoy.enableAccesslog }}'
           - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
             value: '{{ .Values.envoy.includeSuccessfulRequests }}'
-          - name: DISABLE_AUTOSCALING
-            value: '{{ .Values.autoscaling.autoscalingDisabled }}'
+          - name: ENABLE_MODEL_AUTOSCALING
+            value: '{{ .Values.autoscaling.autoscalingModelEnabled }}'
     volumeClaimTemplates:
     - name: scheduler-state
       spec:

--- a/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
@@ -73,6 +73,8 @@ spec:
             value: '{{ .Values.envoy.includeSuccessfulRequests }}'
           - name: ENABLE_MODEL_AUTOSCALING
             value: '{{ .Values.autoscaling.autoscalingModelEnabled }}'
+          - name: ENABLE_SERVER_AUTOSCALING
+            value: '{{ .Values.autoscaling.autoscalingServerEnabled }}'
     volumeClaimTemplates:
     - name: scheduler-state
       spec:

--- a/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
@@ -71,6 +71,8 @@ spec:
             value: '{{ .Values.envoy.enableAccesslog }}'
           - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
             value: '{{ .Values.envoy.includeSuccessfulRequests }}'
+          - name: DISABLE_AUTOSCALING
+            value: '{{ .Values.autoscaling.autoscalingDisabled }}'
     volumeClaimTemplates:
     - name: scheduler-state
       spec:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -347,7 +347,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
+        - --disable-model-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -402,6 +402,8 @@ spec:
           value: 'true'
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: 'false'
+        - name: DISABLE_AUTOSCALING
+          value: 'true'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -407,7 +407,7 @@ spec:
         - name: ENABLE_MODEL_AUTOSCALING
           value: 'false'
         - name: ENABLE_SERVER_AUTOSCALING
-          value: 'false'
+          value: 'true'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -403,11 +403,9 @@ spec:
           value: 'true'
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: 'false'
-        - name: DISABLE_AUTOSCALING
-          value: ''
-        - name: ALLOW_PLAINTXT
-          value: "true"
         - name: ENABLE_MODEL_AUTOSCALING
+          value: 'false'
+        - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -347,7 +347,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-autoscaling=$(DISABLE_AUTOSCALING)
+        - --disable-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -404,8 +404,10 @@ spec:
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: 'false'
         - name: DISABLE_AUTOSCALING
-          value: 'true'
+          value: ''
         - name: ALLOW_PLAINTXT
+          value: "true"
+        - name: DISABLE_MODEL_AUTOSCALING
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -347,7 +347,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-model-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
+        - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -407,7 +407,7 @@ spec:
           value: ''
         - name: ALLOW_PLAINTXT
           value: "true"
-        - name: DISABLE_MODEL_AUTOSCALING
+        - name: ENABLE_MODEL_AUTOSCALING
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -348,6 +348,7 @@ spec:
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
+        - --enable-server-autoscaling=$(ENABLE_SERVER_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -404,6 +405,8 @@ spec:
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: 'false'
         - name: ENABLE_MODEL_AUTOSCALING
+          value: 'false'
+        - name: ENABLE_SERVER_AUTOSCALING
           value: 'false'
         - name: ALLOW_PLAINTXT
           value: "true"

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -347,6 +347,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
+        - --disable-autoscaling=$(DISABLE_AUTOSCALING)
         command:
         - /bin/scheduler
         env:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -243,7 +243,7 @@ spec:
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: "false"
         - name: ENABLE_MODEL_AUTOSCALING
-          value: "true"
+          value: "false"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -246,7 +246,7 @@ spec:
         - name: ENABLE_MODEL_AUTOSCALING
           value: "false"
         - name: ENABLE_SERVER_AUTOSCALING
-          value: "false"
+          value: "true"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -224,7 +224,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
+        - --disable-model-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -224,7 +224,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-model-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
+        - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -242,7 +242,7 @@ spec:
           value: "true"
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: "false"
-        - name: DISABLE_MODEL_AUTOSCALING
+        - name: ENABLE_MODEL_AUTOSCALING
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -224,6 +224,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
+        - --disable-autoscaling=$(DISABLE_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -241,6 +242,8 @@ spec:
           value: "true"
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: "false"
+        - name: DISABLE_AUTOSCALING
+          value: "true"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -224,7 +224,7 @@ spec:
         - --envoy-accesslog-path=$(ENVOY_ACCESSLOG_PATH)
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
-        - --disable-autoscaling=$(DISABLE_AUTOSCALING)
+        - --disable-autoscaling=$(DISABLE_MODEL_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -242,7 +242,7 @@ spec:
           value: "true"
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: "false"
-        - name: DISABLE_AUTOSCALING
+        - name: DISABLE_MODEL_AUTOSCALING
           value: "true"
         - name: POD_NAMESPACE
           valueFrom:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -225,6 +225,7 @@ spec:
         - --enable-envoy-accesslog=$(ENABLE_ENVOY_ACCESSLOG)
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
+        - --enable-server-autoscaling=$(ENABLE_SERVER_AUTOSCALING)
         command:
         - /bin/scheduler
         env:
@@ -243,6 +244,8 @@ spec:
         - name: INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG
           value: "false"
         - name: ENABLE_MODEL_AUTOSCALING
+          value: "false"
+        - name: ENABLE_SERVER_AUTOSCALING
           value: "false"
         - name: POD_NAMESPACE
           valueFrom:

--- a/scheduler/all-host-network.yaml
+++ b/scheduler/all-host-network.yaml
@@ -164,7 +164,7 @@ services:
       - "/mnt/config/tracing-internal.json"
       - --db-path
       - "${DB_PATH_COMPOSE}"
-      - --disable-autoscaling
+      - --disable-model-autoscaling
       - "--kafka-config-path"
       - "/mnt/config/kafka-host.json"
       - "--scheduler-ready-timeout-seconds"

--- a/scheduler/all-host-network.yaml
+++ b/scheduler/all-host-network.yaml
@@ -164,7 +164,7 @@ services:
       - "/mnt/config/tracing-internal.json"
       - --db-path
       - "${DB_PATH_COMPOSE}"
-      - --disable-model-autoscaling=true
+      - --enable-model-autoscaling=false
       - "--kafka-config-path"
       - "/mnt/config/kafka-host.json"
       - "--scheduler-ready-timeout-seconds"

--- a/scheduler/all-host-network.yaml
+++ b/scheduler/all-host-network.yaml
@@ -164,7 +164,7 @@ services:
       - "/mnt/config/tracing-internal.json"
       - --db-path
       - "${DB_PATH_COMPOSE}"
-      - --disable-model-autoscaling
+      - --disable-model-autoscaling=true
       - "--kafka-config-path"
       - "/mnt/config/kafka-host.json"
       - "--scheduler-ready-timeout-seconds"

--- a/scheduler/all-internal.yaml
+++ b/scheduler/all-internal.yaml
@@ -203,7 +203,7 @@ services:
       - "/mnt/config/tracing-internal.json"
       - --db-path
       - ${DB_PATH_COMPOSE}
-      - --disable-model-autoscaling
+      - --disable-model-autoscaling=true
       - "--kafka-config-path"
       - "/mnt/config/kafka-internal.json"
       - "--scheduler-ready-timeout-seconds"

--- a/scheduler/all-internal.yaml
+++ b/scheduler/all-internal.yaml
@@ -203,7 +203,7 @@ services:
       - "/mnt/config/tracing-internal.json"
       - --db-path
       - ${DB_PATH_COMPOSE}
-      - --disable-autoscaling
+      - --disable-model-autoscaling
       - "--kafka-config-path"
       - "/mnt/config/kafka-internal.json"
       - "--scheduler-ready-timeout-seconds"

--- a/scheduler/all-internal.yaml
+++ b/scheduler/all-internal.yaml
@@ -203,7 +203,7 @@ services:
       - "/mnt/config/tracing-internal.json"
       - --db-path
       - ${DB_PATH_COMPOSE}
-      - --disable-model-autoscaling=true
+      - --enable-model-autoscaling=false
       - "--kafka-config-path"
       - "/mnt/config/kafka-internal.json"
       - "--scheduler-ready-timeout-seconds"

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -53,7 +53,7 @@ var (
 	dbPath                       string
 	nodeID                       string
 	allowPlaintxt                bool // scheduler server
-	autoscalingModelDisabled     bool
+	autoscalingModelEnabled     bool
 	kafkaConfigPath              string
 	schedulerReadyTimeoutSeconds uint
 	deletedResourceTTLSeconds    uint
@@ -113,7 +113,7 @@ func init() {
 	flag.BoolVar(&allowPlaintxt, "allow-plaintxt", true, "Allow plain text scheduler server")
 
 	// Whether to enable autoscaling, default is true
-	flag.BoolVar(&autoscalingModelDisabled, "disable-model-autoscaling", false, "Disable native model autoscaling feature")
+	flag.BoolVar(&autoscalingModelEnabled, "enable-model-autoscaling", false, "Disable native model autoscaling feature")
 
 	// Kafka config path
 	flag.StringVar(
@@ -181,7 +181,7 @@ func main() {
 	logger.Debugf("Scheduler ready timeout is set to %d seconds", schedulerReadyTimeoutSeconds)
 	logger.Debugf("Server packing is set to %t", serverPackingEnabled)
 	logger.Debugf("Server packing percentage is set to %f", serverPackingPercentage)
-	logger.Infof("Autoscaling service is set to %t", !autoscalingModelDisabled)
+	logger.Infof("Autoscaling service is set to %t", autoscalingModelEnabled)
 
 	done := make(chan bool, 1)
 
@@ -286,7 +286,7 @@ func main() {
 	}
 
 	// scheduler <-> agent  grpc
-	as := agent.NewAgentServer(logger, ss, sched, eventHub, !autoscalingModelDisabled)
+	as := agent.NewAgentServer(logger, ss, sched, eventHub, autoscalingModelEnabled)
 	err = as.StartGrpcServer(allowPlaintxt, agentPort, agentMtlsPort)
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to start agent gRPC server")

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -53,7 +53,7 @@ var (
 	dbPath                       string
 	nodeID                       string
 	allowPlaintxt                bool // scheduler server
-	autoscalingModelEnabled     bool
+	autoscalingModelEnabled      bool
 	kafkaConfigPath              string
 	schedulerReadyTimeoutSeconds uint
 	deletedResourceTTLSeconds    uint

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -54,6 +54,7 @@ var (
 	nodeID                       string
 	allowPlaintxt                bool // scheduler server
 	autoscalingModelEnabled      bool
+	autoscalingServerEnabled     bool
 	kafkaConfigPath              string
 	schedulerReadyTimeoutSeconds uint
 	deletedResourceTTLSeconds    uint
@@ -112,8 +113,9 @@ func init() {
 	// Allow plaintext servers
 	flag.BoolVar(&allowPlaintxt, "allow-plaintxt", true, "Allow plain text scheduler server")
 
-	// Whether to enable autoscaling, default is true
-	flag.BoolVar(&autoscalingModelEnabled, "enable-model-autoscaling", false, "Disable native model autoscaling feature")
+	// Autoscaling
+	flag.BoolVar(&autoscalingModelEnabled, "enable-model-autoscaling", false, "Enable native model autoscaling feature")
+	flag.BoolVar(&autoscalingServerEnabled, "enable-server-autoscaling", false, "Enable native server autoscaling feature")
 
 	// Kafka config path
 	flag.StringVar(
@@ -278,7 +280,8 @@ func main() {
 	s := schedulerServer.NewSchedulerServer(
 		logger, ss, es, ps, sched, eventHub, sync,
 		schedulerServer.SchedulerServerConfig{
-			PackThreshold: serverPackingPercentage, // note that if threshold is 0, packing is disabled
+			PackThreshold:            serverPackingPercentage, // note that if threshold is 0, packing is disabled
+			AutoScalingServerEnabled: autoscalingServerEnabled,
 		})
 	err = s.StartGrpcServers(allowPlaintxt, schedulerPort, schedulerMtlsPort)
 	if err != nil {

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -113,7 +113,7 @@ func init() {
 	flag.BoolVar(&allowPlaintxt, "allow-plaintxt", true, "Allow plain text scheduler server")
 
 	// Whether to enable autoscaling, default is true
-	flag.BoolVar(&autoscalingDisabled, "disable-autoscaling", false, "Disable autoscaling feature")
+	flag.BoolVar(&autoscalingDisabled, "disable-autoscaling", false, "Disable native autoscaling feature")
 
 	// Kafka config path
 	flag.StringVar(

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -53,7 +53,7 @@ var (
 	dbPath                       string
 	nodeID                       string
 	allowPlaintxt                bool // scheduler server
-	autoscalingDisabled          bool
+	autoscalingModelDisabled          bool
 	kafkaConfigPath              string
 	schedulerReadyTimeoutSeconds uint
 	deletedResourceTTLSeconds    uint
@@ -113,7 +113,7 @@ func init() {
 	flag.BoolVar(&allowPlaintxt, "allow-plaintxt", true, "Allow plain text scheduler server")
 
 	// Whether to enable autoscaling, default is true
-	flag.BoolVar(&autoscalingDisabled, "disable-autoscaling", false, "Disable native autoscaling feature")
+	flag.BoolVar(&autoscalingModelDisabled, "disable-model-autoscaling", false, "Disable native model autoscaling feature")
 
 	// Kafka config path
 	flag.StringVar(
@@ -285,8 +285,8 @@ func main() {
 	}
 
 	// scheduler <-> agent  grpc
-	logger.Infof("Autoscaling service is set to %t", !autoscalingDisabled)
-	as := agent.NewAgentServer(logger, ss, sched, eventHub, !autoscalingDisabled)
+	logger.Infof("Autoscaling service is set to %t", !autoscalingModelDisabled)
+	as := agent.NewAgentServer(logger, ss, sched, eventHub, !autoscalingModelDisabled)
 	err = as.StartGrpcServer(allowPlaintxt, agentPort, agentMtlsPort)
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to start agent gRPC server")

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -53,7 +53,7 @@ var (
 	dbPath                       string
 	nodeID                       string
 	allowPlaintxt                bool // scheduler server
-	autoscalingModelDisabled          bool
+	autoscalingModelDisabled     bool
 	kafkaConfigPath              string
 	schedulerReadyTimeoutSeconds uint
 	deletedResourceTTLSeconds    uint

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -183,7 +183,7 @@ func main() {
 	logger.Debugf("Scheduler ready timeout is set to %d seconds", schedulerReadyTimeoutSeconds)
 	logger.Debugf("Server packing is set to %t", serverPackingEnabled)
 	logger.Debugf("Server packing percentage is set to %f", serverPackingPercentage)
-	logger.Infof("Autoscaling service is set to Model: %t and Server: %t", autoscalingModelEnabled, autoscalingServerEnabled)
+	logger.Infof("Autoscaling (native) service is set to Model: %t and Server: %t", autoscalingModelEnabled, autoscalingServerEnabled)
 	done := make(chan bool, 1)
 
 	namespace = getNamespace()

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -181,6 +181,7 @@ func main() {
 	logger.Debugf("Scheduler ready timeout is set to %d seconds", schedulerReadyTimeoutSeconds)
 	logger.Debugf("Server packing is set to %t", serverPackingEnabled)
 	logger.Debugf("Server packing percentage is set to %f", serverPackingPercentage)
+	logger.Infof("Autoscaling service is set to %t", !autoscalingModelDisabled)
 
 	done := make(chan bool, 1)
 
@@ -285,7 +286,6 @@ func main() {
 	}
 
 	// scheduler <-> agent  grpc
-	logger.Infof("Autoscaling service is set to %t", !autoscalingModelDisabled)
 	as := agent.NewAgentServer(logger, ss, sched, eventHub, !autoscalingModelDisabled)
 	err = as.StartGrpcServer(allowPlaintxt, agentPort, agentMtlsPort)
 	if err != nil {

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -115,7 +115,7 @@ func init() {
 
 	// Autoscaling
 	flag.BoolVar(&autoscalingModelEnabled, "enable-model-autoscaling", false, "Enable native model autoscaling feature")
-	flag.BoolVar(&autoscalingServerEnabled, "enable-server-autoscaling", false, "Enable native server autoscaling feature")
+	flag.BoolVar(&autoscalingServerEnabled, "enable-server-autoscaling", true, "Enable native server autoscaling feature")
 
 	// Kafka config path
 	flag.StringVar(
@@ -183,8 +183,7 @@ func main() {
 	logger.Debugf("Scheduler ready timeout is set to %d seconds", schedulerReadyTimeoutSeconds)
 	logger.Debugf("Server packing is set to %t", serverPackingEnabled)
 	logger.Debugf("Server packing percentage is set to %f", serverPackingPercentage)
-	logger.Infof("Autoscaling service is set to %t", autoscalingModelEnabled)
-
+	logger.Infof("Autoscaling service is set to Model: %t and Server: %t", autoscalingModelEnabled, autoscalingServerEnabled)
 	done := make(chan bool, 1)
 
 	namespace = getNamespace()

--- a/scheduler/pkg/server/server.go
+++ b/scheduler/pkg/server/server.go
@@ -68,7 +68,8 @@ type SchedulerServer struct {
 }
 
 type SchedulerServerConfig struct {
-	PackThreshold float64
+	PackThreshold            float64
+	AutoScalingServerEnabled bool
 }
 
 type ModelEventStream struct {

--- a/scheduler/pkg/server/server_status.go
+++ b/scheduler/pkg/server/server_status.go
@@ -184,15 +184,17 @@ func (s *SchedulerServer) handleServerEvents(event coordinator.ServerEventMsg) {
 		return
 	}
 
-	if event.UpdateContext == coordinator.SERVER_SCALE_DOWN {
-		if ok, replicas := shouldScaleDown(server, float32(s.config.PackThreshold)); ok {
-			logger.Infof("Server %s is scaling down to %d", event.ServerName, replicas)
-			s.sendServerScale(server, replicas)
-		}
-	} else if event.UpdateContext == coordinator.SERVER_SCALE_UP {
-		if ok, replicas := shouldScaleUp(server); ok {
-			logger.Infof("Server %s is scaling up to %d", event.ServerName, replicas)
-			s.sendServerScale(server, replicas)
+	if s.config.AutoScalingServerEnabled {
+		if event.UpdateContext == coordinator.SERVER_SCALE_DOWN {
+			if ok, replicas := shouldScaleDown(server, float32(s.config.PackThreshold)); ok {
+				logger.Infof("Server %s is scaling down to %d", event.ServerName, replicas)
+				s.sendServerScale(server, replicas)
+			}
+		} else if event.UpdateContext == coordinator.SERVER_SCALE_UP {
+			if ok, replicas := shouldScaleUp(server); ok {
+				logger.Infof("Server %s is scaling up to %d", event.ServerName, replicas)
+				s.sendServerScale(server, replicas)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR exposed `enable-server-autoscaling` and `enable-model-autoscaling` flags via helm so that users can have the ability to switch on/off native model and server autoscaling more explicitly.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

The logic per model/server for executing on autoscaling is still set to check whether minReplicas and/or maxReplicas are set (as they currently provide the bounds for min/max replicas).  This is orthogonal to this system wide flags that re are exposing in this change.