### PR TITLE
fix: Desired replicas not being set if not specified in Model spec

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
+++ b/k8s/helm-charts/seldon-core-v2-crds/templates/seldon-v2-crds.yaml
@@ -178,7 +178,7 @@ spec:
       name: Ready
       type: string
     - description: Number of desired replicas
-      jsonPath: .spec.replicas
+      jsonPath: .status.replicas
       name: Desired Replicas
       type: integer
     - description: Number of replicas available to receive inference requests

--- a/k8s/yaml/crds.yaml
+++ b/k8s/yaml/crds.yaml
@@ -181,7 +181,7 @@ spec:
       name: Ready
       type: string
     - description: Number of desired replicas
-      jsonPath: .spec.replicas
+      jsonPath: .status.replicas
       name: Desired Replicas
       type: integer
     - description: Number of replicas available to receive inference requests

--- a/operator/apis/mlops/v1alpha1/model_types.go
+++ b/operator/apis/mlops/v1alpha1/model_types.go
@@ -147,7 +147,7 @@ type ModelStatus struct {
 //+kubebuilder:resource:shortName=mlm
 //+kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 //+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="ModelReady")].status`,description="Model ready status"
-//+kubebuilder:printcolumn:name="Desired Replicas",type=integer,JSONPath=`.spec.replicas`,description="Number of desired replicas"
+//+kubebuilder:printcolumn:name="Desired Replicas",type=integer,JSONPath=`.status.replicas`,description="Number of desired replicas"
 //+kubebuilder:printcolumn:name="Available Replicas",type=integer,JSONPath=`.status.availableReplicas`,description="Number of replicas available to receive inference requests"
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/operator/config/crd/bases/mlops.seldon.io_models.yaml
+++ b/operator/config/crd/bases/mlops.seldon.io_models.yaml
@@ -22,7 +22,7 @@ spec:
       name: Ready
       type: string
     - description: Number of desired replicas
-      jsonPath: .spec.replicas
+      jsonPath: .status.replicas
       name: Desired Replicas
       type: integer
     - description: Number of replicas available to receive inference requests


### PR DESCRIPTION
**What this PR does / why we need it**:
If `replicas` is not set in the `Model` CRD `spec`, the `Desired replicas` print column is showing as empty when a user runs `kubectl get models`. 

**Changes**:
The print column `Desired replicas` not takes its value from `.status.replicas` instead of `.spec.replicas`.

**Special notes for your reviewer**:
Manually run test cases:
- if `replicas` or `minReplicas` is not specified in the `spec`, the desired replicas shows 1 by default
- if `replicas` is set to 1 is the `spec`, the desired replicas shows 1
- if `replicas` is set to 3(and a compatible `Server` has fewer than 3 instances` in the `spec`, the desired replicas shows 3, the available replicas shows as empty and the model is not ready
- if the `minReplicas` is set to 1 in the `spec`, the desired replicas shows 1
- if the `minReplicas` is set to 2 in the `spec`(and a compatible `Server` has 2 instances`, the desired replicas shows 2
- if the `minReplicas` is set to 3 in the `spec`(and a compatible `Server` has 2 instances`, the desired replicas shows 3, and the available replicas show as empty and the model is not ready
- if the `minReplicas` is set to 1 and `maxReplicas` is set to 5 in the `spec`, the desired and available replicas show 1. The same with value 2.
- if the `minReplicas` is set to 3 and `maxReplicas` is set to 5 in the `spec, the desired replicas show 3 and available replicas show as empty, model is not ready - because there are 2 instances of `Server` available.