### PR TITLE
fix(ci): kustomize version environment var

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GITHUB_USER: seldondev
-  KUSTOMIZE_VERSION: 5.2.1
+  KUSTOMIZE_VERSION_V: 5.2.1
   HELM_VERSION: v3.8.1
 
 jobs:
@@ -81,7 +81,7 @@ jobs:
 
       - name: Setup Kustomize
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s -- ${KUSTOMIZE_VERSION}
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s -- ${KUSTOMIZE_VERSION_V}
           sudo mv kustomize /usr/local/bin/
 
       - name: Set versions in helm charts and yaml manifests


### PR DESCRIPTION
The github "draft-release" action defined an environment
variable (`KUSTOMIZE_VERSION`) that is now also used by various Core 2
makefiles. However, within the ci action steps expected the version to be
provided without a leading "v" (i.e not v5.2.1 but just 5.2.1) whereas the
makefiles expected the version with the leading v.

The implemented fix adjusts the name of the variable used directly by the
ci action.