### PR TITLE
fix(agent): force disable auto-scaling of models on agent/scheduler

### DIFF
--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -116,6 +116,9 @@ func termSignalErrHandler(logger *log.Logger, errChan <-chan error) {
 }
 
 func main() {
+	// we force auto-scaling to be disabled until scale-up issue is resoled
+	autoScalingEnabled := false
+
 	logger := log.New()
 
 	cli.UpdateArgs()
@@ -223,8 +226,7 @@ func main() {
 		modelScalingStatsCollector *modelscaling.DataPlaneStatsCollector
 		modelScalingService        *modelscaling.StatsAnalyserService
 	)
-	// we force auto-scaling to be disabled until scale-up issue is resoled
-	autoScalingEnabled := false
+
 	if autoScalingEnabled {
 		modelLagStatsWrapper := modelscaling.ModelScalingStatsWrapper{
 			Stats:     modelscaling.NewModelReplicaLagsKeeper(),

--- a/scheduler/cmd/agent/main.go
+++ b/scheduler/cmd/agent/main.go
@@ -219,24 +219,36 @@ func main() {
 	}()
 	defer func() { _ = promMetrics.Stop() }()
 
-	modelLagStatsWrapper := modelscaling.ModelScalingStatsWrapper{
-		Stats:     modelscaling.NewModelReplicaLagsKeeper(),
-		Operator:  interfaces.Gte,
-		Threshold: uint(cli.ModelInferenceLagThreshold),
-		Reset:     true,
-		EventType: modelscaling.ScaleUpEvent,
-	}
-	modelLastUsedStatsWrapper := modelscaling.ModelScalingStatsWrapper{
-		Stats:     modelscaling.NewModelReplicaLastUsedKeeper(),
-		Operator:  interfaces.Gte,
-		Threshold: uint(cli.ModelInactiveSecondsThreshold),
-		Reset:     false,
-		EventType: modelscaling.ScaleDownEvent,
-	}
-	modelScalingStatsCollector := modelscaling.NewDataPlaneStatsCollector(
-		modelLagStatsWrapper.Stats,
-		modelLastUsedStatsWrapper.Stats,
+	var (
+		modelScalingStatsCollector *modelscaling.DataPlaneStatsCollector
+		modelScalingService        *modelscaling.StatsAnalyserService
 	)
+	// we force auto-scaling to be disabled until scale-up issue is resoled
+	autoScalingEnabled := false
+	if autoScalingEnabled {
+		modelLagStatsWrapper := modelscaling.ModelScalingStatsWrapper{
+			Stats:     modelscaling.NewModelReplicaLagsKeeper(),
+			Operator:  interfaces.Gte,
+			Threshold: uint(cli.ModelInferenceLagThreshold),
+			Reset:     true,
+			EventType: modelscaling.ScaleUpEvent,
+		}
+		modelLastUsedStatsWrapper := modelscaling.ModelScalingStatsWrapper{
+			Stats:     modelscaling.NewModelReplicaLastUsedKeeper(),
+			Operator:  interfaces.Gte,
+			Threshold: uint(cli.ModelInactiveSecondsThreshold),
+			Reset:     false,
+			EventType: modelscaling.ScaleDownEvent,
+		}
+		modelScalingStatsCollector = modelscaling.NewDataPlaneStatsCollector(
+			modelLagStatsWrapper.Stats,
+			modelLastUsedStatsWrapper.Stats,
+		)
+
+		modelScalingService = modelscaling.NewStatsAnalyserService(
+			[]modelscaling.ModelScalingStatsWrapper{modelLagStatsWrapper, modelLastUsedStatsWrapper}, logger, uint(cli.ScalingStatsPeriodSeconds))
+		defer func() { _ = modelScalingService.Stop() }()
+	}
 
 	rpHTTP := agent.NewReverseHTTPProxy(
 		logger,
@@ -260,10 +272,6 @@ func main() {
 
 	agentDebugService := agent.NewAgentDebug(logger, uint(cli.DebugGrpcPort))
 	defer func() { _ = agentDebugService.Stop() }()
-
-	modelScalingService := modelscaling.NewStatsAnalyserService(
-		[]modelscaling.ModelScalingStatsWrapper{modelLagStatsWrapper, modelLastUsedStatsWrapper}, logger, uint(cli.ScalingStatsPeriodSeconds))
-	defer func() { _ = modelScalingService.Stop() }()
 
 	drainerService := drainservice.NewDrainerService(
 		logger, uint(cli.DrainerServicePort))
@@ -301,6 +309,7 @@ func main() {
 		readinessService,
 		promMetrics,
 		clientset,
+		autoScalingEnabled,
 	)
 
 	// Wait for required services to be ready

--- a/scheduler/cmd/scheduler/main.go
+++ b/scheduler/cmd/scheduler/main.go
@@ -356,6 +356,8 @@ func main() {
 	}
 
 	// scheduler <-> agent  grpc
+	// auto-scaling has been disabled for time being, until issue is fixed for scaling models back up
+	autoscalingModelEnabled = false
 	as := agent.NewAgentServer(logger, ss, sched, eventHub, autoscalingModelEnabled, *tlsOptions)
 	err = as.StartGrpcServer(allowPlaintxt, agentPort, agentMtlsPort)
 	if err != nil {

--- a/scheduler/pkg/agent/agent_svc_manager.go
+++ b/scheduler/pkg/agent/agent_svc_manager.go
@@ -219,6 +219,7 @@ func NewAgentServiceManager(
 		agentConfig:              agentConfig,
 		modelTimestamps:          sync.Map{},
 		startTime:                time.Now(),
+		autoScalingEnabled:       autoScalingEnabled,
 	}
 	am.isStartup.Store(true)
 	readinessService.SetState(&am)

--- a/scheduler/pkg/agent/agent_svc_manager.go
+++ b/scheduler/pkg/agent/agent_svc_manager.go
@@ -65,6 +65,7 @@ type AgentServiceManager struct {
 	agentConfig              *AgentServiceConfig
 	modelTimestamps          sync.Map
 	startTime                time.Time
+	autoScalingEnabled       bool
 	StorageManager
 	SchedulerGrpcClientOptions
 	KubernetesOptions
@@ -169,6 +170,7 @@ func NewAgentServiceManager(
 	readinessService interfaces.DependencyServiceInterface,
 	metrics metrics.AgentMetricsHandler,
 	k8sClient k8s.ExtendedClient,
+	autoScalingEnabled bool,
 ) *AgentServiceManager {
 	opts := []grpc.CallOption{
 		grpc.MaxCallSendMsgSize(math.MaxInt32),
@@ -392,9 +394,13 @@ func (am *AgentServiceManager) WaitReadySubServices(isStartup bool) error {
 		am.rpHTTP,
 		am.rpGRPC,
 		am.agentDebugService,
-		am.modelScalingService,
 		am.drainerService,
 	}
+
+	if am.autoScalingEnabled {
+		internalSubServices = append(internalSubServices, am.modelScalingService)
+	}
+
 	wg.Add(2)                        // wait for subservices from other containers in the same pod (rclone, inference server)
 	wg.Add(len(internalSubServices)) // wait for internal subservices
 
@@ -534,16 +540,18 @@ func (am *AgentServiceManager) handleSchedulerSubscription() error {
 
 	logger.Info("Subscribed to scheduler")
 
-	// start model scaling events consumer
-	clientStream, err := grpcClient.ModelScalingTrigger(context.Background())
-	if err != nil {
-		return err
-	}
+	if am.autoScalingEnabled {
+		// start model scaling events consumer
+		clientStream, err := grpcClient.ModelScalingTrigger(context.Background())
+		if err != nil {
+			return err
+		}
 
-	am.modelScalingClientStream = clientStream
-	defer func() {
-		_, _ = clientStream.CloseAndRecv()
-	}()
+		am.modelScalingClientStream = clientStream
+		defer func() {
+			_, _ = clientStream.CloseAndRecv()
+		}()
+	}
 
 	// Mark startup as completed once we have an initial connection to the scheduler
 	// This connection may break and will be retried, but we define the agent as "started"
@@ -737,11 +745,15 @@ func (am *AgentServiceManager) LoadModel(request *agent_pb.ModelOperationMessage
 	// if scheduler ask for autoscaling, add pointers in model scaling stats
 	// we have done it via the scaling service as not to expose here all the model scaling stats
 	// that we have and then call Add on each one of them
-	if request.AutoscalingEnabled {
+	if request.AutoscalingEnabled && am.autoScalingEnabled {
 		logger.Debugf("Enabling autoscaling checks for model %s", modelWithVersion)
 		if err := am.modelScalingService.(*modelscaling.StatsAnalyserService).AddModel(modelWithVersion); err != nil {
 			logger.WithError(err).Warnf("Cannot add model %s to scaling service", modelWithVersion)
 		}
+	}
+
+	if request.AutoscalingEnabled && !am.autoScalingEnabled {
+		logger.Warn("Autoscaling enabled on scheduler but not agent")
 	}
 
 	logger.Infof("Load model %s:%d success", modelName, modelVersion)
@@ -790,15 +802,17 @@ func (am *AgentServiceManager) UnloadModel(request *agent_pb.ModelOperationMessa
 		return err
 	}
 
-	// remove pointers in model scaling stats
-	// we have done it via the scaling service as not to expose here all the model scaling stats that we have and then call Delete on
-	// each one of them
-	// note that we do not check if the model is already enabled for autoscaling, should we?
-	if err := am.modelScalingService.(*modelscaling.StatsAnalyserService).DeleteModel(modelWithVersion); err != nil {
-		logger.WithError(err).Warnf(
-			"Cannot delete model %s from scaling service, likely that it was not enabled in the first place",
-			modelWithVersion,
-		)
+	if am.autoScalingEnabled {
+		// remove pointers in model scaling stats
+		// we have done it via the scaling service as not to expose here all the model scaling stats that we have and then call Delete on
+		// each one of them
+		// note that we do not check if the model is already enabled for autoscaling, should we?
+		if err := am.modelScalingService.(*modelscaling.StatsAnalyserService).DeleteModel(modelWithVersion); err != nil {
+			logger.WithError(err).Warnf(
+				"Cannot delete model %s from scaling service, likely that it was not enabled in the first place",
+				modelWithVersion,
+			)
+		}
 	}
 
 	err := am.ModelRepository.RemoveModelVersion(modelWithVersion)
@@ -927,6 +941,9 @@ func (am *AgentServiceManager) sendModelScalingTriggerEvent(
 }
 
 func (am *AgentServiceManager) modelScalingEventsConsumer() {
+	if !am.autoScalingEnabled {
+		return
+	}
 	ch := am.modelScalingService.(*modelscaling.StatsAnalyserService).GetEventChannel()
 	for am.modelScalingService.Ready() {
 		e := <-ch

--- a/scheduler/pkg/agent/rproxy_grpc.go
+++ b/scheduler/pkg/agent/rproxy_grpc.go
@@ -241,8 +241,10 @@ func (rp *reverseGRPCProxy) ModelInfer(ctx context.Context, r *v2.ModelInferRequ
 	r.ModelName = internalModelName
 	r.ModelVersion = ""
 
-	// handle scaling metrics
-	rp.syncScalingMetrics(internalModelName)
+	if rp.modelScalingStatsCollector != nil {
+		// handle scaling metrics
+		rp.syncScalingMetrics(internalModelName)
+	}
 
 	startTime := time.Now()
 	err = rp.ensureLoadModel(r.ModelName)
@@ -345,8 +347,10 @@ func (rp *reverseGRPCProxy) ModelStreamInfer(stream v2.GRPCInferenceService_Mode
 		return err
 	}
 
-	// handle scaling metrics
-	rp.syncScalingMetrics(internalModelName)
+	if rp.modelScalingStatsCollector != nil {
+		// handle scaling metrics
+		rp.syncScalingMetrics(internalModelName)
+	}
 
 	startTime := time.Now()
 	// TODO: check the model is still loaded while the stream is going, not just at the start of the stream

--- a/scheduler/pkg/agent/server.go
+++ b/scheduler/pkg/agent/server.go
@@ -368,6 +368,11 @@ func (s *Server) AgentEvent(ctx context.Context, message *pb.ModelEventMessage) 
 }
 
 func (s *Server) ModelScalingTrigger(stream pb.AgentService_ModelScalingTriggerServer) error {
+	if !s.autoscalingModelEnabled {
+		s.logger.Warn("Model autoscaling trigger called even though its disabled")
+		return status.Error(codes.Unimplemented, "autoscaling models is disabled")
+	}
+
 	for {
 		message, err := stream.Recv()
 		if err == io.EOF {


### PR DESCRIPTION
## Motivation

Auto-scaling of Models does not work when there are no Models loaded on a Server and a scale up of models is required. This is potentially causing customer's issues where models scale down to 0, during quiet load, but when load increases models stays at 0. Force disabling until rectified. 

## Summary of changes

- force disabled on scheduler, will return error if client attempts to connect to model trigger scaling stream service
- force disable on agent

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
