### PR TITLE
fix(pipeline-gw): failed incoming reqs when partitions not available 

### DIFF
--- a/scheduler/pkg/envoy/xdscache/resource.go
+++ b/scheduler/pkg/envoy/xdscache/resource.go
@@ -54,6 +54,7 @@ const (
 	MirrorRouteConfigurationName  = "listener_1"
 	TLSRouteConfigurationName     = "listener_tls"
 
+	// circuitBreakerMaxRetry max parallel retries
 	circuitBreakerMaxRetry  = 5
 	pipelineMaxBackoffRetry = 5
 )

--- a/scheduler/pkg/kafka/pipeline/broadcaster.go
+++ b/scheduler/pkg/kafka/pipeline/broadcaster.go
@@ -1,0 +1,38 @@
+package pipeline
+
+import "sync"
+
+type Broadcaster struct {
+	mu        sync.RWMutex
+	listeners []chan struct{}
+}
+
+func NewBroadcaster() *Broadcaster {
+	return &Broadcaster{}
+}
+
+func (b *Broadcaster) Subscribe() <-chan struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan struct{})
+	b.listeners = append(b.listeners, ch)
+	return ch
+}
+
+func (b *Broadcaster) HasListeners() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return len(b.listeners) > 0
+}
+
+func (b *Broadcaster) Broadcast() {
+	b.mu.Lock()
+	defer b.mu.Lock()
+
+	for _, ch := range b.listeners {
+		close(ch)
+	}
+	b.listeners = b.listeners[:0]
+}

