### PR TITLE
fix(operator):  unable to set 0 replicas on models/servers

### DIFF
--- a/operator/internal/utils.go
+++ b/operator/internal/utils.go
@@ -36,10 +36,8 @@ func GetValidatedScalingSpec(replicas *int32, minReplicas *int32, maxReplicas *i
 		return &validatedSpec, nil
 	}
 
-	if replicas != nil && *replicas > 0 {
+	if replicas != nil && *replicas >= 0 {
 		validatedSpec.Replicas = uint32(*replicas)
-	} else if replicas != nil && *replicas == 0 && minReplicas != nil && *minReplicas == 0 {
-		validatedSpec.Replicas = uint32(0)
 	} else if minReplicas != nil && *minReplicas > 0 {
 		if replicas != nil && *replicas < *minReplicas {
 			return nil, fmt.Errorf("%w: number of replicas %d cannot be less than minimum replica %d", ErrScalingSpec, *replicas, *minReplicas)

--- a/operator/internal/utils_test.go
+++ b/operator/internal/utils_test.go
@@ -64,7 +64,7 @@ func TestGetValidatedScalingSpec(t *testing.T) {
 			minReplicas: ptr.Int32(1),
 			maxReplicas: nil,
 			expected:    nil,
-			wantErr:     "scaling spec is invalid: number of replicas 0 cannot be less than minimum replica 1",
+			wantErr:     "scaling spec is invalid: number of replicas 0 must be >= min replicas 1",
 		},
 		{
 			name:        "error - min replica is bigger than max replicas",
@@ -83,6 +83,16 @@ func TestGetValidatedScalingSpec(t *testing.T) {
 				Replicas:    0,
 				MinReplicas: 0,
 				MaxReplicas: 4,
+			},
+			wantErr: "",
+		},
+		{
+			name:     "success - replicas = 0",
+			replicas: ptr.Int32(0),
+			expected: &ValidatedScalingSpec{
+				Replicas:    0,
+				MinReplicas: 0,
+				MaxReplicas: math.MaxUint32,
 			},
 			wantErr: "",
 		},


### PR DESCRIPTION
## Motivation

A scaling spec such as 

```yaml
replicas: 0
```

results in a validated scaling spec of 1 replica for models/servers, and in the case of models the scheduler will attempt to load the models.

## Summary of changes

- remove condition which only allows `replicas` = 0 if `minReplicas` == 0

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
