### PR TITLE
fix(pipeline-gw): re-publish in-flight reqs due to partition revoke

### DIFF
--- a/scheduler/pkg/kafka/pipeline/httpserver.go
+++ b/scheduler/pkg/kafka/pipeline/httpserver.go
@@ -164,7 +164,7 @@ func (g *GatewayHttpServer) infer(w http.ResponseWriter, req *http.Request, reso
 	}
 
 	if kafkaRequest.err != nil {
-		logger.Error(string(kafkaRequest.response))
+		logger.WithField("resp_body", kafkaRequest.response).Error("Got upstream error after publishing req")
 		w.WriteHeader(http.StatusBadRequest)
 		_, err = w.Write(createResponseErrorPayload(kafkaRequest.err, kafkaRequest.response))
 		if err != nil {

--- a/scheduler/pkg/kafka/pipeline/httpserver.go
+++ b/scheduler/pkg/kafka/pipeline/httpserver.go
@@ -156,13 +156,13 @@ func (g *GatewayHttpServer) infer(w http.ResponseWriter, req *http.Request, reso
 		return
 	}
 
+	w.Header().Set(util.RequestIdHeader, kafkaRequest.key)
 	for k, vals := range convertKafkaHeadersToHttpHeaders(kafkaRequest.headers) {
 		for _, val := range vals {
 			w.Header().Add(k, val)
 		}
 	}
 
-	w.Header().Set(util.RequestIdHeader, kafkaRequest.key)
 	if kafkaRequest.err != nil {
 		logger.Error(string(kafkaRequest.response))
 		w.WriteHeader(http.StatusBadRequest)

--- a/scheduler/pkg/kafka/pipeline/httpserver.go
+++ b/scheduler/pkg/kafka/pipeline/httpserver.go
@@ -163,27 +163,28 @@ func (g *GatewayHttpServer) infer(w http.ResponseWriter, req *http.Request, reso
 	}
 
 	w.Header().Set(util.RequestIdHeader, kafkaRequest.key)
-	if kafkaRequest.isError {
+	if kafkaRequest.err != nil {
 		logger.Error(string(kafkaRequest.response))
 		w.WriteHeader(http.StatusBadRequest)
-		_, err = w.Write(createResponseErrorPayload(kafkaRequest.errorModel, kafkaRequest.response))
+		_, err = w.Write(createResponseErrorPayload(kafkaRequest.err, kafkaRequest.response))
 		if err != nil {
 			logger.WithError(err).Error("Failed to write error payload")
 		}
+		return
+	}
+
+	resJson, err := ConvertV2ResponseBytesToJson(kafkaRequest.response)
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to convert v2 response to json for resource %s", resourceName)
+		go g.metrics.AddPipelineInferMetrics(resourceName, metrics.MethodTypeRest, elapsedTime, metrics.HttpCodeToString(http.StatusInternalServerError))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	_, err = w.Write(resJson)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
 	} else {
-		resJson, err := ConvertV2ResponseBytesToJson(kafkaRequest.response)
-		if err != nil {
-			logger.WithError(err).Errorf("Failed to convert v2 response to json for resource %s", resourceName)
-			go g.metrics.AddPipelineInferMetrics(resourceName, metrics.MethodTypeRest, elapsedTime, metrics.HttpCodeToString(http.StatusInternalServerError))
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		_, err = w.Write(resJson)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-		} else {
-			go g.metrics.AddPipelineInferMetrics(resourceName, metrics.MethodTypeRest, elapsedTime, metrics.HttpCodeToString(http.StatusOK))
-		}
+		go g.metrics.AddPipelineInferMetrics(resourceName, metrics.MethodTypeRest, elapsedTime, metrics.HttpCodeToString(http.StatusOK))
 	}
 }
 

--- a/scheduler/pkg/kafka/pipeline/kafkamanager_test.go
+++ b/scheduler/pkg/kafka/pipeline/kafkamanager_test.go
@@ -95,6 +95,7 @@ func TestStoreAndLoadPipeline(t *testing.T) {
 			expectedPipelines: 1,
 		},
 	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			km, err := NewKafkaManager(logrus.New(), "default", &kafka_config.KafkaConfig{}, tracer, 10)

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -192,7 +192,9 @@ func (c *MultiTopicsKafkaConsumer) pollAndMatch() error {
 				request.mu.Lock()
 				if request.active {
 					logger.Debugf("Process response for key %s", key)
-					request.errorModel, request.isError = extractErrorHeader(e.Headers)
+					if errMsg, ok := extractErrorHeader(e.Headers); ok {
+						request.err = &errBadRequest{msg: errMsg}
+					}
 					request.response = e.Value
 					request.headers = e.Headers
 					request.wg.Done()

--- a/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
+++ b/scheduler/pkg/kafka/pipeline/multi_topic_consumer.go
@@ -11,6 +11,7 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -193,7 +194,7 @@ func (c *MultiTopicsKafkaConsumer) pollAndMatch() error {
 				if request.active {
 					logger.Debugf("Process response for key %s", key)
 					if errMsg, ok := extractErrorHeader(e.Headers); ok {
-						request.err = &errBadRequest{msg: errMsg}
+						request.err = fmt.Errorf("%s", errMsg)
 					}
 					request.response = e.Value
 					request.headers = e.Headers


### PR DESCRIPTION
# Motivation

When partitions get revoked, we can no loger wait for reqs already published to kafka as we don't have access to the partition and we return an error to the client. This PR will now re-attempt to publish the req once a partition becomes available. 

## Summary of changes

- a new sentinel error `errPartitionRevoked` which infer will treat as a special case and re-attempt to publish the req a max of once, it will wait for a max of 10 seconds for a partition and then error out, at which point envoy backoff retry will manage the retry
- we commit and outstanding offsets when the partitions are revoked

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
