### PR TITLE
chore(helm): 3GB default dataflow memory req/limit

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/values.yaml
+++ b/k8s/helm-charts/seldon-core-v2-setup/values.yaml
@@ -171,7 +171,7 @@ dataflow:
   cores: 4
   resources:
     cpu: 100m
-    memory: 1G
+    memory: 3G
   securityContext:
     fsGroup: 1000
     runAsUser: 1000


### PR DESCRIPTION
# Why

Recently been observed `dataflow-engine` can take up to  `1.5GB` when under load and also seemingly idle. 

# What

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
