### PR TITLE
fix: Add a missing filters directive in the TLS envoy config

### DIFF
--- a/scheduler/config/envoy-tls.yaml
+++ b/scheduler/config/envoy-tls.yaml
@@ -51,31 +51,32 @@ static_resources:
           address: 0.0.0.0
           port_value: 9003
       filter_chains:
-        - name: envoy.http_connection_manager
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-            stat_prefix: util_endpoint_http
-            http_filters:
-            - name: envoy.filters.http.health_check
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                pass_through_mode: false
-                headers:
-                  - exact_match: /ready
-                    name: :path
-            - name: envoy.filters.http.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-            route_config:
-              name: local_admin_interface_route
-              virtual_hosts:
-              - name: admin_interface
-                domains: ["*"]
-                routes:
-                - match:
-                    prefix: /stats
-                  route:
-                    cluster: admin_interface_cluster
+        - filters:
+          - name: envoy.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: util_endpoint_http
+              http_filters:
+              - name: envoy.filters.http.health_check
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                  pass_through_mode: false
+                  headers:
+                    - exact_match: /ready
+                      name: :path
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+              route_config:
+                name: local_admin_interface_route
+                virtual_hosts:
+                - name: admin_interface
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /stats
+                    route:
+                      cluster: admin_interface_cluster
 dynamic_resources:
   ads_config:
     api_type: DELTA_GRPC


### PR DESCRIPTION
# Why
## Issues

## Motivation
Envoy doesn't work when TLS is enabled with the existing config file, it throws the following error
```
Protobuf message (type envoy.config.bootstrap.v3.Bootstrap reason INVALID_ARGUMENT: invalid JSON in envoy.config.bootstrap.v3.Bootstrap @ static_resources.listeners[0].filter_chains[0]: message envoy.config.listener.v3.FilterChain, near 1:1375 (offset 1374): no such field: 'typed_config') has unknown fields
```

# What
## Summary of changes
* Adds the filters directive into the filter_chains. This matches the non-TLS config file.
* Re-indents to match the existing format of the file

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
Using the modified config envoy was able to start up and serve traffic