### PR TITLE
fix(scheduler, dataflow): pipeline loading/unloading on pipeline-gw and dataflow engine topology

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
@@ -252,8 +252,8 @@ class Pipeline(
             val sortedSteps =
                 steps.sortedWith(
                     compareBy(
-                        { step -> step.sourcesList.joinToString(",") { it.topicName } },
                         { step -> step.sink.topicName },
+                        { step -> step.sourcesList.joinToString(",") { it.topicName } },
                         { step -> step.triggersList.joinToString(",") { it.topicName } },
                     ),
                 )

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Pipeline.kt
@@ -246,11 +246,18 @@ class Pipeline(
             kafkaDomainParams: KafkaDomainParams,
             kafkaStreamsSerdes: KafkaStreamsSerdes,
         ): Pair<Topology, Int> {
-            // Sort the steps by the sink to ensure the same
-            // order when building the topology amongst multiple
-            // replicas. The scheduler doesn't send the same message
-            // because the steps are created from iterating over a map
-            val sortedSteps = steps.sortedBy { it.sink.topicName }
+            // Sort ensure the same order when building the topology amongst multiple
+            // replicas. The scheduler doesn't send the same message because the steps
+            // are created from iterating over a map
+            val sortedSteps =
+                steps.sortedWith(
+                    compareBy(
+                        { step -> step.sourcesList.joinToString(",") { it.topicName } },
+                        { step -> step.sink.topicName },
+                        { step -> step.triggersList.joinToString(",") { it.topicName } },
+                    ),
+                )
+
             val builder = StreamsBuilder()
 
             if (metadata.allowCycles) {


### PR DESCRIPTION
# Why
## Issues

* The scheduler was sending messages to pipeline-gw replicas whenever `ModelsReady` changed. However, if the `PipelineGwStatus` was anything other than `Create` or `Delete`, the replicas would not acknowledge the message. As a result, the pipeline status never progressed.
* Sorting steps only by the sink is not always sufficient for the dataflow engine. In some cases, this led to inconsistent topologies, which caused sharding to fail when distributing the pipeline across multiple dataflow engine instances.

## Motivation

# What
## Summary of changes

## Checklist
- [ ] Added/updated unit tests
- [ ] Added/updated documentation
- [ ] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
