### PR TITLE
fix(dataflow): Update default kafka log level for dataflow engine

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -171,7 +171,7 @@ dataflow:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
-  logLevelKafka: info
+  logLevelKafka: warn
 
 controller:
   clusterwide: false

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -171,7 +171,7 @@ dataflow:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
-  logLevelKafka: info
+  logLevelKafka: warn
 
 controller:
   clusterwide: false

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -902,7 +902,7 @@ spec:
         - name: SELDON_LOG_LEVEL_APP
           value: 'INFO'
         - name: SELDON_LOG_LEVEL_KAFKA
-          value: 'INFO'
+          value: 'WARN'
         - name: SELDON_UPSTREAM_HOST
           value: seldon-scheduler
         - name: SELDON_UPSTREAM_PORT


### PR DESCRIPTION
Move from info to warn because kafka streams is very verbose at info level