### PR TITLE
fix(tests): proto imports

### DIFF
--- a/tests/k6/components/scheduler.js
+++ b/tests/k6/components/scheduler.js
@@ -2,7 +2,9 @@ import grpc from 'k6/net/grpc';
 import { check, sleep } from 'k6';
 
 const schedulerClient = new grpc.Client();
-schedulerClient.load([import.meta.resolve('../../../apis/mlops/scheduler/')], 'scheduler.proto');
+schedulerClient.load([
+    import.meta.resolve('../../../apis'),
+    import.meta.resolve('../../../apis/mlops/scheduler/')], 'scheduler.proto');
 
 export function connectScheduler(serverUrl) {
     schedulerClient.connect(serverUrl, {

--- a/tests/k6/components/scheduler_proxy.js
+++ b/tests/k6/components/scheduler_proxy.js
@@ -2,7 +2,8 @@ import grpc from 'k6/net/grpc';
 import {check} from 'k6';
 
 const schedulerClient = new grpc.Client();
-schedulerClient.load([import.meta.resolve('../../../apis/')], 'mlops/proxy/proxy.proto');
+schedulerClient.load([
+    import.meta.resolve('../../../apis/')], 'mlops/proxy/proxy.proto');
 
 export function connectScheduler(serverUrl) {
     schedulerClient.connect(serverUrl, {

--- a/tests/k6/components/v2.js
+++ b/tests/k6/components/v2.js
@@ -6,7 +6,9 @@ import {getConfig} from "./settings.js";
 import {connectControlPlaneOps} from "./utils.js";
 
 const v2Client = new grpc.Client();
-v2Client.load([import.meta.resolve('../../../apis/mlops/v2_dataplane/')], 'v2_dataplane.proto');
+v2Client.load([
+    import.meta.resolve('../../../apis'),
+    import.meta.resolve('../../../apis/mlops/v2_dataplane/')], 'v2_dataplane.proto');
 
 
 export function inferHttp(endpoint, modelName, payload, viaEnvoy, isPipeline = false, debug = false, requestIDPrefix = null, timeout = null) {


### PR DESCRIPTION
## Motivation

Fix proto import when a proto imports another internal Seldon proto

```shell
ERRO[0000] GoError: scheduler.proto:8:8: stat /home/dominicriordan/go/src/github.com/SeldonIO/seldon-core/apis/mlops/scheduler/mlops/chainer/chainer.proto: no such file or directory
        at reflect.methodValueCall (native)
```

# What
## Summary of changes

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
