### PR TITLE
fix: adjust logging level for dataflow

### DIFF
--- a/docs-gb/installation/helm/README.md
+++ b/docs-gb/installation/helm/README.md
@@ -72,6 +72,7 @@ This section details the key Helm configuration parameters for Envoy, Autoscalin
 | `logging.logLevel` | components | Components wide settings for logging level, if individual component levels are not set. Options are: debug, info, error. | info |
 | `controller.logLevel` | components | check zap log level [here](https://pkg.go.dev/go.uber.org/zap#pkg-constants) | |
 | `dataflow.logLevel` | components | | check klogging level [here](https://dokka.klogging.io/-klogging/io.klogging/-level/index.html) |
+| `dataflow.logLevelKafka` | components | | check klogging level [here](https://dokka.klogging.io/-klogging/io.klogging/-level/index.html) |
 | `scheduler.logLevel` | components | check logrus log level [here](https://pkg.go.dev/github.com/sirupsen/logrus#Level) | |
 | `modelgateway.logLevel` | components | check logrus log level [here](https://pkg.go.dev/github.com/sirupsen/logrus#Level) | |
 | `pipelinegateway.logLevel` | components | check logrus log level [here](https://pkg.go.dev/github.com/sirupsen/logrus#Level) | |

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/seldon-v2-components.yaml
@@ -1070,7 +1070,7 @@ spec:
           value: '{{ hasKey .Values.dataflow "logLevel" | ternary .Values.dataflow.logLevel
             .Values.logging.logLevel | upper }}'
         - name: SELDON_LOG_LEVEL_KAFKA
-          value: '{{ hasKey .Values.dataflow "logLevel" | ternary .Values.dataflow.logLevel
+          value: '{{ hasKey .Values.dataflow "logLevelKafka" | ternary .Values.dataflow.logLevelKafka
             .Values.logging.logLevel | upper }}'
         - name: SELDON_UPSTREAM_HOST
           value: seldon-scheduler

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -171,6 +171,7 @@ dataflow:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  logLevelKafka: info
 
 controller:
   clusterwide: false

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -171,6 +171,7 @@ dataflow:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  logLevelKafka: info
 
 controller:
   clusterwide: false

--- a/k8s/kustomize/helm-components-sc/patch_dataflow.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_dataflow.yaml
@@ -56,7 +56,7 @@ spec:
         - name: SELDON_LOG_LEVEL_APP
           value: '{{ hasKey .Values.dataflow "logLevel" | ternary .Values.dataflow.logLevel .Values.logging.logLevel | upper }}'
         - name: SELDON_LOG_LEVEL_KAFKA
-          value: '{{ hasKey .Values.dataflow "logLevel" | ternary .Values.dataflow.logLevel .Values.logging.logLevel | upper }}'
+          value: '{{ hasKey .Values.dataflow "logLevelKafka" | ternary .Values.dataflow.logLevelKafka .Values.logging.logLevel | upper }}'
         resources:
           requests:
             cpu: '{{ .Values.dataflow.resources.cpu }}'

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Logging.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Logging.kt
@@ -21,11 +21,12 @@ object Logging {
         appLevel: Level = Level.INFO,
         kafkaLevel: Level = Level.WARN,
     ) = loggingConfiguration {
-        kloggingMinLogLevel(appLevel)
         sink(STDOUT_SINK, RENDER_ISO8601, STDOUT)
         logging {
-            fromLoggerBase("io.seldon")
-            toSink(STDOUT_SINK)
+            fromMinLevel(appLevel) {
+                fromLoggerBase("io.seldon")
+                toSink(STDOUT_SINK)
+            }
         }
         logging {
             fromMinLevel(kafkaLevel) {

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Logging.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Logging.kt
@@ -21,6 +21,7 @@ object Logging {
         appLevel: Level = Level.INFO,
         kafkaLevel: Level = Level.WARN,
     ) = loggingConfiguration {
+        kloggingMinLogLevel(appLevel)
         sink(STDOUT_SINK, RENDER_ISO8601, STDOUT)
         logging {
             fromMinLevel(appLevel) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR fixes log level for dataflow engine in the following ways:
- Apply app log level properly, previously it was always fixed at debug. 
- Separate out kafka log level from app log level helm config. To this extent, `dataflow.logLevelKafka` is introduced.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
