### PR TITLE
fix: Allow kafka client (`librdkafka`)  to respect log level

### DIFF
--- a/components/kafka/pkg/config/config.go
+++ b/components/kafka/pkg/config/config.go
@@ -38,13 +38,13 @@ const (
 	KafkaLogLevel         = "log_level"
 )
 
-type sysinfoLogLevel int
+type sysLogLevel int
 
 // Based on syslog levels
 // https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
 // which is used in librdkafka log_level
 const (
-	emergLevel sysinfoLogLevel = iota
+	emergLevel sysLogLevel = iota
 	alertLevel
 	critLevel
 	errLevel
@@ -76,7 +76,7 @@ func CloneKafkaConfigMap(m kafka.ConfigMap) kafka.ConfigMap {
 }
 
 // note that we also try to match logrus levels here as well
-func parseSysInfoLogLevel(lvl string) (sysinfoLogLevel, error) {
+func parseSysLogLevel(lvl string) (sysLogLevel, error) {
 	switch strings.ToLower(lvl) {
 	case "panic", "emerg":
 		return emergLevel, nil
@@ -96,8 +96,8 @@ func parseSysInfoLogLevel(lvl string) (sysinfoLogLevel, error) {
 		return debugLevel, nil
 	}
 
-	var l sysinfoLogLevel
-	return l, fmt.Errorf("not a valid sysinfo Level: %q", lvl)
+	var l sysLogLevel
+	return l, fmt.Errorf("not a valid syslog Level: %q", lvl)
 }
 
 func NewKafkaConfig(path string, logLevel string) (*KafkaConfig, error) {
@@ -143,12 +143,12 @@ func NewKafkaConfig(path string, logLevel string) (*KafkaConfig, error) {
 		kc.Producer[KafkaDebug] = kc.Debug
 	}
 
-	sysinfoLogLevel, err := parseSysInfoLogLevel(logLevel)
+	sysLogLevel, err := parseSysLogLevel(logLevel)
 	if err != nil {
 		return nil, err
 	}
-	kc.Consumer[KafkaLogLevel] = int(sysinfoLogLevel)
-	kc.Producer[KafkaLogLevel] = int(sysinfoLogLevel)
+	kc.Consumer[KafkaLogLevel] = int(sysLogLevel)
+	kc.Producer[KafkaLogLevel] = int(sysLogLevel)
 	return &kc, nil
 }
 

--- a/components/kafka/pkg/config/config.go
+++ b/components/kafka/pkg/config/config.go
@@ -41,7 +41,7 @@ const (
 type sysinfoLogLevel int
 
 // Based on syslog levels
-// e.g. https://linuxconfig.org/introduction-to-the-linux-kernel-log-levels
+// https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
 // which is used in librdkafka log_level
 const (
 	emergLevel sysinfoLogLevel = iota

--- a/components/kafka/pkg/config/config.go
+++ b/components/kafka/pkg/config/config.go
@@ -40,7 +40,7 @@ const (
 
 type sysinfoLogLevel int
 
-// Based on sysinfo log levels
+// Based on syslog levels
 // e.g. https://linuxconfig.org/introduction-to-the-linux-kernel-log-levels
 // which is used in librdkafka log_level
 const (

--- a/components/kafka/pkg/config/config.go
+++ b/components/kafka/pkg/config/config.go
@@ -147,8 +147,8 @@ func NewKafkaConfig(path string, logLevel string) (*KafkaConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	kc.Consumer[KafkaLogLevel] = sysinfoLogLevel
-	kc.Producer[KafkaLogLevel] = sysinfoLogLevel
+	kc.Consumer[KafkaLogLevel] = int(sysinfoLogLevel)
+	kc.Producer[KafkaLogLevel] = int(sysinfoLogLevel)
 	return &kc, nil
 }
 

--- a/components/kafka/pkg/config/config.go
+++ b/components/kafka/pkg/config/config.go
@@ -12,6 +12,7 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 
@@ -34,6 +35,23 @@ type stringSet = map[string]none
 const (
 	KafkaBootstrapServers = "bootstrap.servers"
 	KafkaDebug            = "debug"
+	KafkaLogLevel         = "log_level"
+)
+
+type sysinfoLogLevel int
+
+// Based on sysinfo log levels
+// e.g. https://linuxconfig.org/introduction-to-the-linux-kernel-log-levels
+// which is used in librdkafka log_level
+const (
+	emergLevel sysinfoLogLevel = iota
+	alertLevel
+	critLevel
+	errLevel
+	warningLevel
+	noticeLevel
+	infoLevel
+	debugLevel
 )
 
 // Based on config options defined for librdkafka:
@@ -57,7 +75,32 @@ func CloneKafkaConfigMap(m kafka.ConfigMap) kafka.ConfigMap {
 	return m2
 }
 
-func NewKafkaConfig(path string) (*KafkaConfig, error) {
+// note that we also try to match logrus levels here as well
+func parseSysInfoLogLevel(lvl string) (sysinfoLogLevel, error) {
+	switch strings.ToLower(lvl) {
+	case "panic", "emerg":
+		return emergLevel, nil
+	case "fatal", "alert":
+		return alertLevel, nil
+	case "crit":
+		return critLevel, nil
+	case "error", "err":
+		return errLevel, nil
+	case "warn", "warning":
+		return warningLevel, nil
+	case "notice":
+		return noticeLevel, nil
+	case "info":
+		return infoLevel, nil
+	case "debug", "trace":
+		return debugLevel, nil
+	}
+
+	var l sysinfoLogLevel
+	return l, fmt.Errorf("not a valid sysinfo Level: %q", lvl)
+}
+
+func NewKafkaConfig(path string, logLevel string) (*KafkaConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -99,6 +142,13 @@ func NewKafkaConfig(path string) (*KafkaConfig, error) {
 		kc.Consumer[KafkaDebug] = kc.Debug
 		kc.Producer[KafkaDebug] = kc.Debug
 	}
+
+	sysinfoLogLevel, err := parseSysInfoLogLevel(logLevel)
+	if err != nil {
+		return nil, err
+	}
+	kc.Consumer[KafkaLogLevel] = sysinfoLogLevel
+	kc.Producer[KafkaLogLevel] = sysinfoLogLevel
 	return &kc, nil
 }
 

--- a/components/kafka/pkg/config/config_test.go
+++ b/components/kafka/pkg/config/config_test.go
@@ -41,8 +41,8 @@ func TestNewKafkaConfig(t *testing.T) {
 `,
 			expected: &KafkaConfig{
 				BootstrapServers: "kafka:9092",
-				Consumer:         kafka.ConfigMap{"bootstrap.servers": "kafka:9092", "session.timeout.ms": 6000, "someBool": true, "someString": "foo"},
-				Producer:         kafka.ConfigMap{"bootstrap.servers": "kafka:9092", "linger.ms": 0},
+				Consumer:         kafka.ConfigMap{"bootstrap.servers": "kafka:9092", "session.timeout.ms": 6000, "someBool": true, "someString": "foo", "log_level": 7},
+				Producer:         kafka.ConfigMap{"bootstrap.servers": "kafka:9092", "linger.ms": 0, "log_level": 7},
 				Streams:          kafka.ConfigMap{"bootstrap.servers": "kafka:9092", "replication.factor": 1},
 			},
 		},
@@ -58,8 +58,8 @@ func TestNewKafkaConfig(t *testing.T) {
 `,
 			expected: &KafkaConfig{
 				BootstrapServers: "kafka:9092",
-				Consumer:         kafka.ConfigMap{"bootstrap.servers": "foo", "session.timeout.ms": 6000, "someBool": true, "someString": "foo"},
-				Producer:         kafka.ConfigMap{"bootstrap.servers": "foo", "linger.ms": 0},
+				Consumer:         kafka.ConfigMap{"bootstrap.servers": "foo", "session.timeout.ms": 6000, "someBool": true, "someString": "foo", "log_level": 7},
+				Producer:         kafka.ConfigMap{"bootstrap.servers": "foo", "linger.ms": 0, "log_level": 7},
 				Streams:          kafka.ConfigMap{"bootstrap.servers": "foo", "replication.factor": 1},
 			},
 		},

--- a/components/kafka/pkg/config/config_test.go
+++ b/components/kafka/pkg/config/config_test.go
@@ -142,7 +142,7 @@ func TestGetKafkaConsumerName(t *testing.T) {
 	}
 }
 
-func TestParseSysInfoLogLevel(t *testing.T) {
+func TestParseSysLogLevel(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	type test struct {
@@ -222,7 +222,7 @@ func TestParseSysInfoLogLevel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := parseSysInfoLogLevel(test.level)
+			result, err := parseSysLogLevel(test.level)
 			if test.err {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/components/kafka/pkg/config/config_test.go
+++ b/components/kafka/pkg/config/config_test.go
@@ -74,7 +74,7 @@ func TestNewKafkaConfig(t *testing.T) {
 			configFilePath := fmt.Sprintf("%s/kafka.json", t.TempDir())
 			err := os.WriteFile(configFilePath, []byte(test.data), 0644)
 			g.Expect(err).To(BeNil())
-			kc, err := NewKafkaConfig(configFilePath)
+			kc, err := NewKafkaConfig(configFilePath, "debug")
 			if test.err {
 				g.Expect(err).ToNot(BeNil())
 			} else {

--- a/components/kafka/pkg/config/config_test.go
+++ b/components/kafka/pkg/config/config_test.go
@@ -141,3 +141,93 @@ func TestGetKafkaConsumerName(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSysInfoLogLevel(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type test struct {
+		name     string
+		level    string
+		expected int
+		err      bool
+	}
+	tests := []test{
+		{
+			name:     "debug",
+			level:    "debug",
+			expected: 7,
+			err:      false,
+		},
+		{
+			name:     "info",
+			level:    "info",
+			expected: 6,
+			err:      false,
+		},
+		{
+			name:     "warn",
+			level:    "warn",
+			expected: 4,
+			err:      false,
+		},
+		{
+			name:     "error",
+			level:    "error",
+			expected: 3,
+			err:      false,
+		},
+		{
+			name:     "invalid",
+			level:    "invalid",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name:     "panic",
+			level:    "panic",
+			expected: 0,
+			err:      false,
+		},
+		{
+			name:     "warning",
+			level:    "warning",
+			expected: 4,
+			err:      false,
+		},
+		{
+			name:     "warn",
+			level:    "warn",
+			expected: 4,
+			err:      false,
+		},
+		{
+			name:     "alert",
+			level:    "alert",
+			expected: 1,
+			err:      false,
+		},
+		{
+			name:     "crit",
+			level:    "crit",
+			expected: 2,
+			err:      false,
+		},
+		{
+			name:     "emerg",
+			level:    "emerg",
+			expected: 0,
+			err:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := parseSysInfoLogLevel(test.level)
+			if test.err {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(int(result)).To(Equal(test.expected))
+			}
+		})
+	}
+}

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -494,6 +494,7 @@ spec:
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
         - --enable-server-autoscaling=$(ENABLE_SERVER_AUTOSCALING)
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/scheduler
         env:
@@ -556,6 +557,8 @@ spec:
           value: '{{ .Values.autoscaling.autoscalingModelEnabled }}'
         - name: ENABLE_SERVER_AUTOSCALING
           value: '{{ .Values.autoscaling.autoscalingServerEnabled }}'
+        - name: LOG_LEVEL
+          value: '{{ .Values.scheduler.logLevel }}'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -706,6 +706,8 @@ spec:
           value: '{{ .Values.security.controlplane.ssl.client.caPath }}'
         - name: CONTROL_PLANE_SERVER_TLS_CA_LOCATION
           value: '{{ .Values.security.controlplane.ssl.client.serverCaPath }}'
+        - name: LOG_LEVEL
+          value: '{{ .Values.pipelinegateway.logLevel }}'
         - name: SELDON_SCHEDULER_PLAINTXT_PORT
           value: "9004"
         - name: SELDON_SCHEDULER_TLS_PORT
@@ -835,6 +837,8 @@ spec:
           value: '{{ .Values.security.envoy.ssl.downstream.client.caPath }}'
         - name: ENVOY_DOWNSTREAM_SERVER_TLS_CA_LOCATION
           value: '{{ .Values.security.envoy.ssl.downstream.client.serverCaPath }}'
+        - name: LOG_LEVEL
+          value: '{{ .Values.modelgateway.logLevel }}'
         - name: SELDON_SCHEDULER_PLAINTXT_PORT
           value: "9004"
         - name: SELDON_SCHEDULER_TLS_PORT

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -633,6 +633,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/pipelinegateway
         env:
@@ -771,6 +772,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/modelgateway
         env:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1255,6 +1255,8 @@ spec:
         value: ""
       - name: SELDON_SERVER_TYPE
         value: mlserver
+      - name: SELDON_LOG_LEVEL
+        value: '{{ .Values.serverConfig.agent.logLevel }}'
       - name: SELDON_ENVOY_HOST
         value: seldon-mesh
       - name: SELDON_ENVOY_PORT
@@ -1517,6 +1519,8 @@ spec:
         value: "9007"
       - name: SELDON_SERVER_TYPE
         value: triton
+      - name: SELDON_LOG_LEVEL
+        value: '{{ .Values.serverConfig.agent.logLevel }}'
       - name: POD_NAME
         valueFrom:
           fieldRef:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1231,6 +1231,8 @@ spec:
         value: '{{ .Values.security.envoy.ssl.upstream.server.clientCaPath }}'
       - name: MLSERVER_TRACING_SERVER
         value: '{{ .Values.opentelemetry.endpoint }}'
+      - name: SELDON_LOG_LEVEL
+        value: '{{ .Values.serverConfig.agent.logLevel }}'
       - name: SELDON_SERVER_HTTP_PORT
         value: "9000"
       - name: SELDON_SERVER_GRPC_PORT
@@ -1255,8 +1257,6 @@ spec:
         value: ""
       - name: SELDON_SERVER_TYPE
         value: mlserver
-      - name: SELDON_LOG_LEVEL
-        value: '{{ .Values.serverConfig.agent.logLevel }}'
       - name: SELDON_ENVOY_HOST
         value: seldon-mesh
       - name: SELDON_ENVOY_PORT
@@ -1497,6 +1497,8 @@ spec:
         value: '{{ .Values.security.envoy.ssl.upstream.server.caPath }}'
       - name: ENVOY_UPSTREAM_CLIENT_TLS_CA_LOCATION
         value: '{{ .Values.security.envoy.ssl.upstream.server.clientCaPath }}'
+      - name: SELDON_LOG_LEVEL
+        value: '{{ .Values.serverConfig.agent.logLevel }}'
       - name: SELDON_SERVER_HTTP_PORT
         value: "9000"
       - name: SELDON_SERVER_GRPC_PORT
@@ -1519,8 +1521,6 @@ spec:
         value: "9007"
       - name: SELDON_SERVER_TYPE
         value: triton
-      - name: SELDON_LOG_LEVEL
-        value: '{{ .Values.serverConfig.agent.logLevel }}'
       - name: POD_NAME
         valueFrom:
           fieldRef:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -131,6 +131,7 @@ modelgateway:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  logLevel: warn
 
 pipelinegateway:
   image:
@@ -146,6 +147,7 @@ pipelinegateway:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  logLevel: warn
 
 dataflow:
   image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -274,6 +274,7 @@ serverConfig:
     resources:
       cpu: 200m
       memory: 1Gi
+    logLevel: warn
 
   mlserver:
     image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -226,6 +226,7 @@ scheduler:
     runAsGroup: 1000
     runAsNonRoot: true
   schedulerReadyTimeoutSeconds: 600
+  logLevel: warn
   
 autoscaling:
   autoscalingModelEnabled: false

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -131,6 +131,7 @@ modelgateway:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  logLevel: warn
 
 pipelinegateway:
   image:
@@ -146,6 +147,7 @@ pipelinegateway:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  logLevel: warn
 
 dataflow:
   image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -274,6 +274,7 @@ serverConfig:
     resources:
       cpu: 200m
       memory: 1Gi
+    logLevel: warn
 
   mlserver:
     image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -226,6 +226,7 @@ scheduler:
     runAsGroup: 1000
     runAsNonRoot: true
   schedulerReadyTimeoutSeconds: 600
+  logLevel: warn
   
 autoscaling:
   autoscalingModelEnabled: false

--- a/k8s/kustomize/helm-components-sc/patch_mlserver.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_mlserver.yaml
@@ -72,6 +72,8 @@ spec:
         value: '{{ .Values.security.envoy.ssl.upstream.server.clientCaPath }}'
       - name: MLSERVER_TRACING_SERVER
         value: '{{ .Values.opentelemetry.endpoint }}'
+      - name: SELDON_LOG_LEVEL
+        value: '{{ .Values.serverConfig.agent.logLevel }}'
       image: '{{ .Values.serverConfig.agent.image.registry }}/{{ .Values.serverConfig.agent.image.repository }}:{{ .Values.serverConfig.agent.image.tag }}'
       imagePullPolicy: '{{ .Values.serverConfig.agent.image.pullPolicy }}'
       name: agent

--- a/k8s/kustomize/helm-components-sc/patch_modelgateway.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_modelgateway.yaml
@@ -70,6 +70,8 @@ spec:
             value: '{{ .Values.security.envoy.ssl.downstream.client.caPath }}'
           - name: ENVOY_DOWNSTREAM_SERVER_TLS_CA_LOCATION
             value: '{{ .Values.security.envoy.ssl.downstream.client.serverCaPath }}'
+          - name: LOG_LEVEL
+            value: '{{ .Values.modelgateway.logLevel }}'
         resources:
           requests:
             cpu: '{{ .Values.modelgateway.resources.cpu }}'

--- a/k8s/kustomize/helm-components-sc/patch_pipelinegateway.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_pipelinegateway.yaml
@@ -85,3 +85,5 @@ spec:
             value: '{{ .Values.security.controlplane.ssl.client.caPath }}'
           - name: CONTROL_PLANE_SERVER_TLS_CA_LOCATION
             value: '{{ .Values.security.controlplane.ssl.client.serverCaPath }}'
+          - name: LOG_LEVEL
+            value: '{{ .Values.pipelinegateway.logLevel }}'

--- a/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_scheduler.yaml
@@ -75,6 +75,8 @@ spec:
             value: '{{ .Values.autoscaling.autoscalingModelEnabled }}'
           - name: ENABLE_SERVER_AUTOSCALING
             value: '{{ .Values.autoscaling.autoscalingServerEnabled }}'
+          - name: LOG_LEVEL
+            value: '{{ .Values.scheduler.logLevel }}'
     volumeClaimTemplates:
     - name: scheduler-state
       spec:

--- a/k8s/kustomize/helm-components-sc/patch_triton.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_triton.yaml
@@ -70,6 +70,8 @@ spec:
         value: '{{ .Values.security.envoy.ssl.upstream.server.caPath }}'
       - name: ENVOY_UPSTREAM_CLIENT_TLS_CA_LOCATION
         value: '{{ .Values.security.envoy.ssl.upstream.server.clientCaPath }}'
+      - name: SELDON_LOG_LEVEL
+        value: '{{ .Values.serverConfig.agent.logLevel }}'
       image: '{{ .Values.serverConfig.agent.image.registry }}/{{ .Values.serverConfig.agent.image.repository }}:{{ .Values.serverConfig.agent.image.tag }}'
       imagePullPolicy: '{{ .Values.serverConfig.agent.image.pullPolicy }}'
       name: agent

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -553,6 +553,8 @@ spec:
           value: '/tmp/certs/cpc/ca.crt'
         - name: CONTROL_PLANE_SERVER_TLS_CA_LOCATION
           value: '/tmp/certs/cps/ca.crt'
+        - name: LOG_LEVEL
+          value: 'warn'
         - name: SELDON_SCHEDULER_PLAINTXT_PORT
           value: "9004"
         - name: SELDON_SCHEDULER_TLS_PORT
@@ -678,6 +680,8 @@ spec:
           value: '/tmp/certs/ddc/ca.crt'
         - name: ENVOY_DOWNSTREAM_SERVER_TLS_CA_LOCATION
           value: '/tmp/certs/dds/ca.crt'
+        - name: LOG_LEVEL
+          value: 'warn'
         - name: SELDON_SCHEDULER_PLAINTXT_PORT
           value: "9004"
         - name: SELDON_SCHEDULER_TLS_PORT

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -484,6 +484,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/pipelinegateway
         env:
@@ -617,6 +618,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/modelgateway
         env:

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -349,6 +349,7 @@ spec:
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
         - --enable-server-autoscaling=$(ENABLE_SERVER_AUTOSCALING)
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/scheduler
         env:
@@ -408,6 +409,8 @@ spec:
           value: 'false'
         - name: ENABLE_SERVER_AUTOSCALING
           value: 'true'
+        - name: LOG_LEVEL
+          value: 'warn'
         - name: ALLOW_PLAINTXT
           value: "true"
         - name: POD_NAMESPACE

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -1061,6 +1061,8 @@ spec:
         value: '/tmp/certs/duc/ca.crt'
       - name: MLSERVER_TRACING_SERVER
         value: 'seldon-collector.seldon-mesh:4317'
+      - name: SELDON_LOG_LEVEL
+        value: 'warn'
       - name: SELDON_SERVER_HTTP_PORT
         value: "9000"
       - name: SELDON_SERVER_GRPC_PORT
@@ -1315,6 +1317,8 @@ spec:
         value: '/tmp/certs/dus/ca.crt'
       - name: ENVOY_UPSTREAM_CLIENT_TLS_CA_LOCATION
         value: '/tmp/certs/duc/ca.crt'
+      - name: SELDON_LOG_LEVEL
+        value: 'warn'
       - name: SELDON_SERVER_HTTP_PORT
         value: "9000"
       - name: SELDON_SERVER_GRPC_PORT

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -232,6 +232,7 @@ spec:
         - --include-successful-requests-envoy-accesslog=$(INCLUDE_SUCCESSFUL_REQUESTS_ENVOY_ACCESSLOG)
         - --enable-model-autoscaling=$(ENABLE_MODEL_AUTOSCALING)
         - --enable-server-autoscaling=$(ENABLE_SERVER_AUTOSCALING)
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/scheduler
         env:
@@ -253,6 +254,8 @@ spec:
           value: "false"
         - name: ENABLE_SERVER_AUTOSCALING
           value: "true"
+        - name: LOG_LEVEL
+          value: "warn"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -113,6 +113,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/modelgateway
         env:
@@ -122,6 +123,8 @@ spec:
           value: "9044"
         - name: MODELGATEWAY_MAX_NUM_CONSUMERS
           value: "100"
+        - name: LOG_LEVEL
+          value: "warn"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -164,6 +167,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         command:
         - /bin/pipelinegateway
         env:
@@ -171,6 +175,8 @@ spec:
           value: "9004"
         - name: SELDON_SCHEDULER_TLS_PORT
           value: "9044"
+        - name: LOG_LEVEL
+          value: "warn"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/operator/config/serverconfigs/mlserver.yaml
+++ b/operator/config/serverconfigs/mlserver.yaml
@@ -81,6 +81,8 @@ spec:
         value: "seldon-mesh"
       - name: SELDON_ENVOY_PORT
         value: "80"
+      - name: SELDON_LOG_LEVEL
+        value: "warn"
       - name: POD_NAME
         valueFrom:
           fieldRef:

--- a/operator/config/serverconfigs/triton.yaml
+++ b/operator/config/serverconfigs/triton.yaml
@@ -75,6 +75,8 @@ spec:
         value: "9007"
       - name: SELDON_SERVER_TYPE
         value: "triton"
+      - name: SELDON_LOG_LEVEL
+        value: "warn"
       - name: POD_NAME
         valueFrom:
           fieldRef:

--- a/operator/pkg/cli/utils.go
+++ b/operator/pkg/cli/utils.go
@@ -54,7 +54,7 @@ func getKafkaConsumerConfig(kafkaBrokerIsSet bool, kafkaBroker string, config *S
 	var kafkaConfigMap *kafka_config.KafkaConfig
 	if kafkaConfigPath != "" {
 		var err error
-		kafkaConfigMap, err = kafka_config.NewKafkaConfig(kafkaConfigPath)
+		kafkaConfigMap, err = kafka_config.NewKafkaConfig(kafkaConfigPath, "debug")
 		if err != nil {
 			fmt.Printf("Failed to load Kafka config with error: %s\n", err.Error())
 			return nil, "", "", err

--- a/scheduler/cmd/modelgateway/main.go
+++ b/scheduler/cmd/modelgateway/main.go
@@ -126,7 +126,7 @@ func main() {
 		defer tracer.Stop()
 	}
 
-	kafkaConfigMap, err := kafka_config.NewKafkaConfig(kafkaConfigPath)
+	kafkaConfigMap, err := kafka_config.NewKafkaConfig(kafkaConfigPath, logLevel)
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to load Kafka config")
 	}

--- a/scheduler/cmd/pipelinegateway/main.go
+++ b/scheduler/cmd/pipelinegateway/main.go
@@ -148,7 +148,7 @@ func main() {
 		defer tracer.Stop()
 	}
 
-	kafkaConfigMap, err := kafka_config.NewKafkaConfig(kafkaConfigPath)
+	kafkaConfigMap, err := kafka_config.NewKafkaConfig(kafkaConfigPath, logLevel)
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to load Kafka config")
 	}

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -225,7 +225,7 @@ func main() {
 
 	// scheduler <-> dataflow grpc
 	dataFlowLoadBalancer := util.NewRingLoadBalancer(1)
-	kafkaConfigMap, err := kafka_config.NewKafkaConfig(kafkaConfigPath)
+	kafkaConfigMap, err := kafka_config.NewKafkaConfig(kafkaConfigPath, logLevel)
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to load Kafka config")
 	}

--- a/scheduler/k8s/mlserver/mlserver.yaml
+++ b/scheduler/k8s/mlserver/mlserver.yaml
@@ -128,6 +128,8 @@ spec:
           value: "9005"
         - name: SELDON_SERVER_TYPE
           value: "mlserver"
+        - name: SELDON_LOG_LEVEL
+          value: "warn"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/scheduler/k8s/modelgateway/modelgateway.yaml
+++ b/scheduler/k8s/modelgateway/modelgateway.yaml
@@ -27,6 +27,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         image: modelgateway:latest
         imagePullPolicy: IfNotPresent
         name: modelgateway
@@ -39,6 +40,8 @@ spec:
             value: "8"
           - name: MODELGATEWAY_MAX_NUM_CONSUMERS
             value: "100"
+          - name: LOG_LEVEL
+            value: "warn"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/scheduler/k8s/pipelinegateway/pipelinegateway.yaml
+++ b/scheduler/k8s/pipelinegateway/pipelinegateway.yaml
@@ -30,6 +30,7 @@ spec:
         - --envoy-port=80
         - --kafka-config-path=/mnt/kafka/kafka.json
         - --tracing-config-path=/mnt/tracing/tracing.json
+        - --log-level=$(LOG_LEVEL)
         image: pipelinegateway:latest
         imagePullPolicy: IfNotPresent
         name: pipelinegateway
@@ -42,6 +43,8 @@ spec:
             value: "9004"
           - name: SELDON_SCHEDULER_TLS_PORT
             value: "9044"
+          - name: LOG_LEVEL
+            value: "warn"
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/scheduler/k8s/triton/triton.yaml
+++ b/scheduler/k8s/triton/triton.yaml
@@ -128,6 +128,8 @@ spec:
           value: "9005"
         - name: SELDON_SERVER_TYPE
           value: "triton"
+        - name: SELDON_LOG_LEVEL
+          value: "warn"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/scheduler/pkg/kafka/dataflow/server_test.go
+++ b/scheduler/pkg/kafka/dataflow/server_test.go
@@ -810,7 +810,7 @@ func createTestScheduler(t *testing.T, serverName string) (*ChainerServer, *coor
 	`
 	configFilePath := fmt.Sprintf("%s/kafka.json", t.TempDir())
 	_ = os.WriteFile(configFilePath, []byte(data), 0644)
-	kc, _ := kafka_config.NewKafkaConfig(configFilePath)
+	kc, _ := kafka_config.NewKafkaConfig(configFilePath, "debug")
 	b := util.NewRingLoadBalancer(1)
 	b.AddServer(serverName)
 	s, _ := NewChainerServer(logger, eventHub, pipelineServer, "test-ns", b, kc)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Currently we expose on pipelinegateway and modelgateway `--log-level` to set the log level for these components. This PR sets also kafka log level (for librdkafka) from this arg.

Note that `librdkafka` uses sysinfo log levels (in `log_level` @ https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)  which is slightly different from logrus levels. We introduce a mapping to allow it to be used accordingly. 

We also expose this arg via helm, which can be set for these components.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # internal INFRA-1343

**Special notes for your reviewer**:

- [x] Enable settings for scheduler as well?
