### PR TITLE
feat: custom kafka stream join window

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
@@ -194,6 +194,7 @@ class Pipeline(
                             it.sink,
                             it.inputJoinTy,
                             it.triggersJoinTy,
+                            it.joinWindowMs.toLong(),
                             it.batch,
                             kafkaDomainParams,
                         )

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStep.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/PipelineStep.kt
@@ -37,10 +37,19 @@ fun stepFor(
     sink: PipelineTopic,
     joinType: PipelineJoinType,
     triggerJoinType: PipelineJoinType,
+    joinWindowMillis: Long,
     batchProperties: Batch,
     kafkaDomainParams: KafkaDomainParams,
 ): PipelineStep? {
     val triggerTopicsToTensors = parseTriggers(triggerSources)
+    val effectiveKafkaDomainParams =
+        if (joinWindowMillis != 0L) {
+            kafkaDomainParams.copy(
+                joinWindowMillis = joinWindowMillis,
+            )
+        } else {
+            kafkaDomainParams
+        }
     return when (val result = parseSources(sources)) {
         is SourceProjection.Empty -> null
         is SourceProjection.Single ->
@@ -53,7 +62,7 @@ fun stepFor(
                 pipelineVersion,
                 tensorMap,
                 batchProperties,
-                kafkaDomainParams,
+                effectiveKafkaDomainParams,
                 triggerTopicsToTensors.keys,
                 triggerJoinType,
                 triggerTopicsToTensors,
@@ -68,7 +77,7 @@ fun stepFor(
                 pipelineVersion,
                 tensorMap,
                 batchProperties,
-                kafkaDomainParams,
+                effectiveKafkaDomainParams,
                 triggerTopicsToTensors.keys,
                 triggerJoinType,
                 triggerTopicsToTensors,
@@ -82,7 +91,7 @@ fun stepFor(
                 pipelineName,
                 pipelineVersion,
                 tensorMap,
-                kafkaDomainParams,
+                effectiveKafkaDomainParams,
                 joinType,
                 triggerTopicsToTensors.keys,
                 triggerJoinType,
@@ -97,7 +106,7 @@ fun stepFor(
                 pipelineName,
                 pipelineVersion,
                 tensorMap,
-                kafkaDomainParams,
+                effectiveKafkaDomainParams,
                 joinType,
                 triggerTopicsToTensors.keys,
                 triggerJoinType,

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/kafka/PipelineStepTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/kafka/PipelineStepTest.kt
@@ -42,6 +42,7 @@ internal class PipelineStepTest {
                 defaultPipelineTopic,
                 ChainerOuterClass.PipelineStepUpdate.PipelineJoinType.Inner,
                 ChainerOuterClass.PipelineStepUpdate.PipelineJoinType.Inner,
+                0L,
                 ChainerOuterClass.Batch.getDefaultInstance(),
                 kafkaDomainParams,
             )

--- a/scheduler/pkg/kafka/dataflow/server.go
+++ b/scheduler/pkg/kafka/dataflow/server.go
@@ -219,10 +219,11 @@ func (c *ChainerServer) createTriggerSources(inputs []string, pipelineName strin
 
 func (c *ChainerServer) createInputStepUpdate(pv *pipeline.PipelineVersion) *chainer.PipelineStepUpdate {
 	stepUpdate := chainer.PipelineStepUpdate{
-		Sources:   c.createPipelineTopicSources(pv.Input.ExternalInputs),
-		Sink:      &chainer.PipelineTopic{PipelineName: pv.Name, TopicName: c.topicNamer.GetPipelineTopicInputs(pv.Name), Tensor: nil},
-		Triggers:  c.createPipelineTopicSources(pv.Input.ExternalTriggers),
-		TensorMap: c.topicNamer.GetFullyQualifiedPipelineTensorMap(pv.Input.TensorMap),
+		Sources:      c.createPipelineTopicSources(pv.Input.ExternalInputs),
+		Sink:         &chainer.PipelineTopic{PipelineName: pv.Name, TopicName: c.topicNamer.GetPipelineTopicInputs(pv.Name), Tensor: nil},
+		Triggers:     c.createPipelineTopicSources(pv.Input.ExternalTriggers),
+		TensorMap:    c.topicNamer.GetFullyQualifiedPipelineTensorMap(pv.Input.TensorMap),
+		JoinWindowMs: pv.Input.JoinWindowMs,
 	}
 	switch pv.Input.InputsJoinType {
 	case pipeline.JoinInner:
@@ -246,9 +247,10 @@ func (c *ChainerServer) createInputStepUpdate(pv *pipeline.PipelineVersion) *cha
 
 func (c *ChainerServer) createOutputStepUpdate(pv *pipeline.PipelineVersion) *chainer.PipelineStepUpdate {
 	stepUpdate := chainer.PipelineStepUpdate{
-		Sources:   c.createTopicSources(pv.Output.Steps, pv.Name),
-		Sink:      &chainer.PipelineTopic{PipelineName: pv.Name, TopicName: c.topicNamer.GetPipelineTopicOutputs(pv.Name), Tensor: nil},
-		TensorMap: c.topicNamer.GetFullyQualifiedTensorMap(pv.Name, pv.Output.TensorMap),
+		Sources:      c.createTopicSources(pv.Output.Steps, pv.Name),
+		Sink:         &chainer.PipelineTopic{PipelineName: pv.Name, TopicName: c.topicNamer.GetPipelineTopicOutputs(pv.Name), Tensor: nil},
+		TensorMap:    c.topicNamer.GetFullyQualifiedTensorMap(pv.Name, pv.Output.TensorMap),
+		JoinWindowMs: &pv.Output.JoinWindowMs,
 	}
 	switch pv.Output.StepsJoinType {
 	case pipeline.JoinInner:
@@ -264,10 +266,11 @@ func (c *ChainerServer) createOutputStepUpdate(pv *pipeline.PipelineVersion) *ch
 
 func (c *ChainerServer) createStepUpdate(pv *pipeline.PipelineVersion, step *pipeline.PipelineStep) *chainer.PipelineStepUpdate {
 	stepUpdate := chainer.PipelineStepUpdate{
-		Sources:   c.createTopicSources(step.Inputs, pv.Name),
-		Triggers:  c.createTriggerSources(step.Triggers, pv.Name),
-		Sink:      &chainer.PipelineTopic{PipelineName: pv.Name, TopicName: c.topicNamer.GetModelTopicInputs(step.Name), Tensor: nil},
-		TensorMap: c.topicNamer.GetFullyQualifiedTensorMap(pv.Name, step.TensorMap),
+		Sources:      c.createTopicSources(step.Inputs, pv.Name),
+		Triggers:     c.createTriggerSources(step.Triggers, pv.Name),
+		Sink:         &chainer.PipelineTopic{PipelineName: pv.Name, TopicName: c.topicNamer.GetModelTopicInputs(step.Name), Tensor: nil},
+		TensorMap:    c.topicNamer.GetFullyQualifiedTensorMap(pv.Name, step.TensorMap),
+		JoinWindowMs: step.JoinWindowMs,
 	}
 	switch step.InputsJoinType {
 	case pipeline.JoinInner:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
Currently, the `joinWindowMs` for Kafka Streams provided in the manifest file are not passed to the dataflow engine. Dataflow engine uses a predefined value for the length of the joining window (60s). For a pipeline with cycles, this might results in an infinite loop. 

This PR allows the user to pass a custom value for `joinWindowMs` which will be then used by the dataflow engine for the given pipeline, and thus infinite loop scenarios as above can be avoided.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
