### PR TITLE
fix(probes): improve timing of k8s lifecycle probes

### DIFF
--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-deployments.tpl
@@ -607,6 +607,7 @@ spec:
           httpGet:
             path: /live
             port: health
+          initialDelaySeconds: 10
           periodSeconds: 5
         name: scheduler
         ports:
@@ -630,6 +631,7 @@ spec:
           httpGet:
             path: /ready
             port: health
+          initialDelaySeconds: 10
           periodSeconds: 5
         resources:
           limits:
@@ -833,12 +835,12 @@ spec:
             cpu: '{{ .Values.pipelinegateway.resources.cpu }}'
             memory: '{{ .Values.pipelinegateway.resources.memory }}'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -997,12 +999,12 @@ spec:
             cpu: '{{ .Values.modelgateway.resources.cpu }}'
             memory: '{{ .Values.modelgateway.resources.memory }}'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -1266,12 +1268,12 @@ spec:
             cpu: '{{ .Values.dataflow.resources.cpu }}'
             memory: '{{ .Values.dataflow.resources.memory }}'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/schema-registry
           name: kafka-schema-volume

--- a/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
+++ b/k8s/helm-charts/seldon-core-v2-setup/templates/_components-statefulsets.tpl
@@ -607,6 +607,7 @@ spec:
           httpGet:
             path: /live
             port: health
+          initialDelaySeconds: 10
           periodSeconds: 5
         name: scheduler
         ports:
@@ -630,6 +631,7 @@ spec:
           httpGet:
             path: /ready
             port: health
+          initialDelaySeconds: 10
           periodSeconds: 5
         resources:
           limits:
@@ -833,12 +835,12 @@ spec:
             cpu: '{{ .Values.pipelinegateway.resources.cpu }}'
             memory: '{{ .Values.pipelinegateway.resources.memory }}'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -997,12 +999,12 @@ spec:
             cpu: '{{ .Values.modelgateway.resources.cpu }}'
             memory: '{{ .Values.modelgateway.resources.memory }}'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -1266,12 +1268,12 @@ spec:
             cpu: '{{ .Values.dataflow.resources.cpu }}'
             memory: '{{ .Values.dataflow.resources.memory }}'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/schema-registry
           name: kafka-schema-volume

--- a/k8s/yaml/components.yaml
+++ b/k8s/yaml/components.yaml
@@ -449,6 +449,7 @@ spec:
           httpGet:
             path: /live
             port: health
+          initialDelaySeconds: 10
           periodSeconds: 5
         name: scheduler
         ports:
@@ -472,6 +473,7 @@ spec:
           httpGet:
             path: /ready
             port: health
+          initialDelaySeconds: 10
           periodSeconds: 5
         resources:
           limits:
@@ -669,12 +671,12 @@ spec:
             cpu: '100m'
             memory: '1G'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -828,12 +830,12 @@ spec:
             cpu: '100m'
             memory: '1G'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/kafka
           name: kafka-config-volume
@@ -1089,12 +1091,12 @@ spec:
             cpu: '100m'
             memory: '3G'
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /mnt/schema-registry
           name: kafka-schema-volume

--- a/operator/config/seldonconfigs/default.yaml
+++ b/operator/config/seldonconfigs/default.yaml
@@ -45,12 +45,12 @@ spec:
           - containerPort: 8000
             name: health
         startupProbe:
-          failureThreshold: 3
+          failureThreshold: 10
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: 10
+          periodSeconds: 10
         readinessProbe:
           failureThreshold: 3
           httpGet:
@@ -184,9 +184,9 @@ spec:
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /ready
@@ -286,9 +286,9 @@ spec:
           httpGet:
             path: /startup
             port: health
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /ready
@@ -399,12 +399,14 @@ spec:
             port: health
           periodSeconds: 5
           failureThreshold: 3
+          initialDelaySeconds: 10
         livenessProbe:
           httpGet:
             path: /live
             port: health
           periodSeconds: 5
           failureThreshold: 3
+          initialDelaySeconds: 10
         resources:
           limits:
             memory: 1G


### PR DESCRIPTION
Previous timings were leading to spurious restarts, especially on start-up as components waited to connect to the scheduler. It was possible for the scheduler image pull to take sufficiently long (and be timed in an unlucky way), such that other components restarted a number of times. The new timings simply reduce that possibility by being more generous wrt the startup probe.