### PR TITLE
fix(model-gw): repeated identical subscription reqs sent to kafka

### DIFF
--- a/scheduler/pkg/kafka/gateway/manager.go
+++ b/scheduler/pkg/kafka/gateway/manager.go
@@ -214,6 +214,7 @@ func (cm *ConsumerManager) RemoveModel(modelName string, cleanTopicsOnDeletion b
 	if ic == nil {
 		return nil
 	}
+
 	err = ic.RemoveModel(modelName, cleanTopicsOnDeletion, keepTopics)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Motivation

When `model-gw` is receving multiple msgs from `scheduler` informing no replicas are available for a model, `model-gw` is subscribing to the same topics multiple times. This was observed in load testing as a model state changes.

## Summary of changes

- Check if model is currently subscribed to when removal attempted, if not, return nil.

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
