### PR TITLE
docs(storage-secrets): note S3-compatible endpoints for storage secrets

### DIFF
--- a/docs-gb/kubernetes/storage-secrets.md
+++ b/docs-gb/kubernetes/storage-secrets.md
@@ -137,6 +137,10 @@ The easiest way to change this is to update your SeldonRuntime.
 
 {% tabs %}
 {% tab title="S3 MinIO" %}
+{% hint style="info" %}
+The `s3` remote type works with any S3-compatible object store. Amazon S3 requires no `endpoint` parameter, while an S3-compatible provider such as Backblaze B2, Cloudflare R2, or MinIO is selected by setting `provider` and pointing `endpoint` at that provider's published S3 endpoint (for example, `endpoint: https://<s3-compatible-endpoint>`). The MinIO example below sets `endpoint` for an in-cluster deployment.
+{% endhint %}
+
 Assuming you have installed MinIO in the `minio-system` namespace, a corresponding secret could be:
 
 ```yaml


### PR DESCRIPTION
# Why
## Issues

## Motivation

The storage secrets page shows the `s3` remote under a tab titled "S3 MinIO", with an `endpoint` set for an in-cluster MinIO deployment. It is not obvious from that example that the same remote type covers other S3-compatible object stores, or that `endpoint` is what selects one instead of Amazon S3.

# What
## Summary of changes

Adds an info hint to the "S3 MinIO" tab in `docs-gb/kubernetes/storage-secrets.md` noting that the `s3` remote type works with any S3-compatible object store: Amazon S3 needs no `endpoint`, while an S3-compatible provider such as Backblaze B2, Cloudflare R2, or MinIO is selected by setting `provider` and pointing `endpoint` at that provider's S3 endpoint. Uses a placeholder endpoint and points at the existing MinIO example below it. Docs only, no config or code changes.

## Checklist
- [ ] Added/updated unit tests
- [x] Added/updated documentation
- [x] Checked for typos in variable names, comments, etc.
- [ ] Added licences for new files

## Testing
