### PR TITLE
fix(scheduler): Do not try to unload versions that are not live

### DIFF
--- a/scheduler/pkg/scheduler/scheduler.go
+++ b/scheduler/pkg/scheduler/scheduler.go
@@ -157,9 +157,11 @@ func (s *SimpleScheduler) scheduleToServer(modelName string) (*coordinator.Serve
 		// this is because the latest version might not have been applied properly and therefore
 		// the old version might still be dangling around
 		for _, mv := range model.Versions {
-			_, err := s.store.UnloadVersionModels(modelName, mv.GetVersion())
-			if err != nil {
-				logger.WithError(err).Warnf("Failed to unload model %s version %d", modelName, mv.GetVersion())
+			if mv.HasLiveReplicas() {
+				_, err := s.store.UnloadVersionModels(modelName, mv.GetVersion())
+				if err != nil {
+					logger.WithError(err).Warnf("Failed to unload model %s version %d", modelName, mv.GetVersion())
+				}
 			}
 		}
 

--- a/scheduler/pkg/scheduler/scheduler_test.go
+++ b/scheduler/pkg/scheduler/scheduler_test.go
@@ -667,6 +667,9 @@ func TestRemoveAllVersions(t *testing.T) {
 		for i := 1; i <= numVersions; i++ {
 			versions = append(versions, store.NewModelVersion(config, uint32(i), scheduledServer, rmap, false, store.ModelAvailable))
 		}
+		// load a bad version - this should not get unloaded by the test
+		versions = append(versions, store.NewModelVersion(config, uint32(numVersions+1), scheduledServer, map[int]store.ReplicaStatus{}, false, store.ScheduleFailed))
+
 		return &store.ModelSnapshot{
 			Name:     name,
 			Versions: versions,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR adds a guard to skip unloading oldversions of the model that are not live as this is not required.

Otherwise this will cause issues downstream. 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

INFRA-1367 (internal)

**Special notes for your reviewer**:

Expanded test to cover this case.