### PR TITLE
[HELM] fix: added changes required to configure annotations for controller deployment

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
@@ -400,8 +400,8 @@ spec:
       control-plane: v2-controller-manager
   template:
     metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: manager
+      annotations: {{- toYaml .Values.controller.annotations | nindent  8
+        }}
       labels:
         control-plane: v2-controller-manager
     spec:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
@@ -400,8 +400,8 @@ spec:
       control-plane: v2-controller-manager
   template:
     metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: manager
+      annotations: {{- toYaml .Values.controller.annotations | nindent  8
+        }}
       labels:
         control-plane: v2-controller-manager
     spec:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -178,6 +178,9 @@ dataflow:
   logLevelKafka: warn
 
 controller:
+  annotations:
+    sidecar.istio.io/inject: "false"
+    kubectl.kubernetes.io/default-container: manager
   clusterwide: false
   skipOperatorClusterRoleCreation: false
   image:

--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml.template
@@ -178,6 +178,9 @@ dataflow:
   logLevelKafka: warn
 
 controller:
+  annotations:
+    sidecar.istio.io/inject: "false"
+    kubectl.kubernetes.io/default-container: manager
   clusterwide: false
   skipOperatorClusterRoleCreation: false
   image:

--- a/k8s/kustomize/helm-components-sc/patch_controller_json6902.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_controller_json6902.yaml
@@ -1,3 +1,7 @@
 - op: replace
   path: /spec/template/spec/securityContext
   value: HACK_REMOVE_ME{{- toYaml .Values.controller.securityContext | nindent 8 }}
+
+- op: add
+  path: /spec/template/metadata/annotations
+  value: HACK_REMOVE_ME{{- toYaml .Values.controller.annotations | nindent  8 }}

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -258,6 +258,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        sidecar.istio.io/inject: "false"
       labels:
         control-plane: v2-controller-manager
     spec:


### PR DESCRIPTION
# Why

This change will help users to configure annotations to the controller deployment from the values file during helm deployment. Example: to disable istio side car injection 

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

