### PR TITLE
fix(github): Update image build action to support SBOM attestations

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GITHUB_USER: seldondev
-  KUSTOMIZE_VERSION: 4.5.5
+  KUSTOMIZE_VERSION: 5.2.1
   HELM_VERSION: v3.8.1
 
 jobs:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Echo the tags that will be used to push images
         run: echo "Will push images with tag ${{ steps.docker-tag.outputs.value }}"
 
+      - name: Force docker to use the docker-container driver
+        run: |
+          docker buildx create --name container --driver docker-container --use
+
       - name: Push Docker Image for Operator
         working-directory: ./operator
         run: CUSTOM_IMAGE_TAG=${{ steps.docker-tag.outputs.value }} make docker-build-and-push-prod


### PR DESCRIPTION
-------

# Why
## Issues

Github "Build docker images" action fails with "ERROR: failed to build: Attestation is not supported for the docker driver."