### PR TITLE
ci(lint): lint PR title via bash

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -17,6 +17,25 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title matches Conventional Commit format
-        uses: matthiashermsen/lint-pull-request-title@v1.0.0
-        with:
-          allowed-pull-request-types: build,ci,docs,feat,fix,refactor,revert,test
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PATTERN="^(build|ci|docs|feat|fix|refactor|revert|test)\([^)]+\): .+$"
+          
+          echo "Validating PR title: '$PR_TITLE'"
+          
+          if [[ $PR_TITLE =~ $PATTERN ]]; then
+            echo "✅ PR title is valid!"
+          else
+            echo "❌ PR title does not match required format!"
+            echo ""
+            echo "Required: type(scope): description"
+            echo "Types: build, ci, docs, feat, fix, refactor, revert, test"
+            echo ""
+            echo "Examples:"
+            echo "  feat(auth): add login functionality"
+            echo "  fix(api): resolve timeout issue"
+            echo "  docs(readme): update installation guide"
+            echo ""
+            echo "Your title: '$PR_TITLE'"
+            exit 1
+          fi

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -17,10 +17,12 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title matches Conventional Commit format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           PATTERN="^(build|ci|docs|feat|fix|refactor|revert|test)\([^)]+\): .+$"
           
-          if [[ ${{ github.event.pull_request.title }} =~ $PATTERN ]]; then
+          if [[ $PR_TITLE =~ $PATTERN ]]; then
             echo "✅ PR title is valid!"
           else
             echo "❌ PR title does not match required format!"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -18,12 +18,9 @@ jobs:
     steps:
       - name: Check PR title matches Conventional Commit format
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           PATTERN="^(build|ci|docs|feat|fix|refactor|revert|test)\([^)]+\): .+$"
           
-          echo "Validating PR title: '$PR_TITLE'"
-          
-          if [[ $PR_TITLE =~ $PATTERN ]]; then
+          if [[ ${{ github.event.pull_request.title }} =~ $PATTERN ]]; then
             echo "✅ PR title is valid!"
           else
             echo "❌ PR title does not match required format!"
@@ -35,7 +32,5 @@ jobs:
             echo "  feat(auth): add login functionality"
             echo "  fix(api): resolve timeout issue"
             echo "  docs(readme): update installation guide"
-            echo ""
-            echo "Your title: '$PR_TITLE'"
             exit 1
           fi


### PR DESCRIPTION
# Why

The owner of the github action we use to validate PR title's has removed his repo. This change will just run the lint check via bash, implementation fully in our control.

## Issues

## Motivation

# What
## Summary of changes

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
