### PR TITLE
fix(compose): Allow triton rclone port to be set

### DIFF
--- a/scheduler/all-base.yaml
+++ b/scheduler/all-base.yaml
@@ -165,6 +165,11 @@ services:
     image: "${RCLONE_IMAGE_AND_TAG}"
     environment:
       - RCLONE_LOG_LEVEL=DEBUG
+    command:
+      - "rcd"
+      - "--rc-no-auth"
+      - "--config=/rclone/rclone.conf"
+      - "--rc-addr=0.0.0.0:${RCLONE_TRITON_HTTP_PORT}"
 
   scheduler:
     user: "${UID_GID}"


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This is to revert a partial change done in https://github.com/SeldonIO/seldon-core/pull/6312/files#diff-759bb154316174296ba09eb1d405f8adaa82fd21162a04001bb3592ac88427d5, which would allow the rclone container to be started with a custom port (for triton).

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
