### PR TITLE
feat(dataflow-engine): health probes

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
@@ -1182,6 +1182,8 @@ spec:
             .Values.logging.logLevel | upper }}'
         - name: SELDON_PIPELINE_CTLOPS_THREADS
           value: '{{ .Values.dataflow.pipelineCtlopsThreads }}'
+        - name: SELDON_HEALTH_SERVER_PORT
+          value: "8000"
         - name: SELDON_UPSTREAM_HOST
           value: seldon-scheduler
         - name: SELDON_UPSTREAM_PORT
@@ -1208,13 +1210,35 @@ spec:
         image: '{{ .Values.dataflow.image.registry }}/{{ .Values.dataflow.image.repository
           }}:{{ .Values.dataflow.image.tag }}'
         imagePullPolicy: '{{ .Values.dataflow.image.pullPolicy }}'
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: health
+          periodSeconds: 5
         name: dataflow-engine
+        ports:
+        - containerPort: 8000
+          name: health
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: health
+          periodSeconds: 5
         resources:
           limits:
             memory: '{{ .Values.dataflow.resources.memory }}'
           requests:
             cpu: '{{ .Values.dataflow.resources.cpu }}'
             memory: '{{ .Values.dataflow.resources.memory }}'
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /startup
+            port: health
+          initialDelaySeconds: 3
+          periodSeconds: 5
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
@@ -1182,6 +1182,8 @@ spec:
             .Values.logging.logLevel | upper }}'
         - name: SELDON_PIPELINE_CTLOPS_THREADS
           value: '{{ .Values.dataflow.pipelineCtlopsThreads }}'
+        - name: SELDON_HEALTH_SERVER_PORT
+          value: "8000"
         - name: SELDON_UPSTREAM_HOST
           value: seldon-scheduler
         - name: SELDON_UPSTREAM_PORT
@@ -1208,13 +1210,35 @@ spec:
         image: '{{ .Values.dataflow.image.registry }}/{{ .Values.dataflow.image.repository
           }}:{{ .Values.dataflow.image.tag }}'
         imagePullPolicy: '{{ .Values.dataflow.image.pullPolicy }}'
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: health
+          periodSeconds: 5
         name: dataflow-engine
+        ports:
+        - containerPort: 8000
+          name: health
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: health
+          periodSeconds: 5
         resources:
           limits:
             memory: '{{ .Values.dataflow.resources.memory }}'
           requests:
             cpu: '{{ .Values.dataflow.resources.cpu }}'
             memory: '{{ .Values.dataflow.resources.memory }}'
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /startup
+            port: health
+          initialDelaySeconds: 3
+          periodSeconds: 5
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}

--- a/k8s/kustomize/helm-components-sc/patch_dataflow.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_dataflow.yaml
@@ -59,6 +59,8 @@ spec:
           value: '{{ hasKey .Values.dataflow "logLevelKafka" | ternary .Values.dataflow.logLevelKafka .Values.logging.logLevel | upper }}'
         - name: SELDON_PIPELINE_CTLOPS_THREADS
           value: '{{ .Values.dataflow.pipelineCtlopsThreads }}'
+        - name: SELDON_HEALTH_SERVER_PORT
+          value: "8000"
         resources:
           requests:
             cpu: '{{ .Values.dataflow.resources.cpu }}'

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -1005,6 +1005,8 @@ spec:
           value: 'WARN'
         - name: SELDON_PIPELINE_CTLOPS_THREADS
           value: '8'
+        - name: SELDON_HEALTH_SERVER_PORT
+          value: "8000"
         - name: SELDON_UPSTREAM_HOST
           value: seldon-scheduler
         - name: SELDON_UPSTREAM_PORT
@@ -1030,13 +1032,35 @@ spec:
               fieldPath: metadata.namespace
         image: 'docker.io/seldonio/seldon-dataflow-engine:latest'
         imagePullPolicy: 'IfNotPresent'
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: health
+          periodSeconds: 5
         name: dataflow-engine
+        ports:
+        - containerPort: 8000
+          name: health
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: health
+          periodSeconds: 5
         resources:
           limits:
             memory: '1G'
           requests:
             cpu: '100m'
             memory: '1G'
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /startup
+            port: health
+          initialDelaySeconds: 3
+          periodSeconds: 5
       securityContext:
         fsGroup: 1000
         runAsGroup: 1000

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -41,6 +41,28 @@ spec:
           requests:
             cpu: 100m
             memory: 1G
+        ports:
+          - containerPort: 8000
+            name: health
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /startup
+            port: health
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: health
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: health
+          periodSeconds: 5
       serviceAccountName: seldon-scheduler
       terminationGracePeriodSeconds: 5
   - name: seldon-envoy

--- a/scheduler/data-flow/build.gradle.kts
+++ b/scheduler/data-flow/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("com.github.hierynomus.license-report") version "0.16.1"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     kotlin("jvm") version "2.1.0" // the kotlin version
+    kotlin("plugin.serialization") version "2.1.0" // kotlinx serialization plugin
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     java
     application
