### PR TITLE
fix(o11s): Filter gpu metrics on exported_namespace

### DIFF
--- a/prometheus/dashboards/provisioning/seldon-gpu.json
+++ b/prometheus/dashboards/provisioning/seldon-gpu.json
@@ -704,7 +704,7 @@
           "datasource": "",
           "editorMode": "code",
           "exemplar": false,
-          "expr": "DCGM_FI_DEV_FB_USED{namespace=~\"^$namespace$\"}",
+          "expr": "DCGM_FI_DEV_FB_USED{namespace=~\"^$exported_namespace$\"}",
           "interval": "",
           "legendFormat": "{{exported_pod}}",
           "range": true,

--- a/prometheus/dashboards/seldon-gpu.json
+++ b/prometheus/dashboards/seldon-gpu.json
@@ -704,7 +704,7 @@
           "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
           "exemplar": false,
-          "expr": "DCGM_FI_DEV_FB_USED{namespace=~\"^$namespace$\"}",
+          "expr": "DCGM_FI_DEV_FB_USED{namespace=~\"^$exported_namespace$\"}",
           "interval": "",
           "legendFormat": "{{exported_pod}}",
           "range": true,


### PR DESCRIPTION
DCGM exporter could potentially run in a different namespace but the metrics have a label `exported_namespace` that points to where the metrics are collected from. We use this instead for filtering.
