### PR TITLE
fix(agent): enable gRPC keep-alive

### DIFF
--- a/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
+++ b/scheduler/pkg/agent/modelserver_controlplane/oip/v2.go
@@ -51,6 +51,7 @@ func CreateV2GrpcConnection(v2Config V2Config) (*grpc.ClientConn, error) {
 	}
 
 	opts := []grpc.DialOption{
+		grpc.WithKeepaliveParams(util.GetClientKeepAliveParameters()),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(v2Config.GRPCMaxMsgSizeBytes), grpc.MaxCallSendMsgSize(v2Config.GRPCMaxMsgSizeBytes)),
 		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(retryOpts...)),

--- a/scheduler/pkg/kafka/gateway/worker.go
+++ b/scheduler/pkg/kafka/gateway/worker.go
@@ -124,6 +124,7 @@ func (iw *InferWorker) getGrpcClient(host string, port int) (v2.GRPCInferenceSer
 	}
 
 	opts := []grpc.DialOption{
+		grpc.WithKeepaliveParams(util.GetClientKeepAliveParameters()),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(util.GRPCMaxMsgSizeBytes),


### PR DESCRIPTION
# Why

Noticed gRPC keep-alives was not enabled between:
- the agent and the model container within the `Server` pod. 
- `model-gw` and `agent` within `Server`

Should help reduce latency on inference requests.


## Issues

## Motivation

# What
## Summary of changes

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