@@ -53,6 +54,13 @@ dependencies {
 
     // k8s
     implementation("io.kubernetes:client-java:24.0.0")
+
+    // HTTP server for health probes
+    implementation("io.ktor:ktor-server-core:3.0.1")
+    implementation("io.ktor:ktor-server-netty:3.0.1")
+    implementation("io.ktor:ktor-server-content-negotiation:3.0.1")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.3")

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
@@ -40,6 +40,9 @@ object Cli {
     val dataflowReplicaId = Key("dataflow.replica.id", stringType)
     val pipelineCtlopsThreads = Key("pipeline.ctlops.threads", intType)
 
+    // Health probe server
+    val healthServerPort = Key("health.server.port", intType)
+
     // Seldon components
     val upstreamHost = Key("upstream.host", stringType)
     val upstreamPort = Key("upstream.port", intType)
@@ -82,6 +85,7 @@ object Cli {
             namespace,
             dataflowReplicaId,
             pipelineCtlopsThreads,
+            healthServerPort,
             upstreamHost,
             upstreamPort,
             kafkaBootstrapServers,

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/PipelineSubscriber.kt
@@ -66,8 +66,8 @@ class PipelineSubscriber(
     pipelineCtlopsThreads: Int,
     private val queueCleanupDelayMs: Long = 30_000L,
 ) {
-    private val kafkaAdmin = KafkaAdmin(kafkaAdminProperties, kafkaStreamsParams, topicWaitRetryParams)
-    private val channel =
+    val kafkaAdmin = KafkaAdmin(kafkaAdminProperties, kafkaStreamsParams, topicWaitRetryParams)
+    val channel =
         ManagedChannelBuilder
             .forAddress(upstreamHost, upstreamPort)
             .defaultServiceConfig(grpcServiceConfig)

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/GrpcHealthCheck.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/GrpcHealthCheck.kt
@@ -1,0 +1,134 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import io.grpc.ConnectivityState
+import io.grpc.ManagedChannel
+import io.klogging.noCoLogger
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Health check for gRPC channel connectivity
+ */
+class GrpcHealthCheck(
+    private val channel: ManagedChannel,
+    private val serviceName: String,
+    private val timeoutMs: Long = 5000,
+) : HealthCheck {
+    override val name = "grpc-$serviceName"
+    private val logger = noCoLogger(GrpcHealthCheck::class)
+
+    override suspend fun check(): HealthStatus {
+        return try {
+            val result =
+                withTimeoutOrNull(timeoutMs) {
+                    val state = channel.getState(true) // request connection if idle
+
+                    when (state) {
+                        ConnectivityState.READY -> {
+                            HealthStatus(
+                                isHealthy = true,
+                                message = "gRPC connection is ready",
+                                details =
+                                    mapOf(
+                                        "service" to serviceName,
+                                        "state" to state.name,
+                                        "target" to channel.authority(),
+                                    ),
+                            )
+                        }
+                        ConnectivityState.CONNECTING -> {
+                            HealthStatus(
+                                isHealthy = true,
+                                message = "gRPC connection is establishing",
+                                details =
+                                    mapOf(
+                                        "service" to serviceName,
+                                        "state" to state.name,
+                                        "target" to channel.authority(),
+                                    ),
+                            )
+                        }
+                        ConnectivityState.IDLE -> {
+                            HealthStatus(
+                                isHealthy = true,
+                                message = "gRPC connection is idle but available",
+                                details =
+                                    mapOf(
+                                        "service" to serviceName,
+                                        "state" to state.name,
+                                        "target" to channel.authority(),
+                                    ),
+                            )
+                        }
+                        ConnectivityState.TRANSIENT_FAILURE -> {
+                            HealthStatus(
+                                isHealthy = false,
+                                message = "gRPC connection has transient failure",
+                                details =
+                                    mapOf(
+                                        "service" to serviceName,
+                                        "state" to state.name,
+                                        "target" to channel.authority(),
+                                    ),
+                            )
+                        }
+                        ConnectivityState.SHUTDOWN -> {
+                            HealthStatus(
+                                isHealthy = false,
+                                message = "gRPC connection is shutdown",
+                                details =
+                                    mapOf(
+                                        "service" to serviceName,
+                                        "state" to state.name,
+                                        "target" to channel.authority(),
+                                    ),
+                            )
+                        }
+                        else -> {
+                            HealthStatus(
+                                isHealthy = false,
+                                message = "gRPC connection state unknown: $state",
+                                details =
+                                    mapOf(
+                                        "service" to serviceName,
+                                        "state" to state.name,
+                                        "target" to channel.authority(),
+                                    ),
+                            )
+                        }
+                    }
+                }
+
+            result ?: HealthStatus(
+                isHealthy = false,
+                message = "gRPC health check timed out",
+                details =
+                    mapOf(
+                        "service" to serviceName,
+                        "timeout" to "${timeoutMs}ms",
+                        "target" to channel.authority(),
+                    ),
+            )
+        } catch (e: Exception) {
+            logger.error("Unexpected error in gRPC health check for $serviceName", e)
+            HealthStatus(
+                isHealthy = false,
+                message = "gRPC health check error: ${e.message}",
+                details =
+                    mapOf(
+                        "service" to serviceName,
+                        "error" to e.javaClass.simpleName,
+                        "target" to channel.authority(),
+                    ),
+            )
+        }
+    }
+}

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthCheck.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthCheck.kt
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Health check result
+ */
+@Serializable
+data class HealthStatus(
+    val isHealthy: Boolean,
+    val message: String,
+    val details: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Interface for health checks
+ */
+interface HealthCheck {
+    val name: String
+
+    suspend fun check(): HealthStatus
+}
+
+/**
+ * Aggregated health check result
+ */
+@Serializable
+data class HealthCheckResult(
+    val status: String,
+    val checks: Map<String, HealthStatus>,
+    val overallHealthy: Boolean = checks.values.all { it.isHealthy },
+)

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthServer.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthServer.kt
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import io.klogging.noCoLogger
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+
+/**
+ * HTTP server for Kubernetes health probes
+ */
+class HealthServer(
+    private val port: Int,
+    private val healthService: HealthService,
+    private val scope: CoroutineScope,
+) {
+    private val logger = noCoLogger(HealthServer::class)
+    private var server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>? = null
+    private var serverJob: Job? = null
+
+    /**
+     * Start the health server
+     */
+    fun start() {
+        if (server != null) {
+            logger.warn("Health server is already running")
+            return
+        }
+
+        logger.info("Starting health server on port $port")
+
+        server =
+            embeddedServer(Netty, port = port, host = "0.0.0.0", watchPaths = emptyList()) {
+                install(ContentNegotiation) {
+                    json(
+                        Json {
+                            prettyPrint = true
+                            isLenient = true
+                        },
+                    )
+                }
+
+                routing {
+                    get("/live") {
+                        val result = healthService.checkLiveness()
+                        val statusCode = if (result.overallHealthy) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable
+                        if (statusCode != HttpStatusCode.OK) {
+                            logger.warn("Live health check failed: ${result.status}")
+                        } else {
+                            logger.debug("Live health check passed: ${result.status}")
+                        }
+                        call.response.status(statusCode)
+                        call.respond(result)
+                    }
+
+                    get("/ready") {
+                        val result = healthService.checkReadiness()
+                        val statusCode = if (result.overallHealthy) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable
+                        if (statusCode != HttpStatusCode.OK) {
+                            logger.warn("Ready health check failed: ${result.status}")
+                        } else {
+                            logger.debug("Ready health check passed: ${result.status}")
+                        }
+                        call.response.status(statusCode)
+                        call.respond(result)
+                    }
+
+                    get("/startup") {
+                        try {
+                            val result = healthService.checkStartup()
+                            val statusCode = if (result.overallHealthy) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable
+                            if (statusCode != HttpStatusCode.OK) {
+                                logger.warn("Startup health check failed: ${result.status}")
+                            } else {
+                                logger.debug("Startup health check passed: ${result.status}")
+                            }
+                            call.response.status(statusCode)
+                            call.respond(result)
+                        } catch (e: Exception) {
+                            logger.error("Exception occurred during startup health check: ${e.message}", e)
+                            val errorResult =
+                                HealthCheckResult(
+                                    overallHealthy = false,
+                                    status = "DOWN",
+                                    checks =
+                                        mapOf(
+                                            "startup-error" to
+                                                HealthStatus(
+                                                    isHealthy = false,
+                                                    message = "Startup health check failed with exception: ${e.message}",
+                                                    details = mapOf("exception" to e.javaClass.simpleName),
+                                                ),
+                                        ),
+                                )
+                            call.response.status(HttpStatusCode.InternalServerError)
+                            call.respond(errorResult)
+                        }
+                    }
+                }
+            }
+
+        serverJob =
+            scope.launch {
+                try {
+                    server?.start(wait = false)
+                } catch (e: Exception) {
+                    logger.error("Health server failed", e)
+                }
+            }
+
+        logger.info("Health server started successfully on port $port")
+    }
+
+    /**
+     * Stop the health server
+     */
+    fun stop() {
+        logger.info("Stopping health server")
+
+        serverJob?.cancel()
+        server?.stop(1000, 5000)
+
+        server = null
+        serverJob = null
+
+        logger.info("Health server stopped")
+    }
+}

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthService.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthService.kt
@@ -47,13 +47,6 @@ class HealthService {
         logger.debug("Added startup health check: ${healthCheck.name}")
     }
 
-    /**
-     * Register a health check for both liveness and readiness probes
-     */
-    fun addHealthCheck(healthCheck: HealthCheck) {
-        addLivenessCheck(healthCheck)
-        addReadinessCheck(healthCheck)
-    }
 
     /**
      * Execute liveness health checks

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthService.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthService.kt
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import io.klogging.noCoLogger
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Service for managing and executing health checks
+ */
+class HealthService {
+    private val logger = noCoLogger(HealthService::class)
+    private val livenessChecks = mutableListOf<HealthCheck>()
+    private val readinessChecks = mutableListOf<HealthCheck>()
+    private val startupChecks = mutableListOf<HealthCheck>()
+
+    /**
+     * Register a health check for liveness probe
+     */
+    fun addLivenessCheck(healthCheck: HealthCheck) {
+        livenessChecks.add(healthCheck)
+        logger.debug("Added liveness health check: ${healthCheck.name}")
+    }
+
+    /**
+     * Register a health check for readiness probe
+     */
+    fun addReadinessCheck(healthCheck: HealthCheck) {
+        readinessChecks.add(healthCheck)
+        logger.debug("Added readiness health check: ${healthCheck.name}")
+    }
+
+    /**
+     * Register a health check for startup probe
+     */
+    fun addStartupCheck(healthCheck: HealthCheck) {
+        startupChecks.add(healthCheck)
+        logger.debug("Added startup health check: ${healthCheck.name}")
+    }
+
+    /**
+     * Register a health check for both liveness and readiness probes
+     */
+    fun addHealthCheck(healthCheck: HealthCheck) {
+        addLivenessCheck(healthCheck)
+        addReadinessCheck(healthCheck)
+    }
+
+    /**
+     * Execute liveness health checks
+     */
+    suspend fun checkLiveness(): HealthCheckResult {
+        return executeHealthChecks(livenessChecks, "liveness")
+    }
+
+    /**
+     * Execute readiness health checks
+     */
+    suspend fun checkReadiness(): HealthCheckResult {
+        return executeHealthChecks(readinessChecks, "readiness")
+    }
+
+    /**
+     * Execute startup health checks
+     */
+    suspend fun checkStartup(): HealthCheckResult {
+        return executeHealthChecks(startupChecks, "startup")
+    }
+
+    private suspend fun executeHealthChecks(
+        checks: List<HealthCheck>,
+        type: String,
+    ): HealthCheckResult {
+        return try {
+            val results =
+                coroutineScope {
+                    checks.map { healthCheck ->
+                        async {
+                            try {
+                                healthCheck.name to healthCheck.check()
+                            } catch (e: Exception) {
+                                logger.error("Health check ${healthCheck.name} failed with exception", e)
+                                healthCheck.name to
+                                    HealthStatus(
+                                        isHealthy = false,
+                                        message = "Health check failed: ${e.message}",
+                                        details = mapOf("error" to e.javaClass.simpleName),
+                                    )
+                            }
+                        }
+                    }.awaitAll().toMap()
+                }
+
+            val overallHealthy = results.values.all { it.isHealthy }
+            val status = if (overallHealthy) "UP" else "DOWN"
+
+            logger.debug("$type health check result: $status (${results.size} checks)")
+
+            HealthCheckResult(
+                status = status,
+                checks = results,
+                overallHealthy = overallHealthy,
+            )
+        } catch (e: Exception) {
+            logger.error("Failed to execute $type health checks", e)
+            HealthCheckResult(
+                status = "DOWN",
+                checks =
+                    mapOf(
+                        "system" to
+                            HealthStatus(
+                                isHealthy = false,
+                                message = "Failed to execute health checks: ${e.message}",
+                                details = mapOf("error" to e.javaClass.simpleName),
+                            ),
+                    ),
+                overallHealthy = false,
+            )
+        }
+    }
+}

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthService.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/HealthService.kt
@@ -47,7 +47,6 @@ class HealthService {
         logger.debug("Added startup health check: ${healthCheck.name}")
     }
 
-
     /**
      * Execute liveness health checks
      */

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/ServiceHealthCheck.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/health/ServiceHealthCheck.kt
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import io.klogging.noCoLogger
+import io.seldon.dataflow.PipelineSubscriber
+import kotlinx.coroutines.isActive
+
+/**
+ * Health check for internal service health - verifies the service is alive and can potentially recover from external issues
+ */
+class ServiceHealthCheck(
+    private val pipelineSubscriber: PipelineSubscriber,
+) : HealthCheck {
+    override val name = "service"
+    private val logger = noCoLogger(ServiceHealthCheck::class)
+
+    override suspend fun check(): HealthStatus {
+        return try {
+            // Check if the main coroutine scope is still active
+            val scopeActive = pipelineSubscriber.scope.isActive
+
+            // Check if the dispatcher is still functional
+            val dispatcherActive = pipelineSubscriber.dispatcher.isActive
+
+            val isHealthy = scopeActive && dispatcherActive
+
+            val message =
+                when {
+                    !scopeActive -> "Main coroutine scope is not active"
+                    !dispatcherActive -> "Thread dispatcher is shutdown"
+                    else -> "Service is running normally"
+                }
+
+            HealthStatus(
+                isHealthy = isHealthy,
+                message = message,
+                details =
+                    mapOf(
+                        "scopeActive" to scopeActive.toString(),
+                        "dispatcherActive" to dispatcherActive.toString(),
+                    ),
+            )
+        } catch (e: Exception) {
+            logger.error("Unexpected error in service health check", e)
+            HealthStatus(
+                isHealthy = false,
+                message = "Service health check error: ${e.message}",
+                details = mapOf("error" to e.javaClass.simpleName),
+            )
+        }
+    }
+}

--- a/scheduler/data-flow/src/main/resources/local.properties
+++ b/scheduler/data-flow/src/main/resources/local.properties
@@ -27,3 +27,5 @@ topic.create.timeout.millis=60000
 topic.describe.timeout.millis=1000
 topic.describe.retry.attempts=60
 topic.describe.retry.delay.millis=1000
+http.server.port=8000
+

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/GrpcHealthCheckTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/GrpcHealthCheckTest.kt
@@ -24,38 +24,7 @@ class GrpcHealthCheckTest {
     fun `should return healthy status when grpc channel is ready`() =
         runBlocking {
             // Given
-            val mockChannel =
-                object : ManagedChannel() {
-                    override fun getState(requestConnection: Boolean) = ConnectivityState.READY
-
-                    override fun authority() = "test-service:9000"
-
-                    override fun shutdown() = this
-
-                    override fun shutdownNow() = this
-
-                    override fun isShutdown() = false
-
-                    override fun isTerminated() = false
-
-                    override fun awaitTermination(
-                        timeout: Long,
-                        unit: TimeUnit,
-                    ) = false
-
-                    override fun notifyWhenStateChanged(
-                        source: ConnectivityState,
-                        callback: Runnable,
-                    ) {}
-
-                    override fun <RequestT, ResponseT> newCall(
-                        methodDescriptor: io.grpc.MethodDescriptor<RequestT, ResponseT>,
-                        callOptions: io.grpc.CallOptions,
-                    ) = throw UnsupportedOperationException("Mock implementation")
-
-                    override fun resetConnectBackoff() {}
-                }
-
+            val mockChannel = createMockChannel(ConnectivityState.READY)
             val healthCheck = GrpcHealthCheck(mockChannel, "test-service")
 
             // When

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/GrpcHealthCheckTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/GrpcHealthCheckTest.kt
@@ -1,0 +1,178 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import io.grpc.ConnectivityState
+import io.grpc.ManagedChannel
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+import java.util.concurrent.TimeUnit
+
+class GrpcHealthCheckTest {
+    @Test
+    fun `should return healthy status when grpc channel is ready`() =
+        runBlocking {
+            // Given
+            val mockChannel =
+                object : ManagedChannel() {
+                    override fun getState(requestConnection: Boolean) = ConnectivityState.READY
+
+                    override fun authority() = "test-service:9000"
+
+                    override fun shutdown() = this
+
+                    override fun shutdownNow() = this
+
+                    override fun isShutdown() = false
+
+                    override fun isTerminated() = false
+
+                    override fun awaitTermination(
+                        timeout: Long,
+                        unit: TimeUnit,
+                    ) = false
+
+                    override fun notifyWhenStateChanged(
+                        source: ConnectivityState,
+                        callback: Runnable,
+                    ) {}
+
+                    override fun <RequestT, ResponseT> newCall(
+                        methodDescriptor: io.grpc.MethodDescriptor<RequestT, ResponseT>,
+                        callOptions: io.grpc.CallOptions,
+                    ) = throw UnsupportedOperationException("Mock implementation")
+
+                    override fun resetConnectBackoff() {}
+                }
+
+            val healthCheck = GrpcHealthCheck(mockChannel, "test-service")
+
+            // When
+            val result = healthCheck.check()
+
+            // Then
+            expectThat(result) {
+                get { isHealthy }.isTrue()
+                get { message }.isEqualTo("gRPC connection is ready")
+                get { details["service"] }.isEqualTo("test-service")
+                get { details["state"] }.isEqualTo("READY")
+                get { details["target"] }.isEqualTo("test-service:9000")
+            }
+        }
+
+    @Test
+    fun `should return healthy status when grpc channel is connecting`() =
+        runBlocking {
+            // Given
+            val mockChannel = createMockChannel(ConnectivityState.CONNECTING)
+            val healthCheck = GrpcHealthCheck(mockChannel, "test-service")
+
+            // When
+            val result = healthCheck.check()
+
+            // Then
+            expectThat(result) {
+                get { isHealthy }.isTrue()
+                get { message }.isEqualTo("gRPC connection is establishing")
+                get { details["state"] }.isEqualTo("CONNECTING")
+            }
+        }
+
+    @Test
+    fun `should return healthy status when grpc channel is idle`() =
+        runBlocking {
+            // Given
+            val mockChannel = createMockChannel(ConnectivityState.IDLE)
+            val healthCheck = GrpcHealthCheck(mockChannel, "test-service")
+
+            // When
+            val result = healthCheck.check()
+
+            // Then
+            expectThat(result) {
+                get { isHealthy }.isTrue()
+                get { message }.isEqualTo("gRPC connection is idle but available")
+                get { details["state"] }.isEqualTo("IDLE")
+            }
+        }
+
+    @Test
+    fun `should return unhealthy status when grpc channel has transient failure`() =
+        runBlocking {
+            // Given
+            val mockChannel = createMockChannel(ConnectivityState.TRANSIENT_FAILURE)
+            val healthCheck = GrpcHealthCheck(mockChannel, "test-service")
+
+            // When
+            val result = healthCheck.check()
+
+            // Then
+            expectThat(result) {
+                get { isHealthy }.isFalse()
+                get { message }.isEqualTo("gRPC connection has transient failure")
+                get { details["state"] }.isEqualTo("TRANSIENT_FAILURE")
+            }
+        }
+
+    @Test
+    fun `should return unhealthy status when grpc channel is shutdown`() =
+        runBlocking {
+            // Given
+            val mockChannel = createMockChannel(ConnectivityState.SHUTDOWN)
+            val healthCheck = GrpcHealthCheck(mockChannel, "test-service")
+
+            // When
+            val result = healthCheck.check()
+
+            // Then
+            expectThat(result) {
+                get { isHealthy }.isFalse()
+                get { message }.isEqualTo("gRPC connection is shutdown")
+                get { details["state"] }.isEqualTo("SHUTDOWN")
+            }
+        }
+
+    private fun createMockChannel(state: ConnectivityState): ManagedChannel {
+        return object : ManagedChannel() {
+            override fun getState(requestConnection: Boolean) = state
+
+            override fun authority() = "test-service:9000"
+
+            override fun shutdown() = this
+
+            override fun shutdownNow() = this
+
+            override fun isShutdown() = false
+
+            override fun isTerminated() = false
+
+            override fun awaitTermination(
+                timeout: Long,
+                unit: TimeUnit,
+            ) = false
+
+            override fun notifyWhenStateChanged(
+                source: ConnectivityState,
+                callback: Runnable,
+            ) {}
+
+            override fun <RequestT, ResponseT> newCall(
+                methodDescriptor: io.grpc.MethodDescriptor<RequestT, ResponseT>,
+                callOptions: io.grpc.CallOptions,
+            ) = throw UnsupportedOperationException("Mock implementation")
+
+            override fun resetConnectBackoff() {}
+        }
+    }
+}

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/HealthServerTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/HealthServerTest.kt
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.isEqualTo
+import java.net.ServerSocket
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+class HealthServerTest {
+    private var healthServer: HealthServer? = null
+    private val testScope = CoroutineScope(SupervisorJob())
+
+    @AfterEach
+    fun cleanup() {
+        healthServer?.stop()
+        healthServer = null
+    }
+
+    @Test
+    fun `should start and stop health server successfully`() {
+        // Given
+        val healthService = HealthService()
+        healthServer = HealthServer(0, healthService, testScope) // Port 0 for random port
+
+        // When & Then - Should not throw
+        healthServer!!.start()
+        healthServer!!.stop()
+    }
+
+    @Test
+    fun `should respond to health endpoints when started`() =
+        runBlocking {
+            // Given
+            val port = findAvailablePort()
+            val healthService = HealthService()
+            val healthCheck = createMockHealthCheck("test", true, "All good")
+            healthService.addLivenessCheck(healthCheck)
+            healthService.addReadinessCheck(healthCheck)
+
+            healthServer = HealthServer(port, healthService, testScope)
+            healthServer!!.start()
+
+            // Wait for server to start
+            delay(500)
+
+            val client = HttpClient.newHttpClient()
+
+            // When & Then - Test liveness endpoint
+            val livenessRequest =
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:$port/live"))
+                    .GET()
+                    .build()
+
+            val livenessResponse = client.send(livenessRequest, HttpResponse.BodyHandlers.ofString())
+            expectThat(livenessResponse.statusCode()).isEqualTo(200)
+            expectThat(livenessResponse.body()).contains("UP")
+
+            // Test readiness endpoint
+            val readinessRequest =
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:$port/ready"))
+                    .GET()
+                    .build()
+
+            val readinessResponse = client.send(readinessRequest, HttpResponse.BodyHandlers.ofString())
+            expectThat(readinessResponse.statusCode()).isEqualTo(200)
+            expectThat(readinessResponse.body()).contains("UP")
+
+            // Test startup endpoint
+            val startupRequest =
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:$port/startup"))
+                    .GET()
+                    .build()
+
+            val startupResponse = client.send(startupRequest, HttpResponse.BodyHandlers.ofString())
+            expectThat(startupResponse.statusCode()).isEqualTo(200)
+
+            // Test root endpoint
+            val rootRequest =
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:$port/"))
+                    .GET()
+                    .build()
+
+            val rootResponse = client.send(rootRequest, HttpResponse.BodyHandlers.ofString())
+            expectThat(rootResponse.statusCode()).isEqualTo(200)
+            expectThat(rootResponse.body()).contains("Seldon DataFlow Engine Health Server")
+        }
+
+    @Test
+    fun `should return 503 status when health checks fail`() =
+        runBlocking {
+            // Given
+            val port = findAvailablePort()
+            val healthService = HealthService()
+            val unhealthyCheck = createMockHealthCheck("test", false, "Something wrong")
+            healthService.addLivenessCheck(unhealthyCheck)
+            healthService.addReadinessCheck(unhealthyCheck)
+
+            healthServer = HealthServer(port, healthService, testScope)
+            healthServer!!.start()
+
+            // Wait for server to start
+            delay(500)
+
+            val client = HttpClient.newHttpClient()
+
+            // When
+            val request =
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:$port/live"))
+                    .GET()
+                    .build()
+
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+            // Then
+            expectThat(response.statusCode()).isEqualTo(503) // Service Unavailable
+            expectThat(response.body()).contains("DOWN")
+            expectThat(response.body()).contains("Something wrong")
+        }
+
+    private fun createMockHealthCheck(
+        name: String,
+        isHealthy: Boolean,
+        message: String,
+    ): HealthCheck {
+        return object : HealthCheck {
+            override val name = name
+
+            override suspend fun check(): HealthStatus {
+                return HealthStatus(isHealthy, message)
+            }
+        }
+    }
+
+    private fun findAvailablePort(): Int {
+        return ServerSocket(0).use { socket ->
+            socket.localPort
+        }
+    }
+}

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/HealthServiceTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/health/HealthServiceTest.kt
@@ -1,0 +1,237 @@
+/*
+Copyright (c) 2024 Seldon Technologies Ltd.
+
+Use of this software is governed BY
+(1) the license included in the LICENSE file or
+(2) if the license included in the LICENSE file is the Business Source License 1.1,
+the Change License after the Change Date as each is defined in accordance with the LICENSE file.
+*/
+
+package io.seldon.dataflow.health
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isLessThan
+import strikt.assertions.isNotNull
+import strikt.assertions.isTrue
+
+class HealthServiceTest {
+    @Test
+    fun `should return healthy status when all liveness checks pass`() =
+        runBlocking {
+            // Given
+            val healthService = HealthService()
+            val healthyCheck1 = createMockHealthCheck("check1", true, "All good")
+            val healthyCheck2 = createMockHealthCheck("check2", true, "Working fine")
+
+            healthService.addLivenessCheck(healthyCheck1)
+            healthService.addLivenessCheck(healthyCheck2)
+
+            // When
+            val result = healthService.checkLiveness()
+
+            // Then
+            expectThat(result) {
+                get { status }.isEqualTo("UP")
+                get { overallHealthy }.isTrue()
+                get { checks.size }.isEqualTo(2)
+                get { checks["check1"]?.isHealthy }.isTrue()
+                get { checks["check2"]?.isHealthy }.isTrue()
+            }
+        }
+
+    @Test
+    fun `should return unhealthy status when any liveness check fails`() =
+        runBlocking {
+            // Given
+            val healthService = HealthService()
+            val healthyCheck = createMockHealthCheck("healthy", true, "All good")
+            val unhealthyCheck = createMockHealthCheck("unhealthy", false, "Something wrong")
+
+            healthService.addLivenessCheck(healthyCheck)
+            healthService.addLivenessCheck(unhealthyCheck)
+
+            // When
+            val result = healthService.checkLiveness()
+
+            // Then
+            expectThat(result) {
+                get { status }.isEqualTo("DOWN")
+                get { overallHealthy }.isFalse()
+                get { checks.size }.isEqualTo(2)
+                get { checks["healthy"]?.isHealthy }.isTrue()
+                get { checks["unhealthy"]?.isHealthy }.isFalse()
+                get { checks["unhealthy"]?.message }.isEqualTo("Something wrong")
+            }
+        }
+
+    @Test
+    fun `should return healthy status when all readiness checks pass`() =
+        runBlocking {
+            // Given
+            val healthService = HealthService()
+            val readyCheck1 = createMockHealthCheck("ready1", true, "Ready to serve")
+            val readyCheck2 = createMockHealthCheck("ready2", true, "All systems go")
+
+            healthService.addReadinessCheck(readyCheck1)
+            healthService.addReadinessCheck(readyCheck2)
+
+            // When
+            val result = healthService.checkReadiness()
+
+            // Then
+            expectThat(result) {
+                get { status }.isEqualTo("UP")
+                get { overallHealthy }.isTrue()
+                get { checks.size }.isEqualTo(2)
+                get { checks["ready1"]?.isHealthy }.isTrue()
+                get { checks["ready2"]?.isHealthy }.isTrue()
+            }
+        }
+
+    @Test
+    fun `should return unhealthy status when any readiness check fails`() =
+        runBlocking {
+            // Given
+            val healthService = HealthService()
+            val readyCheck = createMockHealthCheck("ready", true, "Ready to serve")
+            val notReadyCheck = createMockHealthCheck("not-ready", false, "Still initializing")
+
+            healthService.addReadinessCheck(readyCheck)
+            healthService.addReadinessCheck(notReadyCheck)
+
+            // When
+            val result = healthService.checkReadiness()
+
+            // Then
+            expectThat(result) {
+                get { status }.isEqualTo("DOWN")
+                get { overallHealthy }.isFalse()
+                get { checks.size }.isEqualTo(2)
+                get { checks["ready"]?.isHealthy }.isTrue()
+                get { checks["not-ready"]?.isHealthy }.isFalse()
+                get { checks["not-ready"]?.message }.isEqualTo("Still initializing")
+            }
+        }
+
+    @Test
+    fun `should handle separate liveness and readiness checks`() =
+        runBlocking {
+            // Given
+            val healthService = HealthService()
+            val livenessCheck = createMockHealthCheck("liveness", true, "Liveness check")
+            val readinessCheck = createMockHealthCheck("readiness", true, "Readiness check")
+
+            healthService.addLivenessCheck(livenessCheck)
+            healthService.addReadinessCheck(readinessCheck)
+
+            // When
+            val livenessResult = healthService.checkLiveness()
+            val readinessResult = healthService.checkReadiness()
+
+            // Then
+            expectThat(livenessResult) {
+                get { checks.size }.isEqualTo(1)
+                get { checks["liveness"]?.isHealthy }.isTrue()
+            }
+
+            expectThat(readinessResult) {
+                get { checks.size }.isEqualTo(1)
+                get { checks["readiness"]?.isHealthy }.isTrue()
+            }
+        }
+
+    @Test
+    fun `should handle exceptions in health checks gracefully`() =
+        runBlocking {
+            // Given
+            val healthService = HealthService()
+            val failingCheck =
+                object : HealthCheck {
+                    override val name = "failing-check"
+
+                    override suspend fun check(): HealthStatus {
+                        throw RuntimeException("Unexpected error")
+                    }
+                }
+
+            healthService.addLivenessCheck(failingCheck)
+
+            // When
+            val result = healthService.checkLiveness()
+
+            // Then
+            expectThat(result) {
+                get { status }.isEqualTo("DOWN")
+                get { overallHealthy }.isFalse()
+                get { checks.size }.isEqualTo(1)
+                get { checks["failing-check"]?.isHealthy }.isFalse()
+                get { checks["failing-check"]?.message }.isNotNull().contains("Health check failed")
+                get { checks["failing-check"]?.details?.get("error") }.isEqualTo("RuntimeException")
+            }
+        }
+
+    @Test
+    fun `should execute health checks in parallel`() =
+        runBlocking {
+            // Given
+            val healthService = HealthService()
+            val slowCheck1 =
+                object : HealthCheck {
+                    override val name = "slow1"
+
+                    override suspend fun check(): HealthStatus {
+                        delay(200)
+                        return HealthStatus(true, "Slow check 1")
+                    }
+                }
+
+            val slowCheck2 =
+                object : HealthCheck {
+                    override val name = "slow2"
+
+                    override suspend fun check(): HealthStatus {
+                        delay(200)
+                        return HealthStatus(true, "Slow check 2")
+                    }
+                }
+
+            healthService.addLivenessCheck(slowCheck1)
+            healthService.addLivenessCheck(slowCheck2)
+
+            // When
+            val startTime = System.currentTimeMillis()
+            val result = healthService.checkLiveness()
+            val duration = System.currentTimeMillis() - startTime
+
+            // Then
+            expectThat(result) {
+                get { status }.isEqualTo("UP")
+                get { overallHealthy }.isTrue()
+                get { checks.size }.isEqualTo(2)
+            }
+
+            // Should complete in less than 350ms (parallel execution)
+            // If sequential, it would take at least 400ms
+            expectThat(duration).isLessThan(350)
+        }
+
+    private fun createMockHealthCheck(
+        name: String,
+        isHealthy: Boolean,
+        message: String,
+    ): HealthCheck {
+        return object : HealthCheck {
+            override val name = name
+
+            override suspend fun check(): HealthStatus {
+                return HealthStatus(isHealthy, message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

We require health probes on `dataflow-engine` for k8s to know if the service is not healthy and if it should be restarted for example.

## Summary of changes

- startup probe to ensure connection to `scheduler` is established
- readiness/liveness probes tests the coroutines are still active and running on the pipeline subsciber 

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
