### PR TITLE
fix(gha): update upload-artifact version

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -95,7 +95,7 @@ jobs:
           make prep-artifacts
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: .release/
@@ -133,7 +133,7 @@ jobs:
           fi
 
       - name: Upload release notes
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-notes
           path: release-notes.txt


### PR DESCRIPTION
Move from `upload-artifact@v3` (deprecated, actions no longer running) to `upload-artifact@v4`

** Notes for reviewer:
Checked all other Core 2 github actions, no other uses of upload-artifact