### PR TITLE
fix(pipeline-gw): temp preStop hook 

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
@@ -787,6 +787,13 @@ spec:
         image: '{{ .Values.pipelinegateway.image.registry }}/{{ .Values.pipelinegateway.image.repository
           }}:{{ .Values.pipelinegateway.image.tag }}'
         imagePullPolicy: '{{ .Values.pipelinegateway.image.pullPolicy }}'
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - sleep 2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
@@ -787,6 +787,13 @@ spec:
         image: '{{ .Values.pipelinegateway.image.registry }}/{{ .Values.pipelinegateway.image.repository
           }}:{{ .Values.pipelinegateway.image.tag }}'
         imagePullPolicy: '{{ .Values.pipelinegateway.image.pullPolicy }}'
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - sleep 2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/k8s/kustomize/helm-components-sc/patch_pipelinegateway.yaml
+++ b/k8s/kustomize/helm-components-sc/patch_pipelinegateway.yaml
@@ -91,3 +91,10 @@ spec:
             value: '{{ hasKey .Values.pipelinegateway "logLevel" | ternary .Values.pipelinegateway.logLevel .Values.logging.logLevel }}'
           - name: PIPELINEGATEWAY_MAX_NUM_CONSUMERS
             value: '{{ .Values.pipelinegateway.maxNumConsumers }}'
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - sleep 2

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -623,6 +623,13 @@ spec:
               fieldPath: metadata.namespace
         image: 'docker.io/seldonio/seldon-pipelinegateway:latest'
         imagePullPolicy: 'IfNotPresent'
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - sleep 2
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
# Why
## Issues
When a pipeline pod is restarted, there is a race condition where the pod begins terminating before Envoy receives the updated endpoint list from Kubernetes. This results in Envoy routing traffic to a pod that is no longer accepting connections, causing intermittent 503 errors.

## Motivation
To prevent this issue, a preStop hook has been added to delay pod termination until the endpoint deregistration propagates to Envoy. This ensures Envoy stops routing traffic to the pod before it fully shuts down. This is a temporary measurement until integration with a more robust approach such as sending request to envoy xDS
# What
## Summary of changes

* PreStop hook  on pipeline gateway with a delay until xDS integration

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