--- a/scheduler/pkg/kafka/pipeline/broadcaster.go
+++ b/scheduler/pkg/kafka/pipeline/broadcaster.go
@@ -8,7 +8,9 @@ type Broadcaster struct {
 }
 
 func NewBroadcaster() *Broadcaster {
-	return &Broadcaster{}
+	return &Broadcaster{
+		listeners: make([]chan struct{}, 0),
+	}
 }
 
 func (b *Broadcaster) Subscribe() <-chan struct{} {

--- a/scheduler/pkg/kafka/pipeline/broadcaster.go
+++ b/scheduler/pkg/kafka/pipeline/broadcaster.go
@@ -31,7 +31,7 @@ func (b *Broadcaster) HasListeners() bool {
 
 func (b *Broadcaster) Broadcast() {
 	b.mu.Lock()
-	defer b.mu.Lock()
+	defer b.mu.Unlock()
 
 	for _, ch := range b.listeners {
 		close(ch)

--- a/scheduler/pkg/kafka/pipeline/broadcaster_test.go
+++ b/scheduler/pkg/kafka/pipeline/broadcaster_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed by
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package pipeline
+
+import (
+	"testing"
+
+	gm "github.com/onsi/gomega"
+)
+
+func TestSubscribe(t *testing.T) {
+	t.Parallel()
+
+	gm.RegisterFailHandler(func(message string, callerSkip ...int) {
+		t.Helper()
+		t.Fatal(message)
+	})
+
+	b := NewBroadcaster()
+
+	ch1 := b.Subscribe()
+	gm.Expect(ch1).ToNot(gm.BeNil())
+
+	ch2 := b.Subscribe()
+	ch3 := b.Subscribe()
+
+	gm.Expect(ch2).ToNot(gm.BeNil())
+	gm.Expect(ch3).ToNot(gm.BeNil())
+
+	gm.Expect(ch1).To(gm.BeIdenticalTo(ch2))
+	gm.Expect(ch1).To(gm.BeIdenticalTo(ch3))
+	gm.Expect(ch2).To(gm.BeIdenticalTo(ch3))
+}
+
+func TestBroadcast(t *testing.T) {
+	t.Parallel()
+
+	gm.RegisterFailHandler(func(message string, callerSkip ...int) {
+		t.Helper()
+		t.Fatal(message)
+	})
+
+	b := NewBroadcaster()
+	b.Broadcast()
+
+	ch1 := b.Subscribe()
+	ch2 := b.Subscribe()
+	ch3 := b.Subscribe()
+
+	b.Broadcast()
+
+	channels := []<-chan struct{}{ch1, ch2, ch3}
+	for i, ch := range channels {
+		gm.Expect(ch).Should(gm.BeClosed(), "channel %d did not receive broadcast", i+1)
+	}
+}
+
+func TestMultipleBroadcasts(t *testing.T) {
+	t.Parallel()
+
+	gm.RegisterFailHandler(func(message string, callerSkip ...int) {
+		t.Helper()
+		t.Fatal(message)
+	})
+
+	b := NewBroadcaster()
+
+	ch1 := b.Subscribe()
+	b.Broadcast()
+
+	gm.Expect(ch1).Should(gm.BeClosed())
+	b.Broadcast()
+
+	ch2 := b.Subscribe()
+	ch3 := b.Subscribe()
+
+	gm.Expect(ch2).Should(gm.Not(gm.BeClosed()))
+	gm.Expect(ch3).Should(gm.Not(gm.BeClosed()))
+
+	b.Broadcast()
+
+	gm.Expect(ch2).Should(gm.BeClosed())
+	gm.Expect(ch3).Should(gm.BeClosed())
+}

--- a/scheduler/pkg/kafka/pipeline/httpserver.go
+++ b/scheduler/pkg/kafka/pipeline/httpserver.go
@@ -182,7 +182,6 @@ func (g *GatewayHttpServer) infer(w http.ResponseWriter, req *http.Request, reso
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		} else {
-			w.WriteHeader(http.StatusOK)
 			go g.metrics.AddPipelineInferMetrics(resourceName, metrics.MethodTypeRest, elapsedTime, metrics.HttpCodeToString(http.StatusOK))
 		}
 	}

--- a/scheduler/pkg/kafka/pipeline/httpserver.go
+++ b/scheduler/pkg/kafka/pipeline/httpserver.go
@@ -126,7 +126,7 @@ func (g *GatewayHttpServer) getRequestId(req *http.Request) string {
 	if len(requestIds) > 0 {
 		requestId = requestIds[0]
 	} else {
-		g.logger.Warning("Failed to find request ID - will generate one")
+		g.logger.Debug("Failed to find request ID - will generate one")
 		requestId = util.CreateRequestId()
 	}
 	return requestId

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -267,14 +267,14 @@ func (km *KafkaManager) Infer(
 	pipeline.consumer.rebalanceMu.RLock()
 	partitions := pipeline.consumer.partitions
 	if len(partitions) == 0 {
-		listener := pipeline.consumer.partitionsReady.Subscribe()
+		ready := pipeline.consumer.partitionsReady.Subscribe()
 		// we must unlock to allow the rebalance callback to notify us when partitions are available
 		pipeline.consumer.rebalanceMu.RUnlock()
 
 		logger := logger.WithField("resource_name", resourceName)
-		logger.Info("Waiting for partition to be available")
+		logger.WithField("timeout", timeoutWaitForPartitions).Warn("Waiting for partition to be available")
 		select {
-		case <-listener:
+		case <-ready:
 			pipeline.consumer.rebalanceMu.RLock()
 		case <-time.After(timeoutWaitForPartitions):
 			return nil, fmt.Errorf("timed out waiting for partitions to be assigned to consumer for pipeline %s", resourceName)

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -15,6 +15,7 @@ import (
 	"math/rand"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/signalfx/splunk-otel-go/instrumentation/github.com/confluentinc/confluent-kafka-go/v2/kafka/splunkkafka"
@@ -32,7 +33,8 @@ import (
 )
 
 const (
-	pollTimeoutMillisecs = 10000
+	pollTimeoutMillisecs     = 10000
+	timeoutWaitForPartitions = time.Second * 5
 )
 
 type PipelineInferer interface {
@@ -265,8 +267,18 @@ func (km *KafkaManager) Infer(
 	pipeline.consumer.rebalanceMu.RLock()
 	partitions := pipeline.consumer.partitions
 	if len(partitions) == 0 {
+		listener := pipeline.consumer.partitionsReady.Subscribe()
 		pipeline.consumer.rebalanceMu.RUnlock()
-		return nil, fmt.Errorf("no partitions assigned for topic %s", resourceName)
+
+		logger.WithField("resource_name", resourceName).Info("Waiting for partition to be available")
+		select {
+		case <-listener:
+			pipeline.consumer.rebalanceMu.RLock()
+		case <-time.After(timeoutWaitForPartitions):
+			return nil, fmt.Errorf("timed out waiting for partitions to be assigned to consumer for pipeline %s", resourceName)
+		}
+
+		logger.WithField("resource_name", resourceName).Info("Received signal, partition ready")
 	}
 
 	// Randomly select a partition to produce the message to
@@ -357,7 +369,7 @@ func createRebalanceCb(km *KafkaManager, mtConsumer *MultiTopicsKafkaConsumer) k
 
 		switch e := ev.(type) {
 		case kafka.AssignedPartitions:
-			logger.Debug("Rebalance: Assigned partitions:", e.Partitions)
+			logger.Info("Rebalance: Assigned partitions:", e.Partitions)
 			err := consumer.Assign(e.Partitions)
 			if err != nil {
 				// Don't modify mtConsumer.partitions on assign failure
@@ -371,8 +383,14 @@ func createRebalanceCb(km *KafkaManager, mtConsumer *MultiTopicsKafkaConsumer) k
 				mtConsumer.partitions[i] = partition.Partition
 			}
 
+			if len(e.Partitions) > 0 && mtConsumer.partitionsReady.HasListeners() {
+				// signal to unblock waiting goroutines to proceed sending inference reqs
+				logger.Infof("Broadcasting to waiting goroutines - partiions are ready")
+				mtConsumer.partitionsReady.Broadcast()
+			}
+
 		case kafka.RevokedPartitions:
-			logger.Debug("Rebalance: Revoked partitions:", e.Partitions)
+			logger.Info("Rebalance: Revoked partitions:", e.Partitions)
 			err := consumer.Unassign()
 			if err != nil {
 				return fmt.Errorf("unassign error: %w", err)

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -386,7 +386,7 @@ func createRebalanceCb(km *KafkaManager, mtConsumer *MultiTopicsKafkaConsumer) k
 
 			if len(e.Partitions) > 0 && mtConsumer.partitionsReady.HasListeners() {
 				// signal to unblock waiting goroutines to proceed sending inference reqs
-				logger.Info("Broadcasting to waiting goroutines - partiions are ready")
+				logger.Info("Broadcasting to waiting goroutines - partitions are ready")
 				mtConsumer.partitionsReady.Broadcast()
 				logger.Info("Broadcast complete")
 			}

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	pollTimeoutMillisecs     = 10000
-	timeoutWaitForPartitions = time.Second * 5
+	timeoutWaitForPartitions = time.Second * 10
 )
 
 type PipelineInferer interface {
@@ -386,8 +386,9 @@ func createRebalanceCb(km *KafkaManager, mtConsumer *MultiTopicsKafkaConsumer) k
 
 			if len(e.Partitions) > 0 && mtConsumer.partitionsReady.HasListeners() {
 				// signal to unblock waiting goroutines to proceed sending inference reqs
-				logger.Infof("Broadcasting to waiting goroutines - partiions are ready")
+				logger.Info("Broadcasting to waiting goroutines - partiions are ready")
 				mtConsumer.partitionsReady.Broadcast()
+				logger.Info("Broadcast complete")
 			}
 
 		case kafka.RevokedPartitions:

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -279,7 +279,9 @@ func (km *KafkaManager) Infer(
 			return nil, fmt.Errorf("timed out waiting for partitions to be assigned to consumer for pipeline %s", resourceName)
 		}
 
-		logger.WithField("resource_name", resourceName).Info("Received signal, partition ready")
+		partitions = pipeline.consumer.partitions
+		logger.WithFields(logrus.Fields{"resource_name": resourceName, "partitions": len(partitions)}).
+			Info("Received signal, partition ready")
 	}
 
 	// Randomly select a partition to produce the message to
@@ -340,7 +342,7 @@ func (km *KafkaManager) Infer(
 	}
 	go func() {
 		evt := <-deliveryChan
-		logger.Infof("Received delivery event %s", evt.String())
+		logger.Debugf("Received delivery event %s", evt.String())
 		span.End()
 	}()
 	logger.Debugf("Waiting for response for request id %s for resource %s on parititon %d", requestId, resourceName, partition)

--- a/scheduler/pkg/kafka/pipeline/kafkamanager.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager.go
@@ -268,6 +268,7 @@ func (km *KafkaManager) Infer(
 	partitions := pipeline.consumer.partitions
 	if len(partitions) == 0 {
 		listener := pipeline.consumer.partitionsReady.Subscribe()
+		// we must unlock to allow the rebalance callback to notify us when partitions are available
 		pipeline.consumer.rebalanceMu.RUnlock()
 
 		logger.WithField("resource_name", resourceName).Info("Waiting for partition to be available")

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -42,6 +42,8 @@ type MultiTopicsKafkaConsumer struct {
 	topicMu     sync.Mutex
 	rebalanceMu sync.RWMutex
 	wg          sync.WaitGroup
+
+	partitionsReady *Broadcaster
 }
 
 func NewMultiTopicsKafkaConsumer(
@@ -51,12 +53,13 @@ func NewMultiTopicsKafkaConsumer(
 	tracer trace.Tracer,
 ) (*MultiTopicsKafkaConsumer, error) {
 	consumer := &MultiTopicsKafkaConsumer{
-		logger:   logger.WithField("source", "MultiTopicsKafkaConsumer"),
-		config:   consumerConfig,
-		topics:   make(map[string]struct{}),
-		id:       id,
-		requests: cmap.New(),
-		tracer:   tracer,
+		logger:          logger.WithField("source", "MultiTopicsKafkaConsumer"),
+		config:          consumerConfig,
+		topics:          make(map[string]struct{}),
+		id:              id,
+		requests:        cmap.New(),
+		tracer:          tracer,
+		partitionsReady: NewBroadcaster(),
 	}
 	err := consumer.createConsumer(logger)
 	return consumer, err

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -37,12 +37,11 @@ type MultiTopicsKafkaConsumer struct {
 	consumer   *kafka.Consumer
 	isActive   atomic.Bool
 	// map of kafka id to request
-	requests    cmap.ConcurrentMap
-	tracer      trace.Tracer
-	topicMu     sync.Mutex
-	rebalanceMu sync.RWMutex
-	wg          sync.WaitGroup
-
+	requests        cmap.ConcurrentMap
+	tracer          trace.Tracer
+	topicMu         sync.Mutex
+	rebalanceMu     sync.RWMutex
+	wg              sync.WaitGroup
 	partitionsReady *Broadcaster
 }
 


### PR DESCRIPTION
# Why

Some inference reqs would fail when no partitions were available to the kafka consumer due to partition revoking, this can happen for many reasons i.e. kafka broker overloaded, connection issues between consumer and broker, consumer too slow etc. 

## Summary of changes

- We now wait for max of `10 seconds` for at least one partition to be available, and then proceed with inference req. If we timeout, we respond with `500`
- Envoy will now backoff retry failed reqs for pipelines which either failed with a `5xx` error or there were connection issues

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
