### PR TITLE
feat(modelgateway): Added support for custom worker timeout

### DIFF
--- a/scheduler/cmd/modelgateway/main.go
+++ b/scheduler/cmd/modelgateway/main.go
@@ -142,6 +142,7 @@ func main() {
 		InferenceServerConfig: inferServerConfig,
 		TraceProvider:         tracer,
 		NumWorkers:            getEnVar(logger, gateway.EnvVarNumWorkers, gateway.DefaultNumWorkers),
+		WorkerTimeout:         getEnVar(logger, gateway.EnvVarWorkerTimeoutMs, gateway.DefaultWorkerTimeoutMs),
 	}
 	kafkaConsumer, err := gateway.NewConsumerManager(logger, &consumerConfig,
 		getEnVar(logger, gateway.EnvMaxNumConsumers, gateway.DefaultMaxNumConsumers))

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -35,7 +35,7 @@ const (
 	pollTimeoutMillisecs        = 10000
 	DefaultNumWorkers           = 8
 	EnvVarNumWorkers            = "MODELGATEWAY_NUM_WORKERS"
-	DefaultWorkerTimeoutMs      = 10 * 60 * 1000
+	DefaultWorkerTimeoutMs      = 2 * 60 * 1000
 	EnvVarWorkerTimeoutMs       = "MODELGATEWAY_WORKER_TIMEOUT_MS"
 	envDefaultReplicationFactor = "KAFKA_DEFAULT_REPLICATION_FACTOR"
 	envDefaultNumPartitions     = "KAFKA_DEFAULT_NUM_PARTITIONS"

--- a/scheduler/pkg/kafka/gateway/infer.go
+++ b/scheduler/pkg/kafka/gateway/infer.go
@@ -35,6 +35,8 @@ const (
 	pollTimeoutMillisecs        = 10000
 	DefaultNumWorkers           = 8
 	EnvVarNumWorkers            = "MODELGATEWAY_NUM_WORKERS"
+	DefaultWorkerTimeoutMs      = 10 * 60 * 1000
+	EnvVarWorkerTimeoutMs       = "MODELGATEWAY_WORKER_TIMEOUT_MS"
 	envDefaultReplicationFactor = "KAFKA_DEFAULT_REPLICATION_FACTOR"
 	envDefaultNumPartitions     = "KAFKA_DEFAULT_NUM_PARTITIONS"
 	defaultReplicationFactor    = 1
@@ -374,7 +376,7 @@ func (kc *InferKafkaHandler) Serve() {
 	jobChan := make(chan *InferWork, kc.consumerConfig.NumWorkers)
 	// Start workers
 	for i := 0; i < kc.consumerConfig.NumWorkers; i++ {
-		go kc.workers[i].Start(jobChan, cancelChan)
+		go kc.workers[i].Start(jobChan, cancelChan, kc.consumerConfig.WorkerTimeout)
 	}
 
 	for run {

--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -46,6 +46,7 @@ type ManagerConfig struct {
 	InferenceServerConfig *InferenceServerConfig
 	TraceProvider         *seldontracer.TracerProvider
 	NumWorkers            int // infer workers
+	WorkerTimeout         int // timeout for workers in ms
 }
 
 func cloneKafkaConfigMap(m kafka.ConfigMap) kafka.ConfigMap {

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -159,7 +159,7 @@ func getProtoInferRequest(job *InferWork) (*v2.ModelInferRequest, error) {
 	return &ireq, nil
 }
 
-func (iw *InferWorker) Start(jobChan <-chan *InferWork, cancelChan <-chan struct{}) {
+func (iw *InferWorker) Start(jobChan <-chan *InferWork, cancelChan <-chan struct{}, inferTimeout int) {
 	for {
 		select {
 		case <-cancelChan:
@@ -167,7 +167,7 @@ func (iw *InferWorker) Start(jobChan <-chan *InferWork, cancelChan <-chan struct
 
 		case job := <-jobChan:
 			ctx := createBaseContextFromKafkaMsg(job.msg)
-			err := iw.processRequest(ctx, job, util.InferTimeoutDefault)
+			err := iw.processRequest(ctx, job, time.Duration(inferTimeout)*time.Millisecond)
 			if err != nil {
 				iw.logger.WithError(err).Errorf("Failed to process request for model %s", job.modelName)
 			}

--- a/scheduler/pkg/util/constants.go
+++ b/scheduler/pkg/util/constants.go
@@ -56,11 +56,6 @@ const (
 	ServerControlPlaneTimeout = time.Second * 5
 )
 
-// inference
-const (
-	InferTimeoutDefault = 10 * time.Minute // TODO: expose this as a config (map)?
-)
-
 const (
 	EnvoyUpdateDefaultBatchWait = 250 * time.Millisecond
 	// note that we keep client and server keepalive times the same


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

This PR adds support for setting a custom worker timeout in modelgateway through envs:
```yaml
env:
  - name: MODELGATEWAY_WORKER_TIMEOUT_MS
    value: "20000"
``` 

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
