### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+If GitHub private vulnerability reporting is available, use the **Report a vulnerability** button on the repository's Security tab. Otherwise, contact the maintainers through the project's documented support channels before sharing details publicly.
+
+When reporting a vulnerability, include the affected version or commit, a concise impact summary, reproduction steps, and any relevant configuration needed to reproduce the issue.


### PR DESCRIPTION
## Summary
- add a SECURITY.md with guidance for reporting vulnerabilities privately

## Why
This repository is listed as a huntr target, but I did not find a repository-level SECURITY.md. Adding one gives security reporters a private-first path and discourages disclosure through public issues.

## Testing
- git diff --check