### PR TITLE
fix(operator): Apply scheduler runtime podSpec override

### DIFF
--- a/operator/controllers/reconcilers/seldon/statefulset_reconciler.go
+++ b/operator/controllers/reconcilers/seldon/statefulset_reconciler.go
@@ -87,6 +87,14 @@ func toStatefulSet(
 	} else {
 		replicas = 1
 	}
+	// Merge specs
+	if override != nil && override.PodSpec != nil {
+		var err error
+		podSpec, err = common.MergePodSpecs(podSpec, override.PodSpec)
+		if err != nil {
+			return nil, err
+		}
+	}
 	metaLabels := utils.MergeMaps(map[string]string{constants.KubernetesNameLabelKey: name}, labels)
 	templateLabels := utils.MergeMaps(map[string]string{constants.KubernetesNameLabelKey: name}, labels)
 	ss := &appsv1.StatefulSet{

--- a/operator/controllers/reconcilers/seldon/statefulset_reconciler_test.go
+++ b/operator/controllers/reconcilers/seldon/statefulset_reconciler_test.go
@@ -81,8 +81,8 @@ func TestStatefulSetReconcile(t *testing.T) {
 					{
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("1"),   // overriden below
-								v1.ResourceMemory: resource.MustParse("1Gi"), // overriden below
+								v1.ResourceCPU:    resource.MustParse("1"),   // overridden below
+								v1.ResourceMemory: resource.MustParse("1Gi"), // overridden below
 							},
 						},
 					},


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR actually applies the runtime override for scheduler.podSpec as perviously they were not including in the merging process for deployment.


**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
Tested in kind